### PR TITLE
Fixed CI pipeline on forked repositories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,19 +12,14 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: "11"
-      - name: Testing
-        run: |
-          echo $GITHUB_REF
-          echo $GITHUB_HEAD_REF
-          echo $GITHUB_BASE_REF
+      # this should either be triggered on the forked repository OR a pull_request
       - name: Build Only
         run: |
           ./gradlew --parallel build
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # this should either be triggered on the forked repository OR a pull_request that is
-        if: github.repository != 'Fraunhofer-AISEC/cpg'
+        if: github.repository != 'Fraunhofer-AISEC/cpg' || github.head_ref != ''
       - name: Build and Quality Check
         run: |
           ./gradlew --parallel build sonarqube \
@@ -36,7 +31,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: github.repository == 'Fraunhofer-AISEC/cpg'
+        if: github.repository == 'Fraunhofer-AISEC/cpg' || github.head_ref == ''
       - name: Publish
         run: |
           export ORG_GRADLE_PROJECT_signingKey=`echo ${{ secrets.GPG_PRIVATE_KEY }} | base64 -d`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: github.head_ref != ''
+        if: github.repository != 'Fraunhofer-AISEC/cpg'
       - name: Build and Quality Check
         run: |
           ./gradlew --parallel build sonarqube \
@@ -28,7 +28,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: github.head_ref == ''
+        if: github.repository == 'Fraunhofer-AISEC/cpg'
       - name: Publish
         run: |
           export ORG_GRADLE_PROJECT_signingKey=`echo ${{ secrets.GPG_PRIVATE_KEY }} | base64 -d`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,14 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: "11"
-      - name: Build
+      - name: Build Only
+        run: |
+          ./gradlew --parallel build
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: github.head.ref != ''
+      - name: Build and Quality Check
         run: |
           ./gradlew --parallel build sonarqube \
           -Dsonar.projectKey=Fraunhofer-AISEC_cpg \
@@ -21,6 +28,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: github.head.ref == ''
       - name: Publish
         run: |
           export ORG_GRADLE_PROJECT_signingKey=`echo ${{ secrets.GPG_PRIVATE_KEY }} | base64 -d`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: github.head.ref != ''
+        if: github.head_ref != ''
       - name: Build and Quality Check
         run: |
           ./gradlew --parallel build sonarqube \
@@ -28,7 +28,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: github.head.ref == ''
+        if: github.head_ref == ''
       - name: Publish
         run: |
           export ORG_GRADLE_PROJECT_signingKey=`echo ${{ secrets.GPG_PRIVATE_KEY }} | base64 -d`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: github.repository == 'Fraunhofer-AISEC/cpg' || github.head_ref == ''
+        if: github.repository == 'Fraunhofer-AISEC/cpg' && github.head_ref == ''
       - name: Publish
         run: |
           export ORG_GRADLE_PROJECT_signingKey=`echo ${{ secrets.GPG_PRIVATE_KEY }} | base64 -d`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: build
 
-on: [push]
+on:
+  - push
+  - pull_request
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,18 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: "11"
+      - name: Testing
+        run: |
+          echo $GITHUB_REF
+          echo $GITHUB_HEAD_REF
+          echo $GITHUB_BASE_REF
       - name: Build Only
         run: |
           ./gradlew --parallel build
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # this should either be triggered on the forked repository OR a pull_request that is
         if: github.repository != 'Fraunhofer-AISEC/cpg'
       - name: Build and Quality Check
         run: |


### PR DESCRIPTION
Fixes #6 

- Detecting repository using `github.repository`
- Skip running SonarQube task since the `SONAR_TOKEN` secret is not available on forked repositories (which is a good thing)