### PR TITLE
Support for C++ attributes as annotations

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/TranslationConfiguration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/TranslationConfiguration.java
@@ -84,6 +84,9 @@ public class TranslationConfiguration {
   /** should the code of a node be shown as parameter in the node * */
   public final boolean codeInNodes;
 
+  /** Set to true to process annotations or annotation-like elements. */
+  public final boolean processAnnotations;
+
   /**
    * Should parser/translation fail on parse/resolving errors (true) or try to continue in a
    * best-effort manner (false).
@@ -112,6 +115,7 @@ public class TranslationConfiguration {
       List<String> includeBlacklist,
       List<Pass> passes,
       boolean codeInNodes,
+      boolean processAnnotations,
       boolean disableCleanup) {
     this.symbols = symbols;
     this.sourceLocations = sourceLocations;
@@ -125,6 +129,7 @@ public class TranslationConfiguration {
     this.passes = passes != null ? passes : new ArrayList<>();
     // Make sure to init this AFTER sourceLocations has been set
     this.codeInNodes = codeInNodes;
+    this.processAnnotations = processAnnotations;
     this.disableCleanup = disableCleanup;
   }
 
@@ -170,11 +175,12 @@ public class TranslationConfiguration {
     private boolean failOnError = false;
     private boolean loadIncludes = false;
     private Map<String, String> symbols = new HashMap<>();
-    private List<String> includePaths = new ArrayList<>();
-    private List<String> includeWhitelist = new ArrayList<>();
-    private List<String> includeBlacklist = new ArrayList<>();
-    private List<Pass> passes = new ArrayList<>();
+    private final List<String> includePaths = new ArrayList<>();
+    private final List<String> includeWhitelist = new ArrayList<>();
+    private final List<String> includeBlacklist = new ArrayList<>();
+    private final List<Pass> passes = new ArrayList<>();
     private boolean codeInNodes = true;
+    private boolean processAnnotations = false;
     private boolean disableCleanup = false;
 
     public Builder symbols(Map<String, String> symbols) {
@@ -329,6 +335,18 @@ public class TranslationConfiguration {
       return this;
     }
 
+    /**
+     * Specifies, whether annotations should be process or not. By default, they are not processed,
+     * since they might populate the graph too much.
+     *
+     * @param b the new value
+     * @return
+     */
+    public Builder processAnnotations(boolean b) {
+      this.processAnnotations = b;
+      return this;
+    }
+
     public TranslationConfiguration build() {
       return new TranslationConfiguration(
           symbols,
@@ -342,6 +360,7 @@ public class TranslationConfiguration {
           includeBlacklist,
           passes,
           codeInNodes,
+          processAnnotations,
           disableCleanup);
     }
   }

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontend.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontend.java
@@ -435,7 +435,9 @@ public class CXXLanguageFrontend extends LanguageFrontend {
         return newLiteral(Integer.parseInt(code), CXXLanguageFrontend.INT_TYPE, code);
       case 130:
         return newLiteral(
-            code.replace("\"", ""), TypeParser.createFrom("const char*", false), code);
+            code.length() >= 2 ? code.substring(1, code.length() - 1) : "",
+            TypeParser.createFrom("const char*", false),
+            code);
       default:
         return newLiteral(code, TypeParser.createFrom("const char*", false), code);
     }

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
@@ -231,7 +231,9 @@ public class DeclarationHandler extends Handler<Declaration, IASTDeclaration, CX
       declaration = handleMultipleDeclarators(ctx);
     }
 
-    this.lang.processAttributes(declaration, ctx);
+    if (declaration != null) {
+      this.lang.processAttributes(declaration, ctx);
+    }
 
     return declaration;
   }

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
@@ -187,6 +187,8 @@ public class DeclarationHandler extends Handler<Declaration, IASTDeclaration, CX
       }
     }
 
+    this.lang.processAttributes(functionDeclaration, ctx);
+
     lang.getScopeManager().leaveScope(functionDeclaration);
 
     if (recordDeclaration != null) {
@@ -220,13 +222,18 @@ public class DeclarationHandler extends Handler<Declaration, IASTDeclaration, CX
       }
     }
 
+    Declaration declaration;
     if (ctx.getDeclarators().length == 0) {
-      return handleNoDeclarator(ctx);
+      declaration = handleNoDeclarator(ctx);
     } else if (ctx.getDeclarators().length == 1) {
-      return handleSingleDeclarator(ctx);
+      declaration = handleSingleDeclarator(ctx);
     } else {
-      return handleMultipleDeclarators(ctx);
+      declaration = handleMultipleDeclarators(ctx);
     }
