### PR TITLE
ScopeManager is now created only once per analysis and for each unit test, not implicitly for every language frontend.

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.java
@@ -52,7 +52,7 @@ public abstract class LanguageFrontend {
 
   protected static final Logger log = LoggerFactory.getLogger(LanguageFrontend.class);
   protected final TranslationConfiguration config;
-  protected ScopeManager scopeManager = new ScopeManager(this);
+  protected ScopeManager scopeManager;
   /**
    * Two data structures used to associate Objects input to a pass to results of a pass, e.g.
    * Javaparser AST-Nodes to CPG-Nodes. The "Listeners" in processedListener are called after the
@@ -73,9 +73,14 @@ public abstract class LanguageFrontend {
 
   // Todo Moving this to scope manager and add listeners and processedMappings to specified scopes.
 
-  public LanguageFrontend(@NonNull TranslationConfiguration config, String namespaceDelimiter) {
+  public LanguageFrontend(
+      @NonNull TranslationConfiguration config,
+      ScopeManager scopeManager,
+      String namespaceDelimiter) {
     this.config = config;
     this.namespaceDelimiter = namespaceDelimiter;
+    this.scopeManager = scopeManager;
+    this.scopeManager.setLang(this);
   }
 
   public void process(Object from, Object to) {
@@ -146,6 +151,7 @@ public abstract class LanguageFrontend {
 
   public void setScopeManager(@NonNull ScopeManager scopeManager) {
     this.scopeManager = scopeManager;
+    this.scopeManager.setLang(this);
   }
 
   public abstract TranslationUnitDeclaration parse(File file) throws TranslationException;

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/LanguageFrontendFactory.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/LanguageFrontendFactory.java
@@ -29,6 +29,7 @@ package de.fraunhofer.aisec.cpg.frontends;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.frontends.cpp.CXXLanguageFrontend;
 import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguageFrontend;
+import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -41,12 +42,13 @@ public class LanguageFrontendFactory {
   private LanguageFrontendFactory() {}
 
   @Nullable
-  public static LanguageFrontend getFrontend(String fileType, TranslationConfiguration config) {
+  public static LanguageFrontend getFrontend(
+      String fileType, TranslationConfiguration config, ScopeManager scopeManager) {
 
     if (JAVA_EXTENSIONS.contains(fileType)) {
-      return new JavaLanguageFrontend(config);
+      return new JavaLanguageFrontend(config, scopeManager);
     } else if (CXX_EXTENSIONS.contains(fileType)) {
-      return new CXXLanguageFrontend(config);
+      return new CXXLanguageFrontend(config, scopeManager);
     } else {
       return null;
     }

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontend.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontend.java
@@ -38,6 +38,7 @@ import de.fraunhofer.aisec.cpg.graph.Type;
 import de.fraunhofer.aisec.cpg.graph.TypeManager;
 import de.fraunhofer.aisec.cpg.graph.ValueDeclaration;
 import de.fraunhofer.aisec.cpg.helpers.Benchmark;
+import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.util.HashMap;
@@ -120,8 +121,8 @@ public class CXXLanguageFrontend extends LanguageFrontend {
   private HashMap<IBinding, Declaration> cachedDeclarations = new HashMap<>();
   private HashMap<Integer, String> comments = new HashMap<>();
 
-  public CXXLanguageFrontend(@NonNull TranslationConfiguration config) {
-    super(config, "::");
+  public CXXLanguageFrontend(@NonNull TranslationConfiguration config, ScopeManager scopeManager) {
+    super(config, scopeManager, "::");
   }
 
   /**

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.java
@@ -69,6 +69,7 @@ import de.fraunhofer.aisec.cpg.graph.TypeManager;
 import de.fraunhofer.aisec.cpg.helpers.Benchmark;
 import de.fraunhofer.aisec.cpg.helpers.CommonPath;
 import de.fraunhofer.aisec.cpg.helpers.Util;
+import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -92,8 +93,8 @@ public class JavaLanguageFrontend extends LanguageFrontend {
   private HashSet<TypeSolver> internalTypeSolvers =
       new HashSet<>(); // we store a reference here to clean them up later
 
-  public JavaLanguageFrontend(@NonNull TranslationConfiguration config) {
-    super(config, ".");
+  public JavaLanguageFrontend(@NonNull TranslationConfiguration config, ScopeManager scopeManager) {
+    super(config, scopeManager, ".");
 
     CombinedTypeSolver typeResolver = new CombinedTypeSolver();
     internalTypeSolvers.add(typeResolver);

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManager.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManager.java
@@ -88,6 +88,10 @@ public class ScopeManager {
     pushScope(new GlobalScope());
   }
 
+  public LanguageFrontend getLang() {
+    return lang;
+  }
+
   public void setLang(LanguageFrontend lang) {
     this.lang = lang;
   }

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManager.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManager.java
@@ -68,6 +68,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * The scope manager builds a multitree-structure of scopes associated to a scope. These Scopes
+ * capture the are of validity of certain (Variable-, Field-, Record-)declarations but are also used
+ * to identify outer scopes that should be target of a jump (continue, break, throw).
+ *
+ * <p>enterScope(Node) and leaveScope(Node) can be used to enter the Tree of scopes and then sitting
+ * at a path, access the currently valid "stack" of scopes.
+ */
 public class ScopeManager {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ScopeManager.class);
@@ -76,9 +84,12 @@ public class ScopeManager {
   private Scope currentScope = null;
   private LanguageFrontend lang;
 
-  public ScopeManager(LanguageFrontend lang) {
-    this.lang = lang;
+  public ScopeManager() {
     pushScope(new GlobalScope());
+  }
+
+  public void setLang(LanguageFrontend lang) {
+    this.lang = lang;
   }
 
   private void pushScope(Scope scope) {

--- a/src/test/java/de/fraunhofer/aisec/cpg/ScopeManagerTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/ScopeManagerTest.java
@@ -1,7 +1,5 @@
 package de.fraunhofer.aisec.cpg;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
 import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguageFrontend;
@@ -22,9 +20,9 @@ public class ScopeManagerTest {
   void testSetScope() throws TranslationException {
     LanguageFrontend frontend = new JavaLanguageFrontend(config, new ScopeManager());
 
-    assert(frontend == frontend.getScopeManager().getLang());
+    assert (frontend == frontend.getScopeManager().getLang());
 
     frontend.setScopeManager(new ScopeManager());
-    assert(frontend == frontend.getScopeManager().getLang());
+    assert (frontend == frontend.getScopeManager().getLang());
   }
 }

--- a/src/test/java/de/fraunhofer/aisec/cpg/ScopeManagerTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/ScopeManagerTest.java
@@ -19,12 +19,12 @@ public class ScopeManagerTest {
   }
 
   @Test
-  void testLiteral() throws TranslationException {
+  void testSetScope() throws TranslationException {
     LanguageFrontend frontend = new JavaLanguageFrontend(config, new ScopeManager());
 
-    assertEquals(frontend, frontend.getScopeManager().getLang());
+    assert(frontend == frontend.getScopeManager().getLang());
 
     frontend.setScopeManager(new ScopeManager());
-    assertEquals(frontend, frontend.getScopeManager().getLang());
+    assert(frontend == frontend.getScopeManager().getLang());
   }
 }

--- a/src/test/java/de/fraunhofer/aisec/cpg/ScopeManagerTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/ScopeManagerTest.java
@@ -1,0 +1,30 @@
+package de.fraunhofer.aisec.cpg;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend;
+import de.fraunhofer.aisec.cpg.frontends.TranslationException;
+import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguageFrontend;
+import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ScopeManagerTest {
+
+  private TranslationConfiguration config;
+
+  @BeforeEach
+  void setUp() {
+    config = TranslationConfiguration.builder().defaultPasses().build();
+  }
+
+  @Test
+  void testLiteral() throws TranslationException {
+    LanguageFrontend frontend = new JavaLanguageFrontend(config, new ScopeManager());
+
+    assertEquals(frontend, frontend.getScopeManager().getLang());
+
+    frontend.setScopeManager(new ScopeManager());
+    assertEquals(frontend, frontend.getScopeManager().getLang());
+  }
+}

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/SubgraphWalkerTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/SubgraphWalkerTest.java
@@ -38,6 +38,7 @@ import de.fraunhofer.aisec.cpg.graph.Node;
 import de.fraunhofer.aisec.cpg.graph.RecordDeclaration;
 import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker;
+import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.File;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -48,7 +49,8 @@ class SubgraphWalkerTest {
   void testASTChildrenGetter() throws TranslationException {
     File file = new File("src/test/resources/compiling/RecordDeclaration.java");
     TranslationConfiguration config = TranslationConfiguration.builder().build();
-    TranslationUnitDeclaration declaration = new JavaLanguageFrontend(config).parse(file);
+    TranslationUnitDeclaration declaration =
+        new JavaLanguageFrontend(config, new ScopeManager()).parse(file);
     NamespaceDeclaration namespace = declaration.getDeclarationAs(0, NamespaceDeclaration.class);
 
     assertNotNull(declaration);

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/BotanExampleTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/BotanExampleTest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
 import de.fraunhofer.aisec.cpg.graph.*;
+import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.File;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -42,7 +43,7 @@ class BotanExampleTest {
   @Test
   void testExample() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new CXXLanguageFrontend(TranslationConfiguration.builder().build())
+        new CXXLanguageFrontend(TranslationConfiguration.builder().build(), new ScopeManager())
             .parse(new File("src/test/resources/botan/symm_block_cipher.cpp"));
 
     assertNotNull(declaration);

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXIncludeTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXIncludeTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
 import de.fraunhofer.aisec.cpg.graph.*;
+import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.File;
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +42,8 @@ class CXXIncludeTest {
   void testDefinitionsAndDeclaration() throws TranslationException {
     TranslationUnitDeclaration tu =
         new CXXLanguageFrontend(
-                TranslationConfiguration.builder().loadIncludes(true).defaultPasses().build())
+                TranslationConfiguration.builder().loadIncludes(true).defaultPasses().build(),
+                new ScopeManager())
             .parse(new File("src/test/resources/include.cpp"));
     assertEquals(4, tu.getDeclarations().size());
 
@@ -69,7 +71,8 @@ class CXXIncludeTest {
     // checks, whether code and region for nodes in includes are properly set
     TranslationUnitDeclaration tu =
         new CXXLanguageFrontend(
-                TranslationConfiguration.builder().loadIncludes(true).defaultPasses().build())
+                TranslationConfiguration.builder().loadIncludes(true).defaultPasses().build(),
+                new ScopeManager())
             .parse(new File("src/test/resources/include.cpp"));
 
     RecordDeclaration someClass =

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
@@ -73,6 +73,7 @@ import de.fraunhofer.aisec.cpg.graph.VariableDeclaration;
 import de.fraunhofer.aisec.cpg.helpers.NodeComparator;
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker;
 import de.fraunhofer.aisec.cpg.helpers.Util;
+import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.File;
 import java.util.HashMap;
 import java.util.List;
@@ -99,7 +100,7 @@ class CXXLanguageFrontendTest {
   @Test
   void testForEach() throws TranslationException {
     TranslationUnitDeclaration tu =
-        new CXXLanguageFrontend(config)
+        new CXXLanguageFrontend(config, new ScopeManager())
             .parse(new File("src/test/resources/components/foreachstmt.cpp"));
 
     FunctionDeclaration main =
@@ -127,7 +128,7 @@ class CXXLanguageFrontendTest {
   @Test
   void testTryCatch() throws TranslationException {
     TranslationUnitDeclaration tu =
-        new CXXLanguageFrontend(config)
+        new CXXLanguageFrontend(config, new ScopeManager())
             .parse(new File("src/test/resources/components/trystmt.cpp"));
 
     FunctionDeclaration main =
@@ -162,7 +163,8 @@ class CXXLanguageFrontendTest {
   @Test
   void testTypeId() throws TranslationException {
     TranslationUnitDeclaration tu =
-        new CXXLanguageFrontend(config).parse(new File("src/test/resources/typeidexpr.cpp"));
+        new CXXLanguageFrontend(config, new ScopeManager())
+            .parse(new File("src/test/resources/typeidexpr.cpp"));
 
     FunctionDeclaration main =
         tu.getDeclarationByName("main", FunctionDeclaration.class).orElse(null);
@@ -196,7 +198,7 @@ class CXXLanguageFrontendTest {
   @Test
   void testCast() throws TranslationException {
     TranslationUnitDeclaration tu =
-        new CXXLanguageFrontend(config)
+        new CXXLanguageFrontend(config, new ScopeManager())
             .parse(new File("src/test/resources/components/castexpr.cpp"));
 
     FunctionDeclaration main = tu.getDeclarationAs(0, FunctionDeclaration.class);
@@ -248,7 +250,8 @@ class CXXLanguageFrontendTest {
   @Test
   void testArrays() throws TranslationException {
     TranslationUnitDeclaration tu =
-        new CXXLanguageFrontend(config).parse(new File("src/test/resources/arrays.cpp"));
+        new CXXLanguageFrontend(config, new ScopeManager())
+            .parse(new File("src/test/resources/arrays.cpp"));
 
     FunctionDeclaration main = tu.getDeclarationAs(0, FunctionDeclaration.class);
 
@@ -280,7 +283,8 @@ class CXXLanguageFrontendTest {
   @Test
   void testFunctionDeclaration() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new CXXLanguageFrontend(config).parse(new File("src/test/resources/functiondecl.cpp"));
+        new CXXLanguageFrontend(config, new ScopeManager())
+            .parse(new File("src/test/resources/functiondecl.cpp"));
 
     // should be four method nodes
     assertEquals(4, declaration.getDeclarations().size());
@@ -324,7 +328,8 @@ class CXXLanguageFrontendTest {
   @Test
   void testCompoundStatement() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new CXXLanguageFrontend(config).parse(new File("src/test/resources/compoundstmt.cpp"));
+        new CXXLanguageFrontend(config, new ScopeManager())
+            .parse(new File("src/test/resources/compoundstmt.cpp"));
 
     FunctionDeclaration function = declaration.getDeclarationAs(0, FunctionDeclaration.class);
 
@@ -351,7 +356,8 @@ class CXXLanguageFrontendTest {
   @Test
   void testPostfixExpression() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new CXXLanguageFrontend(config).parse(new File("src/test/resources/postfixexpression.cpp"));
+        new CXXLanguageFrontend(config, new ScopeManager())
+            .parse(new File("src/test/resources/postfixexpression.cpp"));
 
     List<Statement> statements =
         getStatementsOfFunction(declaration.getDeclarationAs(0, FunctionDeclaration.class));
@@ -387,7 +393,8 @@ class CXXLanguageFrontendTest {
   @Test
   void testIf() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new CXXLanguageFrontend(config).parse(new File("src/test/resources/if.cpp"));
+        new CXXLanguageFrontend(config, new ScopeManager())
+            .parse(new File("src/test/resources/if.cpp"));
 
     List<Statement> statements =
         getStatementsOfFunction(declaration.getDeclarationAs(0, FunctionDeclaration.class));
@@ -411,7 +418,8 @@ class CXXLanguageFrontendTest {
   @Test
   void testSwitch() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new CXXLanguageFrontend(config).parse(new File("src/test/resources/cfg/switch.cpp"));
+        new CXXLanguageFrontend(config, new ScopeManager())
+            .parse(new File("src/test/resources/cfg/switch.cpp"));
 
     List<Node> graphNodes = SubgraphWalker.flattenAST(declaration);
     graphNodes.sort(new NodeComparator());
@@ -436,7 +444,8 @@ class CXXLanguageFrontendTest {
   @Test
   void testDeclarationStatement() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new CXXLanguageFrontend(config).parse(new File("src/test/resources/declstmt.cpp"));
+        new CXXLanguageFrontend(config, new ScopeManager())
+            .parse(new File("src/test/resources/declstmt.cpp"));
 
     FunctionDeclaration function = declaration.getDeclarationAs(0, FunctionDeclaration.class);
 
@@ -504,7 +513,7 @@ class CXXLanguageFrontendTest {
   @Test
   void testAssignmentExpression() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new CXXLanguageFrontend(config)
+        new CXXLanguageFrontend(config, new ScopeManager())
             .parse(new File("src/test/resources/assignmentexpression.cpp"));
 
     // just take a look at the second function
@@ -566,7 +575,8 @@ class CXXLanguageFrontendTest {
   @Test
   void testShiftExpression() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new CXXLanguageFrontend(config).parse(new File("src/test/resources/shiftexpression.cpp"));
+        new CXXLanguageFrontend(config, new ScopeManager())
+            .parse(new File("src/test/resources/shiftexpression.cpp"));
 
     FunctionDeclaration functionDeclaration =
         declaration.getDeclarationAs(0, FunctionDeclaration.class);
@@ -579,7 +589,8 @@ class CXXLanguageFrontendTest {
   @Test
   void testUnaryOperator() throws TranslationException {
     TranslationUnitDeclaration unit =
-        new CXXLanguageFrontend(config).parse(new File("src/test/resources/unaryoperator.cpp"));
+        new CXXLanguageFrontend(config, new ScopeManager())
+            .parse(new File("src/test/resources/unaryoperator.cpp"));
 
     List<Statement> statements =
         getStatementsOfFunction(unit.getDeclarationAs(0, FunctionDeclaration.class));
@@ -649,7 +660,8 @@ class CXXLanguageFrontendTest {
   @Test
   void testBinaryOperator() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new CXXLanguageFrontend(config).parse(new File("src/test/resources/binaryoperator.cpp"));
+        new CXXLanguageFrontend(config, new ScopeManager())
+            .parse(new File("src/test/resources/binaryoperator.cpp"));
 
     List<Statement> statements =
         getStatementsOfFunction(declaration.getDeclarationAs(0, FunctionDeclaration.class));
@@ -704,7 +716,8 @@ class CXXLanguageFrontendTest {
   @Test
   void testRecordDeclaration() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new CXXLanguageFrontend(config).parse(new File("src/test/resources/recordstmt.cpp"));
+        new CXXLanguageFrontend(config, new ScopeManager())
+            .parse(new File("src/test/resources/recordstmt.cpp"));
 
     RecordDeclaration recordDeclaration = declaration.getDeclarationAs(0, RecordDeclaration.class);
 
@@ -744,7 +757,8 @@ class CXXLanguageFrontendTest {
   @Test
   void testLiterals() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new CXXLanguageFrontend(config).parse(new File("src/test/resources/literals.cpp"));
+        new CXXLanguageFrontend(config, new ScopeManager())
+            .parse(new File("src/test/resources/literals.cpp"));
 
     VariableDeclaration s = declaration.getDeclarationAs(0, VariableDeclaration.class);
 
@@ -804,7 +818,7 @@ class CXXLanguageFrontendTest {
   @Test
   void testInitListExpression() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new CXXLanguageFrontend(config)
+        new CXXLanguageFrontend(config, new ScopeManager())
             .parse(new File("src/test/resources/initlistexpression.cpp"));
 
     // x y = { 1, 2 };
@@ -845,7 +859,8 @@ class CXXLanguageFrontendTest {
   @Test
   void testObjectCreation() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new CXXLanguageFrontend(config).parse(new File("src/test/resources/objcreation.cpp"));
+        new CXXLanguageFrontend(config, new ScopeManager())
+            .parse(new File("src/test/resources/objcreation.cpp"));
 
     assertNotNull(declaration);
 
@@ -903,7 +918,8 @@ class CXXLanguageFrontendTest {
   @Test
   void testRegionsCfg() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new CXXLanguageFrontend(config).parse(new File("src/test/resources/cfg.cpp"));
+        new CXXLanguageFrontend(config, new ScopeManager())
+            .parse(new File("src/test/resources/cfg.cpp"));
     assertNotNull(declaration);
 
     FunctionDeclaration fdecl = declaration.getDeclarationAs(0, FunctionDeclaration.class);
@@ -925,7 +941,7 @@ class CXXLanguageFrontendTest {
   @Test
   void testDesignatedInitializer() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new CXXLanguageFrontend(config)
+        new CXXLanguageFrontend(config, new ScopeManager())
             .parse(new File("src/test/resources/components/designatedInitializer.c"));
 
     // should be four method nodes
@@ -1036,7 +1052,7 @@ class CXXLanguageFrontendTest {
   @Test
   void testLocalVariables() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new CXXLanguageFrontend(config)
+        new CXXLanguageFrontend(config, new ScopeManager())
             .parse(new File("src/test/resources/variables/local_variables.cpp"));
 
     FunctionDeclaration function = declaration.getDeclarationAs(2, FunctionDeclaration.class);

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLiteralTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLiteralTest.java
@@ -37,6 +37,7 @@ import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
 import de.fraunhofer.aisec.cpg.graph.Type;
 import de.fraunhofer.aisec.cpg.graph.UnaryOperator;
 import de.fraunhofer.aisec.cpg.graph.VariableDeclaration;
+import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.File;
 import java.math.BigInteger;
 import java.util.Objects;
@@ -57,7 +58,8 @@ public class CXXLiteralTest {
   @Test
   void testDecimalIntegerLiterals() throws TranslationException {
     TranslationUnitDeclaration tu =
-        new CXXLanguageFrontend(config).parse(new File("src/test/resources/integer_literals.cpp"));
+        new CXXLanguageFrontend(config, new ScopeManager())
+            .parse(new File("src/test/resources/integer_literals.cpp"));
 
     FunctionDeclaration decimal =
         tu.getDeclarationByName("decimal", FunctionDeclaration.class).orElse(null);
@@ -93,7 +95,8 @@ public class CXXLiteralTest {
   @Test
   void testOctalIntegerLiterals() throws TranslationException {
     TranslationUnitDeclaration tu =
-        new CXXLanguageFrontend(config).parse(new File("src/test/resources/integer_literals.cpp"));
+        new CXXLanguageFrontend(config, new ScopeManager())
+            .parse(new File("src/test/resources/integer_literals.cpp"));
 
     FunctionDeclaration octal =
         tu.getDeclarationByName("octal", FunctionDeclaration.class).orElse(null);
@@ -113,7 +116,8 @@ public class CXXLiteralTest {
   @ValueSource(strings = {"octal", "hex", "binary"})
   void testNonDecimalIntegerLiterals() throws TranslationException {
     TranslationUnitDeclaration tu =
-        new CXXLanguageFrontend(config).parse(new File("src/test/resources/integer_literals.cpp"));
+        new CXXLanguageFrontend(config, new ScopeManager())
+            .parse(new File("src/test/resources/integer_literals.cpp"));
 
     FunctionDeclaration functionDeclaration =
         tu.getDeclarationByName("hex", FunctionDeclaration.class).orElse(null);
@@ -132,7 +136,7 @@ public class CXXLiteralTest {
   @Test
   void testLargeNegativeNumber() throws TranslationException {
     TranslationUnitDeclaration tu =
-        new CXXLanguageFrontend(config)
+        new CXXLanguageFrontend(config, new ScopeManager())
             .parse(new File("src/test/resources/largenegativenumber.cpp"));
 
     FunctionDeclaration main =

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXSymbolConfigurationTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXSymbolConfigurationTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
 import de.fraunhofer.aisec.cpg.graph.*;
+import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.File;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -41,7 +42,8 @@ public class CXXSymbolConfigurationTest {
   void testWithoutSymbols() throws TranslationException {
     // parse without symbols
     TranslationUnitDeclaration tu =
-        new CXXLanguageFrontend(TranslationConfiguration.builder().defaultPasses().build())
+        new CXXLanguageFrontend(
+                TranslationConfiguration.builder().defaultPasses().build(), new ScopeManager())
             .parse(new File("src/test/resources/symbols.cpp"));
 
     FunctionDeclaration main =
@@ -78,7 +80,8 @@ public class CXXSymbolConfigurationTest {
                             "HELLO_WORLD", "\"Hello World\"",
                             "INCREASE(X)", "X+1"))
                     .defaultPasses()
-                    .build())
+                    .build(),
+                new ScopeManager())
             .parse(new File("src/test/resources/symbols.cpp"));
 
     FunctionDeclaration main =

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
@@ -63,6 +63,7 @@ import de.fraunhofer.aisec.cpg.graph.VariableDeclaration;
 import de.fraunhofer.aisec.cpg.helpers.NodeComparator;
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker;
 import de.fraunhofer.aisec.cpg.helpers.Util;
+import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.File;
 import java.math.BigInteger;
 import java.util.List;
@@ -83,7 +84,7 @@ class JavaLanguageFrontendTest {
   @Test
   void testLargeNegativeNumber() throws TranslationException {
     TranslationUnitDeclaration tu =
-        new JavaLanguageFrontend(config)
+        new JavaLanguageFrontend(config, new ScopeManager())
             .parse(new File("src/test/resources/LargeNegativeNumber.java"));
     RecordDeclaration declaration = (RecordDeclaration) tu.getDeclarations().get(0);
 
@@ -121,7 +122,7 @@ class JavaLanguageFrontendTest {
   @Test
   void testForeach() throws TranslationException {
     TranslationUnitDeclaration tu =
-        new JavaLanguageFrontend(config)
+        new JavaLanguageFrontend(config, new ScopeManager())
             .parse(new File("src/test/resources/components/ForEachStmt.java"));
 
     RecordDeclaration declaration = (RecordDeclaration) tu.getDeclarations().get(0);
@@ -155,7 +156,7 @@ class JavaLanguageFrontendTest {
   @Test
   void testTryCatch() throws TranslationException {
     TranslationUnitDeclaration tu =
-        new JavaLanguageFrontend(config)
+        new JavaLanguageFrontend(config, new ScopeManager())
             .parse(new File("src/test/resources/components/TryStmt.java"));
 
     RecordDeclaration declaration = (RecordDeclaration) tu.getDeclarations().get(0);
@@ -190,7 +191,7 @@ class JavaLanguageFrontendTest {
   @Test
   void testLiteral() throws TranslationException {
     TranslationUnitDeclaration tu =
-        new JavaLanguageFrontend(config)
+        new JavaLanguageFrontend(config, new ScopeManager())
             .parse(new File("src/test/resources/components/LiteralExpr.java"));
 
     RecordDeclaration declaration = (RecordDeclaration) tu.getDeclarations().get(0);
@@ -278,7 +279,7 @@ class JavaLanguageFrontendTest {
   @Test
   void testRecordDeclaration() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new JavaLanguageFrontend(config)
+        new JavaLanguageFrontend(config, new ScopeManager())
             .parse(new File("src/test/resources/compiling/RecordDeclaration.java"));
 
     assertNotNull(declaration);
@@ -308,7 +309,7 @@ class JavaLanguageFrontendTest {
   @Test
   void testVariables() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new JavaLanguageFrontend(config)
+        new JavaLanguageFrontend(config, new ScopeManager())
             .parse(new File("src/test/resources/compiling/Variables.java"));
 
     assertNotNull(declaration);
@@ -317,7 +318,7 @@ class JavaLanguageFrontendTest {
   @Test
   void testNameExpressions() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new JavaLanguageFrontend(config)
+        new JavaLanguageFrontend(config, new ScopeManager())
             .parse(new File("src/test/resources/compiling/NameExpression.java"));
 
     assertNotNull(declaration);
@@ -326,7 +327,7 @@ class JavaLanguageFrontendTest {
   @Test
   void testSwitch() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new JavaLanguageFrontend(TranslationConfiguration.builder().build())
+        new JavaLanguageFrontend(TranslationConfiguration.builder().build(), new ScopeManager())
             .parse(new File("src/test/resources/cfg/Switch.java"));
 
     List<Node> graphNodes = SubgraphWalker.flattenAST(declaration);
@@ -352,7 +353,7 @@ class JavaLanguageFrontendTest {
   @Test
   void testCast() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new JavaLanguageFrontend(TranslationConfiguration.builder().build())
+        new JavaLanguageFrontend(TranslationConfiguration.builder().build(), new ScopeManager())
             .parse(new File("src/test/resources/components/CastExpr.java"));
 
     assertNotNull(declaration);
@@ -395,7 +396,7 @@ class JavaLanguageFrontendTest {
   @Test
   void testArrays() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new JavaLanguageFrontend(TranslationConfiguration.builder().build())
+        new JavaLanguageFrontend(TranslationConfiguration.builder().build(), new ScopeManager())
             .parse(new File("src/test/resources/compiling/Arrays.java"));
 
     assertNotNull(declaration);
@@ -445,7 +446,7 @@ class JavaLanguageFrontendTest {
   @Test
   void testFieldAccessExpressions() throws TranslationException {
     TranslationUnitDeclaration declaration =
-        new JavaLanguageFrontend(TranslationConfiguration.builder().build())
+        new JavaLanguageFrontend(TranslationConfiguration.builder().build(), new ScopeManager())
             .parse(new File("src/test/resources/compiling/FieldAccess.java"));
 
     assertNotNull(declaration);


### PR DESCRIPTION
Inside the Tests when creating the Frontend.