### PR TITLE
Typeparser hotfix

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/TypeManager.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/TypeManager.java
@@ -65,6 +65,10 @@ public class TypeManager {
   private LanguageFrontend frontend;
   private boolean noFrontendWarningIssued = false;
 
+  public static void reset() {
+    INSTANCE = new TypeManager();
+  }
+
   public Map<Type, List<Type>> getTypeState() {
     return typeState;
   }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/type/TypeParser.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/type/TypeParser.java
@@ -29,6 +29,7 @@ package de.fraunhofer.aisec.cpg.graph.type;
 import de.fraunhofer.aisec.cpg.graph.TypeManager;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -49,7 +50,8 @@ public class TypeParser {
       Pattern.compile(
           "(?:(?<functionptr>(\\h|\\()+[a-zA-Z0-9_$.<>:]*\\*\\h*[a-zA-Z0-9_$.<>:]*(\\h|\\))+)\\h*)(?<args>\\(+[a-zA-Z0-9_$.<>,\\*\\&\\h]*\\))");
 
-  private static TypeManager.Language language = TypeManager.getInstance().getLanguage();
+  private static Supplier<TypeManager.Language> languageSupplier =
+      () -> TypeManager.getInstance().getLanguage();
   private static final String VOLATILE_QUALIFIER = "volatile";
   private static final String FINAL_QUALIFIER = "final";
   private static final String CONST_QUALIFIER = "const";
@@ -60,17 +62,14 @@ public class TypeParser {
    * WARNING: This is only intended for Test Purposes of the TypeParser itself without parsing
    * files. Do not use this.
    *
-   * @param language frontend language Java or CPP
+   * @param languageSupplier frontend language Java or CPP
    */
-  public static void setLanguage(TypeManager.Language language) {
-    TypeParser.language = language;
+  public static void setLanguageSupplier(Supplier<TypeManager.Language> languageSupplier) {
+    TypeParser.languageSupplier = languageSupplier;
   }
 
   public static TypeManager.Language getLanguage() {
-    if (TypeManager.getInstance().getFrontend() == null) {
-      return language;
-    }
-    return TypeManager.getInstance().getLanguage();
+    return TypeParser.languageSupplier.get();
   }
 
   /**

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/type/TypeParser.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/type/TypeParser.java
@@ -58,6 +58,10 @@ public class TypeParser {
   private static final String RESTRICT_QUALIFIER = "restrict";
   private static final String ATOMIC_QUALIFIER = "atomic";
 
+  public static void reset() {
+    TypeParser.languageSupplier = () -> TypeManager.getInstance().getLanguage();
+  }
+
   /**
    * WARNING: This is only intended for Test Purposes of the TypeParser itself without parsing
    * files. Do not use this.

--- a/src/test/java/de/fraunhofer/aisec/cpg/BaseTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/BaseTest.java
@@ -1,0 +1,18 @@
+package de.fraunhofer.aisec.cpg;
+
+import de.fraunhofer.aisec.cpg.graph.TypeManager;
+import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
+import org.junit.jupiter.api.BeforeEach;
+
+public abstract class BaseTest {
+
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
+}

--- a/src/test/java/de/fraunhofer/aisec/cpg/ScopeManagerTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/ScopeManagerTest.java
@@ -29,29 +29,17 @@ package de.fraunhofer.aisec.cpg;
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
 import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguageFrontend;
-import de.fraunhofer.aisec.cpg.graph.TypeManager;
-import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ScopeManagerTest {
+public class ScopeManagerTest extends BaseTest {
 
   private TranslationConfiguration config;
 
   @BeforeEach
   void setUp() {
     config = TranslationConfiguration.builder().defaultPasses().build();
-  }
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
   }
 
   @Test

--- a/src/test/java/de/fraunhofer/aisec/cpg/ScopeManagerTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/ScopeManagerTest.java
@@ -29,6 +29,8 @@ package de.fraunhofer.aisec.cpg;
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
 import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguageFrontend;
+import de.fraunhofer.aisec.cpg.graph.TypeManager;
+import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,6 +42,16 @@ public class ScopeManagerTest {
   @BeforeEach
   void setUp() {
     config = TranslationConfiguration.builder().defaultPasses().build();
+  }
+
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
   }
 
   @Test

--- a/src/test/java/de/fraunhofer/aisec/cpg/ScopeManagerTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/ScopeManagerTest.java
@@ -33,7 +33,7 @@ import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ScopeManagerTest extends BaseTest {
+class ScopeManagerTest extends BaseTest {
 
   private TranslationConfiguration config;
 

--- a/src/test/java/de/fraunhofer/aisec/cpg/TypeTests.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/TypeTests.java
@@ -37,7 +37,7 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class TypeTests extends BaseTest {
+class TypeTests extends BaseTest {
 
   @Test
   void reference() {

--- a/src/test/java/de/fraunhofer/aisec/cpg/TypeTests.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/TypeTests.java
@@ -35,20 +35,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class TypeTests {
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
-  }
+public class TypeTests extends BaseTest {
 
   @Test
   void reference() {

--- a/src/test/java/de/fraunhofer/aisec/cpg/TypeTests.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/TypeTests.java
@@ -35,9 +35,20 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class TypeTests {
+
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
 
   @Test
   void reference() {

--- a/src/test/java/de/fraunhofer/aisec/cpg/TypeTests.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/TypeTests.java
@@ -42,7 +42,7 @@ public class TypeTests {
   @Test
   void reference() {
 
-    TypeParser.setLanguage(TypeManager.Language.CXX);
+    TypeParser.setLanguageSupplier(() -> TypeManager.Language.CXX);
 
     Type objectType =
         new ObjectType(
@@ -96,7 +96,7 @@ public class TypeTests {
   @Test
   void dereference() {
 
-    TypeParser.setLanguage(TypeManager.Language.CXX);
+    TypeParser.setLanguageSupplier(() -> TypeManager.Language.CXX);
 
     Type objectType =
         new ObjectType(
@@ -146,7 +146,7 @@ public class TypeTests {
     Type result;
     Type expected;
 
-    TypeParser.setLanguage(TypeManager.Language.JAVA);
+    TypeParser.setLanguageSupplier(() -> TypeManager.Language.JAVA);
 
     // Test 1: Ignore Access Modifier Keyword (public, private, protected)
     typeString = "private int a";
@@ -327,7 +327,7 @@ public class TypeTests {
     String typeString;
     Type result;
 
-    TypeParser.setLanguage(TypeManager.Language.CXX);
+    TypeParser.setLanguageSupplier(() -> TypeManager.Language.CXX);
 
     // Test 1: Function pointer
     typeString = "void (*single_param)(int)";

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/ConstructorsTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/ConstructorsTest.java
@@ -3,19 +3,27 @@ package de.fraunhofer.aisec.cpg.enhancements;
 import static org.junit.jupiter.api.Assertions.*;
 
 import de.fraunhofer.aisec.cpg.TestUtils;
-import de.fraunhofer.aisec.cpg.graph.ConstructExpression;
-import de.fraunhofer.aisec.cpg.graph.ConstructorDeclaration;
-import de.fraunhofer.aisec.cpg.graph.NewExpression;
-import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
-import de.fraunhofer.aisec.cpg.graph.VariableDeclaration;
+import de.fraunhofer.aisec.cpg.graph.*;
+import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.helpers.Util;
 import java.nio.file.Path;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class ConstructorsTest {
 
   private Path topLevel = Path.of("src", "test", "resources", "constructors");
+
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
 
   @Test
   void testJava() throws Exception {

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/ConstructorsTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/ConstructorsTest.java
@@ -14,7 +14,7 @@ import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class ConstructorsTest extends BaseTest {
+class ConstructorsTest extends BaseTest {
 
   private Path topLevel = Path.of("src", "test", "resources", "constructors");
 

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/ConstructorsTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/ConstructorsTest.java
@@ -2,28 +2,21 @@ package de.fraunhofer.aisec.cpg.enhancements;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TestUtils;
-import de.fraunhofer.aisec.cpg.graph.*;
-import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
+import de.fraunhofer.aisec.cpg.graph.ConstructExpression;
+import de.fraunhofer.aisec.cpg.graph.ConstructorDeclaration;
+import de.fraunhofer.aisec.cpg.graph.NewExpression;
+import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
+import de.fraunhofer.aisec.cpg.graph.VariableDeclaration;
 import de.fraunhofer.aisec.cpg.helpers.Util;
 import java.nio.file.Path;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ConstructorsTest {
+public class ConstructorsTest extends BaseTest {
 
   private Path topLevel = Path.of("src", "test", "resources", "constructors");
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
-  }
 
   @Test
   void testJava() throws Exception {

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/EOGTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/EOGTest.java
@@ -62,7 +62,7 @@ import org.neo4j.ogm.exception.TransactionException;
  *
  * @author konrad.weiss@aisec.fraunhofer.de
  */
-public class EOGTest extends BaseTest {
+class EOGTest extends BaseTest {
 
   public static String REFNODESTRINGJAVA = "System.out.println();";
   public static String REFNODESTRINGCXX = "printf(\"\\n\");";

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/EOGTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/EOGTest.java
@@ -40,6 +40,7 @@ import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationManager;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
 import de.fraunhofer.aisec.cpg.graph.*;
+import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.helpers.NodeComparator;
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker;
 import de.fraunhofer.aisec.cpg.helpers.Util;
@@ -53,6 +54,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.neo4j.ogm.exception.TransactionException;
 
@@ -65,6 +67,16 @@ public class EOGTest {
 
   public static String REFNODESTRINGJAVA = "System.out.println();";
   public static String REFNODESTRINGCXX = "printf(\"\\n\");";
+
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
 
   @Test
   void testJavaIf() throws TranslationException {

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/EOGTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/EOGTest.java
@@ -36,11 +36,11 @@ import static de.fraunhofer.aisec.cpg.sarif.PhysicalLocation.locationLink;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationManager;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
 import de.fraunhofer.aisec.cpg.graph.*;
-import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.helpers.NodeComparator;
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker;
 import de.fraunhofer.aisec.cpg.helpers.Util;
@@ -54,7 +54,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.neo4j.ogm.exception.TransactionException;
 
@@ -63,20 +62,10 @@ import org.neo4j.ogm.exception.TransactionException;
  *
  * @author konrad.weiss@aisec.fraunhofer.de
  */
-public class EOGTest {
+public class EOGTest extends BaseTest {
 
   public static String REFNODESTRINGJAVA = "System.out.println();";
   public static String REFNODESTRINGCXX = "printf(\"\\n\");";
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
-  }
 
   @Test
   void testJavaIf() throws TranslationException {

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/FunctionPointerTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/FunctionPointerTest.java
@@ -31,11 +31,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import de.fraunhofer.aisec.cpg.TestUtils;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationManager;
-import de.fraunhofer.aisec.cpg.graph.CallExpression;
-import de.fraunhofer.aisec.cpg.graph.FunctionDeclaration;
-import de.fraunhofer.aisec.cpg.graph.Node;
-import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
-import de.fraunhofer.aisec.cpg.graph.VariableDeclaration;
+import de.fraunhofer.aisec.cpg.graph.*;
+import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.helpers.Util;
 import java.io.File;
 import java.nio.file.Files;
@@ -49,9 +46,20 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class FunctionPointerTest {
+
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
 
   private List<TranslationUnitDeclaration> analyze(String language) throws Exception {
     Path topLevel = Path.of("src", "test", "resources", "functionPointers");

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/FunctionPointerTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/FunctionPointerTest.java
@@ -28,11 +28,15 @@ package de.fraunhofer.aisec.cpg.enhancements;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TestUtils;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationManager;
-import de.fraunhofer.aisec.cpg.graph.*;
-import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
+import de.fraunhofer.aisec.cpg.graph.CallExpression;
+import de.fraunhofer.aisec.cpg.graph.FunctionDeclaration;
+import de.fraunhofer.aisec.cpg.graph.Node;
+import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
+import de.fraunhofer.aisec.cpg.graph.VariableDeclaration;
 import de.fraunhofer.aisec.cpg.helpers.Util;
 import java.io.File;
 import java.nio.file.Files;
@@ -46,20 +50,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class FunctionPointerTest {
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
-  }
+public class FunctionPointerTest extends BaseTest {
 
   private List<TranslationUnitDeclaration> analyze(String language) throws Exception {
     Path topLevel = Path.of("src", "test", "resources", "functionPointers");

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/FunctionPointerTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/FunctionPointerTest.java
@@ -52,7 +52,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
-public class FunctionPointerTest extends BaseTest {
+class FunctionPointerTest extends BaseTest {
 
   private List<TranslationUnitDeclaration> analyze(String language) throws Exception {
     Path topLevel = Path.of("src", "test", "resources", "functionPointers");
@@ -78,7 +78,7 @@ public class FunctionPointerTest extends BaseTest {
     return analyzer.analyze().get().getTranslationUnits();
   }
 
-  public void test(String language) throws Exception {
+  void test(String language) throws Exception {
     List<TranslationUnitDeclaration> result = analyze(language);
     List<FunctionDeclaration> functions = Util.subnodesOfType(result, FunctionDeclaration.class);
     FunctionDeclaration main = TestUtils.findByUniqueName(functions, "main");
@@ -188,12 +188,12 @@ public class FunctionPointerTest extends BaseTest {
   }
 
   @Test
-  public void testC() throws Exception {
+  void testC() throws Exception {
     test("C");
   }
 
   @Test
-  public void testCPP() throws Exception {
+  void testCPP() throws Exception {
     test("CPP");
   }
 }

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/JavaVsCppTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/JavaVsCppTest.java
@@ -29,29 +29,18 @@ package de.fraunhofer.aisec.cpg.enhancements;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.github.javaparser.utils.Pair;
+import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationManager;
 import de.fraunhofer.aisec.cpg.TranslationResult;
 import de.fraunhofer.aisec.cpg.graph.*;
-import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import java.io.File;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class JavaVsCppTest {
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
-  }
+class JavaVsCppTest extends BaseTest {
 
   @Test
   void cpp() throws ExecutionException, InterruptedException {

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/JavaVsCppTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/JavaVsCppTest.java
@@ -33,13 +33,25 @@ import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationManager;
 import de.fraunhofer.aisec.cpg.TranslationResult;
 import de.fraunhofer.aisec.cpg.graph.*;
+import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import java.io.File;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class JavaVsCppTest {
+
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
 
   @Test
   void cpp() throws ExecutionException, InterruptedException {

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/StaticImportsTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/StaticImportsTest.java
@@ -43,7 +43,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
-public class StaticImportsTest extends BaseTest {
+class StaticImportsTest extends BaseTest {
 
   private Path topLevel = Path.of("src", "test", "resources", "staticImports");
 

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/StaticImportsTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/StaticImportsTest.java
@@ -28,28 +28,22 @@ package de.fraunhofer.aisec.cpg.enhancements;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TestUtils;
-import de.fraunhofer.aisec.cpg.graph.*;
-import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
+import de.fraunhofer.aisec.cpg.graph.CallExpression;
+import de.fraunhofer.aisec.cpg.graph.FieldDeclaration;
+import de.fraunhofer.aisec.cpg.graph.MemberExpression;
+import de.fraunhofer.aisec.cpg.graph.MethodDeclaration;
+import de.fraunhofer.aisec.cpg.graph.RecordDeclaration;
+import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
 import de.fraunhofer.aisec.cpg.helpers.Util;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class StaticImportsTest {
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
-  }
+public class StaticImportsTest extends BaseTest {
 
   private Path topLevel = Path.of("src", "test", "resources", "staticImports");
 

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/StaticImportsTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/StaticImportsTest.java
@@ -29,20 +29,27 @@ package de.fraunhofer.aisec.cpg.enhancements;
 import static org.junit.jupiter.api.Assertions.*;
 
 import de.fraunhofer.aisec.cpg.TestUtils;
-import de.fraunhofer.aisec.cpg.graph.CallExpression;
-import de.fraunhofer.aisec.cpg.graph.FieldDeclaration;
-import de.fraunhofer.aisec.cpg.graph.MemberExpression;
-import de.fraunhofer.aisec.cpg.graph.MethodDeclaration;
-import de.fraunhofer.aisec.cpg.graph.RecordDeclaration;
-import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
+import de.fraunhofer.aisec.cpg.graph.*;
+import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.helpers.Util;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class StaticImportsTest {
+
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
 
   private Path topLevel = Path.of("src", "test", "resources", "staticImports");
 

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/SubgraphWalkerTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/SubgraphWalkerTest.java
@@ -30,29 +30,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
 import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguageFrontend;
-import de.fraunhofer.aisec.cpg.graph.*;
-import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
+import de.fraunhofer.aisec.cpg.graph.NamespaceDeclaration;
+import de.fraunhofer.aisec.cpg.graph.Node;
+import de.fraunhofer.aisec.cpg.graph.RecordDeclaration;
+import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker;
 import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.File;
 import java.util.Set;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class SubgraphWalkerTest {
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
-  }
+class SubgraphWalkerTest extends BaseTest {
 
   @Test
   void testASTChildrenGetter() throws TranslationException {

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/SubgraphWalkerTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/SubgraphWalkerTest.java
@@ -33,17 +33,26 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
 import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguageFrontend;
-import de.fraunhofer.aisec.cpg.graph.NamespaceDeclaration;
-import de.fraunhofer.aisec.cpg.graph.Node;
-import de.fraunhofer.aisec.cpg.graph.RecordDeclaration;
-import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
+import de.fraunhofer.aisec.cpg.graph.*;
+import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker;
 import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.File;
 import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class SubgraphWalkerTest {
+
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
 
   @Test
   void testASTChildrenGetter() throws TranslationException {

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/SuperCallTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/SuperCallTest.java
@@ -4,16 +4,28 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import de.fraunhofer.aisec.cpg.TestUtils;
 import de.fraunhofer.aisec.cpg.graph.*;
+import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.helpers.Util;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class SuperCallTest {
 
   private final Path topLevel = Path.of("src", "test", "resources", "superCalls");
+
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
 
   @Test
   void testSimpleCall() throws Exception {

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/SuperCallTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/SuperCallTest.java
@@ -2,30 +2,19 @@ package de.fraunhofer.aisec.cpg.enhancements;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TestUtils;
 import de.fraunhofer.aisec.cpg.graph.*;
-import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.helpers.Util;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class SuperCallTest {
+class SuperCallTest extends BaseTest {
 
   private final Path topLevel = Path.of("src", "test", "resources", "superCalls");
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
-  }
 
   @Test
   void testSimpleCall() throws Exception {

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/TypedefTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/TypedefTest.java
@@ -7,14 +7,26 @@ import de.fraunhofer.aisec.cpg.graph.RecordDeclaration;
 import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
 import de.fraunhofer.aisec.cpg.graph.TypeManager;
 import de.fraunhofer.aisec.cpg.graph.ValueDeclaration;
+import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.helpers.Util;
 import java.nio.file.Path;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class TypedefTest {
 
   private Path topLevel = Path.of("src", "test", "resources", "typedefs");
+
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
 
   @Test
   void testSingle() throws Exception {

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/TypedefTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/TypedefTest.java
@@ -2,31 +2,20 @@ package de.fraunhofer.aisec.cpg.enhancements;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TestUtils;
 import de.fraunhofer.aisec.cpg.graph.RecordDeclaration;
 import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
 import de.fraunhofer.aisec.cpg.graph.TypeManager;
 import de.fraunhofer.aisec.cpg.graph.ValueDeclaration;
-import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.helpers.Util;
 import java.nio.file.Path;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class TypedefTest {
+public class TypedefTest extends BaseTest {
 
   private Path topLevel = Path.of("src", "test", "resources", "typedefs");
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
-  }
 
   @Test
   void testSingle() throws Exception {

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/TypedefTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/TypedefTest.java
@@ -13,7 +13,7 @@ import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class TypedefTest extends BaseTest {
+class TypedefTest extends BaseTest {
 
   private Path topLevel = Path.of("src", "test", "resources", "typedefs");
 

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/VariableResolverTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/VariableResolverTest.java
@@ -33,6 +33,7 @@ import de.fraunhofer.aisec.cpg.TestUtils;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationManager;
 import de.fraunhofer.aisec.cpg.graph.*;
+import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.helpers.Util;
 import java.io.File;
 import java.nio.file.Path;
@@ -40,11 +41,22 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class VariableResolverTest {
 
   private final Path topLevel = Path.of("src", "test", "resources", "variables");
+
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
 
   @Test
   public void testFields() throws Exception {

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/VariableResolverTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/VariableResolverTest.java
@@ -29,11 +29,11 @@ package de.fraunhofer.aisec.cpg.enhancements;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TestUtils;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationManager;
 import de.fraunhofer.aisec.cpg.graph.*;
-import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.helpers.Util;
 import java.io.File;
 import java.nio.file.Path;
@@ -41,22 +41,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class VariableResolverTest {
+public class VariableResolverTest extends BaseTest {
 
   private final Path topLevel = Path.of("src", "test", "resources", "variables");
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
-  }
 
   @Test
   public void testFields() throws Exception {

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/VariableResolverTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/VariableResolverTest.java
@@ -43,12 +43,12 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
-public class VariableResolverTest extends BaseTest {
+class VariableResolverTest extends BaseTest {
 
   private final Path topLevel = Path.of("src", "test", "resources", "variables");
 
   @Test
-  public void testFields() throws Exception {
+  void testFields() throws Exception {
     List<TranslationUnitDeclaration> result = TestUtils.analyze("java", topLevel);
     List<MethodDeclaration> methods = Util.subnodesOfType(result, MethodDeclaration.class);
     List<FieldDeclaration> fields = Util.subnodesOfType(result, FieldDeclaration.class);
@@ -64,7 +64,7 @@ public class VariableResolverTest extends BaseTest {
   }
 
   @Test
-  public void testLocalVars() throws Exception {
+  void testLocalVars() throws Exception {
     List<TranslationUnitDeclaration> result = TestUtils.analyze("java", topLevel);
     List<MethodDeclaration> methods = Util.subnodesOfType(result, MethodDeclaration.class);
     List<FieldDeclaration> fields = Util.subnodesOfType(result, FieldDeclaration.class);
@@ -87,7 +87,7 @@ public class VariableResolverTest extends BaseTest {
   }
 
   @Test
-  public void testLocalVarsCpp() throws ExecutionException, InterruptedException {
+  void testLocalVarsCpp() throws ExecutionException, InterruptedException {
     TranslationConfiguration config =
         TranslationConfiguration.builder()
             .sourceLocations(new File("src/test/resources/variables/local_variables.cpp"))

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/LanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/LanguageFrontendTest.java
@@ -28,27 +28,15 @@ package de.fraunhofer.aisec.cpg.frontends;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationManager;
 import de.fraunhofer.aisec.cpg.TranslationResult;
-import de.fraunhofer.aisec.cpg.graph.TypeManager;
-import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import java.io.File;
 import java.util.concurrent.ExecutionException;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class LanguageFrontendTest {
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
-  }
+class LanguageFrontendTest extends BaseTest {
 
   @Test
   void testParseDirectory() throws ExecutionException, InterruptedException {

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/LanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/LanguageFrontendTest.java
@@ -31,11 +31,24 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationManager;
 import de.fraunhofer.aisec.cpg.TranslationResult;
+import de.fraunhofer.aisec.cpg.graph.TypeManager;
+import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import java.io.File;
 import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class LanguageFrontendTest {
+
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
 
   @Test
   void testParseDirectory() throws ExecutionException, InterruptedException {

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/BotanExampleTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/BotanExampleTest.java
@@ -33,12 +33,24 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
 import de.fraunhofer.aisec.cpg.graph.*;
+import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.File;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class BotanExampleTest {
+
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
 
   @Test
   void testExample() throws TranslationException {

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/BotanExampleTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/BotanExampleTest.java
@@ -30,27 +30,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
 import de.fraunhofer.aisec.cpg.graph.*;
-import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.File;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class BotanExampleTest {
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
-  }
+class BotanExampleTest extends BaseTest {
 
   @Test
   void testExample() throws TranslationException {

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXBindingsTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXBindingsTest.java
@@ -2,29 +2,17 @@ package de.fraunhofer.aisec.cpg.frontends.cpp;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.graph.Declaration;
 import de.fraunhofer.aisec.cpg.graph.DeclaredReferenceExpression;
 import de.fraunhofer.aisec.cpg.graph.Expression;
-import de.fraunhofer.aisec.cpg.graph.TypeManager;
-import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.File;
 import org.eclipse.cdt.core.dom.ast.IBinding;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class CXXBindingsTest {
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
-  }
+class CXXBindingsTest extends BaseTest {
 
   void checkBindings(CXXLanguageFrontend cxxLanguageFrontend) {
     for (IBinding binding : cxxLanguageFrontend.getCachedDeclarations().keySet()) {

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXBindingsTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXBindingsTest.java
@@ -6,12 +6,25 @@ import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.graph.Declaration;
 import de.fraunhofer.aisec.cpg.graph.DeclaredReferenceExpression;
 import de.fraunhofer.aisec.cpg.graph.Expression;
+import de.fraunhofer.aisec.cpg.graph.TypeManager;
+import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.File;
 import org.eclipse.cdt.core.dom.ast.IBinding;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class CXXBindingsTest {
+
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
 
   void checkBindings(CXXLanguageFrontend cxxLanguageFrontend) {
     for (IBinding binding : cxxLanguageFrontend.getCachedDeclarations().keySet()) {

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXCfgTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXCfgTest.java
@@ -55,7 +55,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author julian
  */
-public class CXXCfgTest extends BaseTest {
+class CXXCfgTest extends BaseTest {
 
   @Test
   void testCfg() throws TranslationException, InterruptedException, ExecutionException {

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXCfgTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXCfgTest.java
@@ -30,12 +30,17 @@ import static de.fraunhofer.aisec.cpg.TestUtils.getByLineNr;
 import static de.fraunhofer.aisec.cpg.sarif.PhysicalLocation.locationLink;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationManager;
 import de.fraunhofer.aisec.cpg.TranslationResult;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
-import de.fraunhofer.aisec.cpg.graph.*;
-import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
+import de.fraunhofer.aisec.cpg.graph.CompoundStatement;
+import de.fraunhofer.aisec.cpg.graph.FunctionDeclaration;
+import de.fraunhofer.aisec.cpg.graph.IfStatement;
+import de.fraunhofer.aisec.cpg.graph.Node;
+import de.fraunhofer.aisec.cpg.graph.Statement;
+import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker;
 import de.fraunhofer.aisec.cpg.passes.ControlFlowGraphPass;
 import de.fraunhofer.aisec.cpg.passes.EvaluationOrderGraphPass;
@@ -43,7 +48,6 @@ import java.io.File;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -51,17 +55,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author julian
  */
-public class CXXCfgTest {
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
-  }
+public class CXXCfgTest extends BaseTest {
 
   @Test
   void testCfg() throws TranslationException, InterruptedException, ExecutionException {

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXCfgTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXCfgTest.java
@@ -34,12 +34,8 @@ import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationManager;
 import de.fraunhofer.aisec.cpg.TranslationResult;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
-import de.fraunhofer.aisec.cpg.graph.CompoundStatement;
-import de.fraunhofer.aisec.cpg.graph.FunctionDeclaration;
-import de.fraunhofer.aisec.cpg.graph.IfStatement;
-import de.fraunhofer.aisec.cpg.graph.Node;
-import de.fraunhofer.aisec.cpg.graph.Statement;
-import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
+import de.fraunhofer.aisec.cpg.graph.*;
+import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker;
 import de.fraunhofer.aisec.cpg.passes.ControlFlowGraphPass;
 import de.fraunhofer.aisec.cpg.passes.EvaluationOrderGraphPass;
@@ -47,6 +43,7 @@ import java.io.File;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -55,6 +52,16 @@ import org.junit.jupiter.api.Test;
  * @author julian
  */
 public class CXXCfgTest {
+
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
 
   @Test
   void testCfg() throws TranslationException, InterruptedException, ExecutionException {

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXIncludeTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXIncludeTest.java
@@ -32,13 +32,25 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
 import de.fraunhofer.aisec.cpg.graph.*;
+import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation;
 import de.fraunhofer.aisec.cpg.sarif.Region;
 import java.io.File;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class CXXIncludeTest {
+
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
 
   @Test
   void testDefinitionsAndDeclaration() throws TranslationException {

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXIncludeTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXIncludeTest.java
@@ -29,28 +29,17 @@ package de.fraunhofer.aisec.cpg.frontends.cpp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
 import de.fraunhofer.aisec.cpg.graph.*;
-import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation;
 import de.fraunhofer.aisec.cpg.sarif.Region;
 import java.io.File;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class CXXIncludeTest {
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
-  }
+class CXXIncludeTest extends BaseTest {
 
   @Test
   void testDefinitionsAndDeclaration() throws TranslationException {

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.frontends.cpp;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
 import de.fraunhofer.aisec.cpg.graph.*;
@@ -48,7 +49,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class CXXLanguageFrontendTest {
+class CXXLanguageFrontendTest extends BaseTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CXXLanguageFrontendTest.class);
 
@@ -57,16 +58,6 @@ class CXXLanguageFrontendTest {
   @BeforeEach
   void setUp() {
     config = TranslationConfiguration.builder().defaultPasses().build();
-  }
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
   }
 
   @Test

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
@@ -1039,7 +1039,7 @@ class CXXLanguageFrontendTest extends BaseTest {
   }
 
   @Test
-  public void testLocation() throws TranslationException {
+  void testLocation() throws TranslationException {
     TranslationUnitDeclaration tu =
         new CXXLanguageFrontend(config, new ScopeManager())
             .parse(new File("src/test/resources/components/foreachstmt.cpp"));

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
@@ -59,6 +59,16 @@ class CXXLanguageFrontendTest {
     config = TranslationConfiguration.builder().defaultPasses().build();
   }
 
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
+
   @Test
   void testForEach() throws TranslationException {
     TranslationUnitDeclaration tu =

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLiteralTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLiteralTest.java
@@ -29,6 +29,7 @@ package de.fraunhofer.aisec.cpg.frontends.cpp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
 import de.fraunhofer.aisec.cpg.graph.*;
@@ -43,23 +44,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class CXXLiteralTest {
+public class CXXLiteralTest extends BaseTest {
 
   private TranslationConfiguration config;
 
   @BeforeEach
   void setUp() {
     config = TranslationConfiguration.builder().defaultPasses().build();
-  }
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
   }
 
   @Test

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLiteralTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLiteralTest.java
@@ -52,6 +52,16 @@ public class CXXLiteralTest {
     config = TranslationConfiguration.builder().defaultPasses().build();
   }
 
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
+
   @Test
   void testZeroIntegerLiterals() throws TranslationException {
     TranslationUnitDeclaration tu =

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLiteralTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLiteralTest.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class CXXLiteralTest extends BaseTest {
+class CXXLiteralTest extends BaseTest {
 
   private TranslationConfiguration config;
 

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXSymbolConfigurationTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXSymbolConfigurationTest.java
@@ -29,28 +29,16 @@ package de.fraunhofer.aisec.cpg.frontends.cpp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
 import de.fraunhofer.aisec.cpg.graph.*;
-import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.File;
 import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class CXXSymbolConfigurationTest {
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
-  }
-
+public class CXXSymbolConfigurationTest extends BaseTest {
   @Test
   void testWithoutSymbols() throws TranslationException {
     // parse without symbols

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXSymbolConfigurationTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXSymbolConfigurationTest.java
@@ -32,12 +32,25 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
 import de.fraunhofer.aisec.cpg.graph.*;
+import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.File;
 import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class CXXSymbolConfigurationTest {
+
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
+
   @Test
   void testWithoutSymbols() throws TranslationException {
     // parse without symbols

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXSymbolConfigurationTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXSymbolConfigurationTest.java
@@ -38,7 +38,7 @@ import java.io.File;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-public class CXXSymbolConfigurationTest extends BaseTest {
+class CXXSymbolConfigurationTest extends BaseTest {
   @Test
   void testWithoutSymbols() throws TranslationException {
     // parse without symbols

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/DemoTests.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/DemoTests.java
@@ -42,10 +42,10 @@ import java.nio.file.Paths;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class DemoTests extends BaseTest {
+class DemoTests extends BaseTest {
 
   @Test
-  public void testHierarchy() throws Exception {
+  void testHierarchy() throws Exception {
 
     //    assertTrue(Database.getInstance().connect(), "Couldn't connect to the database!");
     //    Database.getInstance().purgeDatabase();
@@ -74,7 +74,7 @@ public class DemoTests extends BaseTest {
   }
 
   @Test
-  public void testPartial() throws Exception {
+  void testPartial() throws Exception {
 
     Path topLevel = Paths.get("src/test/resources/partial");
 

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/DemoTests.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/DemoTests.java
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.frontends.java;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationManager;
 import de.fraunhofer.aisec.cpg.TranslationResult;
@@ -41,17 +42,7 @@ import java.nio.file.Paths;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class DemoTests {
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
-  }
+public class DemoTests extends BaseTest {
 
   @Test
   public void testHierarchy() throws Exception {

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/DemoTests.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/DemoTests.java
@@ -32,13 +32,26 @@ import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationManager;
 import de.fraunhofer.aisec.cpg.TranslationResult;
 import de.fraunhofer.aisec.cpg.graph.Node;
+import de.fraunhofer.aisec.cpg.graph.TypeManager;
+import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class DemoTests {
+
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
 
   @Test
   public void testHierarchy() throws Exception {

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaCfgTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaCfgTest.java
@@ -53,7 +53,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author julian
  */
-public class JavaCfgTest extends BaseTest {
+class JavaCfgTest extends BaseTest {
 
   /**
    * Tests do-while and while-do loops.

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaCfgTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaCfgTest.java
@@ -33,18 +33,14 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationManager;
 import de.fraunhofer.aisec.cpg.TranslationResult;
-import de.fraunhofer.aisec.cpg.graph.CompoundStatement;
-import de.fraunhofer.aisec.cpg.graph.IfStatement;
-import de.fraunhofer.aisec.cpg.graph.NamespaceDeclaration;
-import de.fraunhofer.aisec.cpg.graph.Node;
-import de.fraunhofer.aisec.cpg.graph.RecordDeclaration;
-import de.fraunhofer.aisec.cpg.graph.Statement;
-import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
+import de.fraunhofer.aisec.cpg.graph.*;
+import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker;
 import de.fraunhofer.aisec.cpg.passes.ControlFlowGraphPass;
 import java.io.File;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -53,6 +49,16 @@ import org.junit.jupiter.api.Test;
  * @author julian
  */
 public class JavaCfgTest {
+
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
 
   /**
    * Tests do-while and while-do loops.

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaCfgTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaCfgTest.java
@@ -30,17 +30,22 @@ import static de.fraunhofer.aisec.cpg.TestUtils.getByLineNr;
 import static de.fraunhofer.aisec.cpg.sarif.PhysicalLocation.locationLink;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationManager;
 import de.fraunhofer.aisec.cpg.TranslationResult;
-import de.fraunhofer.aisec.cpg.graph.*;
-import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
+import de.fraunhofer.aisec.cpg.graph.CompoundStatement;
+import de.fraunhofer.aisec.cpg.graph.IfStatement;
+import de.fraunhofer.aisec.cpg.graph.NamespaceDeclaration;
+import de.fraunhofer.aisec.cpg.graph.Node;
+import de.fraunhofer.aisec.cpg.graph.RecordDeclaration;
+import de.fraunhofer.aisec.cpg.graph.Statement;
+import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker;
 import de.fraunhofer.aisec.cpg.passes.ControlFlowGraphPass;
 import java.io.File;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -48,17 +53,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author julian
  */
-public class JavaCfgTest {
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
-  }
+public class JavaCfgTest extends BaseTest {
 
   /**
    * Tests do-while and while-do loops.

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
@@ -57,6 +57,16 @@ class JavaLanguageFrontendTest {
     config = TranslationConfiguration.builder().defaultPasses().build();
   }
 
+  /**
+   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
+   * all tests in order to avoid strange errors
+   */
+  @BeforeEach
+  void resetPersistentState() {
+    TypeParser.reset();
+    TypeManager.reset();
+  }
+
   @Test
   void testLargeNegativeNumber() throws TranslationException {
     TranslationUnitDeclaration tu =

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
@@ -481,7 +481,7 @@ class JavaLanguageFrontendTest extends BaseTest {
   }
 
   @Test
-  public void testLocation() throws TranslationException {
+  void testLocation() throws TranslationException {
     TranslationUnitDeclaration declaration =
         new JavaLanguageFrontend(TranslationConfiguration.builder().build(), new ScopeManager())
             .parse(new File("src/test/resources/compiling/FieldAccess.java"));

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.frontends.java;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
 import de.fraunhofer.aisec.cpg.graph.*;
@@ -48,23 +49,13 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class JavaLanguageFrontendTest {
+class JavaLanguageFrontendTest extends BaseTest {
 
   private TranslationConfiguration config;
 
   @BeforeEach
   void setUp() {
     config = TranslationConfiguration.builder().defaultPasses().build();
-  }
-
-  /**
-   * {@link TypeParser} and {@link TypeManager} hold static state. This needs to be cleared before
-   * all tests in order to avoid strange errors
-   */
-  @BeforeEach
-  void resetPersistentState() {
-    TypeParser.reset();
-    TypeManager.reset();
   }
 
   @Test


### PR DESCRIPTION
The fix to the type parser turned out to not be robust enough, in cases automatic cleanup after the analysis phase has to be skipped. Thus I fixed it in a better way now, and introduced measures to reset all statically held state before each and every unit test, to avoid undefined results in the future