### PR TITLE
Fixed an issue that added too many dummy returns

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
@@ -125,17 +125,17 @@ public class DeclarationHandler extends Handler<Declaration, IASTDeclaration, CX
 
         // get the last statement
         Statement lastStatement = null;
-        if (statements.size() > 1) {
+        if (!statements.isEmpty()) {
           lastStatement = statements.get(statements.size() - 1);
         }
-        // make sure, method contains a return statement
-        // todo to-be-discussed: do we need a dummy return statement?
+
+        // add an implicit return statement, if there is none
         if (!(lastStatement instanceof ReturnStatement)) {
-          // statements.add(new StatementHandler(this.lang).handle(new CPPASTReturnStatement()));
           ReturnStatement returnStatement = NodeBuilder.newReturnStatement("return;");
-          returnStatement.setDummy(true);
+          returnStatement.setImplicit(true);
           statements.add(returnStatement);
         }
+
         functionDeclaration.setBody(body);
       }
     }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/Node.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/Node.java
@@ -87,11 +87,20 @@ public class Node {
 
   @Relationship(value = "DFG")
   protected Set<Node> nextDFG = new HashSet<>();
+
   /**
    * If a node is marked as being a dummy, it means that it was created artificially and does not
    * necessarily have a real counterpart in the actual source code
    */
-  protected boolean dummy = false;
+  @Deprecated protected boolean dummy = false;
+
+  /**
+   * Specifies, whether this node is implicit, i.e. is not really existing in source code but only
+   * exists implicitly. This mostly relates to implicit casts, return statements or implicit this
+   * expressions.
+   */
+  protected boolean implicit = false;
+
   /** Required field for object graph mapping. It contains the node id. */
   @Id @GeneratedValue private Long id;
   /** Index of the argument if this node is used in a function call or parameter list. */
@@ -205,8 +214,18 @@ public class Node {
     return dummy;
   }
 
+  /** @deprecated You should rather use {@link #isImplicit()}, if it is an implicit expression */
+  @Deprecated
   public void setDummy(boolean dummy) {
     this.dummy = dummy;
+  }
+
+  public void setImplicit(boolean implicit) {
+    this.implicit = implicit;
+  }
+
+  public boolean isImplicit() {
+    return this.implicit;
   }
 
   @Override

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/Node.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/Node.java
@@ -73,10 +73,12 @@ public class Node {
   /** Incoming control flow edges. */
   @Relationship(value = "EOG", direction = "INCOMING")
   protected List<Node> prevEOG = new ArrayList<>();
+
   /** outgoing control flow edges. */
   @Relationship(value = "EOG", direction = "OUTGOING")
   @NonNull
   protected List<Node> nextEOG = new ArrayList<>();
+
   /** outgoing control flow edges. */
   @NonNull
   @Relationship(value = "CFG", direction = "OUTGOING")
@@ -92,7 +94,7 @@ public class Node {
    * If a node is marked as being a dummy, it means that it was created artificially and does not
    * necessarily have a real counterpart in the actual source code
    */
-  @Deprecated protected boolean dummy = false;
+  protected boolean dummy = false;
 
   /**
    * Specifies, whether this node is implicit, i.e. is not really existing in source code but only
@@ -103,6 +105,7 @@ public class Node {
 
   /** Required field for object graph mapping. It contains the node id. */
   @Id @GeneratedValue private Long id;
+
   /** Index of the argument if this node is used in a function call or parameter list. */
   private int argumentIndex;
 
@@ -214,8 +217,8 @@ public class Node {
     return dummy;
   }
 
-  /** @deprecated You should rather use {@link #isImplicit()}, if it is an implicit expression */
-  @Deprecated
+  /** @deprecated You should rather use {@link #setImplicit(boolean)}, if it is an implicit expression */
+  @Deprecated(forRemoval = true)
   public void setDummy(boolean dummy) {
     this.dummy = dummy;
   }

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
@@ -286,25 +286,39 @@ class CXXLanguageFrontendTest {
     assertEquals(4, declaration.getDeclarations().size());
 
     FunctionDeclaration method = declaration.getDeclarationAs(0, FunctionDeclaration.class);
-
     assertEquals("function0(int)void", method.getSignature());
 
     method = declaration.getDeclarationAs(1, FunctionDeclaration.class);
-
     assertEquals("function1(int, std.string, SomeType*, AnotherType&)int", method.getSignature());
 
     List<String> args =
         method.getParameters().stream().map(Node::getName).collect(Collectors.toList());
-
     assertEquals(List.of("arg0", "arg1", "arg2", "arg3"), args);
 
     method = declaration.getDeclarationAs(2, FunctionDeclaration.class);
-
     assertEquals("function0(int)void", method.getSignature());
 
-    method = declaration.getDeclarationAs(3, FunctionDeclaration.class);
+    List<Statement> statements = ((CompoundStatement) method.getBody()).getStatements();
+    assertFalse(statements.isEmpty());
+    assertEquals(2, statements.size());
 
+    // last statement should be an implicit return
+    ReturnStatement statement =
+        method.getBodyStatementAs(statements.size() - 1, ReturnStatement.class);
+    assertNotNull(statement);
+    assertTrue(statement.isImplicit());
+
+    method = declaration.getDeclarationAs(3, FunctionDeclaration.class);
     assertEquals("function2()void*", method.getSignature());
+
+    statements = ((CompoundStatement) method.getBody()).getStatements();
+    assertFalse(statements.isEmpty());
+    assertEquals(1, statements.size());
+
+    // should only contain 1 explicit return statement
+    statement = method.getBodyStatementAs(0, ReturnStatement.class);
+    assertNotNull(statement);
+    assertFalse(statement.isImplicit());
   }
 
   @Test
@@ -321,8 +335,7 @@ class CXXLanguageFrontendTest {
     assertNotNull(functionBody);
 
     List<Statement> statements = ((CompoundStatement) functionBody).getStatements();
-
-    assertEquals(2, statements.size());
+    assertEquals(1, statements.size());
 
     ReturnStatement returnStatement = (ReturnStatement) statements.get(0);
 

--- a/src/test/resources/functiondecl.cpp
+++ b/src/test/resources/functiondecl.cpp
@@ -8,7 +8,8 @@ int function1(int arg0, std::string arg1, SomeType* arg2, AnotherType &arg3) {
 
 // body for the function declared earlier. should connect the body to the original declaration
 void function0(int arg0) {
-
+  callSomething();
+  // no explicit return
 }
 
 void* function2() {


### PR DESCRIPTION
There was a bug in the way we add "dummy" return statements. If the function contained only 1 line and this line was already a return statement, a second return statement was added.

Additionally, I have introduced a new property on nodes called `implicit`, this should be used instead of the now deprecated `dummy` property to denote that this node is valid here, but was added to the CPG because it was only implicitly here, i.e. the aforementioned return statements. This will probably also apply to implicit casts or the implicit use of the `this` statement.

We need to think about how we annotate notes that we added as an educated guess, i.e. a reference to a record declaration where we have not seen the actual declaration but know of its existence. Not sure if `dummy` is the correct term