### PR TITLE
Fix: Field "fqn" of CallExpression/MemberCallExpression must not contain modifiers "*" or "[]" for PointerTypes

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.java
@@ -392,14 +392,15 @@ class ExpressionHandler extends Handler<Expression, IASTInitializerClause, CXXLa
 
     CallExpression callExpression;
     if (reference instanceof MemberExpression) {
-      String baseTypename =
-          ((Expression) ((MemberExpression) reference).getBase()).getType().getTypeName();
-      // FIXME this is only true if we are in a namespace! If we are in a class, this is wrong!
-      //  happens again in l398
-      // String fullNamePrefix = lang.getScopeManager().getFullNamePrefix();
-      // if (!fullNamePrefix.isEmpty()) {
-      //  baseTypename = fullNamePrefix + "." + baseTypename;
-      // }
+      String baseTypename;
+      // Pointer types contain * or []. We do not want that here.
+      Type baseType = ((Expression) ((MemberExpression) reference).getBase()).getType();
+      if (baseType instanceof PointerType) {
+        baseTypename = (((PointerType) baseType).getElementType().getTypeName());
+      } else {
+        baseTypename = baseType.getTypeName();
+      }
+
       callExpression =
           NodeBuilder.newMemberCallExpression(
               ((MemberExpression) reference).getMember().getName(),

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.java
@@ -31,10 +31,7 @@ import static de.fraunhofer.aisec.cpg.helpers.Util.warnWithFileLocation;
 
 import de.fraunhofer.aisec.cpg.frontends.Handler;
 import de.fraunhofer.aisec.cpg.graph.*;
-import de.fraunhofer.aisec.cpg.graph.type.PointerType;
-import de.fraunhofer.aisec.cpg.graph.type.Type;
-import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
-import de.fraunhofer.aisec.cpg.graph.type.UnknownType;
+import de.fraunhofer.aisec.cpg.graph.type.*;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
@@ -394,12 +391,9 @@ class ExpressionHandler extends Handler<Expression, IASTInitializerClause, CXXLa
     if (reference instanceof MemberExpression) {
       String baseTypename;
       // Pointer types contain * or []. We do not want that here.
-      Type baseType = ((Expression) ((MemberExpression) reference).getBase()).getType();
-      if (baseType instanceof PointerType) {
-        baseTypename = (((PointerType) baseType).getElementType().getTypeName());
-      } else {
-        baseTypename = baseType.getTypeName();
-      }
+      Type baseType = ((Expression) ((MemberExpression) reference).getBase()).getType().getRoot();
+      assert !(baseType instanceof SecondOrderType);
+      baseTypename = baseType.getTypeName();
 
       callExpression =
           NodeBuilder.newMemberCallExpression(

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/CallExpression.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/CallExpression.java
@@ -27,7 +27,6 @@
 package de.fraunhofer.aisec.cpg.graph;
 
 import de.fraunhofer.aisec.cpg.graph.HasType.TypeListener;
-import de.fraunhofer.aisec.cpg.graph.type.PointerType;
 import de.fraunhofer.aisec.cpg.graph.type.Type;
 import de.fraunhofer.aisec.cpg.helpers.Util;
 import java.util.*;
@@ -112,11 +111,7 @@ public class CallExpression extends Expression implements TypeListener {
   @Override
   public void typeChanged(HasType src, HasType root, Type oldType) {
     if (src == base) {
-      if (src.getType() instanceof PointerType) {
-        setFqn(((PointerType) src.getType()).getElementType().getTypeName() + "." + this.getName());
-      } else {
-        setFqn(src.getType().getTypeName() + "." + this.getName());
-      }
+      setFqn(src.getType().getRoot().getTypeName() + "." + this.getName());
     } else {
       Type previous = this.type;
       List<Type> types =

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/CallExpression.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/CallExpression.java
@@ -27,6 +27,7 @@
 package de.fraunhofer.aisec.cpg.graph;
 
 import de.fraunhofer.aisec.cpg.graph.HasType.TypeListener;
+import de.fraunhofer.aisec.cpg.graph.type.PointerType;
 import de.fraunhofer.aisec.cpg.graph.type.Type;
 import de.fraunhofer.aisec.cpg.helpers.Util;
 import java.util.*;

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/CallExpression.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/CallExpression.java
@@ -111,7 +111,11 @@ public class CallExpression extends Expression implements TypeListener {
   @Override
   public void typeChanged(HasType src, HasType root, Type oldType) {
     if (src == base) {
-      setFqn(src.getType().getTypeName() + "." + this.getName());
+      if (src.getType() instanceof PointerType) {
+        setFqn(((PointerType) src.getType()).getElementType().getTypeName() + "." + this.getName());
+      } else {
+        setFqn(src.getType().getTypeName() + "." + this.getName());
+      }
     } else {
       Type previous = this.type;
       List<Type> types =


### PR DESCRIPTION
Codyze relies on the fact that type names in the "fqn" field of `CallExpression`/`MemberCallExpression` do not have any pointer modifiers.

The new type system introduced such modifiers and was simply copying them into the `fqn` field. This PR leaves `Type.getTypeName()` untouched but restores the original representation in `MemberCallExpression.fqn`.