### PR TITLE
Simple try to make analysis run in parallel

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/LanguageFrontendFactory.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/LanguageFrontendFactory.java
@@ -29,7 +29,9 @@ package de.fraunhofer.aisec.cpg.frontends;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.frontends.cpp.CXXLanguageFrontend;
 import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguageFrontend;
+import de.fraunhofer.aisec.cpg.helpers.Util;
 import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
+import java.io.File;
 import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -43,12 +45,14 @@ public class LanguageFrontendFactory {
 
   @Nullable
   public static LanguageFrontend getFrontend(
-      String fileType, TranslationConfiguration config, ScopeManager scopeManager) {
+      File file, TranslationConfiguration config, ScopeManager scopeManager) {
+
+    String fileType = Util.getExtension(file);
 
     if (JAVA_EXTENSIONS.contains(fileType)) {
-      return new JavaLanguageFrontend(config, scopeManager);
+      return new JavaLanguageFrontend(file, config);
     } else if (CXX_EXTENSIONS.contains(fileType)) {
-      return new CXXLanguageFrontend(config, scopeManager);
+      return new CXXLanguageFrontend(file, config);
     } else {
       return null;
     }

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontend.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontend.java
@@ -192,8 +192,8 @@ public class CXXLanguageFrontend extends LanguageFrontend {
   private HashMap<IBinding, List<Expression>> cachedExpressions = new HashMap<>();
   private HashMap<Integer, String> comments = new HashMap<>();
 
-  public CXXLanguageFrontend(@NonNull TranslationConfiguration config, ScopeManager scopeManager) {
-    super(config, scopeManager, "::");
+  public CXXLanguageFrontend(File file, @NonNull TranslationConfiguration config) {
+    super(file, config, new ScopeManager(), "::");
   }
 
   /**
@@ -245,7 +245,7 @@ public class CXXLanguageFrontend extends LanguageFrontend {
   }
 
   @Override
-  public TranslationUnitDeclaration parse(File file) throws TranslationException {
+  protected TranslationUnitDeclaration parse(File file) throws TranslationException {
     TypeManager.getInstance().setLanguageFrontend(this);
     FileContent content = FileContent.createForExternalFileLocation(file.getAbsolutePath());
 

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.java
@@ -76,8 +76,8 @@ public class JavaLanguageFrontend extends LanguageFrontend {
   private JavaSymbolSolver javaSymbolResolver;
   private CombinedTypeSolver internalTypeSolver = new CombinedTypeSolver();
 
-  public JavaLanguageFrontend(@NonNull TranslationConfiguration config, ScopeManager scopeManager) {
-    super(config, scopeManager, ".");
+  public JavaLanguageFrontend(File file, @NonNull TranslationConfiguration config) {
+    super(file, config, new ScopeManager(), ".");
 
     ReflectionTypeSolver reflectionTypeSolver = new ReflectionTypeSolver();
     internalTypeSolver.add(reflectionTypeSolver);
@@ -98,7 +98,7 @@ public class JavaLanguageFrontend extends LanguageFrontend {
   }
 
   @Override
-  public TranslationUnitDeclaration parse(File file) throws TranslationException {
+  protected TranslationUnitDeclaration parse(File file) throws TranslationException {
     TypeManager.getInstance().setLanguageFrontend(this);
 
     // load in the file

--- a/src/test/java/de/fraunhofer/aisec/cpg/ScopeManagerTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/ScopeManagerTest.java
@@ -44,7 +44,7 @@ class ScopeManagerTest extends BaseTest {
 
   @Test
   void testSetScope() throws TranslationException {
-    LanguageFrontend frontend = new JavaLanguageFrontend(config, new ScopeManager());
+    LanguageFrontend frontend = new JavaLanguageFrontend(null, config);
 
     assert (frontend == frontend.getScopeManager().getLang());
 

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXBindingsTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXBindingsTest.java
@@ -7,7 +7,6 @@ import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.graph.Declaration;
 import de.fraunhofer.aisec.cpg.graph.DeclaredReferenceExpression;
 import de.fraunhofer.aisec.cpg.graph.Expression;
-import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.File;
 import org.eclipse.cdt.core.dom.ast.IBinding;
 import org.junit.jupiter.api.Test;
@@ -27,18 +26,20 @@ class CXXBindingsTest extends BaseTest {
 
   @Test
   void testUseThenDeclaration() throws Exception {
+    File file = new File("src/test/resources/bindings/use_then_declare.cpp");
     CXXLanguageFrontend cxxLanguageFrontend =
-        new CXXLanguageFrontend(TranslationConfiguration.builder().build(), new ScopeManager());
-    cxxLanguageFrontend.parse(new File("src/test/resources/bindings/use_then_declare.cpp"));
+        new CXXLanguageFrontend(file, TranslationConfiguration.builder().build());
+    cxxLanguageFrontend.parse(file);
 
     checkBindings(cxxLanguageFrontend);
   }
 
   @Test
   void testDeclarationReplacement() throws Exception {
+    File file = new File("src/test/resources/bindings/replace_declaration.cpp");
     CXXLanguageFrontend cxxLanguageFrontend =
-        new CXXLanguageFrontend(TranslationConfiguration.builder().build(), new ScopeManager());
-    cxxLanguageFrontend.parse(new File("src/test/resources/bindings/replace_declaration.cpp"));
+        new CXXLanguageFrontend(file, TranslationConfiguration.builder().build());
+    cxxLanguageFrontend.parse(file);
 
     checkBindings(cxxLanguageFrontend);
   }

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXSymbolConfigurationTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXSymbolConfigurationTest.java
@@ -26,26 +26,26 @@
 
 package de.fraunhofer.aisec.cpg.frontends.cpp;
 
+import static de.fraunhofer.aisec.cpg.TestUtils.analyzeAndGetFirstTU;
+import static de.fraunhofer.aisec.cpg.TestUtils.analyzeWithBuilder;
 import static org.junit.jupiter.api.Assertions.*;
 
 import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
-import de.fraunhofer.aisec.cpg.frontends.TranslationException;
 import de.fraunhofer.aisec.cpg.graph.*;
-import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import java.io.File;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class CXXSymbolConfigurationTest extends BaseTest {
   @Test
-  void testWithoutSymbols() throws TranslationException {
+  void testWithoutSymbols() throws Exception {
+    File file = new File("src/test/resources/symbols.cpp");
     // parse without symbols
     TranslationUnitDeclaration tu =
-        new CXXLanguageFrontend(
-                TranslationConfiguration.builder().defaultPasses().build(), new ScopeManager())
-            .parse(new File("src/test/resources/symbols.cpp"));
+        analyzeAndGetFirstTU(List.of(file), file.getParentFile().toPath(), true);
 
     Set<FunctionDeclaration> main = tu.getDeclarationsByName("main", FunctionDeclaration.class);
     assertFalse(main.isEmpty());
@@ -71,19 +71,21 @@ class CXXSymbolConfigurationTest extends BaseTest {
   }
 
   @Test
-  void testWithSymbols() throws TranslationException {
-    // let's try with symbol definitions
+  void testWithSymbols() throws Exception {
+    File file = new File("src/test/resources/symbols.cpp");
+
     TranslationUnitDeclaration tu =
-        new CXXLanguageFrontend(
+        analyzeWithBuilder(
                 TranslationConfiguration.builder()
+                    .sourceLocations(List.of(file))
+                    .topLevel(file.getParentFile())
                     .symbols(
                         Map.of(
                             "HELLO_WORLD", "\"Hello World\"",
                             "INCREASE(X)", "X+1"))
-                    .defaultPasses()
-                    .build(),
-                new ScopeManager())
-            .parse(new File("src/test/resources/symbols.cpp"));
+                    .defaultPasses())
+            .iterator()
+            .next();
 
     Set<FunctionDeclaration> main = tu.getDeclarationsByName("main", FunctionDeclaration.class);
     assertFalse(main.isEmpty());


### PR DESCRIPTION
Just a draft for now. This is a very basic implementation of a parallel *frontend* run. Passes will be executed after all frontends have run and then passes will run after each other.

Problem: ScopeManager loses its context after each frontend run now, since I just created a new ScopeManager for each frontend. This is probably not a problem currently, since all passes do not use the scope manager information anyway but will be a problem, once @konradweiss re-organises the scope manager. So it might be worth having in mind that the scope manager should be 

The type manager and parser are probably not thread-safe as well.