### PR TITLE
Fix leaking types

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/TranslationConfiguration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/TranslationConfiguration.java
@@ -266,6 +266,11 @@ public class TranslationConfiguration {
       return this;
     }
 
+    public Builder disableCleanup() {
+      this.disableCleanup = true;
+      return this;
+    }
+
     /**
      * Adds the specified file to the include blacklist. Relative and absolute paths are supported.
      *

--- a/src/main/java/de/fraunhofer/aisec/cpg/TranslationConfiguration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/TranslationConfiguration.java
@@ -74,6 +74,13 @@ public class TranslationConfiguration {
    */
   public final List<String> includeBlacklist;
 
+  /**
+   * Switch off cleaning up TypeManager memory after analysis.
+   *
+   * <p>Set this to {@code true} only for testing.
+   */
+  public boolean disableCleanup = false;
+
   /** should the code of a node be shown as parameter in the node * */
   public final boolean codeInNodes;
 
@@ -104,7 +111,8 @@ public class TranslationConfiguration {
       List<String> includeWhitelist,
       List<String> includeBlacklist,
       List<Pass> passes,
-      boolean codeInNodes) {
+      boolean codeInNodes,
+      boolean disableCleanup) {
     this.symbols = symbols;
     this.sourceLocations = sourceLocations;
     this.topLevel = topLevel;
@@ -117,6 +125,7 @@ public class TranslationConfiguration {
     this.passes = passes != null ? passes : new ArrayList<>();
     // Make sure to init this AFTER sourceLocations has been set
     this.codeInNodes = codeInNodes;
+    this.disableCleanup = disableCleanup;
   }
 
   public static Builder builder() {
@@ -166,6 +175,7 @@ public class TranslationConfiguration {
     private List<String> includeBlacklist = new ArrayList<>();
     private List<Pass> passes = new ArrayList<>();
     private boolean codeInNodes = true;
+    private boolean disableCleanup = false;
 
     public Builder symbols(Map<String, String> symbols) {
       this.symbols = symbols;
@@ -326,7 +336,8 @@ public class TranslationConfiguration {
           includeWhitelist,
           includeBlacklist,
           passes,
-          codeInNodes);
+          codeInNodes,
+          disableCleanup);
     }
   }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/TranslationManager.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/TranslationManager.java
@@ -106,15 +106,17 @@ public class TranslationManager {
             throw new CompletionException(ex);
           } finally {
             outerBench.stop();
-            log.debug("Cleaning up {} Passes", passesNeedCleanup.size());
-            passesNeedCleanup.forEach(Pass::cleanup);
+            if (!this.config.disableCleanup) {
+              log.debug("Cleaning up {} Passes", passesNeedCleanup.size());
+              passesNeedCleanup.forEach(Pass::cleanup);
 
-            if (frontendsNeedCleanup != null) {
-              log.debug("Cleaning up {} Frontends", frontendsNeedCleanup.size());
-              frontendsNeedCleanup.forEach(LanguageFrontend::cleanup);
+              if (frontendsNeedCleanup != null) {
+                log.debug("Cleaning up {} Frontends", frontendsNeedCleanup.size());
+                frontendsNeedCleanup.forEach(LanguageFrontend::cleanup);
+              }
+
+              TypeManager.getInstance().cleanup();
             }
-
-            TypeManager.getInstance().cleanup();
           }
           return result;
         });

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/TypeManager.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/TypeManager.java
@@ -73,6 +73,7 @@ public class TypeManager {
     INSTANCE = new TypeManager();
   }
 
+  @NonNull
   public Map<Type, List<Type>> getTypeState() {
     return typeState;
   }
@@ -182,7 +183,8 @@ public class TypeManager {
     }
   }
 
