### PR TITLE
Fix: MemberCalls with MemberExpressions

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
@@ -32,9 +32,10 @@ import de.fraunhofer.aisec.cpg.graph.*;
 import de.fraunhofer.aisec.cpg.graph.type.FunctionPointerType;
 import de.fraunhofer.aisec.cpg.graph.type.Type;
 import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
-import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker;
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker.ScopedWalker;
 import de.fraunhofer.aisec.cpg.helpers.Util;
+import de.fraunhofer.aisec.cpg.processing.IVisitor;
+import de.fraunhofer.aisec.cpg.processing.strategy.Strategy;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -263,7 +264,13 @@ public class CallResolver extends Pass {
       if (curr instanceof CallExpression) {
         resolve(curr, curClass);
       } else {
-        SubgraphWalker.getAstChildren(curr).forEach(worklist::push);
+        curr.accept(
+            Strategy::AST_FORWARD,
+            new IVisitor<Node>() {
+              public void visit(ValueDeclaration t) {
+                worklist.push(t);
+              }
+            });
       }
     }
   }

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
@@ -35,6 +35,8 @@ import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.helpers.NodeComparator;
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker;
 import de.fraunhofer.aisec.cpg.helpers.Util;
+import de.fraunhofer.aisec.cpg.processing.IVisitor;
+import de.fraunhofer.aisec.cpg.processing.strategy.Strategy;
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation;
 import de.fraunhofer.aisec.cpg.sarif.Region;
 import java.io.File;
@@ -459,6 +461,26 @@ class JavaLanguageFrontendTest extends BaseTest {
     assertNotNull(length);
     assertEquals("length", length.getMember().getName());
     assertEquals("int", length.getType().getTypeName());
+  }
+
+  @Test
+  void testMemberCallExpressions() throws Exception {
+    File file = new File("src/test/resources/compiling/MemberCallExpression.java");
+    TranslationUnitDeclaration tu =
+        TestUtils.analyzeAndGetFirstTU(List.of(file), file.getParentFile().toPath(), true);
+
+    assertNotNull(tu);
+
+    // Simply count MemberCallExpressions
+    final int[] count = {0};
+    tu.accept(
+        Strategy::AST_FORWARD,
+        new IVisitor<Node>() {
+          public void visit(MemberCallExpression ex) {
+            count[0]++;
+          }
+        });
+    assertEquals(6, count[0]);
   }
 
   @Test

--- a/src/test/resources/compiling/MemberCallExpression.java
+++ b/src/test/resources/compiling/MemberCallExpression.java
@@ -1,0 +1,43 @@
+/**
+ * Tests for different ways of providing argument to method calls.
+ *
+ * Resolution is expected to cope with all of them.
+ */
+public class CT {
+
+	public static final int CONSTANT = 3;
+
+	enum Color
+	{
+		RED, GREEN, BLUE;
+	}
+
+	public static void main(String[] args){
+		CT c = new CT();
+
+		// Enum as argument
+		c.foo(Color.RED);
+
+		// Field as argument
+		c.bar(CT.CONSTANT);
+
+		// Constant as argument
+		c.bar(3);
+
+		// Expression as argument
+		c.bar(2+1);
+
+		// MethodCallExpression as argument
+		c.bar(c.red());
+	}
+
+	private void bar(int constant) {
+	}
+
+	private void foo(Color red) {
+	}
+
+	private int red() {
+		return 0;
+	}
+}


### PR DESCRIPTION
MemberCallExpressions with MemberExpressions as arguments could result in infinite recursion when the `base` of a MemberExpression refers to the 'RecordDeclaration` that contains the original MemberCallExpression.

Resolution of arguments is now limited to `ValueDeclarations`.

With the new type system, I suggest using a `Type` object rather than the `RecordDeclaration` as the value for a `base`.