### PR TITLE
Adds a bugfix for #31 and adds some comments at other places

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.java
@@ -139,7 +139,10 @@ public class SubgraphWalker {
     list.add(n);
 
     // add all the ast children
-    SubgraphWalker.getAstChildren(n).forEach(node -> list.addAll(flattenAST(node)));
+    list.addAll(
+        SubgraphWalker.getAstChildren(n).stream()
+            .flatMap(node -> flattenAST(node).stream())
+            .collect(Collectors.toSet()));
 
     // sort it
     list.sort(new NodeComparator());

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.java
@@ -128,6 +128,14 @@ public class EvaluationOrderGraphPass implements Pass {
 
   private LanguageFrontend lang;
 
+  /**
+   * Searches backwards in the EOG Graph on whether or not there is a path from a function
+   * declaration to the given node. After the construction phase some unreachable nodes may have EOG
+   * edges. This function also serves to truncate the EOG graph by unreachable paths.
+   *
+   * @param node - That lies on the reachable or unreachable path
+   * @return true if the node can bea reached from a function declaration
+   */
   private static boolean reachableFromValidEOGRoot(@NonNull Node node) {
     Set<Node> passedBy = new HashSet<>();
     List<Node> workList = new ArrayList<>(node.getPrevEOG());
@@ -372,6 +380,7 @@ public class EvaluationOrderGraphPass implements Pass {
 
       // push statement itself
       pushToEOG(statement);
+
     } else if (statement instanceof ReturnStatement) {
       // analyze the return value
       createEOG(((ReturnStatement) statement).getReturnValue());
@@ -386,8 +395,21 @@ public class EvaluationOrderGraphPass implements Pass {
 
       BinaryOperator binOp = (BinaryOperator) statement;
       createEOG(binOp.getLhs());
+
+      List<Node> shortCircuitNodes = new ArrayList<>();
+
+      lang.getScopeManager().leaveScope(statement);
+
+      // Two operators that don't evaluate the second operator if the first evaluates to a certain
+      // value.
+      if (binOp.getOperatorCode().equals("&&") || binOp.getOperatorCode().equals("||")) {
+        shortCircuitNodes.addAll(currentEOG);
+      }
+
       createEOG(binOp.getRhs());
 
+      shortCircuitNodes.addAll(currentEOG);
+      setCurrentEOGs(shortCircuitNodes);
       // push the statement itself
       pushToEOG(statement);
 
@@ -419,12 +441,13 @@ public class EvaluationOrderGraphPass implements Pass {
             throwType = new Type("UKNOWN_THROW_TYPE");
           }
         }
-
         pushToEOG(statement);
+
         if (catchingScope instanceof TryScope) {
           ((TryScope) catchingScope)
               .getCatchesOrRelays()
               .put(throwType, new ArrayList<>(this.currentEOG));
+
         } else if (catchingScope instanceof FunctionScope) {
           ((FunctionScope) catchingScope)
               .getCatchesOrRelays()
@@ -434,6 +457,7 @@ public class EvaluationOrderGraphPass implements Pass {
       } else {
         pushToEOG(statement);
       }
+
     } else if (statement instanceof CompoundStatement) {
       lang.getScopeManager().enterScope(statement);
       // analyze the contained statements
@@ -442,9 +466,11 @@ public class EvaluationOrderGraphPass implements Pass {
       }
       lang.getScopeManager().leaveScope(statement);
       pushToEOG(statement);
+
     } else if (statement instanceof CompoundStatementExpression) {
       createEOG(((CompoundStatementExpression) statement).getStatement());
       pushToEOG(statement);
+
     } else if (statement instanceof IfStatement) {
       IfStatement ifs = (IfStatement) statement;
       List<Node> openBranchNodes = new ArrayList<>();
@@ -466,6 +492,7 @@ public class EvaluationOrderGraphPass implements Pass {
 
       setCurrentEOGs(openBranchNodes);
       pushToEOG(statement); // Todo Remove root, if not wanted
+
     } else if (statement instanceof AssertStatement) {
       AssertStatement ifs = (AssertStatement) statement;
       createEOG(ifs.getCondition());
@@ -473,6 +500,7 @@ public class EvaluationOrderGraphPass implements Pass {
       createEOG(ifs.getMessage());
       setCurrentEOGs(openConditionEOGs);
       pushToEOG(statement);
+
     } else if (statement instanceof WhileStatement) {
 
       lang.getScopeManager().enterScope(statement);
@@ -497,6 +525,7 @@ public class EvaluationOrderGraphPass implements Pass {
       currentEOG.addAll(tmpEOGNodes);
 
       pushToEOG(statement); // Todo Remove root, if not wanted
+
     } else if (statement instanceof DoStatement) {
       lang.getScopeManager().enterScope(statement);
       DoStatement dos = (DoStatement) statement;
@@ -513,6 +542,7 @@ public class EvaluationOrderGraphPass implements Pass {
       }
 
       pushToEOG(statement); // Todo Remove root, if not wanted
+
     } else if (statement instanceof ForStatement) {
       lang.getScopeManager().enterScope(statement);
       ForStatement forStmt = (ForStatement) statement;
@@ -538,6 +568,7 @@ public class EvaluationOrderGraphPass implements Pass {
       currentEOG.addAll(tmpEOGNodes);
 
       pushToEOG(statement); // Todo Remove root, if not wanted
+
     } else if (statement instanceof ForEachStatement) {
       lang.getScopeManager().enterScope(statement);
       ForEachStatement forStmt = (ForEachStatement) statement;
@@ -562,6 +593,7 @@ public class EvaluationOrderGraphPass implements Pass {
       currentEOG.addAll(tmpEOGNodes);
 
       pushToEOG(statement); // Todo Remove root, if not wanted
+
     } else if (statement instanceof TryStatement) {
       lang.getScopeManager().enterScope(statement);
       TryScope tryScope = (TryScope) lang.getScopeManager().getCurrentScope();
@@ -642,6 +674,7 @@ public class EvaluationOrderGraphPass implements Pass {
       }
 
       pushToEOG(statement);
+
     } else if (statement instanceof ContinueStatement) {
       pushToEOG(statement);
 

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/EOGTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/EOGTest.java
@@ -30,6 +30,7 @@ import static de.fraunhofer.aisec.cpg.helpers.Util.Connect.NODE;
 import static de.fraunhofer.aisec.cpg.helpers.Util.Connect.SUBTREE;
 import static de.fraunhofer.aisec.cpg.helpers.Util.Edge.ENTRIES;
 import static de.fraunhofer.aisec.cpg.helpers.Util.Edge.EXITS;
+import static de.fraunhofer.aisec.cpg.helpers.Util.Quantifier.ALL;
 import static de.fraunhofer.aisec.cpg.helpers.Util.Quantifier.ANY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -153,6 +154,23 @@ public class EOGTest {
             ifBranched,
             ifBranched.getThenStatement(),
             ifBranched.getElseStatement()));
+  }
+
+  @Test
+  void testConditionShortCircuit() throws TransactionException {
+    List<Node> nodes = translateToNodes("src/test/resources/cfg/ShortCircuit.java");
+
+    List<BinaryOperator> binaryOperators =
+        Util.filterCast(nodes, BinaryOperator.class).stream()
+            .filter(bo -> bo.getOperatorCode().equals("&&") || bo.getOperatorCode().equals("||"))
+            .collect(Collectors.toList());
+
+    for (BinaryOperator bo : binaryOperators) {
+      assertTrue(Util.eogConnect(ALL, SUBTREE, EXITS, bo.getLhs(), SUBTREE, bo.getRhs()));
+      assertTrue(Util.eogConnect(ALL, SUBTREE, EXITS, bo.getLhs(), NODE, bo));
+
+      assertTrue(bo.getLhs().getNextEOG().size() == 2);
+    }
   }
 
   @Test

--- a/src/test/resources/cfg/ShortCircuit.java
+++ b/src/test/resources/cfg/ShortCircuit.java
@@ -1,0 +1,9 @@
+package cfg;
+
+public class Loops {
+
+    public static void main(String[] args) {
+        boolean containsArg = args.length > 0 && args[0].equals("SomeArg");
+        boolean empty = args == null || args.length == 0;
+    }
+}


### PR DESCRIPTION
Fixed a mistake in the EOG where the short-circuit evaluation of && and || was not considered.

Fixes #31 