-  public Optional<Type> getCommonType(Collection<Type> types) {
+  @NonNull
+  public Optional<Type> getCommonType(@NonNull Collection<Type> types) {
 
     boolean sameType =
         types.stream().map(t -> t.getClass().getCanonicalName()).collect(Collectors.toSet()).size()
@@ -286,6 +288,7 @@ public class TypeManager {
     return ancestors;
   }
 
+  @NonNull
   public Language getLanguage() {
     if (frontend instanceof JavaLanguageFrontend) {
       return Language.JAVA;

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/TypeManager.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/TypeManager.java
@@ -38,6 +38,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,14 +51,16 @@ public class TypeManager {
       List.of("byte", "short", "int", "long", "float", "double", "boolean", "char");
   private static final Pattern funPointerPattern =
       Pattern.compile("\\(?\\*(?<alias>[^()]+)\\)?\\(.*\\)");
-  private static TypeManager INSTANCE = new TypeManager();
+  @NonNull private static TypeManager INSTANCE = new TypeManager();
 
   public enum Language {
     JAVA,
     CXX
   }
 
-  private Map<String, RecordDeclaration> typeToRecord = new HashMap<>();
+  @NonNull private Map<String, RecordDeclaration> typeToRecord = new HashMap<>();
+
+  @NonNull
   private Map<Type, List<Type>> typeState =
       new HashMap<>(); // Stores all the unique types ObjectType as Key and Reference-/PointerTypes
   // as Values
@@ -97,7 +101,7 @@ public class TypeManager {
     return INSTANCE;
   }
 
-  public void setLanguageFrontend(LanguageFrontend frontend) {
+  public void setLanguageFrontend(@NonNull LanguageFrontend frontend) {
     this.frontend = frontend;
   }
 
@@ -290,6 +294,7 @@ public class TypeManager {
     }
   }
 
+  @Nullable
   public LanguageFrontend getFrontend() {
     return frontend;
   }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/type/TypeParser.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/type/TypeParser.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Class responsible for parsing the type definition and create the same Type as described by the
@@ -227,7 +229,8 @@ public class TypeParser {
    * @param type separated type string
    * @return true if function pointer structure is found in typeString, false if not
    */
-  private static Matcher isFunctionPointer(List<String> type) {
+  @Nullable
+  private static Matcher getFunctionPtrMatcher(@NonNull List<String> type) {
 
     StringBuilder typeStringBuilder = new StringBuilder();
     for (String typePart : type) {
@@ -313,7 +316,8 @@ public class TypeParser {
    * @param type string with the entire type definition
    * @return list of strings in which every piece of type information is one element of the list
    */
-  public static List<String> separate(String type) {
+  @NonNull
+  public static List<String> separate(@NonNull String type) {
 
     // Remove :: CPP operator, use . instead
     type = type.replace("::", ".");
@@ -661,7 +665,7 @@ public class TypeParser {
    * @param resolveAlias should replace with original type in typedefs
    * @return new type representing the type string
    */
-  public static Type createFrom(String type, boolean resolveAlias) {
+  public static Type createFrom(@NonNull String type, boolean resolveAlias) {
     // Check if Problems during Parsing
     if (type.contains("?")
         || type.contains("org.eclipse.cdt.internal.core.dom.parser.ProblemType@")
@@ -713,8 +717,7 @@ public class TypeParser {
 
     // Once all preceding known keywords (if any) are handled the next word must be the TypeName
     if (counter >= typeBlocks.size()) {
-      // TODO Note that "const auto bla = ..." will end here with typeName="const" as "auto" is not
-      // supported.
+      // Note that "const auto ..." will end here with typeName="const" as auto is not supported.
       return UnknownType.getUnknownType();
     }
     assert counter < typeBlocks.size();
@@ -725,7 +728,7 @@ public class TypeParser {
     TypeManager typeManager = TypeManager.getInstance();
 
     // Check if type is FunctionPointer
-    Matcher funcptr = isFunctionPointer(typeBlocks.subList(counter, typeBlocks.size()));
+    Matcher funcptr = getFunctionPtrMatcher(typeBlocks.subList(counter, typeBlocks.size()));
 
     if (funcptr != null) {
       Type returnType = createFrom(typeName, false);

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/type/TypeParser.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/type/TypeParser.java
@@ -712,6 +712,12 @@ public class TypeParser {
     Type.Qualifier qualifier = calcQualifier(qualifierList, null);
 
     // Once all preceding known keywords (if any) are handled the next word must be the TypeName
+    if (counter >= typeBlocks.size()) {
+      // TODO Note that "const auto bla = ..." will end here with typeName="const" as "auto" is not
+      // supported.
+      return UnknownType.getUnknownType();
+    }
+    assert counter < typeBlocks.size();
     String typeName = typeBlocks.get(counter);
     counter++;
 

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/type/TypeParser.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/type/TypeParser.java
@@ -665,7 +665,7 @@ public class TypeParser {
     // Check if Problems during Parsing
     if (type.contains("?")
         || type.contains("org.eclipse.cdt.internal.core.dom.parser.ProblemType@")
-        || type.length() == 0) {
+        || type.trim().length() == 0) {
       return UnknownType.getUnknownType();
     }
 

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/type/TypeParser.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/type/TypeParser.java
@@ -41,10 +41,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class TypeParser {
 
-  private TypeParser() {
-    throw new IllegalStateException("Do not instantiate the TypeParser");
-  }
-
   public static final String UNKNOWN_TYPE_STRING = "UNKNOWN";
   private static final List<String> primitives =
       List.of("byte", "short", "int", "long", "float", "double", "boolean", "char");
@@ -64,6 +60,10 @@ public class TypeParser {
   private static final String ELABORATED_TYPE_STRUCT = "struct";
   private static final String ELABORATED_TYPE_UNION = "union";
   private static final String ELABORATED_TYPE_ENUM = "enum";
+
+  private TypeParser() {
+    throw new IllegalStateException("Do not instantiate the TypeParser");
+  }
 
   public static void reset() {
     TypeParser.languageSupplier = () -> TypeManager.getInstance().getLanguage();
@@ -237,7 +237,7 @@ public class TypeParser {
       typeStringBuilder.append(typePart);
     }
 
-    String typeString = typeStringBuilder.toString().strip();
+    String typeString = typeStringBuilder.toString().trim();
 
     Matcher matcher = functionPtrRegex.matcher(typeString);
     if (matcher.find()) {
@@ -247,7 +247,7 @@ public class TypeParser {
   }
 
   private static boolean isIncompleteType(String typeName) {
-    return typeName.strip().equals("void");
+    return typeName.trim().equals("void");
   }
 
   private static boolean isUnknownType(String typeName) {
@@ -261,7 +261,8 @@ public class TypeParser {
    * @param type typeString
    * @return typeString without spaces in the generic Expression
    */
-  private static String fixGenerics(String type) {
+  @NonNull
+  private static String fixGenerics(@NonNull String type) {
     StringBuilder out = new StringBuilder();
     int bracketCount = 0;
     int iterator = 0;
@@ -303,7 +304,7 @@ public class TypeParser {
   }
 
   private static void processBlockUntilLastSplit(
-      String type, int lastSplit, int newPosition, List<String> typeBlocks) {
+      @NonNull String type, int lastSplit, int newPosition, @NonNull List<String> typeBlocks) {
     String substr = type.substring(lastSplit, newPosition);
     if (substr.length() != 0) {
       typeBlocks.add(substr);
@@ -323,9 +324,9 @@ public class TypeParser {
     type = type.replace("::", ".");
     type = type.split("=")[0];
 
-    // Guarantee that there is no arbitraty number of whitespces
+    // Guarantee that there is no arbitrary number of whitespaces
     String[] typeSubpart = type.split(" ");
-    type = String.join(" ", typeSubpart).strip();
+    type = String.join(" ", typeSubpart).trim();
 
     List<String> typeBlocks = new ArrayList<>();
 
@@ -395,13 +396,13 @@ public class TypeParser {
 
   private static List<Type> getParameterList(String parameterList) {
     if (parameterList.startsWith("(") && parameterList.endsWith(")")) {
-      parameterList = parameterList.strip().substring(1, parameterList.strip().length() - 1);
+      parameterList = parameterList.trim().substring(1, parameterList.trim().length() - 1);
     }
     List<Type> parameters = new ArrayList<>();
     String[] parametersSplit = parameterList.split(",");
     for (String parameter : parametersSplit) {
       if (parameter.length() > 0) {
-        parameters.add(createFrom(parameter.strip(), true));
+        parameters.add(createFrom(parameter.trim(), true));
       }
     }
 
@@ -414,7 +415,7 @@ public class TypeParser {
       List<Type> genericList = new ArrayList<>();
       String[] parametersSplit = generics.split(",");
       for (String parameter : parametersSplit) {
-        genericList.add(createFrom(parameter.strip(), true));
+        genericList.add(createFrom(parameter.trim(), true));
       }
 
       return genericList;
@@ -461,12 +462,13 @@ public class TypeParser {
    * Makes sure to apply Expressions containing brackets that change the binding of operators e.g.
    * () can change the binding order of operators
    *
-   * @param finalType Modifications are applyed to this type which is the result of the preceding
+   * @param finalType Modifications are applied to this type which is the result of the preceding
    *     type calculations
    * @param bracketExpressions List of Strings containing bracket expressions
    * @return modified finalType performing the resolution of the bracket expressions
    */
-  private static Type resolveBracketExpression(Type finalType, List<String> bracketExpressions) {
+  private static Type resolveBracketExpression(
+      @NonNull Type finalType, @NonNull List<String> bracketExpressions) {
     for (String bracketExpression : bracketExpressions) {
       List<String> splitExpression =
           separate(bracketExpression.substring(1, bracketExpression.length() - 1));
@@ -479,13 +481,13 @@ public class TypeParser {
   }
 
   /**
-   * Help function that removes access modifier from the typeString
+   * Helper function that removes access modifier from the typeString.
    *
    * @param type provided typeString
    * @return typeString without access modifier
    */
-  private static String clear(String type) {
-    return type.replaceAll("public|private|protected", "").strip();
+  private static String clear(@NonNull String type) {
+    return type.replaceAll("public|private|protected", "").trim();
   }
 
   /**
@@ -495,7 +497,7 @@ public class TypeParser {
    * @param stringList
    * @return
    */
-  private static boolean isPrimitiveType(List<String> stringList) {
+  private static boolean isPrimitiveType(@NonNull List<String> stringList) {
     for (String s : stringList) {
       if (primitives.contains(s)) {
         return true;
@@ -511,7 +513,8 @@ public class TypeParser {
    * @param typeBlocks
    * @return separated words of compound types are joined into one string
    */
-  private static List<String> joinPrimitive(List<String> typeBlocks) {
+  @NonNull
+  private static List<String> joinPrimitive(@NonNull List<String> typeBlocks) {
     List<String> joinedTypeBlocks = new ArrayList<>();
     StringBuilder primitiveType = new StringBuilder();
     boolean foundPrimitive = false;
@@ -547,7 +550,8 @@ public class TypeParser {
    * @param newRoot root the chain is swapped with
    * @return oldchain but root replaced with newRoot
    */
-  public static Type reWrapType(Type oldChain, Type newRoot) {
+  @NonNull
+  public static Type reWrapType(@NonNull Type oldChain, @NonNull Type newRoot) {
     if (oldChain.isFirstOrderType()) {
       newRoot.setTypeOrigin(oldChain.getTypeOrigin());
     }
@@ -582,12 +586,16 @@ public class TypeParser {
    * @param string the string representation of the type
    * @return the type
    */
-  public static Type createIgnoringAlias(String string) {
+  @NonNull
+  public static Type createIgnoringAlias(@NonNull String string) {
     return createFrom(string, false);
   }
 
+  @NonNull
   private static Type postTypeParsing(
-      List<String> subPart, Type finalType, List<String> bracketExpressions) {
+      @NonNull List<String> subPart,
+      @NonNull Type finalType,
+      @NonNull List<String> bracketExpressions) {
     for (String part : subPart) {
       if (part.equals("*")) {
         // Creates a Pointer to the finalType
@@ -665,6 +673,7 @@ public class TypeParser {
    * @param resolveAlias should replace with original type in typedefs
    * @return new type representing the type string
    */
+  @NonNull
   public static Type createFrom(@NonNull String type, boolean resolveAlias) {
     // Check if Problems during Parsing
     if (type.contains("?")

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/TypeResolver.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/TypeResolver.java
@@ -254,5 +254,7 @@ public class TypeResolver extends Pass {
   public void cleanup() {
     this.firstOrderTypes.clear();
     this.typeState.clear();
+    TypeParser.reset();
+    TypeManager.reset();
   }
 }

--- a/src/test/java/de/fraunhofer/aisec/cpg/TestUtils.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/TestUtils.java
@@ -101,6 +101,7 @@ public class TestUtils {
             .sourceLocations(files)
             .topLevel(topLevel.toFile())
             .loadIncludes(true)
+            .disableCleanup()
             .debugParser(true)
             .failOnError(true);
     if (usePasses) {


### PR DESCRIPTION
There is one major problem and a few minor ones with the TypeManager:
The major problem is that the singleton instance of TypeManager keeps lists of Types. These Types may refer to RecordDeclarations (including the whole AST of a source file) and were never removed from memory. This is not only a memory leak but also messes up later analysis runs.

The minor problems are related to unclear nullability of fields and the fact that unit tests call TranslationManager.analyze(), but expect that TypeManager is still populated afterwards (although it should in fact be cleaned up). Actually, tests are making false assumptions here.