### PR TITLE
Implemented type listening in ConstructExpression

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
@@ -169,7 +169,7 @@ public class DeclarationHandler extends Handler<Declaration, IASTDeclaration, CX
 
       return handle.get(0);
     } else {
-      log.error("More than one declaration, this should not happpen here.");
+      log.error("More than one declaration, this should not happen here.");
     }
 
     return null;

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.java
@@ -88,7 +88,7 @@ class DeclaratorHandler extends Handler<Declaration, IASTNameOwner, CXXLanguageF
     // type will be filled out later
     VariableDeclaration declaration =
         NodeBuilder.newVariableDeclaration(
-            ctx.getName().toString(), Type.getUnknown(), ctx.getRawSignature());
+            ctx.getName().toString(), Type.UNKNOWN, ctx.getRawSignature());
 
     IASTInitializer init = ctx.getInitializer();
 
@@ -192,7 +192,7 @@ class DeclaratorHandler extends Handler<Declaration, IASTNameOwner, CXXLanguageF
     // wraps this list
     if (ctx.takesVarArgs()) {
       ParamVariableDeclaration varargs =
-          NodeBuilder.newMethodParameterIn("va_args", Type.getUnknown(), true, "");
+          NodeBuilder.newMethodParameterIn("va_args", Type.UNKNOWN, true, "");
       varargs.setArgumentIndex(i);
       lang.getScopeManager().addValueDeclaration(varargs);
     }

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.java
@@ -466,7 +466,7 @@ class ExpressionHandler extends Handler<Expression, IASTInitializerClause, CXXLa
           declaredReferenceExpression.setType(((ValueDeclaration) declaration).getType());
         } else {
           log.debug("Unknown declaration type, setting to UNKNOWN");
-          declaredReferenceExpression.setType(Type.createFrom("UNKNOWNdeclType"));
+          declaredReferenceExpression.setType(Type.createFrom("UNKNOWN"));
         }
       } else {
         log.debug("Could not deduce type manually, setting to UNKNOWN");

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.java
@@ -466,11 +466,11 @@ class ExpressionHandler extends Handler<Expression, IASTInitializerClause, CXXLa
           declaredReferenceExpression.setType(((ValueDeclaration) declaration).getType());
         } else {
           log.debug("Unknown declaration type, setting to UNKNOWN");
-          declaredReferenceExpression.getType().setFrom("UNKNOWNdeclType");
+          declaredReferenceExpression.setType(Type.createFrom("UNKNOWNdeclType"));
         }
       } else {
         log.debug("Could not deduce type manually, setting to UNKNOWN");
-        declaredReferenceExpression.getType().setFrom("UNKNOWN1");
+        declaredReferenceExpression.setType(Type.createFrom("UNKNOWN1"));
       }
     } else {
       declaredReferenceExpression.setType(Type.createFrom(expressionTypeProxy(ctx).toString()));

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.java
@@ -290,7 +290,7 @@ class ExpressionHandler extends Handler<Expression, IASTInitializerClause, CXXLa
     String identifierName = ctx.getFieldName().toString();
     DeclaredReferenceExpression member =
         NodeBuilder.newDeclaredReferenceExpression(
-            identifierName, Type.getUnknown(), ctx.getFieldName().getRawSignature());
+            identifierName, Type.UNKNOWN, ctx.getFieldName().getRawSignature());
 
     lang.setCodeAndRegion(member, ctx);
 

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.java
@@ -470,7 +470,7 @@ class ExpressionHandler extends Handler<Expression, IASTInitializerClause, CXXLa
         }
       } else {
         log.debug("Could not deduce type manually, setting to UNKNOWN");
-        declaredReferenceExpression.setType(Type.createFrom("UNKNOWN1"));
+        declaredReferenceExpression.setType(Type.createFrom("UNKNOWN"));
       }
     } else {
       declaredReferenceExpression.setType(Type.createFrom(expressionTypeProxy(ctx).toString()));

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/InitializerHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/InitializerHandler.java
@@ -57,16 +57,8 @@ public class InitializerHandler extends Handler<Expression, IASTInitializer, CXX
   }
 
   private Expression handleConstructorInitializer(CPPASTConstructorInitializer ctx) {
-    // ctx.getRawSignature(); only returns "(1)" for "new Botan(1)". no way to get Botan(1) except:
-    String code = ctx.getRawSignature();
-    if (ctx.getParent() != null && ctx.getParent().getRawSignature() != null) {
-      if (ctx.getParent().getRawSignature().startsWith("new ")) {
-        code = ctx.getParent().getRawSignature().substring(4);
-      } else {
-        code = ctx.getParent().getRawSignature();
-      }
-    }
-    ConstructExpression constructExpression = NodeBuilder.newConstructExpression(code);
+    ConstructExpression constructExpression =
+        NodeBuilder.newConstructExpression(ctx.getRawSignature());
 
     int i = 0;
     for (IASTInitializerClause argument : ctx.getArguments()) {

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ParameterDeclarationHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ParameterDeclarationHandler.java
@@ -87,10 +87,7 @@ public class ParameterDeclarationHandler
 
     ParamVariableDeclaration paramVariableDeclaration =
         NodeBuilder.newMethodParameterIn(
-            ctx.getDeclarator().getName().toString(),
-            Type.getUnknown(),
-            false,
-            ctx.getRawSignature());
+            ctx.getDeclarator().getName().toString(), Type.UNKNOWN, false, ctx.getRawSignature());
 
     // set type
     paramVariableDeclaration.setType(Type.createFrom(ctx.getDeclSpecifier().toString()));

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java
@@ -301,7 +301,7 @@ public class ExpressionHandler
             baseType = new Type(qualifiedNameFromImports);
           } else {
             log.info("Unknown base type for {}", fieldAccessExpr);
-            baseType = Type.getUnknown();
+            baseType = Type.UNKNOWN;
           }
         }
       }
