### PR TITLE
Performance tweaks

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontend.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontend.java
@@ -233,11 +233,11 @@ public class CXXLanguageFrontend extends LanguageFrontend {
 
     s.append(" ".repeat(indent));
 
-    log.debug(
+    log.trace(
         "{}{} -> {}",
         s,
         node.getClass().getSimpleName(),
-        node.getRawSignature().replaceAll("\n", " \\ ").replaceAll("\\s+", "  "));
+        node.getRawSignature().replace('\n', '\\').replace('\t', ' '));
 
     for (IASTNode iastNode : children) {
       explore(iastNode, indent + 2);

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/Expression.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/Expression.java
@@ -88,6 +88,7 @@ public class Expression extends Statement implements HasType {
 
   @Override
   public void setType(Type type, HasType root) {
+    //TODO Document this method. It is called very often (potentially for each AST node) and performs less than optimal.
     if (type == null || root == this) {
       return;
     }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/NodeBuilder.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/NodeBuilder.java
@@ -181,7 +181,7 @@ public class NodeBuilder {
   }
 
   private static void log(Node node) {
-    LOGGER.debug("Creating {}", node);
+    LOGGER.trace("Creating {}", node);
   }
 
   public static ReturnStatement newReturnStatement(String code) {

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/TypeManager.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/TypeManager.java
@@ -133,6 +133,7 @@ public class TypeManager {
   }
 
   private Set<Type> unwrapTypes(Collection<Type> types, WrapState wrapState) {
+    // TODO Performance: This method is called very often (for each setType()) and does four iterations over "types". Reduce number of iterations.
     Set<Type> original = new HashSet<>(types);
     Set<Type> unwrappedTypes = new HashSet<>();
     int depth = 0;


### PR DESCRIPTION
These are just two small performance quick wins.

Logging each element of the AST is super expensive, especially as a simple line such as 
```
log.debug("Node: {}", node);
```
is actually doing pretty much: It checks for log level, calls `toString()` of a node, which in turn applies some expensive `PrettyPrinter`, does some additional magic to catch endless recursions and then prints the node to console and to the file. Note that the "node" can be the whole source code file, so you were pretty printing a multitude of the whole AST.