+
+    this.lang.processAttributes(declaration, ctx);
+
+    return declaration;
   }
 
   private Declaration handleNoDeclarator(CPPASTSimpleDeclaration ctx) {

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationListHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationListHandler.java
@@ -74,6 +74,9 @@ class DeclarationListHandler
       // cache binding
       this.lang.cacheDeclaration(declarator.getName().resolveBinding(), declaration);
 
+      // process attributes
+      this.lang.processAttributes(declaration, ctx);
+
       list.add(declaration);
     }
 

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/Annotation.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/Annotation.java
@@ -27,6 +27,7 @@
 package de.fraunhofer.aisec.cpg.graph;
 
 import java.util.List;
+import java.util.Objects;
 
 public class Annotation extends Node {
 
@@ -39,5 +40,23 @@ public class Annotation extends Node {
 
   public void setValues(List<Expression> values) {
     this.values = values;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Annotation)) {
+      return false;
+    }
+
+    Annotation that = (Annotation) o;
+    return super.equals(that) && Objects.equals(values, that.values);
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
   }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/Annotation.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/Annotation.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, Fraunhofer AISEC. All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+
+package de.fraunhofer.aisec.cpg.graph;
+
+import java.util.List;
+
+public class Annotation extends Node {
+
+  // should be extended later into annotation members
+  private List<Expression> values;
+
+  public List<Expression> getValues() {
+    return values;
+  }
+
+  public void setValues(List<Expression> values) {
+    this.values = values;
+  }
+}

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/ConstructorDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/ConstructorDeclaration.java
@@ -55,6 +55,7 @@ public class ConstructorDeclaration extends MethodDeclaration {
     c.setBody(methodDeclaration.getBody());
     c.setLocation(methodDeclaration.getLocation());
     c.setParameters(methodDeclaration.getParameters());
+    c.setAnnotations(methodDeclaration.getAnnotations());
 
     return c;
   }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/FieldDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/FieldDeclaration.java
@@ -74,6 +74,7 @@ public class FieldDeclaration extends ValueDeclaration implements TypeListener {
     this.location = declaration.getLocation();
     this.type = declaration.getType();
     this.initializer = declaration.getInitializer();
+    this.annotations = declaration.getAnnotations();
   }
 
   public static FieldDeclaration from(VariableDeclaration declaration) {

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/MethodDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/MethodDeclaration.java
@@ -59,6 +59,7 @@ public class MethodDeclaration extends FunctionDeclaration {
     md.setParameters(functionDeclaration.getParameters());
     md.setBody(functionDeclaration.getBody());
     md.setType(functionDeclaration.getType());
+    md.setAnnotations(functionDeclaration.getAnnotations());
     md.setRecordDeclaration(recordDeclaration);
 
     return md;

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/Node.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/Node.java
@@ -114,6 +114,10 @@ public class Node extends IVisitable<Node> {
   /** Index of the argument if this node is used in a function call or parameter list. */
   private int argumentIndex;
 
+  /** List of annotations associated with that node. */
+  @SubGraph("AST")
+  protected List<Annotation> annotations;
+
   public Long getId() {
     return id;
   }
@@ -321,5 +325,13 @@ public class Node extends IVisitable<Node> {
   @Override
   public int hashCode() {
     return Objects.hash(name, this.getClass());
+  }
+
+  public void setAnnotations(List<Annotation> annotations) {
+    this.annotations = annotations;
+  }
+
+  public List<Annotation> getAnnotations() {
+    return annotations;
   }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/NodeBuilder.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/NodeBuilder.java
@@ -695,4 +695,12 @@ public class NodeBuilder {
     cse.setCode(code);
     return cse;
   }
+
+  public static Annotation newAnnotation(String name, @NonNull String code) {
+    Annotation annotation = new Annotation();
+    annotation.setName(name);
+    annotation.setCode(code);
+
+    return annotation;
+  }
 }

--- a/src/test/resources/attributes.cpp
+++ b/src/test/resources/attributes.cpp
@@ -1,0 +1,13 @@
+[[function_attribute()]]
+int main() {
+}
+
+[[record_attribute()]]
+class SomeClass {
+    [[property_attribute("a", main, 2)]]
+    int a;
+
+    // defined by a macro set by the test
+    PROPERTY_ATTRIBUTE(SomeCategory, SomeOtherThing)
+    int b;
+};


### PR DESCRIPTION
This PR parses C++ attributes (https://en.cppreference.com/w/cpp/language/attributes) as annotation nodes. It is not yet a full annotation support, this will be a separate PR.