@@ -332,7 +332,7 @@ public class ExpressionHandler
           baseType = new Type(qualifiedNameFromImports);
         } else {
           log.info("Unknown base type for {}", fieldAccessExpr);
-          baseType = Type.getUnknown();
+          baseType = Type.UNKNOWN;
         }
         base =
             NodeBuilder.newStaticReferenceExpression(
@@ -358,7 +358,7 @@ public class ExpressionHandler
         fieldType = new Type("int");
       } else {
         log.info("Unknown field type for {}", fieldAccessExpr);
-        fieldType = Type.getUnknown();
+        fieldType = Type.UNKNOWN;
       }
       member =
           NodeBuilder.newStaticReferenceExpression(
@@ -374,7 +374,7 @@ public class ExpressionHandler
     LiteralExpr literalExpr = expr.asLiteralExpr();
 
     // meh, no easy way to get the type
-    Type type = Type.getUnknown();
+    Type type = Type.UNKNOWN;
     String val = literalExpr.toString();
     if (literalExpr instanceof IntegerLiteralExpr) {
       type.setFrom("int");
@@ -617,7 +617,7 @@ public class ExpressionHandler
           NodeBuilder.newCallExpression(name, qualifiedName, methodCallExpr.toString());
     }
 
-    String type = Type.UNKNOWN_TYPE;
+    String type = Type.UNKNOWN_TYPE_STRING;
     try {
       type = methodCallExpr.resolve().getReturnType().describe();
     } catch (Throwable e) {

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java
@@ -377,20 +377,20 @@ public class ExpressionHandler
     Type type = Type.UNKNOWN;
     String val = literalExpr.toString();
     if (literalExpr instanceof IntegerLiteralExpr) {
-      type.setFrom("int");
+      type = Type.createFrom("int");
     } else if (literalExpr instanceof StringLiteralExpr) {
-      type.setFrom("java.lang.String");
+      type = Type.createFrom("java.lang.String");
       val = ((StringLiteralExpr) literalExpr).getValue();
     } else if (literalExpr instanceof BooleanLiteralExpr) {
-      type.setFrom("boolean");
+      type = Type.createFrom("boolean");
     } else if (literalExpr instanceof CharLiteralExpr) {
-      type.setFrom("char");
+      type = Type.createFrom("char");
     } else if (literalExpr instanceof DoubleLiteralExpr) {
-      type.setFrom("double");
+      type = Type.createFrom("double");
     } else if (literalExpr instanceof LongLiteralExpr) {
-      type.setFrom("long");
+      type = Type.createFrom("long");
     } else if (literalExpr instanceof NullLiteralExpr) {
-      type.setFrom("null");
+      type = Type.createFrom("null");
     }
 
     // create a LITERAL node
@@ -617,14 +617,14 @@ public class ExpressionHandler
           NodeBuilder.newCallExpression(name, qualifiedName, methodCallExpr.toString());
     }
 
-    String type = Type.UNKNOWN_TYPE_STRING;
+    String typeString = Type.UNKNOWN_TYPE_STRING;
     try {
-      type = methodCallExpr.resolve().getReturnType().describe();
+      typeString = methodCallExpr.resolve().getReturnType().describe();
     } catch (Throwable e) {
       log.debug("Could not resolve return type for {}", methodCallExpr);
     }
 
-    callExpression.getType().setFrom(type);
+    callExpression.setType(Type.createFrom(typeString));
 
     NodeList<Expression> arguments = methodCallExpr.getArguments();
 

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/StatementAnalyzer.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/StatementAnalyzer.java
@@ -462,7 +462,7 @@ public class StatementAnalyzer
 
   public String getCodeBetweenTokens(JavaToken startToken, JavaToken endToken) {
     if (startToken == null || endToken == null) {
-      return Type.UNKNOWN_TYPE;
+      return Type.UNKNOWN_TYPE_STRING;
     }
     StringBuilder newCode = new StringBuilder(startToken.getText());
     JavaToken current = startToken;

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/ConstructorDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/ConstructorDeclaration.java
@@ -41,7 +41,7 @@ public class ConstructorDeclaration extends MethodDeclaration {
     ConstructorDeclaration c = new ConstructorDeclaration();
 
     // constructors always have void type
-    c.getType().setFrom(VOID_TYPE);
+    c.setType(Type.createFrom(VOID_TYPE_STRING));
 
     c.name = functionDeclaration.getName();
     c.body = functionDeclaration.getBody();

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/Expression.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/Expression.java
@@ -54,7 +54,7 @@ public class Expression extends Statement implements HasType {
 
   /** The type of the value after evaluation. */
   @Convert(TypeConverter.class)
-  protected Type type = Type.getUnknown();
+  protected Type type = Type.UNKNOWN;
 
   @Transient private Set<TypeListener> typeListeners = new HashSet<>();
 
@@ -63,7 +63,9 @@ public class Expression extends Statement implements HasType {
 
   @Override
   public Type getType() {
-    return type;
+    // just to make sure that we REALLY always return a valid type in case this somehow gets set to
+    // null
+    return type != null ? type : Type.UNKNOWN;
   }
 
   @Override

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/FunctionDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/FunctionDeclaration.java
@@ -70,7 +70,7 @@ public class FunctionDeclaration extends ValueDeclaration {
             .map(x -> x.getType().toString())
             .collect(Collectors.joining(COMMA + WHITESPACE))
         + BRACKET_RIGHT
-        + Objects.requireNonNullElse(this.type, Type.UNKNOWN_TYPE);
+        + Objects.requireNonNullElse(this.type, Type.UNKNOWN_TYPE_STRING);
   }
 
   public boolean hasSignature(List<Type> targetSignature) {

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/FunctionDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/FunctionDeclaration.java
@@ -36,8 +36,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 /** Represents the declaration or definition of a function. */
 public class FunctionDeclaration extends ValueDeclaration {
 
-  static final String VOID_TYPE = "void";
-  private static final String INT_TYPE = "int";
+  static final String VOID_TYPE_STRING = "void";
+  private static final String INT_TYPE_STRING = "int";
   private static final String WHITESPACE = " ";
   private static final String BRACKET_LEFT = "(";
   private static final String COMMA = ",";

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/NewExpression.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/NewExpression.java
@@ -55,7 +55,20 @@ public class NewExpression extends Expression {
   }
 
   public void setInitializer(Expression initializer) {
+    // TODO: The VariableDeclaration::setInitializer does some DFG stuff. Needed here aswell?
+
+    if (this.initializer instanceof TypeListener) {
+      this.unregisterTypeListener((TypeListener) this.initializer);
+    }
+
     this.initializer = initializer;
+
+    // if the initializer implements a type listener, inform it about our type changes
+    // since the type is tied to the declaration but it is convenient to have the type
+    // information in the initializer, i.e. in a ConstructExpression.
+    if (initializer instanceof TypeListener) {
+      this.registerTypeListener((TypeListener) initializer);
+    }
   }
 
   @Override

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/Type.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/Type.java
@@ -124,7 +124,7 @@ public class Type {
     this.type = type;
   }
 
-  public void setFrom(String string) {
+  private void setFrom(String string) {
     String cleaned = clean(string);
     Matcher matcher = TYPE_FROM_STRING.matcher(cleaned);
     if (matcher.matches()) {

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/Type.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/Type.java
@@ -36,7 +36,10 @@ import org.slf4j.LoggerFactory;
 
 public class Type {
 
-  public static final String UNKNOWN_TYPE = "UNKNOWN";
+  public static final String UNKNOWN_TYPE_STRING = "UNKNOWN";
+
+  public static final Type UNKNOWN = new Type();
+
   private static final Logger LOGGER = LoggerFactory.getLogger(Type.class);
   // Compile regex patterns once and for all.
   private static final Pattern DOUBLE_COLON = Pattern.compile("::");
@@ -45,7 +48,7 @@ public class Type {
       Pattern.compile(
           "(?:(?<modifier>[a-zA-Z]*) )?(?<type>[a-zA-Z0-9_$.<>]*)(?<adjustment>[\\[\\]*\\s]*)?");
   /** The type of the declaration. */
-  protected String type = UNKNOWN_TYPE;
+  protected String type = UNKNOWN_TYPE_STRING;
   /** Specifies whether this node has any type adjustments, such as a pointer or reference. */
   protected String typeAdjustment = "";
   /** Specifies whether this node has any type modifiers, such as const, final, ... */
@@ -54,6 +57,10 @@ public class Type {
   protected Origin typeOrigin = Origin.UNRESOLVED;
 
   @Id @GeneratedValue private Long id;
+
+  private Type() {
+    // type is initialized as unknown per default
+  }
 
   public Type(String type) {
     setFrom(type);
@@ -81,14 +88,10 @@ public class Type {
     this.typeOrigin = src.typeOrigin;
   }
 
-  public static Type getUnknown() {
-    return new Type("UNKNOWN");
-  }
-
   private static String clean(String type) {
     if (type.contains("?")
         || type.contains("org.eclipse.cdt.internal.core.dom.parser.ProblemType@")) {
-      return UNKNOWN_TYPE;
+      return UNKNOWN_TYPE_STRING;
     }
     type = type.replaceAll("^struct ", "");
     // remove artifacts from unidentified C++ namespaces
@@ -102,10 +105,15 @@ public class Type {
     return type.strip();
   }
 
+  /**
+   * Creates a new type from a string representation. This is basically syntactic sugar for calling
+   * the constructor.
+   *
+   * @param string the string representation of the type
+   * @return the type
+   */
   public static Type createFrom(String string) {
-    Type t = getUnknown();
-    t.setFrom(string);
-    return t;
+    return new Type(string);
   }
 
   public String getTypeName() {

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/TypeManager.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/TypeManager.java
@@ -70,7 +70,7 @@ public class TypeManager {
   }
 
   public boolean isUnknown(String type) {
-    return type.contains(Type.UNKNOWN_TYPE)
+    return type.contains(Type.UNKNOWN_TYPE_STRING)
         || type.contains("?")
         || type.equals("var")
         || type.equals("");

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/ValueDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/ValueDeclaration.java
@@ -40,7 +40,7 @@ import org.neo4j.ogm.annotation.typeconversion.Convert;
 public abstract class ValueDeclaration extends Declaration implements HasType {
 
   @Convert(TypeConverter.class)
-  protected Type type = Type.getUnknown();
+  protected Type type = Type.UNKNOWN;
 
   @Convert(TypeSetConverter.class)
   protected Set<Type> possibleSubTypes = new HashSet<>();

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/VariableDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/VariableDeclaration.java
@@ -59,8 +59,11 @@ public class VariableDeclaration extends ValueDeclaration implements TypeListene
       this.addPrevDFG(initializer);
       initializer.registerTypeListener(this);
 
-      if (initializer instanceof ConstructExpression) {
-        this.registerTypeListener((ConstructExpression) initializer);
+      // if the initializer implements a type listener, inform it about our type changes
+      // since the type is tied to the declaration but it is convenient to have the type
+      // information in the initializer, i.e. in a ConstructExpression.
+      if (initializer instanceof TypeListener) {
+        this.registerTypeListener((TypeListener) initializer);
       }
     }
   }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/VariableDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/VariableDeclaration.java
@@ -58,6 +58,10 @@ public class VariableDeclaration extends ValueDeclaration implements TypeListene
     if (initializer != null) {
       this.addPrevDFG(initializer);
       initializer.registerTypeListener(this);
+
+      if (initializer instanceof ConstructExpression) {
+        this.registerTypeListener((ConstructExpression) initializer);
+      }
     }
   }
 

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/VariableDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/VariableDeclaration.java
@@ -51,6 +51,10 @@ public class VariableDeclaration extends ValueDeclaration implements TypeListene
     if (this.initializer != null) {
       this.removePrevDFG(this.initializer);
       this.initializer.unregisterTypeListener(this);
+
+      if (this.initializer instanceof TypeListener) {
+        this.unregisterTypeListener((TypeListener) this.initializer);
+      }
     }
 
     this.initializer = initializer;

--- a/src/main/java/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.java
@@ -50,7 +50,6 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import javax.swing.border.Border;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/ImportResolver.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/ImportResolver.java
@@ -207,7 +207,7 @@ public class ImportResolver implements Pass {
       // the target might be a field or a method, we don't know. Thus we need to create both
       FieldDeclaration targetField =
           NodeBuilder.newFieldDeclaration(
-              name, Type.getUnknown(), new ArrayList<>(), "", new Region(-1, -1, -1, -1), null);
+              name, Type.UNKNOWN, new ArrayList<>(), "", new Region(-1, -1, -1, -1), null);
       targetField.setDummy(true);
       MethodDeclaration targetMethod = NodeBuilder.newMethodDeclaration(name, "", true);
       targetMethod.setDummy(true);

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.java
@@ -181,7 +181,7 @@ public class VariableUsageResolver implements Pass {
                       .findFirst()
                       .orElse(null);
         } else {
-          Type baseType = new Type(Type.UNKNOWN_TYPE);
+          Type baseType = Type.UNKNOWN;
           if (base instanceof HasType) {
             baseType = ((HasType) base).getType();
           }
@@ -253,7 +253,10 @@ public class VariableUsageResolver implements Pass {
     recordMap.putIfAbsent(
         base,
         NodeBuilder.newRecordDeclaration(
-            base.getTypeName(), new ArrayList<>(), Type.UNKNOWN_TYPE, Type.UNKNOWN_TYPE));
+            base.getTypeName(),
+            new ArrayList<>(),
+            Type.UNKNOWN_TYPE_STRING,
+            Type.UNKNOWN_TYPE_STRING));
     // fields.putIfAbsent(base, new ArrayList<>());
     List<FieldDeclaration> declarations = recordMap.get(base).getFields();
     Optional<FieldDeclaration> target =

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
@@ -34,7 +34,36 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
-import de.fraunhofer.aisec.cpg.graph.*;
+import de.fraunhofer.aisec.cpg.graph.BinaryOperator;
+import de.fraunhofer.aisec.cpg.graph.CallExpression;
+import de.fraunhofer.aisec.cpg.graph.CaseStatement;
+import de.fraunhofer.aisec.cpg.graph.CompoundStatement;
+import de.fraunhofer.aisec.cpg.graph.ConstructExpression;
+import de.fraunhofer.aisec.cpg.graph.ConstructorDeclaration;
+import de.fraunhofer.aisec.cpg.graph.Declaration;
+import de.fraunhofer.aisec.cpg.graph.DeclarationStatement;
+import de.fraunhofer.aisec.cpg.graph.DeclaredReferenceExpression;
+import de.fraunhofer.aisec.cpg.graph.DefaultStatement;
+import de.fraunhofer.aisec.cpg.graph.DesignatedInitializerExpression;
+import de.fraunhofer.aisec.cpg.graph.Expression;
+import de.fraunhofer.aisec.cpg.graph.FieldDeclaration;
+import de.fraunhofer.aisec.cpg.graph.FunctionDeclaration;
+import de.fraunhofer.aisec.cpg.graph.IfStatement;
+import de.fraunhofer.aisec.cpg.graph.InitializerListExpression;
+import de.fraunhofer.aisec.cpg.graph.Literal;
+import de.fraunhofer.aisec.cpg.graph.MemberCallExpression;
+import de.fraunhofer.aisec.cpg.graph.MethodDeclaration;
+import de.fraunhofer.aisec.cpg.graph.NewExpression;
+import de.fraunhofer.aisec.cpg.graph.Node;
+import de.fraunhofer.aisec.cpg.graph.RecordDeclaration;
+import de.fraunhofer.aisec.cpg.graph.Region;
+import de.fraunhofer.aisec.cpg.graph.ReturnStatement;
+import de.fraunhofer.aisec.cpg.graph.Statement;
+import de.fraunhofer.aisec.cpg.graph.SwitchStatement;
+import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
+import de.fraunhofer.aisec.cpg.graph.Type;
+import de.fraunhofer.aisec.cpg.graph.UnaryOperator;
+import de.fraunhofer.aisec.cpg.graph.VariableDeclaration;
 import de.fraunhofer.aisec.cpg.helpers.NodeComparator;
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker;
 import de.fraunhofer.aisec.cpg.helpers.Util;
@@ -631,10 +660,30 @@ class CXXLanguageFrontendTest {
     assertEquals(new Type("Integer"), i.getType());
 
     // initializer should be a construct expression
-    ConstructExpression expr = (ConstructExpression) i.getInitializer();
+    ConstructExpression constructExpression = (ConstructExpression) i.getInitializer();
 
     // type of the construct expression should also be Integer
-    assertEquals(new Type("Integer"), expr.getType());
+    assertEquals(new Type("Integer"), constructExpression.getType());
+
+    // auto (Integer) k
+    VariableDeclaration k =
+        (VariableDeclaration)
+            ((DeclarationStatement) statement.getStatements().get(5)).getSingleDeclaration();
+
+    // type should be Integer
+    assertEquals(new Type("Integer"), k.getType());
+
+    // initializer should be a new expression
+    NewExpression newExpression = (NewExpression) k.getInitializer();
+
+    // type of the new expression should also be Integer
+    assertEquals(new Type("Integer"), newExpression.getType());
+
+    // initializer should be a construct expression
+    constructExpression = (ConstructExpression) newExpression.getInitializer();
+
+    // type of the construct expression should also be Integer
+    assertEquals(new Type("Integer"), constructExpression.getType());
   }
 
   List<Statement> getStatementsOfFunction(FunctionDeclaration declaration) {

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
@@ -34,33 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
-import de.fraunhofer.aisec.cpg.graph.BinaryOperator;
-import de.fraunhofer.aisec.cpg.graph.CallExpression;
-import de.fraunhofer.aisec.cpg.graph.CaseStatement;
-import de.fraunhofer.aisec.cpg.graph.CompoundStatement;
-import de.fraunhofer.aisec.cpg.graph.ConstructorDeclaration;
-import de.fraunhofer.aisec.cpg.graph.Declaration;
-import de.fraunhofer.aisec.cpg.graph.DeclarationStatement;
-import de.fraunhofer.aisec.cpg.graph.DeclaredReferenceExpression;
-import de.fraunhofer.aisec.cpg.graph.DefaultStatement;
-import de.fraunhofer.aisec.cpg.graph.DesignatedInitializerExpression;
-import de.fraunhofer.aisec.cpg.graph.Expression;
-import de.fraunhofer.aisec.cpg.graph.FieldDeclaration;
-import de.fraunhofer.aisec.cpg.graph.FunctionDeclaration;
-import de.fraunhofer.aisec.cpg.graph.IfStatement;
-import de.fraunhofer.aisec.cpg.graph.InitializerListExpression;
-import de.fraunhofer.aisec.cpg.graph.Literal;
-import de.fraunhofer.aisec.cpg.graph.MemberCallExpression;
-import de.fraunhofer.aisec.cpg.graph.MethodDeclaration;
-import de.fraunhofer.aisec.cpg.graph.Node;
-import de.fraunhofer.aisec.cpg.graph.RecordDeclaration;
-import de.fraunhofer.aisec.cpg.graph.Region;
-import de.fraunhofer.aisec.cpg.graph.ReturnStatement;
-import de.fraunhofer.aisec.cpg.graph.Statement;
-import de.fraunhofer.aisec.cpg.graph.SwitchStatement;
-import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
-import de.fraunhofer.aisec.cpg.graph.UnaryOperator;
-import de.fraunhofer.aisec.cpg.graph.VariableDeclaration;
+import de.fraunhofer.aisec.cpg.graph.*;
 import de.fraunhofer.aisec.cpg.helpers.NodeComparator;
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker;
 import de.fraunhofer.aisec.cpg.helpers.Util;
@@ -643,6 +617,24 @@ class CXXLanguageFrontendTest {
             .parse(new File("src/test/resources/objcreation.cpp"));
 
     assertNotNull(declaration);
+
+    // get the main method
+    FunctionDeclaration main = declaration.getDeclarationAs(3, FunctionDeclaration.class);
+    CompoundStatement statement = (CompoundStatement) main.getBody();
+
+    // Integer i
+    VariableDeclaration i =
+        (VariableDeclaration)
+            ((DeclarationStatement) statement.getStatements().get(0)).getSingleDeclaration();
+
+    // type should be Integer
+    assertEquals(new Type("Integer"), i.getType());
+
+    // initializer should be a construct expression
+    ConstructExpression expr = (ConstructExpression) i.getInitializer();
+
+    // type of the construct expression should also be Integer
+    assertEquals(new Type("Integer"), expr.getType());
   }
 
   List<Statement> getStatementsOfFunction(FunctionDeclaration declaration) {


### PR DESCRIPTION
- [x] Registering the type listener of `ConstructExpression` in the `setInitializer` function in `VariableDeclaration` to inform the construct expression of the type it is constructing. 
- [x] Similarly did this in `NewExpression` 

This fixes #22.

It is discussable whether we should update the type of the `ConstructExpression`, if `ConstructorDeclaration` is resolved by the `CallResolver` since it might then have a better type in the hierarchy - or is this automagically done now anyway?

