### PR TITLE
Slightly smarter way to handle CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,26 +12,22 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: "11"
-      # this should either be triggered on the forked repository OR a pull_request
-      - name: Build Only
+      - name: Build
         run: |
-          ./gradlew --parallel build
+          if [ "$SONAR_TOKEN" != "" ]
+          then
+            ./gradlew --parallel build sonarqube \
+            -Dsonar.projectKey=Fraunhofer-AISEC_cpg \
+            -Dsonar.organization=fraunhofer-aisec \
+            -Dsonar.host.url=https://sonarcloud.io \
+            -Dsonar.login=$SONAR_TOKEN \
+            -Dsonar.branch.name=${GITHUB_REF:11}
+          else
+            ./gradlew --parallel build
+          fi
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: github.repository != 'Fraunhofer-AISEC/cpg' || github.head_ref != ''
-      - name: Build and Quality Check
-        run: |
-          ./gradlew --parallel build sonarqube \
-          -Dsonar.projectKey=Fraunhofer-AISEC_cpg \
-          -Dsonar.organization=fraunhofer-aisec \
-          -Dsonar.host.url=https://sonarcloud.io \
-          -Dsonar.login=$SONAR_TOKEN \
-          -Dsonar.branch.name=${GITHUB_REF:11}
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: github.repository == 'Fraunhofer-AISEC/cpg' && github.head_ref == ''
       - name: Publish
         run: |
           export ORG_GRADLE_PROJECT_signingKey=`echo ${{ secrets.GPG_PRIVATE_KEY }} | base64 -d`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,19 @@ on:
   - pull_request
 
 jobs:
+  # we need to at least execute one job otherwise the overall thing will fail, this is a known issue of GitHub actions
+  # see https://github.community/t5/GitHub-Actions/Workflow-is-failing-if-no-job-can-be-ran-due-to-condition/td-p/38085
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Do nothing
+        run: |
+          echo 1
   build:
     runs-on: ubuntu-latest
+    # only execute if this is coming from a push or from a PR from a forked repository
+    # otherwise this will get executed twice for PR from internal branches
+    if: github.event_name == 'push' || github.event_name == 'pull_request' && (github.event.pull_request.base.repo.full_name != github.event.pull_request.head.repo.full_name)
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1
@@ -16,14 +27,14 @@ jobs:
         run: |
           if [ "$SONAR_TOKEN" != "" ]
           then
-            ./gradlew --parallel build sonarqube \
+            ./gradlew --parallel spotlessCheck build sonarqube \
             -Dsonar.projectKey=Fraunhofer-AISEC_cpg \
             -Dsonar.organization=fraunhofer-aisec \
             -Dsonar.host.url=https://sonarcloud.io \
             -Dsonar.login=$SONAR_TOKEN \
             -Dsonar.branch.name=${GITHUB_REF:11}
           else
-            ./gradlew --parallel build
+            ./gradlew --parallel spotlessCheck build
           fi
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
- Checking for the existence of `SONAR_TOKEN` now instead of weird if expressions
- Checking if it is either a `push` or a `pull_request` coming from another repo
- There seems to be an issue (https://github.community/t5/GitHub-Actions/Workflow-is-failing-if-no-job-can-be-ran-due-to-condition/td-p/38085) that prevents us from just skipping all jobs in case it is an internal PR so we need to add a fake job ('noop`) so that at least something runs in this case