### PR TITLE
TranslationUnitDeclaration

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/TranslationUnitDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/TranslationUnitDeclaration.java
@@ -26,11 +26,10 @@
 
 package de.fraunhofer.aisec.cpg.graph;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 /** The top most declaration, representing a translation unit, for example a file. */
 public class TranslationUnitDeclaration extends Declaration {
@@ -52,19 +51,24 @@ public class TranslationUnitDeclaration extends Declaration {
   }
 
   /**
-   * This returns the first declaration of a specified type and clazz, if it exists.
+   * Returns a non-null, possibly empty {@code Set} of the declaration of a specified type and clazz.
+   *
+   * The set may contain more than one element if a declaration exists in the {@link TranslationUnitDeclaration}
+   * itself and in an included header file.
    *
    * @param name the name to search for
    * @param clazz the declaration class, such as {@link FunctionDeclaration}.
    * @param <T> the type of the declaration
-   * @return an optional containing the declaration if found
+   * @return a {@code Set} containing the declarations, if any.
    */
-  public <T extends Declaration> Optional<T> getDeclarationByName(String name, Class<T> clazz) {
+  @NonNull
+  public <T extends Declaration> Set<T> getDeclarationsByName(
+      @NonNull String name, @NonNull Class<T> clazz) {
     return this.declarations.stream()
         .filter(declaration -> clazz.isAssignableFrom(declaration.getClass()))
         .map(clazz::cast)
         .filter(declaration -> Objects.equals(declaration.getName(), name))
-        .findFirst();
+        .collect(Collectors.toSet());
   }
 
   public List<Declaration> getDeclarations() {
@@ -90,9 +94,10 @@ public class TranslationUnitDeclaration extends Declaration {
   public void add(Declaration decl) {
     if (decl instanceof IncludeDeclaration) {
       includes.add(decl);
-    } else {
-      declarations.add(decl);
+    } else if (decl instanceof NamespaceDeclaration) {
+      namespaces.add(decl);
     }
+    declarations.add(decl);
   }
 
   @Override

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/TranslationUnitDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/TranslationUnitDeclaration.java
@@ -36,25 +36,30 @@ public class TranslationUnitDeclaration extends Declaration {
 
   /** A list of declarations within this unit. */
   @SubGraph("AST")
+  @NonNull
   private List<Declaration> declarations = new ArrayList<>();
 
   /** A list of includes within this unit. */
   @SubGraph("AST")
+  @NonNull
   private List<Declaration> includes = new ArrayList<>();
 
   /** A list of namespaces within this unit. */
   @SubGraph("AST")
+  @NonNull
   private List<Declaration> namespaces = new ArrayList<>();
 
+  // TODO Fragile! May easily throw ClassCastException. Use visitor instead.
   public <T> T getDeclarationAs(int i, Class<T> clazz) {
     return clazz.cast(this.declarations.get(i));
   }
 
   /**
-   * Returns a non-null, possibly empty {@code Set} of the declaration of a specified type and clazz.
+   * Returns a non-null, possibly empty {@code Set} of the declaration of a specified type and
+   * clazz.
    *
-   * The set may contain more than one element if a declaration exists in the {@link TranslationUnitDeclaration}
-   * itself and in an included header file.
+   * <p>The set may contain more than one element if a declaration exists in the {@link
+   * TranslationUnitDeclaration} itself and in an included header file.
    *
    * @param name the name to search for
    * @param clazz the declaration class, such as {@link FunctionDeclaration}.
@@ -71,27 +76,22 @@ public class TranslationUnitDeclaration extends Declaration {
         .collect(Collectors.toSet());
   }
 
+  @NonNull
   public List<Declaration> getDeclarations() {
-    return declarations;
+    return Collections.unmodifiableList(declarations);
   }
 
-  public void setDeclarations(List<Declaration> declarations) {
-    this.declarations = declarations;
-  }
-
+  @NonNull
   public List<Declaration> getIncludes() {
-    return includes;
+    return Collections.unmodifiableList(includes);
   }
 
-  public void setIncludes(List<Declaration> includes) {
-    this.includes = includes;
-  }
-
+  @NonNull
   public List<Declaration> getNamespaces() {
-    return namespaces;
+    return Collections.unmodifiableList(namespaces);
   }
 
-  public void add(Declaration decl) {
+  public void add(@NonNull Declaration decl) {
     if (decl instanceof IncludeDeclaration) {
       includes.add(decl);
     } else if (decl instanceof NamespaceDeclaration) {

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.java
@@ -422,7 +422,7 @@ public class VariableUsageResolver extends Pass {
       } else {
         declaration.setType(type);
       }
-      currTu.getDeclarations().add(declaration);
+      currTu.add(declaration);
       declaration.setImplicit(true);
       return declaration;
     } else {

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXIncludeTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXIncludeTest.java
@@ -26,8 +26,7 @@
 
 package de.fraunhofer.aisec.cpg.frontends.cpp;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TestUtils;
@@ -36,6 +35,7 @@ import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation;
 import de.fraunhofer.aisec.cpg.sarif.Region;
 import java.io.File;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class CXXIncludeTest extends BaseTest {
@@ -45,25 +45,28 @@ class CXXIncludeTest extends BaseTest {
     File file = new File("src/test/resources/include.cpp");
     TranslationUnitDeclaration tu =
         TestUtils.analyzeAndGetFirstTU(List.of(file), file.getParentFile().toPath(), true);
-    assertEquals(4, tu.getDeclarations().size());
+    for (Declaration d : tu.getDeclarations()) {
+      System.out.println(d.getName() + " " + d.getLocation());
+    }
+    assertEquals(5, tu.getDeclarations().size());
 
-    RecordDeclaration someClass =
-        tu.getDeclarationByName("SomeClass", RecordDeclaration.class).orElse(null);
-    assertNotNull(someClass);
+    Set<RecordDeclaration> someClass =
+        tu.getDeclarationsByName("SomeClass", RecordDeclaration.class);
+    assertFalse(someClass.isEmpty());
 
-    FunctionDeclaration main =
-        tu.getDeclarationByName("main", FunctionDeclaration.class).orElse(null);
-    assertNotNull(main);
+    Set<FunctionDeclaration> main = tu.getDeclarationsByName("main", FunctionDeclaration.class);
+    assertFalse(main.isEmpty());
 
-    ConstructorDeclaration someClassConstructor =
-        tu.getDeclarationByName("SomeClass", ConstructorDeclaration.class).orElse(null);
-    assertNotNull(someClassConstructor);
-    assertEquals(someClass, someClassConstructor.getRecordDeclaration());
+    Set<ConstructorDeclaration> someClassConstructor =
+        tu.getDeclarationsByName("SomeClass", ConstructorDeclaration.class);
+    assertFalse(someClassConstructor.isEmpty());
+    assertEquals(
+        someClass.iterator().next(), someClassConstructor.iterator().next().getRecordDeclaration());
 
-    MethodDeclaration doSomething =
-        tu.getDeclarationByName("DoSomething", MethodDeclaration.class).orElse(null);
-    assertNotNull(doSomething);
-    assertEquals(someClass, doSomething.getRecordDeclaration());
+    Set<MethodDeclaration> doSomething =
+        tu.getDeclarationsByName("DoSomething", MethodDeclaration.class);
+    assertFalse(doSomething.isEmpty());
+    assertEquals(someClass.iterator().next(), doSomething.iterator().next().getRecordDeclaration());
   }
 
   @Test
@@ -73,11 +76,11 @@ class CXXIncludeTest extends BaseTest {
     TranslationUnitDeclaration tu =
         TestUtils.analyzeAndGetFirstTU(List.of(file), file.getParentFile().toPath(), true);
 
-    RecordDeclaration someClass =
-        tu.getDeclarationByName("SomeClass", RecordDeclaration.class).orElse(null);
-    assertNotNull(someClass);
+    Set<RecordDeclaration> someClass =
+        tu.getDeclarationsByName("SomeClass", RecordDeclaration.class);
+    assertFalse(someClass.isEmpty());
 
-    ConstructorDeclaration decl = someClass.getConstructors().get(0);
+    ConstructorDeclaration decl = someClass.iterator().next().getConstructors().get(0);
     assertEquals("SomeClass();", decl.getCode());
 
     PhysicalLocation location = decl.getLocation();

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
@@ -42,6 +42,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,16 +57,17 @@ class CXXLanguageFrontendTest extends BaseTest {
     TranslationUnitDeclaration tu =
         TestUtils.analyzeAndGetFirstTU(List.of(file), file.getParentFile().toPath(), true);
 
-    FunctionDeclaration main =
-        tu.getDeclarationByName("main", FunctionDeclaration.class).orElse(null);
-    assertNotNull(main);
+    @NonNull
+    Set<FunctionDeclaration> main = tu.getDeclarationsByName("main", FunctionDeclaration.class);
+    assertFalse(main.isEmpty());
 
-    VariableDeclaration ls = main.getVariableDeclarationByName("ls").orElse(null);
+    FunctionDeclaration decl = main.iterator().next();
+    VariableDeclaration ls = decl.getVariableDeclarationByName("ls").orElse(null);
     assertNotNull(ls);
     assertEquals(TypeParser.createFrom("std::vector<int>", true), ls.getType());
     assertEquals("ls", ls.getName());
 
-    ForEachStatement forEachStatement = main.getBodyStatementAs(1, ForEachStatement.class);
+    ForEachStatement forEachStatement = decl.getBodyStatementAs(1, ForEachStatement.class);
     assertNotNull(forEachStatement);
 
     // should loop over ls
@@ -85,11 +87,10 @@ class CXXLanguageFrontendTest extends BaseTest {
     TranslationUnitDeclaration tu =
         TestUtils.analyzeAndGetFirstTU(List.of(file), file.getParentFile().toPath(), true);
 
-    FunctionDeclaration main =
-        tu.getDeclarationByName("main", FunctionDeclaration.class).orElse(null);
-    assertNotNull(main);
+    Set<FunctionDeclaration> main = tu.getDeclarationsByName("main", FunctionDeclaration.class);
+    assertFalse(main.isEmpty());
 
-    TryStatement tryStatement = main.getBodyStatementAs(0, TryStatement.class);
+    TryStatement tryStatement = main.iterator().next().getBodyStatementAs(0, TryStatement.class);
     assertNotNull(tryStatement);
 
     List<CatchClause> catchClauses = tryStatement.getCatchClauses();
@@ -120,11 +121,11 @@ class CXXLanguageFrontendTest extends BaseTest {
     TranslationUnitDeclaration tu =
         TestUtils.analyzeAndGetFirstTU(List.of(file), file.getParentFile().toPath(), true);
 
-    FunctionDeclaration main =
-        tu.getDeclarationByName("main", FunctionDeclaration.class).orElse(null);
+    Set<FunctionDeclaration> main = tu.getDeclarationsByName("main", FunctionDeclaration.class);
     assertNotNull(main);
 
-    VariableDeclaration i = main.getVariableDeclarationByName("i").orElse(null);
+    FunctionDeclaration funcDecl = main.iterator().next();
+    VariableDeclaration i = funcDecl.getVariableDeclarationByName("i").orElse(null);
     assertNotNull(i);
 
     TypeIdExpression sizeof = (TypeIdExpression) i.getInitializer();
@@ -132,7 +133,7 @@ class CXXLanguageFrontendTest extends BaseTest {
     assertEquals("sizeof", sizeof.getName());
     assertEquals(TypeParser.createFrom("std::size_t", true), sizeof.getType());
 
-    VariableDeclaration typeInfo = main.getVariableDeclarationByName("typeInfo").orElse(null);
+    VariableDeclaration typeInfo = funcDecl.getVariableDeclarationByName("typeInfo").orElse(null);
     assertNotNull(typeInfo);
 
     TypeIdExpression typeid = (TypeIdExpression) typeInfo.getInitializer();
@@ -140,7 +141,7 @@ class CXXLanguageFrontendTest extends BaseTest {
     assertEquals("typeid", typeid.getName());
     assertEquals(TypeParser.createFrom("const std::type_info&", true), typeid.getType());
 
-    VariableDeclaration j = main.getVariableDeclarationByName("j").orElse(null);
+    VariableDeclaration j = funcDecl.getVariableDeclarationByName("j").orElse(null);
     assertNotNull(j);
 
     TypeIdExpression alignof = (TypeIdExpression) j.getInitializer();
@@ -1033,11 +1034,10 @@ class CXXLanguageFrontendTest extends BaseTest {
     TranslationUnitDeclaration tu =
         TestUtils.analyzeAndGetFirstTU(List.of(file), file.getParentFile().toPath(), true);
 
-    FunctionDeclaration main =
-        tu.getDeclarationByName("main", FunctionDeclaration.class).orElse(null);
-    assertNotNull(main);
+    Set<FunctionDeclaration> main = tu.getDeclarationsByName("main", FunctionDeclaration.class);
+    assertFalse(main.isEmpty());
 
-    PhysicalLocation location = main.getLocation();
+    PhysicalLocation location = main.iterator().next().getLocation();
 
     assertNotNull(location);
 

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLiteralTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLiteralTest.java
@@ -26,8 +26,7 @@
 
 package de.fraunhofer.aisec.cpg.frontends.cpp;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TestUtils;
@@ -38,6 +37,7 @@ import java.io.File;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -50,18 +50,19 @@ class CXXLiteralTest extends BaseTest {
     TranslationUnitDeclaration tu =
         TestUtils.analyzeAndGetFirstTU(List.of(file), file.getParentFile().toPath(), true);
 
-    FunctionDeclaration zero =
-        tu.getDeclarationByName("zero", FunctionDeclaration.class).orElse(null);
-    assertNotNull(zero);
-    assertEquals("zero", zero.getName());
+    Set<FunctionDeclaration> zero = tu.getDeclarationsByName("zero", FunctionDeclaration.class);
+    assertFalse(zero.isEmpty());
+    FunctionDeclaration funcDecl = zero.iterator().next();
+    assertEquals("zero", funcDecl.getName());
 
-    assertLiteral(0, TypeParser.createFrom("int", true), zero, "i");
-    assertLiteral(0L, TypeParser.createFrom("long", true), zero, "l_with_suffix");
-    assertLiteral(0L, TypeParser.createFrom("long long", true), zero, "l_long_long_with_suffix");
+    assertLiteral(0, TypeParser.createFrom("int", true), funcDecl, "i");
+    assertLiteral(0L, TypeParser.createFrom("long", true), funcDecl, "l_with_suffix");
+    assertLiteral(
+        0L, TypeParser.createFrom("long long", true), funcDecl, "l_long_long_with_suffix");
     assertLiteral(
         BigInteger.valueOf(0),
         TypeParser.createFrom("unsigned long long", true),
-        zero,
+        funcDecl,
         "l_unsigned_long_long_with_suffix");
   }
 
@@ -71,35 +72,36 @@ class CXXLiteralTest extends BaseTest {
     TranslationUnitDeclaration tu =
         TestUtils.analyzeAndGetFirstTU(List.of(file), file.getParentFile().toPath(), true);
 
-    FunctionDeclaration decimal =
-        tu.getDeclarationByName("decimal", FunctionDeclaration.class).orElse(null);
-    assertNotNull(decimal);
-    assertEquals("decimal", decimal.getName());
+    Set<FunctionDeclaration> decimal =
+        tu.getDeclarationsByName("decimal", FunctionDeclaration.class);
+    assertFalse(decimal.isEmpty());
+    FunctionDeclaration funcDecl = decimal.iterator().next();
+    assertEquals("decimal", funcDecl.getName());
 
-    assertLiteral(42, TypeParser.createFrom("int", true), decimal, "i");
-    assertLiteral(9223372036854775807L, TypeParser.createFrom("long", true), decimal, "l");
+    assertLiteral(42, TypeParser.createFrom("int", true), funcDecl, "i");
+    assertLiteral(9223372036854775807L, TypeParser.createFrom("long", true), funcDecl, "l");
     assertLiteral(
-        9223372036854775807L, TypeParser.createFrom("long", true), decimal, "l_with_suffix");
+        9223372036854775807L, TypeParser.createFrom("long", true), funcDecl, "l_with_suffix");
     assertLiteral(
         9223372036854775807L,
         TypeParser.createFrom("long long", true),
-        decimal,
+        funcDecl,
         "l_long_long_with_suffix");
 
     assertLiteral(
         new BigInteger("9223372036854775809"),
         TypeParser.createFrom("unsigned long", true),
-        decimal,
+        funcDecl,
         "l_unsigned_long_with_suffix");
     assertLiteral(
         new BigInteger("9223372036854775808"),
         TypeParser.createFrom("unsigned long long", true),
-        decimal,
+        funcDecl,
         "l_long_long_implicit");
     assertLiteral(
         new BigInteger("9223372036854775809"),
         TypeParser.createFrom("unsigned long long", true),
-        decimal,
+        funcDecl,
         "l_unsigned_long_long_with_suffix");
   }
 
@@ -109,17 +111,17 @@ class CXXLiteralTest extends BaseTest {
     TranslationUnitDeclaration tu =
         TestUtils.analyzeAndGetFirstTU(List.of(file), file.getParentFile().toPath(), true);
 
-    FunctionDeclaration octal =
-        tu.getDeclarationByName("octal", FunctionDeclaration.class).orElse(null);
-    assertNotNull(octal);
-    assertEquals("octal", octal.getName());
+    Set<FunctionDeclaration> octal = tu.getDeclarationsByName("octal", FunctionDeclaration.class);
+    assertFalse(octal.isEmpty());
+    FunctionDeclaration funcDecl = octal.iterator().next();
+    assertEquals("octal", funcDecl.getName());
 
-    assertLiteral(42, TypeParser.createFrom("int", true), octal, "i");
-    assertLiteral(42L, TypeParser.createFrom("long", true), octal, "l_with_suffix");
+    assertLiteral(42, TypeParser.createFrom("int", true), funcDecl, "i");
+    assertLiteral(42L, TypeParser.createFrom("long", true), funcDecl, "l_with_suffix");
     assertLiteral(
         BigInteger.valueOf(42),
         TypeParser.createFrom("unsigned long long", true),
-        octal,
+        funcDecl,
         "l_unsigned_long_long_with_suffix");
   }
 
@@ -130,17 +132,17 @@ class CXXLiteralTest extends BaseTest {
     TranslationUnitDeclaration tu =
         TestUtils.analyzeAndGetFirstTU(List.of(file), file.getParentFile().toPath(), true);
 
-    FunctionDeclaration functionDeclaration =
-        tu.getDeclarationByName("hex", FunctionDeclaration.class).orElse(null);
-    assertNotNull(functionDeclaration);
-    assertEquals("hex", functionDeclaration.getName());
+    Set<FunctionDeclaration> hex = tu.getDeclarationsByName("hex", FunctionDeclaration.class);
+    assertNotNull(hex.isEmpty());
+    FunctionDeclaration funcDecl = hex.iterator().next();
+    assertEquals("hex", funcDecl.getName());
 
-    assertLiteral(42, TypeParser.createFrom("int", true), functionDeclaration, "i");
-    assertLiteral(42L, TypeParser.createFrom("long", true), functionDeclaration, "l_with_suffix");
+    assertLiteral(42, TypeParser.createFrom("int", true), funcDecl, "i");
+    assertLiteral(42L, TypeParser.createFrom("long", true), funcDecl, "l_with_suffix");
     assertLiteral(
         BigInteger.valueOf(42),
         TypeParser.createFrom("unsigned long long", true),
-        functionDeclaration,
+        funcDecl,
         "l_unsigned_long_long_with_suffix");
   }
 
@@ -150,11 +152,11 @@ class CXXLiteralTest extends BaseTest {
     TranslationUnitDeclaration tu =
         TestUtils.analyzeAndGetFirstTU(List.of(file), file.getParentFile().toPath(), true);
 
-    FunctionDeclaration main =
-        tu.getDeclarationByName("main", FunctionDeclaration.class).orElse(null);
-    assertNotNull(main);
+    Set<FunctionDeclaration> main = tu.getDeclarationsByName("main", FunctionDeclaration.class);
+    assertFalse(main.isEmpty());
+    FunctionDeclaration funcDecl = main.iterator().next();
 
-    VariableDeclaration a = main.getVariableDeclarationByName("a").orElse(null);
+    VariableDeclaration a = funcDecl.getVariableDeclarationByName("a").orElse(null);
     assertNotNull(a);
     assertEquals(
         1,
@@ -166,21 +168,21 @@ class CXXLiteralTest extends BaseTest {
     // in an integer, it should be automatically converted to a long. The resulting value
     // -2147483648 however is small enough to fit into an int, so it is ok for the variable a to
     // have an int type
-    VariableDeclaration b = main.getVariableDeclarationByName("b").orElse(null);
+    VariableDeclaration b = funcDecl.getVariableDeclarationByName("b").orElse(null);
     assertNotNull(b);
     assertEquals(
         2147483648L,
         ((Literal) Objects.requireNonNull(b.getInitializerAs(UnaryOperator.class)).getInput())
             .getValue());
 
-    VariableDeclaration c = main.getVariableDeclarationByName("c").orElse(null);
+    VariableDeclaration c = funcDecl.getVariableDeclarationByName("c").orElse(null);
     assertNotNull(c);
     assertEquals(
         2147483649L,
         ((Literal) Objects.requireNonNull(c.getInitializerAs(UnaryOperator.class)).getInput())
             .getValue());
 
-    VariableDeclaration d = main.getVariableDeclarationByName("d").orElse(null);
+    VariableDeclaration d = funcDecl.getVariableDeclarationByName("d").orElse(null);
     assertNotNull(d);
     assertEquals(
         new BigInteger("9223372036854775808"),

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLiteralTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLiteralTest.java
@@ -133,7 +133,7 @@ class CXXLiteralTest extends BaseTest {
         TestUtils.analyzeAndGetFirstTU(List.of(file), file.getParentFile().toPath(), true);
 
     Set<FunctionDeclaration> hex = tu.getDeclarationsByName("hex", FunctionDeclaration.class);
-    assertNotNull(hex.isEmpty());
+    assertFalse(hex.isEmpty());
     FunctionDeclaration funcDecl = hex.iterator().next();
     assertEquals("hex", funcDecl.getName());
 

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXSymbolConfigurationTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXSymbolConfigurationTest.java
@@ -26,8 +26,7 @@
 
 package de.fraunhofer.aisec.cpg.frontends.cpp;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
@@ -36,6 +35,7 @@ import de.fraunhofer.aisec.cpg.graph.*;
 import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.File;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class CXXSymbolConfigurationTest extends BaseTest {
@@ -47,11 +47,11 @@ class CXXSymbolConfigurationTest extends BaseTest {
                 TranslationConfiguration.builder().defaultPasses().build(), new ScopeManager())
             .parse(new File("src/test/resources/symbols.cpp"));
 
-    FunctionDeclaration main =
-        tu.getDeclarationByName("main", FunctionDeclaration.class).orElse(null);
-    assertNotNull(main);
+    Set<FunctionDeclaration> main = tu.getDeclarationsByName("main", FunctionDeclaration.class);
+    assertFalse(main.isEmpty());
+    FunctionDeclaration funcDecl = main.iterator().next();
 
-    BinaryOperator binaryOperator = main.getBodyStatementAs(0, BinaryOperator.class);
+    BinaryOperator binaryOperator = funcDecl.getBodyStatementAs(0, BinaryOperator.class);
     assertNotNull(binaryOperator);
 
     // without additional symbols, the first line will look like a reference (to something we do not
@@ -60,7 +60,7 @@ class CXXSymbolConfigurationTest extends BaseTest {
     assertNotNull(dre);
     assertEquals("HELLO_WORLD", dre.getName());
 
-    binaryOperator = main.getBodyStatementAs(1, BinaryOperator.class);
+    binaryOperator = funcDecl.getBodyStatementAs(1, BinaryOperator.class);
     assertNotNull(binaryOperator);
 
     // without additional symbols, the second line will look like a function call (to something we
@@ -85,18 +85,18 @@ class CXXSymbolConfigurationTest extends BaseTest {
                 new ScopeManager())
             .parse(new File("src/test/resources/symbols.cpp"));
 
-    FunctionDeclaration main =
-        tu.getDeclarationByName("main", FunctionDeclaration.class).orElse(null);
-    assertNotNull(main);
+    Set<FunctionDeclaration> main = tu.getDeclarationsByName("main", FunctionDeclaration.class);
+    assertFalse(main.isEmpty());
+    FunctionDeclaration funcDecl = main.iterator().next();
 
-    BinaryOperator binaryOperator = main.getBodyStatementAs(0, BinaryOperator.class);
+    BinaryOperator binaryOperator = funcDecl.getBodyStatementAs(0, BinaryOperator.class);
     assertNotNull(binaryOperator);
 
     // should be a literal now
     Literal<?> literal = binaryOperator.getRhsAs(Literal.class);
     assertEquals("Hello World", literal.getValue());
 
-    binaryOperator = main.getBodyStatementAs(1, BinaryOperator.class);
+    binaryOperator = funcDecl.getBodyStatementAs(1, BinaryOperator.class);
     assertNotNull(binaryOperator);
 
     // should be expanded to another binary operation 1+1


### PR DESCRIPTION
This PR fixes three issues:

1) `TranslationUnitDeclaration.getDeclarationByName()` was pretty useless, as it non-deterministically returned a single element from a set in form of an Optional. Now returns a non-null, possibly empty `Set` has has been renamed to `getDeclarationsByName()`(plural)

2) Bug in `TranslationUnitDeclaration.add(Declaration)` was not never adding `NamespaceDeclaration`s and did not always add to `declarations` list.

3) Adding items to `declarations` list was a bit chaotic: Sometimes using `add()` method, sometimes adding via getter. Has been unified to `add()` now, getters return `UnmodifiableList`.