### PR TITLE
Handling void function parameters

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/type/TypeParser.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/type/TypeParser.java
@@ -430,7 +430,7 @@ public class TypeParser {
     String[] parametersSplit = parameterList.split(",");
     for (String parameter : parametersSplit) {
       // ignore void parameters
-      if (parameter.length() > 0 && !parameter.equals("void")) {
+      if (parameter.length() > 0 && !parameter.trim().equals("void")) {
         parameters.add(createFrom(parameter.trim(), true));
       }
     }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/type/TypeParser.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/type/TypeParser.java
@@ -429,7 +429,8 @@ public class TypeParser {
     List<Type> parameters = new ArrayList<>();
     String[] parametersSplit = parameterList.split(",");
     for (String parameter : parametersSplit) {
-      if (parameter.length() > 0) {
+      // ignore void parameters
+      if (parameter.length() > 0 && !parameter.equals("void")) {
         parameters.add(createFrom(parameter.trim(), true));
       }
     }

--- a/src/test/java/de/fraunhofer/aisec/cpg/TypeTests.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/TypeTests.java
@@ -28,13 +28,13 @@ package de.fraunhofer.aisec.cpg;
 
 import static de.fraunhofer.aisec.cpg.TestUtils.findByUniqueName;
 import static de.fraunhofer.aisec.cpg.TestUtils.subnodesOfType;
+import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.*;
 
 import de.fraunhofer.aisec.cpg.graph.*;
 import de.fraunhofer.aisec.cpg.graph.type.*;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -64,7 +64,7 @@ class TypeTests extends BaseTest {
                 "int",
                 Type.Storage.AUTO,
                 new Type.Qualifier(),
-                Collections.emptyList(),
+                emptyList(),
                 ObjectType.Modifier.SIGNED,
                 true));
     Type functionPointerType =
@@ -118,7 +118,7 @@ class TypeTests extends BaseTest {
                 "int",
                 Type.Storage.AUTO,
                 new Type.Qualifier(),
-                Collections.emptyList(),
+                emptyList(),
                 ObjectType.Modifier.SIGNED,
                 true));
     Type functionPointerType =
@@ -340,7 +340,7 @@ class TypeTests extends BaseTest {
                 "int",
                 Type.Storage.AUTO,
                 new Type.Qualifier(),
-                Collections.emptyList(),
+                emptyList(),
                 ObjectType.Modifier.SIGNED,
                 true));
     Type expected =
@@ -363,7 +363,7 @@ class TypeTests extends BaseTest {
                     "char",
                     Type.Storage.AUTO,
                     new Type.Qualifier(),
-                    Collections.emptyList(),
+                    emptyList(),
                     ObjectType.Modifier.SIGNED,
                     true),
                 PointerType.PointerOrigin.ARRAY),
@@ -380,7 +380,7 @@ class TypeTests extends BaseTest {
                 "char",
                 Type.Storage.AUTO,
                 new Type.Qualifier(),
-                Collections.emptyList(),
+                emptyList(),
                 ObjectType.Modifier.SIGNED,
                 true),
             PointerType.PointerOrigin.POINTER);
@@ -405,7 +405,7 @@ class TypeTests extends BaseTest {
                 "char",
                 Type.Storage.AUTO,
                 new Type.Qualifier(true, false, false, false),
-                Collections.emptyList(),
+                emptyList(),
                 ObjectType.Modifier.SIGNED,
                 true),
             PointerType.PointerOrigin.POINTER);
@@ -420,7 +420,7 @@ class TypeTests extends BaseTest {
                 "char",
                 Type.Storage.AUTO,
                 new Type.Qualifier(false, false, false, false),
-                Collections.emptyList(),
+                emptyList(),
                 ObjectType.Modifier.SIGNED,
                 true),
             PointerType.PointerOrigin.POINTER);
@@ -436,7 +436,7 @@ class TypeTests extends BaseTest {
                 "char",
                 Type.Storage.AUTO,
                 new Type.Qualifier(true, false, false, false),
-                Collections.emptyList(),
+                emptyList(),
                 ObjectType.Modifier.SIGNED,
                 true),
             PointerType.PointerOrigin.POINTER);
