### PR TITLE
Allow scanning of all files in a folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ import de.fraunhofer.aisec.cpg.TranslationManager;
 import de.fraunhofer.aisec.cpg.graph.FunctionDeclaration;
 
 var path = Paths.get("src/test/resources/openssl/client.cpp");
-var config = TranslationConfiguration.builder().sourceFiles(path.toFile()).defaultPasses().debugParser(true).build();
+var config = TranslationConfiguration.builder().sourceLocations(path.toFile()).defaultPasses().debugParser(true).build();
 var analyzer = TranslationManager.builder().config(config).build();
 var result = analyzer.analyze().get();
 var tu = result.getTranslationUnits().get(0);

--- a/src/main/java/de/fraunhofer/aisec/cpg/TranslationConfiguration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/TranslationConfiguration.java
@@ -81,14 +81,14 @@ public class TranslationConfiguration {
   public final Map<String, String> symbols;
 
   /** Source code files to parse. */
-  private List<File> sourceFiles;
+  private List<File> sourceLocations;
 
   private File topLevel;
   private List<Pass> passes;
 
   private TranslationConfiguration(
       Map<String, String> symbols,
-      List<File> sourceFiles,
+      List<File> sourceLocations,
       File topLevel,
       boolean debugParser,
       boolean failOnError,
@@ -97,14 +97,14 @@ public class TranslationConfiguration {
       List<Pass> passes,
       boolean codeInNodes) {
     this.symbols = symbols;
-    this.sourceFiles = sourceFiles;
+    this.sourceLocations = sourceLocations;
     this.topLevel = topLevel;
     this.debugParser = debugParser;
     this.failOnError = failOnError;
     this.loadIncludes = loadIncludes;
     this.includePaths = includePaths;
     this.passes = passes != null ? passes : new ArrayList<>();
-    // Make sure to init this AFTER sourceFiles has been set
+    // Make sure to init this AFTER sourceLocations has been set
     this.codeInNodes = codeInNodes;
   }
 
@@ -117,7 +117,7 @@ public class TranslationConfiguration {
   }
 
   public List<File> getSourceLocations() {
-    return this.sourceFiles;
+    return this.sourceLocations;
   }
 
   public File getTopLevel() {

--- a/src/main/java/de/fraunhofer/aisec/cpg/TranslationConfiguration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/TranslationConfiguration.java
@@ -112,7 +112,7 @@ public class TranslationConfiguration {
     return this.symbols;
   }
 
-  public List<File> getSourceFiles() {
+  public List<File> getSourceLocations() {
     return this.sourceFiles;
   }
 

--- a/src/main/java/de/fraunhofer/aisec/cpg/TranslationManager.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/TranslationManager.java
@@ -36,7 +36,13 @@ import de.fraunhofer.aisec.cpg.passes.Pass;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -76,8 +82,8 @@ public class TranslationManager {
           Benchmark outerBench =
               new Benchmark(TranslationManager.class, "Translation into full graph");
 
-          HashSet<Pass> passesNeedCleanup = new HashSet<>();
-          HashSet<LanguageFrontend> frontendsNeedCleanup = null;
+          Set<Pass> passesNeedCleanup = new HashSet<>();
+          Set<LanguageFrontend> frontendsNeedCleanup = null;
 
           try {
             // Parse Java/C/CPP files
@@ -178,8 +184,8 @@ public class TranslationManager {
         usedFrontends.add(frontend);
 
         // remember which frontend parsed each file
-        HashMap<String, String> sfToFe =
-            (HashMap<String, String>)
+        Map<String, String> sfToFe =
+            (Map<String, String>)
                 result
                     .getScratch()
                     .computeIfAbsent(

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.java
@@ -33,7 +33,13 @@ import de.fraunhofer.aisec.cpg.graph.Region;
 import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
 import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 import org.apache.commons.lang3.StringUtils;
@@ -84,25 +90,31 @@ public abstract class LanguageFrontend {
     // Iterate over existing predicate based listeners, if the predicate matches the
     // listener/handler is executed on the new object.
     for (Map.Entry<BiPredicate<Object, Object>, BiConsumer<Object, Object>> pListener :
-        predicateListeners.entrySet())
+        predicateListeners.entrySet()) {
       if (pListener.getKey().test(from, to)) {
         pListener.getValue().accept(from, to);
         // Delete line if Node should be processed multiple times and should again invoke the
         // listener, e.g. refinement.
         predicateListeners.remove(pListener.getKey());
       }
+    }
   }
 
   public void registerObjectListener(Object from, BiConsumer<Object, Object> biConsumer) {
-    if (processedMapping.containsKey(from)) biConsumer.accept(from, processedMapping.get(from));
+    if (processedMapping.containsKey(from)) {
+      biConsumer.accept(from, processedMapping.get(from));
+    }
     objectListeners.put(from, biConsumer);
   }
 
   public void registerPredicateListener(
       BiPredicate<Object, Object> predicate, BiConsumer<Object, Object> biConsumer) {
-    List<Map.Entry> matchingEntries = new ArrayList<>();
-    for (Map.Entry mapping : processedMapping.entrySet())
-      if (predicate.test(mapping.getKey(), mapping.getValue())) matchingEntries.add(mapping);
+    List<Entry> matchingEntries = new ArrayList<>();
+    for (Map.Entry mapping : processedMapping.entrySet()) {
+      if (predicate.test(mapping.getKey(), mapping.getValue())) {
+        matchingEntries.add(mapping);
+      }
+    }
 
     if (!matchingEntries.isEmpty()) {
       for (Map.Entry match : matchingEntries) {
@@ -181,10 +193,11 @@ public abstract class LanguageFrontend {
    */
   public String getNewLineType(Node node) {
     List<String> nls = Arrays.asList("\n\r", "\r\n", "\n");
-    for (String nl : nls)
+    for (String nl : nls) {
       if (node.toString().endsWith(nl)) {
         return nl;
       }
+    }
     log.debug("Could not determine newline type. Assuming \\n. {}", node.toString());
     return "\n";
   }
@@ -206,20 +219,22 @@ public abstract class LanguageFrontend {
     String nlType = getNewLineType(node);
     int start;
     int end;
-    if (subRegion.getStartLine() == nodeRegion.getStartLine())
+    if (subRegion.getStartLine() == nodeRegion.getStartLine()) {
       start = subRegion.getStartColumn() - nodeRegion.getStartColumn();
-    else
+    } else {
       start =
           StringUtils.ordinalIndexOf(
                   code, nlType, subRegion.getStartLine() - nodeRegion.getStartLine())
               + subRegion.getStartColumn();
-    if (subRegion.getEndLine() == nodeRegion.getStartLine())
+    }
+    if (subRegion.getEndLine() == nodeRegion.getStartLine()) {
       end = subRegion.getStartColumn() - nodeRegion.getStartColumn();
-    else
+    } else {
       end =
           StringUtils.ordinalIndexOf(
                   code, nlType, subRegion.getEndLine() - nodeRegion.getStartLine())
               + subRegion.getEndColumn();
+    }
     return code.substring(start, end);
   }
 

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.java
@@ -32,19 +32,16 @@ import de.fraunhofer.aisec.cpg.graph.RecordDeclaration;
 import de.fraunhofer.aisec.cpg.graph.Region;
 import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
 import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.BiConsumer;
-import java.util.function.BiPredicate;
 import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.function.BiPredicate;
 
 public abstract class LanguageFrontend {
 
@@ -124,7 +121,7 @@ public abstract class LanguageFrontend {
 
   public List<TranslationUnitDeclaration> parseAll() throws TranslationException {
     ArrayList<TranslationUnitDeclaration> units = new ArrayList<>();
-    for (File sourceFile : this.config.getSourceFiles()) {
+    for (File sourceFile : this.config.getSourceLocations()) {
       units.add(parse(sourceFile));
     }
 

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.java
@@ -103,11 +103,11 @@ public class JavaLanguageFrontend extends LanguageFrontend {
     if (config != null) {
       File root = config.getTopLevel();
       if (root == null) {
-        root = CommonPath.commonPath(config.getSourceFiles());
+        root = CommonPath.commonPath(config.getSourceLocations());
       }
 
       if (root == null) {
-        log.warn("Could not determine source root for {}", config.getSourceFiles());
+        log.warn("Could not determine source root for {}", config.getSourceLocations());
       } else {
         log.info("Source file root used for type solver: {}", root);
         JavaParserTypeSolver javaParserTypeSolver = new JavaParserTypeSolver(root);

--- a/src/main/java/de/fraunhofer/aisec/cpg/helpers/Util.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/helpers/Util.java
@@ -30,15 +30,13 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import de.fraunhofer.aisec.cpg.graph.Node;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.IdentityHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class Util {
 
@@ -206,6 +204,15 @@ public class Util {
         return true;
       }
     };
+  }
+
+  public static String getExtension(@NonNull File file) {
+    int pos = file.getName().lastIndexOf('.');
+    if (pos > 0) {
+      return file.getName().substring(pos).toLowerCase();
+    } else {
+      return "";
+    }
   }
 
   public enum Connect {

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/LanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/LanguageFrontendTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2019, Fraunhofer AISEC. All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+
+package de.fraunhofer.aisec.cpg.frontends;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import de.fraunhofer.aisec.cpg.TranslationConfiguration;
+import de.fraunhofer.aisec.cpg.TranslationManager;
+import de.fraunhofer.aisec.cpg.TranslationResult;
+import java.io.File;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+
+class LanguageFrontendTest {
+
+  @Test
+  void testParseDirectory() throws ExecutionException, InterruptedException {
+    TranslationManager analyzer =
+        TranslationManager.builder()
+            .config(
+                TranslationConfiguration.builder()
+                    .sourceFiles(new File("src/test/resources/botan"))
+                    .debugParser(true)
+                    .build())
+            .build();
+    TranslationResult res = analyzer.analyze().get();
+    assertEquals(3, res.getTranslationUnits().size());
+  }
+}


### PR DESCRIPTION
CPG was only scanning the files that were explicitly added to its configuration. This PR makes it accept folder or file names. In case of folders, all source files in folder and sub-folders will be parsed.

This PR is required for `feature/cli` branch of analysisserver.