### PR TITLE
Add private default constructors to types for OGM compatibility

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/type/FunctionPointerType.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/type/FunctionPointerType.java
@@ -15,6 +15,8 @@ public class FunctionPointerType extends Type {
     this.returnType = returnType;
   }
 
+  private FunctionPointerType() {}
+
   public FunctionPointerType(
       Type.Qualifier qualifier, Type.Storage storage, List<Type> parameters, Type returnType) {
     super("", storage, qualifier);

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/type/PointerType.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/type/PointerType.java
@@ -43,6 +43,8 @@ public class PointerType extends Type implements SecondOrderType {
 
   private PointerOrigin pointerOrigin;
 
+  private PointerType() {}
+
   public PointerType(Type elementType, PointerOrigin pointerOrigin) {
     super();
     if (pointerOrigin == PointerOrigin.ARRAY) {

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/type/ReferenceType.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/type/ReferenceType.java
@@ -38,6 +38,8 @@ public class ReferenceType extends Type implements SecondOrderType {
 
   private Type reference;
 
+  private ReferenceType() {}
+
   public ReferenceType(Type reference) {
     super();
     this.name = reference.getName() + "&";


### PR DESCRIPTION
Should close #137 in conjunction with Fraunhofer-AISEC/codyze#22