@@ -453,7 +453,7 @@ class TypeTests extends BaseTest {
                     "char",
                     Type.Storage.STATIC,
                     new Type.Qualifier(true, false, false, false),
-                    Collections.emptyList(),
+                    emptyList(),
                     ObjectType.Modifier.SIGNED,
                     true),
                 PointerType.PointerOrigin.POINTER),
@@ -474,7 +474,7 @@ class TypeTests extends BaseTest {
                         "char",
                         Type.Storage.STATIC,
                         new Type.Qualifier(true, false, false, false),
-                        Collections.emptyList(),
+                        emptyList(),
                         ObjectType.Modifier.SIGNED,
                         true),
                     PointerType.PointerOrigin.POINTER),
@@ -491,7 +491,7 @@ class TypeTests extends BaseTest {
             "int",
             Type.Storage.AUTO,
             new Type.Qualifier(),
-            Collections.emptyList(),
+            emptyList(),
             ObjectType.Modifier.SIGNED,
             true));
     expected =
@@ -724,6 +724,10 @@ class TypeTests extends BaseTest {
         TestUtils.analyzeAndGetFirstTU(
             List.of(topLevel.resolve("fptr_type.cpp").toFile()), topLevel, true);
 
+    FunctionPointerType noParamType =
+        new FunctionPointerType(
+            new Type.Qualifier(), Type.Storage.AUTO, emptyList(), new IncompleteType());
+
     FunctionPointerType oneParamType =
         new FunctionPointerType(
             new Type.Qualifier(),
@@ -773,6 +777,14 @@ class TypeTests extends BaseTest {
     VariableDeclaration localOneParam = findByUniqueName(variables, "local_one_param");
     assertNotNull(localOneParam);
     assertEquals(oneParamType, localOneParam.getType());
+
+    VariableDeclaration globalNoParam = findByUniqueName(variables, "global_no_param");
+    assertNotNull(globalNoParam);
+    assertEquals(noParamType, globalNoParam.getType());
+
+    VariableDeclaration globalNoParamVoid = findByUniqueName(variables, "global_no_param_void");
+    assertNotNull(globalNoParamVoid);
+    assertEquals(noParamType, globalNoParamVoid.getType());
 
     VariableDeclaration globalTwoParam = findByUniqueName(variables, "global_two_param");
     assertNotNull(globalTwoParam);

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
@@ -287,7 +287,7 @@ class CXXLanguageFrontendTest extends BaseTest {
         TestUtils.analyzeAndGetFirstTU(List.of(file), file.getParentFile().toPath(), true);
 
     // should be six function nodes
-    assertEquals(6, declaration.getDeclarations().size());
+    assertEquals(7, declaration.getDeclarations().size());
 
     FunctionDeclaration method = declaration.getDeclarationAs(0, FunctionDeclaration.class);
     assertEquals("function0(int)void", method.getSignature());
@@ -325,10 +325,17 @@ class CXXLanguageFrontendTest extends BaseTest {
     assertFalse(statement.isImplicit());
 
     method = declaration.getDeclarationAs(4, FunctionDeclaration.class);
+    assertNotNull(method);
     assertEquals("function3()UnknownType*", method.getSignature());
 
     method = declaration.getDeclarationAs(5, FunctionDeclaration.class);
+    assertNotNull(method);
     assertEquals("function4(int)void", method.getSignature());
+
+    method = declaration.getDeclarationAs(6, FunctionDeclaration.class);
+    assertNotNull(method);
+    assertEquals(0, method.getParameters().size());
+    assertEquals("function5()void", method.getSignature());
   }
 
   @Test

--- a/src/test/resources/functiondecl.cpp
+++ b/src/test/resources/functiondecl.cpp
@@ -20,3 +20,6 @@ class UnknownType* function3();
 
 #define SOME_MACRO(x) x
 void function4(int a = SOME_MACRO(1));
+
+// void parameter without name
+void function5(void);

--- a/src/test/resources/types/fptr_type.cpp
+++ b/src/test/resources/types/fptr_type.cpp
@@ -1,3 +1,5 @@
+void (*global_no_param_void)(void);
+void (*global_no_param)();
 void ((*global_one_param)(int));
 int (*global_two_param)(int, unsigned long);
 


### PR DESCRIPTION
Fixes #208 

How should we deal with error cases? For example, specifying `void` more than once is not allowed and also specifying `void` in a named parameter is not allowed. CDT does not enforce this as it just produces a parse tree.

For now, I just emitted a warning but continued parsing the erroneous cases.