### PR TITLE
Converting refersTo back to a single edge field for convenience

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/DeclaredReferenceExpression.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/DeclaredReferenceExpression.java
@@ -43,7 +43,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class DeclaredReferenceExpression extends Expression implements TypeListener {
 
-  /** The {@link ValueDeclaration}s this expression might refer to. */
+  /** The {@link Declaration}s this expression might refer to. */
   @Nullable private ValueDeclaration refersTo;
 
   /**
@@ -52,9 +52,24 @@ public class DeclaredReferenceExpression extends Expression implements TypeListe
    */
   private AccessValues access = AccessValues.READ;
 
-  @Deprecated
-  public Set<ValueDeclaration> getRefersTo() {
-    return Set.of(refersTo);
+  public @Nullable ValueDeclaration getRefersTo() {
+    return this.refersTo;
+  }
+
+  /**
+   * Returns the contents of {@link #refersTo} as the specified class, if the class is assignable.
+   * Otherwise, it will return null.
+   *
+   * @param clazz the expected class
+   * @param <T> the type
+   * @return the declaration cast to the expected class, or null if the class is not assignable
+   */
+  public @Nullable <T extends VariableDeclaration> T getRefersToAs(Class<T> clazz) {
+    if (this.refersTo == null) {
+      return null;
+    }
+
+    return clazz.isAssignableFrom(this.refersTo.getClass()) ? clazz.cast(this.refersTo) : null;
   }
 
   public AccessValues getAccess() {

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/DeclaredReferenceExpression.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/DeclaredReferenceExpression.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.neo4j.ogm.annotation.Relationship;
 
 /**
  * An expression, which refers to something which is declared, e.g. a variable. For example, the
@@ -44,6 +45,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class DeclaredReferenceExpression extends Expression implements TypeListener {
 
   /** The {@link Declaration}s this expression might refer to. */
+  @Relationship(value = "REFERS_TO")
   @Nullable private ValueDeclaration refersTo;
 
   /**

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/DFGTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/DFGTest.java
@@ -1,6 +1,7 @@
 package de.fraunhofer.aisec.cpg.enhancements;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.fraunhofer.aisec.cpg.TestUtils;
@@ -38,12 +39,11 @@ class DFGTest {
     assertTrue(literal2.getNextDFG().contains(a2));
     assertEquals(1, a2.getNextDFG().size()); // Outgoing DFG Edges only to VariableDeclaration
 
-    assertEquals(1, a2.getRefersTo().size());
-    Node refersTo = a2.getRefersTo().iterator().next();
-    assertTrue(refersTo instanceof VariableDeclaration);
-    VariableDeclaration a = (VariableDeclaration) refersTo;
-    assertEquals(0, a.getNextDFG().size());
-    assertEquals(a2.getNextDFG().iterator().next(), a);
+    var refersTo = a2.getRefersToAs(VariableDeclaration.class);
+    assertNotNull(refersTo);
+
+    assertEquals(0, refersTo.getNextDFG().size());
+    assertEquals(a2.getNextDFG().iterator().next(), refersTo);
 
     // Test Else-Block with System.out.println()
     Literal<?> literal1 =

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/VariableResolverTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/VariableResolverTest.java
@@ -73,15 +73,15 @@ class VariableResolverTest extends BaseTest {
         TestUtils.subnodesOfType(getLocal, VariableDeclaration.class).get(0);
     DeclaredReferenceExpression returnValue =
         (DeclaredReferenceExpression) returnStatement.getReturnValue();
-    assertNotEquals(Set.of(field), returnValue.getRefersTo());
-    assertEquals(Set.of(local), returnValue.getRefersTo());
+    assertNotEquals(field, returnValue.getRefersTo());
+    assertEquals(local, returnValue.getRefersTo());
 
     MethodDeclaration getShadow = TestUtils.findByUniqueName(methods, "getShadow");
     returnStatement = TestUtils.subnodesOfType(getShadow, ReturnStatement.class).get(0);
     local = TestUtils.subnodesOfType(getShadow, VariableDeclaration.class).get(0);
     returnValue = (DeclaredReferenceExpression) returnStatement.getReturnValue();
-    assertNotEquals(Set.of(field), returnValue.getRefersTo());
-    assertEquals(Set.of(local), returnValue.getRefersTo());
+    assertNotEquals(field, returnValue.getRefersTo());
+    assertEquals(local, returnValue.getRefersTo());
   }
 
   @Test

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/variable_resolution/VRUtil.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/variable_resolution/VRUtil.java
@@ -1,5 +1,6 @@
 package de.fraunhofer.aisec.cpg.enhancements.variable_resolution;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -7,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import de.fraunhofer.aisec.cpg.graph.DeclaredReferenceExpression;
 import de.fraunhofer.aisec.cpg.graph.MemberExpression;
 import de.fraunhofer.aisec.cpg.graph.Node;
-import java.util.Collection;
 
 /**
  * Utility-class to bundle functionality for the both test classes {@link VariableResolverCppTest}
@@ -45,7 +45,7 @@ public class VRUtil {
     } else {
       assertTrue(usingNode instanceof DeclaredReferenceExpression);
       DeclaredReferenceExpression reference = (DeclaredReferenceExpression) usingNode;
-      assertSameOrContains(reference.getRefersTo(), usedNode);
+      assertEquals(reference.getRefersTo(), usedNode);
     }
   }
 
@@ -73,15 +73,6 @@ public class VRUtil {
       Node member = memberExpression.getMember();
       assertUsageOf(base, usedBase);
       assertUsageOf(member, usedMember);
-    }
-  }
-
-  public static void assertSameOrContains(Object potentialCollection, Object toCompair) {
-    if (REFERES_TO_IS_A_COLLECTION && potentialCollection instanceof Collection) {
-      Collection collection = (Collection) potentialCollection;
-      assertTrue(collection.stream().anyMatch(obj -> obj == toCompair));
-    } else {
-      assertSame(potentialCollection, toCompair);
     }
   }
 }

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXBindingsTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXBindingsTest.java
@@ -1,6 +1,6 @@
 package de.fraunhofer.aisec.cpg.frontends.cpp;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
@@ -18,9 +18,7 @@ class CXXBindingsTest extends BaseTest {
     for (IBinding binding : cxxLanguageFrontend.getCachedDeclarations().keySet()) {
       Declaration declaration = cxxLanguageFrontend.getCachedDeclaration(binding);
       for (Expression expression : cxxLanguageFrontend.getCachedExpression(binding)) {
-        for (Declaration refersTo : ((DeclaredReferenceExpression) expression).getRefersTo()) {
-          assertEquals(declaration, refersTo);
-        }
+        assertEquals(declaration, ((DeclaredReferenceExpression) expression).getRefersTo());
       }
     }
   }

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXIncludeTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXIncludeTest.java
@@ -79,7 +79,7 @@ class CXXIncludeTest extends BaseTest {
     FieldDeclaration someField = someClass.getField("someField");
     assertNotNull(someField);
 
-    assertTrue(ref.getRefersTo().contains(someField));
+    assertEquals(someField, ref.getRefersTo());
   }
 
   @Test

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
@@ -117,8 +117,7 @@ class CXXLanguageFrontendTest extends BaseTest {
     assertNotNull(forEachStatement);
 
     // should loop over ls
-    assertEquals(
-        Set.of(ls), ((DeclaredReferenceExpression) forEachStatement.getIterable()).getRefersTo());
+    assertEquals(ls, ((DeclaredReferenceExpression) forEachStatement.getIterable()).getRefersTo());
 
     // should declare auto i (so far no concrete type inferrable)
     VariableDeclaration i = (VariableDeclaration) forEachStatement.getVariable();
@@ -277,7 +276,7 @@ class CXXLanguageFrontendTest extends BaseTest {
         (ArraySubscriptionExpression) statement.getStatements().get(1);
     assertNotNull(ase);
 
-    assertEquals(Set.of(x), ((DeclaredReferenceExpression) ase.getArrayExpression()).getRefersTo());
+    assertEquals(x, ((DeclaredReferenceExpression) ase.getArrayExpression()).getRefersTo());
     assertEquals(0, ((Literal<Integer>) ase.getSubscriptExpression()).getValue().intValue());
   }
 
@@ -602,7 +601,7 @@ class CXXLanguageFrontendTest extends BaseTest {
 
   private void assertRefersTo(Expression expression, Declaration b) {
     if (expression instanceof DeclaredReferenceExpression) {
-      assertEquals(Set.of(b), ((DeclaredReferenceExpression) expression).getRefersTo());
+      assertEquals(b, ((DeclaredReferenceExpression) expression).getRefersTo());
     } else {
       fail();
     }

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
@@ -44,7 +44,6 @@ import java.math.BigInteger;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
@@ -132,8 +131,7 @@ class JavaLanguageFrontendTest extends BaseTest {
     assertNotNull(forEachStatement);
 
     // should loop over ls
-    assertEquals(
-        Set.of(ls), ((DeclaredReferenceExpression) forEachStatement.getIterable()).getRefersTo());
+    assertEquals(ls, ((DeclaredReferenceExpression) forEachStatement.getIterable()).getRefersTo());
 
     // should declare String s
     VariableDeclaration s = (VariableDeclaration) forEachStatement.getVariable();
@@ -378,7 +376,7 @@ class JavaLanguageFrontendTest extends BaseTest {
     // expression itself should be a reference
     DeclaredReferenceExpression ref = (DeclaredReferenceExpression) cast.getExpression();
     assertNotNull(ref);
-    assertEquals(Set.of(e), ref.getRefersTo());
+    assertEquals(e, ref.getRefersTo());
   }
 
   @Test
@@ -427,7 +425,7 @@ class JavaLanguageFrontendTest extends BaseTest {
     // initializer is array subscription
     ArraySubscriptionExpression ase = (ArraySubscriptionExpression) b.getInitializer();
     assertNotNull(ase);
-    assertEquals(Set.of(a), ((DeclaredReferenceExpression) ase.getArrayExpression()).getRefersTo());
+    assertEquals(a, ((DeclaredReferenceExpression) ase.getArrayExpression()).getRefersTo());
     assertEquals(0, ((Literal<Integer>) ase.getSubscriptExpression()).getValue().intValue());
   }
 


### PR DESCRIPTION
Closes #217 

# Graph Changes

The proposed change *should* actually not have a change in the graph structure, because the relationship of the field stays the same, even though the Java representation has changed.

# API Changes

The `refersTo` field of a `DeclaredReferenceExpression` is no longer a collection, but rather a single reference to a `ValueDeclaration`.
