### PR TITLE
Restored ICU dependency and made sourceLocations consistent

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -159,6 +159,7 @@ val versions = mapOf(
         "slf4j" to "1.8.0-beta4",
         "javaparser" to "3.15.10",
         "cdt" to "6.10.0.201912051559",
+        "eclipse-core" to "3.17.0",
         "icu4j" to "65.1"
 )
 
@@ -170,7 +171,8 @@ dependencies {
     api("com.github.javaparser", "javaparser-symbol-solver-core", versions["javaparser"])
 
     // Eclipse dependencies
-    api("org.eclipse.platform", "org.eclipse.core.runtime", "3.17.0")
+    api("org.eclipse.platform", "org.eclipse.core.runtime", versions["eclipse-core"])
+    api("com.ibm.icu", "icu4j", versions["icu4j"])
 
     // CDT
     api("org.eclipse.cdt", "core", versions["cdt"])

--- a/src/main/java/de/fraunhofer/aisec/cpg/TranslationConfiguration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/TranslationConfiguration.java
@@ -122,7 +122,7 @@ public class TranslationConfiguration {
   }
 
   public static class Builder {
-    private List<File> sourceFiles = new ArrayList<>();
+    private List<File> sourceLocations = new ArrayList<>();
     private File topLevel = null;
     private boolean debugParser = false;
     private boolean failOnError = false;
@@ -137,8 +137,8 @@ public class TranslationConfiguration {
       return this;
     }
 
-    public Builder sourceFiles(File... sourceFiles) {
-      this.sourceFiles = Arrays.asList(sourceFiles);
+    public Builder sourceLocations(File... sourceLocations) {
+      this.sourceLocations = Arrays.asList(sourceLocations);
       return this;
     }
 
@@ -191,7 +191,7 @@ public class TranslationConfiguration {
       String[] paths = new String[this.includePaths.size()];
       return new TranslationConfiguration(
           symbols,
-          sourceFiles,
+          sourceLocations,
           topLevel,
           debugParser,
           failOnError,

--- a/src/main/java/de/fraunhofer/aisec/cpg/TranslationManager.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/TranslationManager.java
@@ -188,7 +188,7 @@ public class TranslationManager {
                 result
                     .getScratch()
                     .computeIfAbsent(
-                        TranslationResult.SOURCEFILESTOFRONTEND,
+                        TranslationResult.SOURCE_LOCATIONS_TO_FRONTEND,
                         x -> new HashMap<String, String>());
         sfToFe.put(sourceLocation.getName(), frontend.getClass().getSimpleName());
 

--- a/src/main/java/de/fraunhofer/aisec/cpg/TranslationResult.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/TranslationResult.java
@@ -38,7 +38,7 @@ import java.util.Map;
  * de.fraunhofer.aisec.cpg.passes.Pass} can extend it.
  */
 public class TranslationResult {
-  public static final String SOURCEFILESTOFRONTEND = "sourceFilesToFrontend";
+  public static final String SOURCE_LOCATIONS_TO_FRONTEND = "sourceLocationsToFrontend";
   private final TranslationManager translationManager;
   /** Entry points to the CPG: "TranslationUnits" refer to source files. */
   private List<TranslationUnitDeclaration> translationUnits = new ArrayList<>();

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/EOGTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/EOGTest.java
@@ -538,7 +538,7 @@ public class EOGTest {
         TranslationManager.builder()
             .config(
                 TranslationConfiguration.builder()
-                    .sourceFiles(new File(path))
+                    .sourceLocations(new File(path))
                     .registerPass(new EvaluationOrderGraphPass()) // creates EOG
                     .registerPass(new CallResolver()) // creates CG
                     .build())

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/JavaVsCppTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/JavaVsCppTest.java
@@ -67,7 +67,7 @@ class JavaVsCppTest {
         TranslationManager.builder()
             .config(
                 TranslationConfiguration.builder()
-                    .sourceFiles(new File(pathname))
+                    .sourceLocations(new File(pathname))
                     .defaultPasses()
                     .debugParser(false)
                     .codeInNodes(false)

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/StaticImportsTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/StaticImportsTest.java
@@ -63,7 +63,7 @@ public class StaticImportsTest {
 
     TranslationConfiguration config =
         TranslationConfiguration.builder()
-            .sourceFiles(files)
+            .sourceLocations(files)
             .topLevel(topLevel.toFile())
             .defaultPasses()
             .debugParser(true)

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/VariableResolverTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/VariableResolverTest.java
@@ -57,7 +57,7 @@ public class VariableResolverTest {
 
     TranslationConfiguration config =
         TranslationConfiguration.builder()
-            .sourceFiles(files)
+            .sourceLocations(files)
             .topLevel(topLevel.toFile())
             .defaultPasses()
             .debugParser(true)
@@ -112,7 +112,7 @@ public class VariableResolverTest {
   public void testLocalVarsCpp() throws ExecutionException, InterruptedException {
     TranslationConfiguration config =
         TranslationConfiguration.builder()
-            .sourceFiles(new File("src/test/resources/variables/local_variables.cpp"))
+            .sourceLocations(new File("src/test/resources/variables/local_variables.cpp"))
             .topLevel(new File("src/test/resources/variables/"))
             .defaultPasses()
             .debugParser(true)

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/LanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/LanguageFrontendTest.java
@@ -43,7 +43,7 @@ class LanguageFrontendTest {
         TranslationManager.builder()
             .config(
                 TranslationConfiguration.builder()
-                    .sourceFiles(new File("src/test/resources/botan"))
+                    .sourceLocations(new File("src/test/resources/botan"))
                     .debugParser(true)
                     .build())
             .build();

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXCfgTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXCfgTest.java
@@ -61,7 +61,7 @@ public class CXXCfgTest {
         TranslationManager.builder()
             .config(
                 TranslationConfiguration.builder()
-                    .sourceFiles(new File("src/test/resources/cfg.cpp"))
+                    .sourceLocations(new File("src/test/resources/cfg.cpp"))
                     .registerPass(new ControlFlowGraphPass()) // creates CFG
                     .registerPass(new EvaluationOrderGraphPass()) // creates EOG
                     .debugParser(true)
@@ -120,7 +120,7 @@ public class CXXCfgTest {
         TranslationManager.builder()
             .config(
                 TranslationConfiguration.builder()
-                    .sourceFiles(new File("src/test/resources/cfg/loopscfg.cpp"))
+                    .sourceLocations(new File("src/test/resources/cfg/loopscfg.cpp"))
                     .registerPass(new ControlFlowGraphPass()) // creates CFG
                     .debugParser(true)
                     .build())
@@ -183,7 +183,7 @@ public class CXXCfgTest {
         TranslationManager.builder()
             .config(
                 TranslationConfiguration.builder()
-                    .sourceFiles(new File("src/test/resources/cfg/if.cpp"))
+                    .sourceLocations(new File("src/test/resources/cfg/if.cpp"))
                     .registerPass(new ControlFlowGraphPass()) // creates CFG
                     .debugParser(true)
                     .build())
@@ -245,7 +245,7 @@ public class CXXCfgTest {
         TranslationManager.builder()
             .config(
                 TranslationConfiguration.builder()
-                    .sourceFiles(new File("src/test/resources/cfg/break_continue.cpp"))
+                    .sourceLocations(new File("src/test/resources/cfg/break_continue.cpp"))
                     .registerPass(new ControlFlowGraphPass()) // creates CFG
                     .debugParser(true)
                     .build())

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/DemoTests.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/DemoTests.java
@@ -56,7 +56,7 @@ public class DemoTests {
 
     TranslationConfiguration config =
         TranslationConfiguration.builder()
-            .sourceFiles(files)
+            .sourceLocations(files)
             .topLevel(topLevel.toFile())
             .defaultPasses()
             .debugParser(true)
@@ -83,7 +83,7 @@ public class DemoTests {
 
     TranslationConfiguration config =
         TranslationConfiguration.builder()
-            .sourceFiles(files)
+            .sourceLocations(files)
             .topLevel(topLevel.toFile())
             .defaultPasses()
             .debugParser(true)

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaCfgTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaCfgTest.java
@@ -66,7 +66,7 @@ public class JavaCfgTest {
         TranslationManager.builder()
             .config(
                 TranslationConfiguration.builder()
-                    .sourceFiles(new File("src/test/resources/cfg/Loops.java"))
+                    .sourceLocations(new File("src/test/resources/cfg/Loops.java"))
                     .registerPass(new ControlFlowGraphPass()) // creates CFG
                     .debugParser(true)
                     .build())
@@ -128,7 +128,7 @@ public class JavaCfgTest {
         TranslationManager.builder()
             .config(
                 TranslationConfiguration.builder()
-                    .sourceFiles(new File("src/test/resources/cfg/If.java"))
+                    .sourceLocations(new File("src/test/resources/cfg/If.java"))
                     .registerPass(new ControlFlowGraphPass()) // creates CFG
                     .debugParser(true)
                     .build())
@@ -190,7 +190,7 @@ public class JavaCfgTest {
         TranslationManager.builder()
             .config(
                 TranslationConfiguration.builder()
-                    .sourceFiles(new File("src/test/resources/cfg/BreakContinue.java"))
+                    .sourceLocations(new File("src/test/resources/cfg/BreakContinue.java"))
                     .registerPass(new ControlFlowGraphPass()) // creates CFG
                     .debugParser(true)
                     .build())


### PR DESCRIPTION
It seems that the ICU dependency was removed by accident, but it is needed to handle eclipse CDT problem descriptions.