### PR TITLE
Fix for null parent of field expression, leading to missing locations.

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java
@@ -492,7 +492,11 @@ public class ExpressionHandler
         if (!field.isStatic()) {
           // convert to FieldAccessExpr
           FieldAccessExpr fieldAccessExpr = new FieldAccessExpr(new ThisExpr(), field.getName());
+          expr.getRange().ifPresent(fieldAccessExpr::setRange);
+          expr.getTokenRange().ifPresent(fieldAccessExpr::setTokenRange);
+          expr.getParentNode().ifPresent(fieldAccessExpr::setParentNode);
           expr.replace(fieldAccessExpr);
+          fieldAccessExpr.getParentNode().ifPresent(expr::setParentNode);
 
           // handle it as a field expression
           return (de.fraunhofer.aisec.cpg.graph.Expression) handle(fieldAccessExpr);
@@ -500,7 +504,11 @@ public class ExpressionHandler
           FieldAccessExpr fieldAccessExpr =
               new FieldAccessExpr(
                   new NameExpr(field.declaringType().getClassName()), field.getName());
+          expr.getRange().ifPresent(fieldAccessExpr::setRange);
+          expr.getTokenRange().ifPresent(fieldAccessExpr::setTokenRange);
+          expr.getParentNode().ifPresent(fieldAccessExpr::setParentNode);
           expr.replace(fieldAccessExpr);
+          fieldAccessExpr.getParentNode().ifPresent(expr::setParentNode);
 
           // handle it as a field expression
           return (de.fraunhofer.aisec.cpg.graph.Expression) handle(fieldAccessExpr);


### PR DESCRIPTION
In [1] and [2], `ExpressionHandler` simplifies the AST by replacing some nodes by a `FieldAccessExpr`. However, the newly created `FieldAccessExpr` lacks some properties - especially its `parent`, `range`, and `tokenRange` are null. This results later in an `IllegalArgumentException` when a rule violation is found at that node and we try to retrieve its position in the code.

This PR fixes #96. But the original author might want to review and possibly simplify the method in general.

[1] https://github.com/Fraunhofer-AISEC/cpg/blob/487558afba9539db62484b02eb23112ecc85478a/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java#L498