### PR TITLE
Correctly setting the type of a CPP simple declaration

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
@@ -339,7 +339,7 @@ public class DeclarationHandler extends Handler<Declaration, IASTDeclaration, CX
   static String getTypeStringFromDeclarator(
       IASTDeclarator declarator, IASTDeclSpecifier declSpecifier) {
     // use the declaration specifier as basis
-    StringBuilder typeString = new StringBuilder(declSpecifier.getRawSignature());
+    StringBuilder typeString = new StringBuilder(declSpecifier.toString());
 
     // append names, pointer operators and array modifiers and such
     for (IASTNode node : declarator.getChildren()) {

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
@@ -27,6 +27,7 @@
 package de.fraunhofer.aisec.cpg.frontends.cpp;
 
 import static de.fraunhofer.aisec.cpg.helpers.Util.errorWithFileLocation;
+import static de.fraunhofer.aisec.cpg.helpers.Util.getRawFunctionReturnType;
 
 import de.fraunhofer.aisec.cpg.frontends.Handler;
 import de.fraunhofer.aisec.cpg.graph.*;
@@ -109,9 +110,10 @@ public class DeclarationHandler extends Handler<Declaration, IASTDeclaration, CX
 
     lang.getScopeManager().enterScope(functionDeclaration);
 
-    functionDeclaration.setType(
-        TypeParser.createFrom(
-            ctx.getRawSignature().split(functionDeclaration.getName())[0].trim(), true));
+    // use our own version, since the decl specifier might be imprecise, i.e. not having pointers
+    typeString = getRawFunctionReturnType(functionDeclaration, ctx.getRawSignature());
+
+    functionDeclaration.setType(TypeParser.createFrom(typeString, true));
 
     if (ctx.getBody() != null) {
       Statement bodyStatement = this.lang.getStatementHandler().handle(ctx.getBody());

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationListHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationListHandler.java
@@ -26,7 +26,7 @@
 
 package de.fraunhofer.aisec.cpg.frontends.cpp;
 
-import static de.fraunhofer.aisec.cpg.helpers.Util.getRawFunctionReturnType;
+import static de.fraunhofer.aisec.cpg.frontends.cpp.DeclarationHandler.getTypeStringFromDeclarator;
 
 import de.fraunhofer.aisec.cpg.frontends.Handler;
 import de.fraunhofer.aisec.cpg.graph.Declaration;
@@ -60,14 +60,9 @@ class DeclarationListHandler
           (ValueDeclaration) this.lang.getDeclaratorHandler().handle(declarator);
 
       String typeString;
-      if (declaration instanceof FunctionDeclaration) {
-        // if it is a function definition, we are only interested in the return type
-        typeString =
-            getRawFunctionReturnType((FunctionDeclaration) declaration, ctx.getRawSignature());
-      } else if (declaration instanceof VariableDeclaration) {
-        // if it is a variable declaration, we are only interested in the declaration, not the
-        // initializer (if any)
-        typeString = ctx.getRawSignature().split("[=]")[0];
+      if (declaration instanceof FunctionDeclaration
+          || declaration instanceof VariableDeclaration) {
+        typeString = getTypeStringFromDeclarator(declarator, ctx.getDeclSpecifier());
       } else {
         // otherwise, use the complete raw code and let the type parser handle it
         typeString = ctx.getRawSignature();

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationListHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationListHandler.java
@@ -35,7 +35,6 @@ import de.fraunhofer.aisec.cpg.graph.type.Type;
 import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import java.util.ArrayList;
 import java.util.List;
-import org.eclipse.cdt.core.dom.ast.IASTDeclSpecifier;
 import org.eclipse.cdt.core.dom.ast.IASTDeclaration;
 import org.eclipse.cdt.core.dom.ast.IASTDeclarator;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTSimpleDeclaration;
@@ -58,12 +57,10 @@ class DeclarationListHandler
       ValueDeclaration declaration =
           (ValueDeclaration) this.lang.getDeclaratorHandler().handle(declarator);
 
-      IASTDeclSpecifier declSpecifier = ctx.getDeclSpecifier();
-
       String typeString;
       if (declaration instanceof FunctionDeclaration) {
         // if it is a function definition, we are only interested in the return type
-        typeString = ctx.getRawSignature().split("[ ]")[0];
+        typeString = ctx.getRawSignature().split(declaration.getName())[0].trim();
       } else if (declaration instanceof VariableDeclaration) {
         // if it is a variable declaration, we are only interested in the declaration, not the
         // initializer (if any)

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationListHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationListHandler.java
@@ -33,11 +33,14 @@ import de.fraunhofer.aisec.cpg.graph.ValueDeclaration;
 import de.fraunhofer.aisec.cpg.graph.VariableDeclaration;
 import de.fraunhofer.aisec.cpg.graph.type.Type;
 import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
+
 import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.cdt.core.dom.ast.IASTDeclaration;
 import org.eclipse.cdt.core.dom.ast.IASTDeclarator;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTSimpleDeclaration;
+
+import static de.fraunhofer.aisec.cpg.helpers.Util.getRawFunctionReturnType;
 
 class DeclarationListHandler
     extends Handler<List<Declaration>, IASTDeclaration, CXXLanguageFrontend> {
@@ -60,7 +63,8 @@ class DeclarationListHandler
       String typeString;
       if (declaration instanceof FunctionDeclaration) {
         // if it is a function definition, we are only interested in the return type
-        typeString = ctx.getRawSignature().split(declaration.getName())[0].trim();
+        typeString =
+            getRawFunctionReturnType((FunctionDeclaration) declaration, ctx.getRawSignature());
       } else if (declaration instanceof VariableDeclaration) {
         // if it is a variable declaration, we are only interested in the declaration, not the
         // initializer (if any)

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationListHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationListHandler.java
@@ -26,6 +26,8 @@
 
 package de.fraunhofer.aisec.cpg.frontends.cpp;
 
+import static de.fraunhofer.aisec.cpg.helpers.Util.getRawFunctionReturnType;
+
 import de.fraunhofer.aisec.cpg.frontends.Handler;
 import de.fraunhofer.aisec.cpg.graph.Declaration;
 import de.fraunhofer.aisec.cpg.graph.FunctionDeclaration;
@@ -33,14 +35,11 @@ import de.fraunhofer.aisec.cpg.graph.ValueDeclaration;
 import de.fraunhofer.aisec.cpg.graph.VariableDeclaration;
 import de.fraunhofer.aisec.cpg.graph.type.Type;
 import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
-
 import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.cdt.core.dom.ast.IASTDeclaration;
 import org.eclipse.cdt.core.dom.ast.IASTDeclarator;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTSimpleDeclaration;
-
-import static de.fraunhofer.aisec.cpg.helpers.Util.getRawFunctionReturnType;
 
 class DeclarationListHandler
     extends Handler<List<Declaration>, IASTDeclaration, CXXLanguageFrontend> {

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationListHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationListHandler.java
@@ -55,7 +55,7 @@ class DeclarationListHandler
       ValueDeclaration declaration =
           (ValueDeclaration) this.lang.getDeclaratorHandler().handle(declarator);
 
-      Type result = TypeParser.createFrom(ctx.getRawSignature(), true);
+      Type result = TypeParser.createFrom(ctx.getDeclSpecifier().toString(), true);
       declaration.setType(result);
 
       // cache binding

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.java
@@ -92,6 +92,14 @@ class DeclaratorHandler extends Handler<Declaration, IASTNameOwner, CXXLanguageF
     }
     String name = ctx.getName().toString();
 
+    /* as always, there are some special cases to consider and one of those are C++ operators.
+     * They are regarded as functions and eclipse CDT for some reason introduces a whitespace in the function name, which will complicate things later on
+     */
+
+    if (name.startsWith("operator")) {
+      name = name.replace(" ", "");
+    }
+
     FunctionDeclaration declaration;
 
     // check for function definitions that are really methods and constructors

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.java
@@ -69,7 +69,12 @@ class DeclaratorHandler extends Handler<Declaration, IASTNameOwner, CXXLanguageF
     }
   }
 
-  private VariableDeclaration handleDeclarator(CPPASTDeclarator ctx) {
+  private Declaration handleDeclarator(CPPASTDeclarator ctx) {
+    // this is just a nested declarator, i.e. () wrapping the real declarator
+    if (ctx.getInitializer() == null && ctx.getNestedDeclarator() instanceof CPPASTDeclarator) {
+      return handle(ctx.getNestedDeclarator());
+    }
+
     // type will be filled out later
     VariableDeclaration declaration =
         NodeBuilder.newVariableDeclaration(
@@ -92,10 +97,10 @@ class DeclaratorHandler extends Handler<Declaration, IASTNameOwner, CXXLanguageF
     }
     String name = ctx.getName().toString();
 
-    /* as always, there are some special cases to consider and one of those are C++ operators.
+    /*
+     * As always, there are some special cases to consider and one of those are C++ operators.
      * They are regarded as functions and eclipse CDT for some reason introduces a whitespace in the function name, which will complicate things later on
      */
-
     if (name.startsWith("operator")) {
       name = name.replace(" ", "");
     }
@@ -162,8 +167,8 @@ class DeclaratorHandler extends Handler<Declaration, IASTNameOwner, CXXLanguageF
     // unfortunately we are not told whether this is a field or not, so we have to find it out
     // ourselves
     ValueDeclaration result;
-    FunctionDeclaration currFunction = lang.getScopeManager().getCurrentFunction();
-    if (currFunction != null) {
+    RecordDeclaration recordDeclaration = lang.getScopeManager().getCurrentRecord();
+    if (recordDeclaration == null) {
       // variable
       result =
           NodeBuilder.newVariableDeclaration(
@@ -172,9 +177,6 @@ class DeclaratorHandler extends Handler<Declaration, IASTNameOwner, CXXLanguageF
               ctx.getRawSignature(),
               true);
       ((VariableDeclaration) result).setInitializer(initializer);
-      result.setLocation(lang.getLocationFromRawNode(ctx));
-      result.setType(TypeParser.createFrom(ctx.getParent().getRawSignature(), true));
-      result.refreshType();
     } else {
       // field
       String code = ctx.getRawSignature();
@@ -193,10 +195,33 @@ class DeclaratorHandler extends Handler<Declaration, IASTNameOwner, CXXLanguageF
               lang.getLocationFromRawNode(ctx),
               initializer,
               true);
-      result.setLocation(lang.getLocationFromRawNode(ctx));
-      result.setType(TypeParser.createFrom(ctx.getParent().getRawSignature(), true));
-      result.refreshType();
     }
+
+    /*
+     * Now it gets tricky, because we are looking for the parent declaration to get the full
+     * raw signature. However it could be that the declarator is wrapped in nested declarators,
+     * so we need to loop.
+     *
+     * Comment from @oxisto: I think it would still be better to parse the type in the handleSimpleDeclaration
+     * and going downwards into the decl-specifiers and declarator and see whether we can re-construct them in
+     * the correct order for the function type rather than going upwards from the declarator and use the raw string,
+     * but that is the way it is for now.
+     */
+    IASTNode parent = ctx.getParent();
+
+    while (parent != null && !(parent instanceof CPPASTSimpleDeclaration)) {
+      parent = parent.getParent();
+    }
+
+    if (parent != null) {
+      result.setType(TypeParser.createFrom(parent.getRawSignature(), true));
+      result.refreshType();
+    } else {
+      log.warn("Could not find suitable parent ast node for function pointer node: {}", this);
+    }
+
+    result.setLocation(lang.getLocationFromRawNode(ctx));
+
     return result;
   }
 

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/ConstructorDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/ConstructorDeclaration.java
@@ -41,14 +41,16 @@ public class ConstructorDeclaration extends MethodDeclaration {
    * @return the constructor declaration
    */
   public static ConstructorDeclaration from(MethodDeclaration methodDeclaration) {
+    RecordDeclaration recordDeclaration = methodDeclaration.getRecordDeclaration();
+
     ConstructorDeclaration c =
         NodeBuilder.newConstructorDeclaration(
-            methodDeclaration.getName(),
-            methodDeclaration.getCode(),
-            methodDeclaration.getRecordDeclaration());
+            methodDeclaration.getName(), methodDeclaration.getCode(), recordDeclaration);
 
-    // constructors always have void type
-    c.setType(TypeParser.createFrom(VOID_TYPE_STRING, true));
+    if (recordDeclaration != null) {
+      // constructors always have implicitly the return type of their class
+      c.setType(TypeParser.createFrom(recordDeclaration.getName(), true));
+    }
 
     c.setBody(methodDeclaration.getBody());
     c.setLocation(methodDeclaration.getLocation());

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/type/TypeParser.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/type/TypeParser.java
@@ -219,7 +219,7 @@ public class TypeParser {
   }
 
   private static boolean isUnknownType(String typeName) {
-    return typeName.toUpperCase().contains(UNKNOWN_TYPE_STRING);
+    return typeName.equals(UNKNOWN_TYPE_STRING);
   }
 
   /**

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/type/TypeParser.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/type/TypeParser.java
@@ -180,6 +180,11 @@ public class TypeParser {
     int i = 0;
 
     while (counter != 0) {
+      if (i >= string.length()) {
+        // dirty hack for now
+        return string.length();
+      }
+
       char actualChar = string.charAt(i);
       if (actualChar == openBracket) {
         counter++;

--- a/src/main/java/de/fraunhofer/aisec/cpg/helpers/Util.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/helpers/Util.java
@@ -58,6 +58,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 
 public class Util {
@@ -450,9 +451,16 @@ public class Util {
    * @param rawSignature the function's raw signature
    * @return the raw function return type
    */
+  @Nullable
   public static String getRawFunctionReturnType(
       FunctionDeclaration functionDeclaration, String rawSignature) {
-    return rawSignature.substring(0, rawSignature.indexOf(functionDeclaration.getName())).trim();
+    int index = rawSignature.indexOf(functionDeclaration.getName());
+
+    if (index == -1) {
+      return "";
+    }
+
+    return rawSignature.substring(0, index).trim();
   }
 
   public enum Connect {

--- a/src/main/java/de/fraunhofer/aisec/cpg/helpers/Util.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/helpers/Util.java
@@ -58,7 +58,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 
 public class Util {
@@ -440,27 +439,6 @@ public class Util {
 
     paramName.append(i);
     return paramName.toString();
-  }
-
-  /**
-   * Returns the raw return type of a function declaration before types are parsed. This is primarly
-   * used to clean the type before dispatching it to the {@link
-   * de.fraunhofer.aisec.cpg.graph.type.TypeParser}.
-   *
-   * @param functionDeclaration the function declaration
-   * @param rawSignature the function's raw signature
-   * @return the raw function return type
-   */
-  @Nullable
-  public static String getRawFunctionReturnType(
-      FunctionDeclaration functionDeclaration, String rawSignature) {
-    int index = rawSignature.indexOf(functionDeclaration.getName());
-
-    if (index == -1) {
-      return "";
-    }
-
-    return rawSignature.substring(0, index).trim();
   }
 
   public enum Connect {

--- a/src/main/java/de/fraunhofer/aisec/cpg/helpers/Util.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/helpers/Util.java
@@ -441,6 +441,20 @@ public class Util {
     return paramName.toString();
   }
 
+  /**
+   * Returns the raw return type of a function declaration before types are parsed. This is primarly
+   * used to clean the type before dispatching it to the {@link
+   * de.fraunhofer.aisec.cpg.graph.type.TypeParser}.
+   *
+   * @param functionDeclaration the function declaration
+   * @param rawSignature the function's raw signature
+   * @return the raw function return type
+   */
+  public static String getRawFunctionReturnType(
+      FunctionDeclaration functionDeclaration, String rawSignature) {
+    return rawSignature.substring(0, rawSignature.indexOf(functionDeclaration.getName())).trim();
+  }
+
   public enum Connect {
     NODE,
     SUBTREE;

--- a/src/test/java/de/fraunhofer/aisec/cpg/TypeTests.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/TypeTests.java
@@ -667,6 +667,39 @@ class TypeTests extends BaseTest {
     assertEquals(regularInt.getType(), propagated.getType());
   }
 
+  /**
+   * Test for usage of getTypeStringFromDeclarator to determine function pointer raw type string
+   *
+   * @throws Exception Any exception thrown during the analysis process
+   */
+  @Test
+  void fptrRawTypeStringTest() throws Exception {
+    Path topLevel = Path.of("src", "test", "resources", "types");
+    List<TranslationUnitDeclaration> result =
+        TestUtils.analyze(List.of(topLevel.resolve("fptr_type.cpp").toFile()), topLevel, true);
+
+    // TODO: Apparently there is another issue, as the name of the VariableDeclaration is empty
+    // instead of being single_param
+    // As there is only one VariableDeclaration in the provided snippet we can access it this way
+    VariableDeclaration variableDeclaration =
+        Util.subnodesOfType(result, VariableDeclaration.class).get(0);
+
+    List<Type> parameterList =
+        List.of(
+            new ObjectType(
+                "int",
+                Type.Storage.AUTO,
+                new Type.Qualifier(),
+                new ArrayList<>(),
+                ObjectType.Modifier.SIGNED,
+                true));
+    FunctionPointerType fptrType =
+        new FunctionPointerType(
+            new Type.Qualifier(), Type.Storage.AUTO, parameterList, new IncompleteType());
+
+    assertEquals(fptrType, variableDeclaration.getType());
+  }
+
   @Test
   void getCommonTypeTestJava() throws Exception {
     TestUtils.disableTypeManagerCleanup();

--- a/src/test/java/de/fraunhofer/aisec/cpg/TypeTests.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/TypeTests.java
@@ -673,19 +673,45 @@ class TypeTests extends BaseTest {
    * @throws Exception Any exception thrown during the analysis process
    */
   @Test
-  void fptrRawTypeStringTest() throws Exception {
+  void testFunctionPointerTypes() throws Exception {
     Path topLevel = Path.of("src", "test", "resources", "types");
-    List<TranslationUnitDeclaration> result =
-        TestUtils.analyze(List.of(topLevel.resolve("fptr_type.cpp").toFile()), topLevel, true);
+    TranslationUnitDeclaration tu =
+        TestUtils.analyzeAndGetFirstTU(
+            List.of(topLevel.resolve("fptr_type.cpp").toFile()), topLevel, true);
 
-    // TODO: Apparently there is another issue, as the name of the VariableDeclaration is empty
-    // instead of being single_param
-    // As there is only one VariableDeclaration in the provided snippet we can access it this way
-    VariableDeclaration variableDeclaration =
-        Util.subnodesOfType(result, VariableDeclaration.class).get(0);
+    FunctionPointerType oneParamType =
+        new FunctionPointerType(
+            new Type.Qualifier(),
+            Type.Storage.AUTO,
+            List.of(
+                new ObjectType(
+                    "int",
+                    Type.Storage.AUTO,
+                    new Type.Qualifier(),
+                    new ArrayList<>(),
+                    ObjectType.Modifier.SIGNED,
+                    true)),
+            new IncompleteType());
 
-    List<Type> parameterList =
-        List.of(
+    FunctionPointerType twoParamType =
+        new FunctionPointerType(
+            new Type.Qualifier(),
+            Type.Storage.AUTO,
+            List.of(
+                new ObjectType(
+                    "int",
+                    Type.Storage.AUTO,
+                    new Type.Qualifier(),
+                    new ArrayList<>(),
+                    ObjectType.Modifier.SIGNED,
+                    true),
+                new ObjectType(
+                    "long",
+                    Type.Storage.AUTO,
+                    new Type.Qualifier(),
+                    new ArrayList<>(),
+                    ObjectType.Modifier.UNSIGNED,
+                    true)),
             new ObjectType(
                 "int",
                 Type.Storage.AUTO,
@@ -693,11 +719,23 @@ class TypeTests extends BaseTest {
                 new ArrayList<>(),
                 ObjectType.Modifier.SIGNED,
                 true));
-    FunctionPointerType fptrType =
-        new FunctionPointerType(
-            new Type.Qualifier(), Type.Storage.AUTO, parameterList, new IncompleteType());
 
-    assertEquals(fptrType, variableDeclaration.getType());
+    List<VariableDeclaration> variables = Util.subnodesOfType(tu, VariableDeclaration.class);
+    VariableDeclaration localTwoParam = TestUtils.findByUniqueName(variables, "local_two_param");
+    assertNotNull(localTwoParam);
+    assertEquals(twoParamType, localTwoParam.getType());
+
+    VariableDeclaration localOneParam = TestUtils.findByUniqueName(variables, "local_one_param");
+    assertNotNull(localOneParam);
+    assertEquals(oneParamType, localOneParam.getType());
+
+    VariableDeclaration globalTwoParam = TestUtils.findByUniqueName(variables, "global_two_param");
+    assertNotNull(globalTwoParam);
+    assertEquals(twoParamType, globalTwoParam.getType());
+
+    VariableDeclaration globalOneParam = TestUtils.findByUniqueName(variables, "global_one_param");
+    assertNotNull(globalOneParam);
+    assertEquals(oneParamType, globalOneParam.getType());
   }
 
   @Test

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
@@ -713,6 +713,16 @@ class CXXLanguageFrontendTest extends BaseTest {
     assertEquals(recordDeclaration.getName(), constructor.getName());
     assertEquals(TypeParser.createFrom("SomeClass", true), constructor.getType());
     assertTrue(constructor.hasBody());
+
+    ConstructorDeclaration constructorDefinition =
+        declaration.getDeclarationAs(2, ConstructorDeclaration.class);
+
+    assertNotNull(constructorDefinition);
+    assertEquals(1, constructorDefinition.getParameters().size());
+    assertEquals(
+        TypeParser.createFrom("int", true), constructorDefinition.getParameters().get(0).getType());
+    assertEquals(TypeParser.createFrom("SomeClass", true), constructorDefinition.getType());
+    assertTrue(constructorDefinition.hasBody());
   }
 
   @Test

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
@@ -241,8 +241,8 @@ class CXXLanguageFrontendTest extends BaseTest {
     TranslationUnitDeclaration declaration =
         TestUtils.analyzeAndGetFirstTU(List.of(file), file.getParentFile().toPath(), true);
 
-    // should be four method nodes
-    assertEquals(4, declaration.getDeclarations().size());
+    // should be six function nodes
+    assertEquals(6, declaration.getDeclarations().size());
 
     FunctionDeclaration method = declaration.getDeclarationAs(0, FunctionDeclaration.class);
     assertEquals("function0(int)void", method.getSignature());
@@ -278,6 +278,12 @@ class CXXLanguageFrontendTest extends BaseTest {
     statement = method.getBodyStatementAs(0, ReturnStatement.class);
     assertNotNull(statement);
     assertFalse(statement.isImplicit());
+
+    method = declaration.getDeclarationAs(4, FunctionDeclaration.class);
+    assertEquals("function3()UnknownType*", method.getSignature());
+
+    method = declaration.getDeclarationAs(5, FunctionDeclaration.class);
+    assertEquals("function4(int)void", method.getSignature());
   }
 
   @Test

--- a/src/test/resources/functiondecl.cpp
+++ b/src/test/resources/functiondecl.cpp
@@ -16,7 +16,7 @@ void* function2() {
   return NULL;
 }
 
-UnknownType* function3();
+class UnknownType* function3();
 
 #define SOME_MACRO(x) x
 void function4(int a = SOME_MACRO(1));

--- a/src/test/resources/functiondecl.cpp
+++ b/src/test/resources/functiondecl.cpp
@@ -15,3 +15,8 @@ void function0(int arg0) {
 void* function2() {
   return NULL;
 }
+
+UnknownType* function3();
+
+#define SOME_MACRO(x) x
+void function4(int a = SOME_MACRO(1));

--- a/src/test/resources/recordstmt.cpp
+++ b/src/test/resources/recordstmt.cpp
@@ -5,8 +5,6 @@ private:
 public:
   void* method();
 
-  // cannot parse inline correctly (issue #4)
-  //inline void* inlineMethod() {
   void* inlineMethod() {
     return 0;
   }

--- a/src/test/resources/recordstmt.cpp
+++ b/src/test/resources/recordstmt.cpp
@@ -12,10 +12,15 @@ public:
   SomeClass() {
 
   }
+
+  SomeClass(int a);
 };
 
 void* SomeClass::method() {
   return 0;
+}
+
+SomeClass::SomeClass(int a) {
 }
 
 int main() {

--- a/src/test/resources/types/fptr_type.cpp
+++ b/src/test/resources/types/fptr_type.cpp
@@ -1,3 +1,7 @@
-int main(){
-void ((*single_param)(int));
+void ((*global_one_param)(int));
+int (*global_two_param)(int, unsigned long);
+
+int main() {
+  void ((*local_one_param)(int));
+  int (*local_two_param)(int, unsigned long);
 }

--- a/src/test/resources/types/fptr_type.cpp
+++ b/src/test/resources/types/fptr_type.cpp
@@ -1,0 +1,3 @@
+int main(){
+void ((*single_param)(int));
+}


### PR DESCRIPTION
This sets the type of a CPP simple declaration according to its declspecifier instead of the raw signature.

This partially fixes #153. It will not occur that often now probably but the core issue is still there.

