### PR TITLE
Restored behaviour of ScopeManager::replaceNode

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.java
@@ -356,7 +356,6 @@ class DeclaratorHandler extends Handler<Declaration, IASTNameOwner, CXXLanguageF
       if (declaration instanceof FunctionDeclaration) {
         MethodDeclaration method =
             MethodDeclaration.from((FunctionDeclaration) declaration, recordDeclaration);
-        declaration.disconnectFromGraph();
 
         // check, if its a constructor
         if (declaration.getName().equals(recordDeclaration.getName())) {

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManager.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManager.java
@@ -26,6 +26,8 @@
 
 package de.fraunhofer.aisec.cpg.passes.scopes;
 
+import static de.fraunhofer.aisec.cpg.helpers.Util.errorWithFileLocation;
+
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend;
 import de.fraunhofer.aisec.cpg.graph.AssertStatement;
 import de.fraunhofer.aisec.cpg.graph.BreakStatement;
@@ -277,10 +279,17 @@ public class ScopeManager {
     Scope leaveScope = getFirstScopeThat(scope -> Objects.equals(scope.astNode, nodeToLeave));
     if (leaveScope == null) {
       if (scopeMap.containsKey(nodeToLeave)) {
-        LOGGER.error(
-            "Node of type {} has a scope but is not active in the moment.", nodeToLeave.getClass());
+        errorWithFileLocation(
+            nodeToLeave,
+            LOGGER,
+            "Node of type {} has a scope but is not active in the moment.",
+            nodeToLeave.getClass());
       } else {
-        LOGGER.error("Node of type {} is not associated with a scope.", nodeToLeave.getClass());
+        errorWithFileLocation(
+            nodeToLeave,
+            LOGGER,
+            "Node of type {} is not associated with a scope.",
+            nodeToLeave.getClass());
       }
       return null;
     }
@@ -426,7 +435,7 @@ public class ScopeManager {
     // check, if old node has a scope
     if (scope != null) {
       // update ast node
-      // scope.astNode = newNode;
+      scope.astNode = newNode;
       // update key
       scopeMap.remove(oldNode);
       scopeMap.put(newNode, scope);

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
@@ -755,6 +755,7 @@ class CXXLanguageFrontendTest extends BaseTest {
         TestUtils.analyzeAndGetFirstTU(List.of(file), file.getParentFile().toPath(), true);
 
     RecordDeclaration recordDeclaration = declaration.getDeclarationAs(0, RecordDeclaration.class);
+    assertNotNull(recordDeclaration);
 
     assertEquals("SomeClass", recordDeclaration.getName());
     assertEquals("class", recordDeclaration.getKind());


### PR DESCRIPTION
Fixes #225. Restoring the old behaviour of `ScopeManager::replaceNode`, which was changed in #198 

Also added a test that checks for the correct scope assignment of constructors and method declarations.