### PR TITLE
Adding declarations to translation units through ScopeManager

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.java
@@ -28,7 +28,6 @@ package de.fraunhofer.aisec.cpg.frontends;
 
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.graph.Node;
-import de.fraunhofer.aisec.cpg.graph.RecordDeclaration;
 import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
 import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager;
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation;
@@ -40,7 +39,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 import org.apache.commons.lang3.StringUtils;
@@ -68,10 +66,6 @@ public abstract class LanguageFrontend {
   protected Map<Object, Object> processedMapping = new HashMap<>();
   private String namespaceDelimiter;
   protected TranslationUnitDeclaration currentTU = null;
-
-  /* Cache functions. */
-  //  private Map<String, FunctionDeclaration> functions = new HashMap<>();
-  private Map<String, RecordDeclaration> records = new HashMap<>();
 
   // Todo Moving this to scope manager and add listeners and processedMappings to specified scopes.
 
@@ -284,47 +278,7 @@ public abstract class LanguageFrontend {
     return ret;
   }
 
-  // TODO: Move this class to the scope manager to properly handle namespaces
-  public void addRecord(RecordDeclaration record) {
-    this.records.put(record.getName(), record);
-  }
-
-  public Map<String, RecordDeclaration> getRecords() {
-    return records;
-  }
-
-  //  public void addFunctionDeclaration(FunctionDeclaration functionDeclaration) {
-  //    this.functions.put(functionDeclaration.getSignature(), functionDeclaration);
-  //  }
-
-  //  public FunctionDeclaration getMethod(String signature) {
-  //    return this.functions.get(signature);
-  //  }
-
-  //  public FunctionDeclaration findMethod(CallExpression call) {
-  //    // filter for functions with the same name and number of arguments
-  //    List<FunctionDeclaration> candidates =
-  //        this.functions.values().stream()
-  //            .filter(
-  //                function ->
-  //                    function.getName().equals(call.getName())
-  //                        && function.getParameters().size() == call.getArguments().size())
-  //            .collect(Collectors.toList());
-  //
-  //    if (candidates.isEmpty()) {
-  //      return null;
-  //    } else if (candidates.size() == 1) {
-  //      return candidates.get(0);
-  //    } else {
-  //      // for now just return the first, but we could try deduce it via some type parameters
-  //      return candidates.get(0);
-  //    }
-  //  }
-
   public void cleanup() {
-    records.clear();
-    //    functions.clear();
-    //    functions = null;
     clearProcessed();
   }
 
@@ -333,14 +287,4 @@ public abstract class LanguageFrontend {
   }
 
   public abstract <S, T> void setComment(S s, T ctx);
-
-  /**
-   * Returns a record declaration, if it exists for the given name
-   *
-   * @param name the record name
-   * @return an optional containing the {@link RecordDeclaration}, if it exists.
-   */
-  public Optional<RecordDeclaration> getRecordForName(String name) {
-    return Optional.ofNullable(this.records.get(name));
-  }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontend.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontend.java
@@ -263,10 +263,14 @@ public class CXXLanguageFrontend extends LanguageFrontend {
 
     try {
       Benchmark bench = new Benchmark(this.getClass(), "Parsing sourcefile");
-      IASTTranslationUnit translationUnit =
-          GPPLanguage.getDefault()
-              .getASTTranslationUnit(
-                  content, scannerInfo, includeFileContentProvider, null, opts, log);
+      CPPASTTranslationUnit translationUnit =
+          (CPPASTTranslationUnit)
+              GPPLanguage.getDefault()
+                  .getASTTranslationUnit(
+                      content, scannerInfo, includeFileContentProvider, null, opts, log);
+
+      var length = translationUnit.getLength();
+      LOGGER.info("Parsed {} bytes corresponding roughly to {} LoC", length, length / 50);
       bench.stop();
 
       bench = new Benchmark(this.getClass(), "Transform to CPG");

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
@@ -372,8 +372,6 @@ public class DeclarationHandler extends Handler<Declaration, IASTDeclaration, CX
             problematicIncludes.computeIfAbsent(
                 ((ProblemDeclaration) decl).getFilename(), k -> new HashSet<>());
         problems.add((ProblemDeclaration) decl);
-      } else {
-        // node.add(decl);
       }
     }
 

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
@@ -50,6 +50,7 @@ import de.fraunhofer.aisec.cpg.graph.VariableDeclaration;
 import de.fraunhofer.aisec.cpg.graph.type.Type;
 import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.helpers.Util;
+import de.fraunhofer.aisec.cpg.passes.scopes.RecordScope;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -149,7 +150,7 @@ public class DeclarationHandler extends Handler<Declaration, IASTDeclaration, CX
         functionDeclaration instanceof MethodDeclaration
             ? ((MethodDeclaration) functionDeclaration).getRecordDeclaration()
             : null;
-    var outsideOfRecord = !this.lang.getScopeManager().isInRecord();
+    var outsideOfRecord = !(lang.getScopeManager().getCurrentScope() instanceof RecordScope);
 
     if (recordDeclaration != null) {
       if (outsideOfRecord) {

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
@@ -417,8 +417,9 @@ public class DeclarationHandler extends Handler<Declaration, IASTDeclaration, CX
 
         // attach to root note
         for (String incl : allIncludes.get(translationUnit.getFilePath())) {
-          node.add(includeMap.get(incl));
+          node.addDeclaration(includeMap.get(incl));
         }
+
         allIncludes.remove(translationUnit.getFilePath());
         // attach to remaining nodes
         for (Map.Entry<String, HashSet<String>> entry : allIncludes.entrySet()) {

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
@@ -127,10 +127,15 @@ public class DeclarationHandler extends Handler<Declaration, IASTDeclaration, CX
   }
 
   private Declaration handleProblem(CPPASTProblemDeclaration ctx) {
-    return NodeBuilder.newProblemDeclaration(
-        ctx.getContainingFilename(),
-        ctx.getProblem().getMessage(),
-        ctx.getProblem().getFileLocation().toString());
+    var problem =
+        NodeBuilder.newProblemDeclaration(
+            ctx.getContainingFilename(),
+            ctx.getProblem().getMessage(),
+            ctx.getProblem().getFileLocation().toString());
+
+    this.lang.getScopeManager().addDeclaration(problem);
+
+    return problem;
   }
 
   private FunctionDeclaration handleFunctionDefinition(CPPASTFunctionDefinition ctx) {
@@ -362,7 +367,7 @@ public class DeclarationHandler extends Handler<Declaration, IASTDeclaration, CX
         continue; // do not care about these for now
       }
 
-      Declaration decl = handle(declaration);
+      var decl = handle(declaration);
       if (decl == null) {
         continue;
       }
@@ -375,6 +380,8 @@ public class DeclarationHandler extends Handler<Declaration, IASTDeclaration, CX
       }
     }
 
+    // TODO: Remark CB: I am not quite sure, what the point of the code beyord this line is.
+    // Probably needs to be refactored
     boolean addIncludesToGraph = true; // todo move to config
     if (addIncludesToGraph) {
 

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.java
@@ -39,7 +39,6 @@ import de.fraunhofer.aisec.cpg.graph.FunctionDeclaration;
 import de.fraunhofer.aisec.cpg.graph.MethodDeclaration;
 import de.fraunhofer.aisec.cpg.graph.NodeBuilder;
 import de.fraunhofer.aisec.cpg.graph.ParamVariableDeclaration;
-import de.fraunhofer.aisec.cpg.graph.ProblemDeclaration;
 import de.fraunhofer.aisec.cpg.graph.RecordDeclaration;
 import de.fraunhofer.aisec.cpg.graph.ValueDeclaration;
 import de.fraunhofer.aisec.cpg.graph.VariableDeclaration;
@@ -356,7 +355,7 @@ class DeclaratorHandler extends Handler<Declaration, IASTNameOwner, CXXLanguageF
     lang.getScopeManager().enterScope(recordDeclaration);
     lang.getScopeManager().addDeclaration(recordDeclaration.getThis());
 
-    processMembers(ctx, recordDeclaration);
+    processMembers(ctx);
 
     if (recordDeclaration.getConstructors().isEmpty()) {
       de.fraunhofer.aisec.cpg.graph.ConstructorDeclaration constructorDeclaration =
@@ -378,26 +377,14 @@ class DeclaratorHandler extends Handler<Declaration, IASTNameOwner, CXXLanguageF
     return recordDeclaration;
   }
 
-  private void processMembers(
-      CPPASTCompositeTypeSpecifier ctx, RecordDeclaration recordDeclaration) {
+  private void processMembers(CPPASTCompositeTypeSpecifier ctx) {
     for (IASTDeclaration member : ctx.getMembers()) {
       if (member instanceof CPPASTVisibilityLabel) {
         // TODO: parse visibility
         continue;
       }
 
-      Declaration declaration = lang.getDeclarationHandler().handle(member);
-
-      /*if (declaration instanceof VariableDeclaration) {
-        FieldDeclaration fieldDeclaration =
-            FieldDeclaration.from((VariableDeclaration) declaration);
-        recordDeclaration.getFields().add(fieldDeclaration);
-        this.lang.replaceDeclarationInExpression(fieldDeclaration, declaration);
-      } else */ if (declaration instanceof ProblemDeclaration) {
-        // there is no place to put them here so let's attach them to the translation unit so that
-        // we do not loose them
-        lang.getCurrentTU().add(declaration);
-      }
+      lang.getDeclarationHandler().handle(member);
     }
   }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.java
@@ -239,7 +239,8 @@ public class DeclarationHandler
     recordDeclaration.setStaticImportStatements(partitioned.get(true));
     recordDeclaration.setImportStatements(partitioned.get(false));
 
-    this.lang.addRecord(recordDeclaration);
+    lang.getScopeManager().addDeclaration(recordDeclaration);
+
     lang.getScopeManager().enterScope(recordDeclaration);
     lang.getScopeManager().addDeclaration(recordDeclaration.getThis());
 

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.java
@@ -26,7 +26,11 @@
 
 package de.fraunhofer.aisec.cpg.frontends.java;
 
-import com.github.javaparser.*;
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.Range;
+import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
@@ -50,7 +54,11 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeS
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend;
 import de.fraunhofer.aisec.cpg.frontends.TranslationException;
-import de.fraunhofer.aisec.cpg.graph.*;
+import de.fraunhofer.aisec.cpg.graph.IncludeDeclaration;
+import de.fraunhofer.aisec.cpg.graph.NamespaceDeclaration;
+import de.fraunhofer.aisec.cpg.graph.NodeBuilder;
+import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
+import de.fraunhofer.aisec.cpg.graph.TypeManager;
 import de.fraunhofer.aisec.cpg.graph.type.TypeParser;
 import de.fraunhofer.aisec.cpg.helpers.Benchmark;
 import de.fraunhofer.aisec.cpg.helpers.CommonPath;
@@ -121,41 +129,35 @@ public class JavaLanguageFrontend extends LanguageFrontend {
       TranslationUnitDeclaration fileDeclaration =
           NodeBuilder.newTranslationUnitDeclaration(file.toString(), context.toString());
       setCurrentTU(fileDeclaration);
-      Declaration declaration = fileDeclaration;
+
+      scopeManager.resetToGlobal(fileDeclaration);
 
       PackageDeclaration packDecl = context.getPackageDeclaration().orElse(null);
       NamespaceDeclaration namespaceDeclaration = null;
       if (packDecl != null) {
         namespaceDeclaration = NodeBuilder.newNamespaceDeclaration(packDecl.getName().asString());
         // Todo set region and code and push/pop scope
+
+        scopeManager.addDeclaration(namespaceDeclaration);
+
         scopeManager.enterScope(namespaceDeclaration);
-        if (declaration instanceof TranslationUnitDeclaration) {
-          ((TranslationUnitDeclaration) declaration).add(namespaceDeclaration);
-        }
-        declaration = namespaceDeclaration;
       }
 
       for (TypeDeclaration<?> type : context.getTypes()) {
-        Declaration typeD = getDeclarationHandler().handle(type);
-        if (declaration instanceof TranslationUnitDeclaration) {
-          ((TranslationUnitDeclaration) declaration).add(typeD);
-        } else {
-          scopeManager.addDeclaration(typeD);
-        }
+        // handle each type. all declaration in this type will be added by the scope manager along
+        // the way
+        getDeclarationHandler().handle(type);
       }
 
       for (ImportDeclaration anImport : context.getImports()) {
         IncludeDeclaration incl = NodeBuilder.newIncludeDeclaration(anImport.getNameAsString());
-        if (declaration instanceof TranslationUnitDeclaration) {
-          ((TranslationUnitDeclaration) declaration).add(incl);
-        } else {
-          scopeManager.addDeclaration(incl);
-        }
+        scopeManager.addDeclaration(incl);
       }
 
       if (packDecl != null) {
         scopeManager.leaveScope(namespaceDeclaration);
       }
+
       bench.stop();
 
       return fileDeclaration;

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/CompoundStatement.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/CompoundStatement.java
@@ -27,16 +27,18 @@
 package de.fraunhofer.aisec.cpg.graph;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A statement which contains a list of statements. A common example is a function body within a
  * {@link FunctionDeclaration}.
  */
-public class CompoundStatement extends Statement {
+public class CompoundStatement extends Statement implements DeclarationHolder {
 
   /** The list of statements. */
   @NonNull
@@ -71,5 +73,11 @@ public class CompoundStatement extends Statement {
   @Override
   public int hashCode() {
     return super.hashCode();
+  }
+
+  @Override
+  public @Nullable Collection<? extends Declaration> getContainerForDeclaration(
+      Declaration declaration) {
+    return this.getLocals();
   }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/CompoundStatement.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/CompoundStatement.java
@@ -27,12 +27,10 @@
 package de.fraunhofer.aisec.cpg.graph;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A statement which contains a list of statements. A common example is a function body within a
@@ -76,8 +74,9 @@ public class CompoundStatement extends Statement implements DeclarationHolder {
   }
 
   @Override
-  public @Nullable Collection<? extends Declaration> getContainerForDeclaration(
-      Declaration declaration) {
-    return this.getLocals();
+  public void addDeclaration(@NonNull Declaration declaration) {
+    if (declaration instanceof VariableDeclaration) {
+      this.locals.add((VariableDeclaration) declaration);
+    }
   }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/CompoundStatement.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/CompoundStatement.java
@@ -36,7 +36,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  * A statement which contains a list of statements. A common example is a function body within a
  * {@link FunctionDeclaration}.
  */
-public class CompoundStatement extends Statement implements DeclarationHolder {
+public class CompoundStatement extends Statement {
 
   /** The list of statements. */
   @NonNull
@@ -71,12 +71,5 @@ public class CompoundStatement extends Statement implements DeclarationHolder {
   @Override
   public int hashCode() {
     return super.hashCode();
-  }
-
-  @Override
-  public void addDeclaration(@NonNull Declaration declaration) {
-    if (declaration instanceof VariableDeclaration) {
-      this.locals.add((VariableDeclaration) declaration);
-    }
   }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/ConstructorDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/ConstructorDeclaration.java
@@ -35,34 +35,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class ConstructorDeclaration extends MethodDeclaration {
 
-  /**
-   * Creates a constructor declaration from an existing {@link MethodDeclaration}.
-   *
-   * @param methodDeclaration the {@link MethodDeclaration}.
-   * @return the constructor declaration
-   */
-  public static ConstructorDeclaration from(MethodDeclaration methodDeclaration) {
-    RecordDeclaration recordDeclaration = methodDeclaration.getRecordDeclaration();
-
-    ConstructorDeclaration c =
-        NodeBuilder.newConstructorDeclaration(
-            methodDeclaration.getName(), methodDeclaration.getCode(), recordDeclaration);
-
-    c.setBody(methodDeclaration.getBody());
-    c.setLocation(methodDeclaration.getLocation());
-    c.setParameters(methodDeclaration.getParameters());
-    c.addAnnotations(methodDeclaration.getAnnotations());
-    c.setIsDefinition(methodDeclaration.isDefinition());
-
-    if (!c.isDefinition()) {
-      // do not call getDefinition if this is a definition itself, otherwise this
-      // will return a 'this' to the old method declaration
-      c.setDefinition(methodDeclaration.getDefinition());
-    }
-
-    return c;
-  }
-
   @Override
   public void setRecordDeclaration(@Nullable RecordDeclaration recordDeclaration) {
     super.setRecordDeclaration(recordDeclaration);

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/DeclarationHolder.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/DeclarationHolder.java
@@ -27,16 +27,22 @@
 package de.fraunhofer.aisec.cpg.graph;
 
 import java.util.Collection;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public interface DeclarationHolder {
 
   /**
-   * Returns a list of declaration that is suitable for the supplied declaration.
+   * Adds the specified declaration to this declaration holder. Ideally, the declaration holder
+   * should use the {@link #addIfNotContains(Collection, Declaration)} method to consistently add
+   * declarations.
    *
-   * @param declaration the declaration which needs to be stored
-   * @return the appropriate list or null
+   * @param declaration the declaration
    */
-  @Nullable
-  Collection<? extends Declaration> getContainerForDeclaration(Declaration declaration);
+  void addDeclaration(@NonNull Declaration declaration);
+
+  default <N extends Declaration> void addIfNotContains(Collection<N> collection, N declaration) {
+    if (!collection.contains(declaration)) {
+      collection.add(declaration);
+    }
+  }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/DeclarationHolder.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/DeclarationHolder.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019, Fraunhofer AISEC. All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+
+package de.fraunhofer.aisec.cpg.graph;
+
+import java.util.Collection;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public interface DeclarationHolder {
+
+  /**
+   * Returns a list of declaration that is suitable for the supplied declaration.
+   *
+   * @param declaration the declaration which needs to be stored
+   * @return the appropriate list or null
+   */
+  @Nullable
+  Collection<? extends Declaration> getContainerForDeclaration(Declaration declaration);
+}

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/FieldDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/FieldDeclaration.java
@@ -66,21 +66,6 @@ public class FieldDeclaration extends ValueDeclaration implements TypeListener {
 
   private List<String> modifiers = new ArrayList<>();
 
-  public FieldDeclaration() {}
-
-  private FieldDeclaration(VariableDeclaration declaration) {
-    this.name = declaration.getName();
-    this.code = declaration.getCode();
-    this.location = declaration.getLocation();
-    this.type = declaration.getType();
-    this.initializer = declaration.getInitializer();
-    this.annotations = declaration.getAnnotations();
-  }
-
-  public static FieldDeclaration from(VariableDeclaration declaration) {
-    return new FieldDeclaration(declaration);
-  }
-
   @Nullable
   public Expression getInitializer() {
     return initializer;

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/FunctionDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/FunctionDeclaration.java
@@ -28,14 +28,19 @@ package de.fraunhofer.aisec.cpg.graph;
 
 import de.fraunhofer.aisec.cpg.graph.type.Type;
 import de.fraunhofer.aisec.cpg.graph.type.UnknownType;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.neo4j.ogm.annotation.Relationship;
 
 /** Represents the declaration or definition of a function. */
-public class FunctionDeclaration extends ValueDeclaration {
+public class FunctionDeclaration extends ValueDeclaration implements DeclarationHolder {
 
   private static final String WHITESPACE = " ";
   private static final String BRACKET_LEFT = "(";
@@ -274,5 +279,19 @@ public class FunctionDeclaration extends ValueDeclaration {
 
   public void setRecords(List<RecordDeclaration> records) {
     this.records = records;
+  }
+
+  @Override
+  public @Nullable Collection<? extends Declaration> getContainerForDeclaration(
+      Declaration declaration) {
+    if (declaration instanceof ParamVariableDeclaration) {
+      return this.parameters;
+    }
+
+    if (declaration instanceof RecordDeclaration) {
+      return this.records;
+    }
+
+    return null;
   }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/FunctionDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/FunctionDeclaration.java
@@ -29,13 +29,13 @@ package de.fraunhofer.aisec.cpg.graph;
 import de.fraunhofer.aisec.cpg.graph.type.Type;
 import de.fraunhofer.aisec.cpg.graph.type.UnknownType;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.neo4j.ogm.annotation.Relationship;
 
@@ -282,16 +282,13 @@ public class FunctionDeclaration extends ValueDeclaration implements Declaration
   }
 
   @Override
-  public @Nullable Collection<? extends Declaration> getContainerForDeclaration(
-      Declaration declaration) {
+  public void addDeclaration(@NonNull Declaration declaration) {
     if (declaration instanceof ParamVariableDeclaration) {
-      return this.parameters;
+      addIfNotContains(parameters, (ParamVariableDeclaration) declaration);
     }
 
     if (declaration instanceof RecordDeclaration) {
-      return this.records;
+      addIfNotContains(records, (RecordDeclaration) declaration);
     }
-
-    return null;
   }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/MethodDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/MethodDeclaration.java
@@ -42,36 +42,6 @@ public class MethodDeclaration extends FunctionDeclaration {
    */
   @Nullable private RecordDeclaration recordDeclaration;
 
-  /**
-   * Creates a method declaration from an existing {@link FunctionDeclaration}.
-   *
-   * @param functionDeclaration the {@link FunctionDeclaration}.
-   * @param recordDeclaration the {@link RecordDeclaration} this constructor belongs to.
-   * @return the new method declaration
-   */
-  public static MethodDeclaration from(
-      FunctionDeclaration functionDeclaration, @Nullable RecordDeclaration recordDeclaration) {
-    MethodDeclaration md =
-        NodeBuilder.newMethodDeclaration(
-            functionDeclaration.getName(), functionDeclaration.getCode(), false, recordDeclaration);
-
-    md.setLocation(functionDeclaration.getLocation());
-    md.setParameters(functionDeclaration.getParameters());
-    md.setBody(functionDeclaration.getBody());
-    md.setType(functionDeclaration.getType());
-    md.addAnnotations(functionDeclaration.getAnnotations());
-    md.setRecordDeclaration(recordDeclaration);
-    md.setIsDefinition(functionDeclaration.isDefinition());
-
-    if (!md.isDefinition()) {
-      // do not call getDefinition if this is a definition itself, otherwise this
-      // will return a 'this' to the old function declaration
-      md.setDefinition(functionDeclaration.getDefinition());
-    }
-
-    return md;
-  }
-
   public boolean isStatic() {
     return isStatic;
   }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/NamespaceDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/NamespaceDeclaration.java
@@ -28,13 +28,11 @@ package de.fraunhofer.aisec.cpg.graph;
 
 import de.fraunhofer.aisec.cpg.helpers.Util;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Declares the scope of a namespace and appends its own name to the current namespace-prefix to
@@ -115,8 +113,7 @@ public class NamespaceDeclaration extends Declaration implements DeclarationHold
   }
 
   @Override
-  public @Nullable Collection<? extends Declaration> getContainerForDeclaration(
-      Declaration declaration) {
-    return this.declarations;
+  public void addDeclaration(@NonNull Declaration declaration) {
+    addIfNotContains(this.declarations, declaration);
   }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/NamespaceDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/NamespaceDeclaration.java
@@ -28,11 +28,13 @@ package de.fraunhofer.aisec.cpg.graph;
 
 import de.fraunhofer.aisec.cpg.helpers.Util;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Declares the scope of a namespace and appends its own name to the current namespace-prefix to
@@ -44,7 +46,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  * semantical difference between NamespaceDeclaration and {@link RecordDeclaration} lies in the
  * non-instantiabillity of a namespace.
  */
-public class NamespaceDeclaration extends Declaration {
+public class NamespaceDeclaration extends Declaration implements DeclarationHolder {
 
   /**
    * Edges to nested namespaces, records, functions, fields etc. contained in the current namespace.
@@ -110,5 +112,11 @@ public class NamespaceDeclaration extends Declaration {
   @Override
   public int hashCode() {
     return super.hashCode();
+  }
+
+  @Override
+  public @Nullable Collection<? extends Declaration> getContainerForDeclaration(
+      Declaration declaration) {
+    return this.declarations;
   }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/RecordDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/RecordDeclaration.java
@@ -27,7 +27,12 @@
 package de.fraunhofer.aisec.cpg.graph;
 
 import de.fraunhofer.aisec.cpg.graph.type.Type;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -36,7 +41,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.neo4j.ogm.annotation.Transient;
 
 /** Represents a C++ union/struct/class or Java class */
-public class RecordDeclaration extends Declaration {
+public class RecordDeclaration extends Declaration implements DeclarationHolder {
 
   /** The kind, i.e. struct, class, union or enum. */
   private String kind;
@@ -241,5 +246,21 @@ public class RecordDeclaration extends Declaration {
   @Override
   public int hashCode() {
     return super.hashCode();
+  }
+
+  @Override
+  public @Nullable Collection<? extends Declaration> getContainerForDeclaration(
+      Declaration declaration) {
+    if (declaration instanceof ConstructorDeclaration) {
+      return this.constructors;
+    } else if (declaration instanceof MethodDeclaration) {
+      return this.methods;
+    } else if (declaration instanceof FieldDeclaration) {
+      return this.fields;
+    } else if (declaration instanceof RecordDeclaration) {
+      return this.records;
+    }
+
+    return null;
   }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/RecordDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/RecordDeclaration.java
@@ -249,18 +249,15 @@ public class RecordDeclaration extends Declaration implements DeclarationHolder 
   }
 
   @Override
-  public @Nullable Collection<? extends Declaration> getContainerForDeclaration(
-      Declaration declaration) {
+  public void addDeclaration(@NonNull Declaration declaration) {
     if (declaration instanceof ConstructorDeclaration) {
-      return this.constructors;
+      addIfNotContains(this.constructors, (ConstructorDeclaration) declaration);
     } else if (declaration instanceof MethodDeclaration) {
-      return this.methods;
+      addIfNotContains(this.methods, (MethodDeclaration) declaration);
     } else if (declaration instanceof FieldDeclaration) {
-      return this.fields;
+      addIfNotContains(this.fields, (FieldDeclaration) declaration);
     } else if (declaration instanceof RecordDeclaration) {
-      return this.records;
+      addIfNotContains(this.records, (RecordDeclaration) declaration);
     }
-
-    return null;
   }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/Statement.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/Statement.java
@@ -29,15 +29,17 @@ package de.fraunhofer.aisec.cpg.graph;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 /** A statement. */
-public class Statement extends Node {
+public class Statement extends Node implements DeclarationHolder {
 
   /**
    * A list of local variables associated to this statement, defined by their {@link
    * VariableDeclaration} extracted from Block because for, while, if, switch can declare locals in
    * their condition or initializers
    */
+  // TODO: This is actually an AST node just for a subset of nodes, i.e. initializers in for-loops
   @SubGraph("AST")
   protected List<VariableDeclaration> locals = new ArrayList<>();
 
@@ -64,5 +66,12 @@ public class Statement extends Node {
   @Override
   public int hashCode() {
     return super.hashCode();
+  }
+
+  @Override
+  public void addDeclaration(@NonNull Declaration declaration) {
+    if (declaration instanceof VariableDeclaration) {
+      this.locals.add((VariableDeclaration) declaration);
+    }
   }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/Statement.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/Statement.java
@@ -38,7 +38,8 @@ public class Statement extends Node {
    * VariableDeclaration} extracted from Block because for, while, if, switch can declare locals in
    * their condition or initializers
    */
-  private @SubGraph("AST") List<VariableDeclaration> locals = new ArrayList<>();
+  @SubGraph("AST")
+  protected List<VariableDeclaration> locals = new ArrayList<>();
 
   public List<VariableDeclaration> getLocals() {
     return locals;

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/TranslationUnitDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/TranslationUnitDeclaration.java
@@ -99,7 +99,7 @@ public class TranslationUnitDeclaration extends Declaration {
 
   @NonNull
   public List<Declaration> getDeclarations() {
-    return Collections.unmodifiableList(declarations);
+    return declarations;
   }
 
   @NonNull

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/TranslationUnitDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/TranslationUnitDeclaration.java
@@ -37,7 +37,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** The top most declaration, representing a translation unit, for example a file. */
-public class TranslationUnitDeclaration extends Declaration {
+public class TranslationUnitDeclaration extends Declaration implements DeclarationHolder {
 
   /** A list of declarations within this unit. */
   @SubGraph("AST")
@@ -152,5 +152,9 @@ public class TranslationUnitDeclaration extends Declaration {
   @Override
   public int hashCode() {
     return super.hashCode();
+  }
+
+  public @NonNull List<? extends Declaration> getContainerForDeclaration(Declaration declaration) {
+    return this.declarations;
   }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/TranslationUnitDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/TranslationUnitDeclaration.java
@@ -112,17 +112,14 @@ public class TranslationUnitDeclaration extends Declaration implements Declarati
     return Collections.unmodifiableList(namespaces);
   }
 
-  public void add(@NonNull Declaration decl) {
-    if (decl instanceof DeclarationSequence) {
-      declarations.addAll(((DeclarationSequence) decl).asList());
-    } else {
-      if (decl instanceof IncludeDeclaration) {
-        includes.add(decl);
-      } else if (decl instanceof NamespaceDeclaration) {
-        namespaces.add(decl);
-      }
-      declarations.add(decl);
+  public void addDeclaration(@NonNull Declaration declaration) {
+    if (declaration instanceof IncludeDeclaration) {
+      includes.add(declaration);
+    } else if (declaration instanceof NamespaceDeclaration) {
+      namespaces.add(declaration);
     }
+
+    addIfNotContains(declarations, declaration);
   }
 
   @Override
@@ -152,9 +149,5 @@ public class TranslationUnitDeclaration extends Declaration implements Declarati
   @Override
   public int hashCode() {
     return super.hashCode();
-  }
-
-  public @NonNull List<? extends Declaration> getContainerForDeclaration(Declaration declaration) {
-    return this.declarations;
   }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
@@ -495,7 +495,7 @@ public class CallResolver extends Pass {
             "No current translation unit when trying to generate function dummy {}",
             dummy.getName());
       } else {
-        currentTU.add(dummy);
+        currentTU.addDeclaration(dummy);
       }
       return dummy;
     }

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.java
@@ -46,6 +46,7 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -284,6 +285,7 @@ public class VariableUsageResolver extends Pass {
     }
   }
 
+  @Nullable
   private Declaration resolveBase(DeclaredReferenceExpression reference) {
     // check if this refers to an enum
     if (enumMap.containsKey(reference.getType())) {
@@ -304,10 +306,7 @@ public class VariableUsageResolver extends Pass {
         }
       }
     } else {
-      log.info(
-          "Type declaration for {} not found in graph, using dummy to collect all " + "usages",
-          reference.getType());
-      return handleUnknownField(reference.getType(), reference.getName(), reference.getType());
+      return null;
     }
   }
 

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.java
@@ -404,7 +404,7 @@ public class VariableUsageResolver extends Pass {
       declaration.setType(returnType);
       declaration.setParameters(Util.createParameters(signature));
 
-      currTu.add(declaration);
+      currTu.addDeclaration(declaration);
       declaration.setImplicit(true);
       return declaration;
     } else {

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/GlobalScope.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/GlobalScope.java
@@ -26,8 +26,18 @@
 
 package de.fraunhofer.aisec.cpg.passes.scopes;
 
+import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
+
 public class GlobalScope extends StructureDeclarationScope {
 
+  /**
+   * This should ideally only be called once. It constructs a new global scope, which is not
+   * associated to any AST node. However, depending on the language, a language frontend can
+   * explicitly set the ast node using {@link
+   * ScopeManager#resetToGlobal(TranslationUnitDeclaration)} if the language needs a global scope
+   * that is restricted to a translation unit, i.e. C++ while still maintaing a unique list of
+   * global variables.
+   */
   public GlobalScope() {
     super(null);
   }
@@ -46,4 +56,5 @@ public class GlobalScope extends StructureDeclarationScope {
   public void addVariable(VariableDeclaration variable) {
     this.variables.add(variable);
   }*/
+
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/RecordScope.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/RecordScope.java
@@ -30,6 +30,8 @@ import de.fraunhofer.aisec.cpg.graph.Node;
 
 public class RecordScope extends NameScope {
 
+  enum Visiblity {}
+
   public RecordScope(Node node, String currentPrefix, String delimiter) {
     super(node, currentPrefix, delimiter);
   }

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/RecordScope.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/RecordScope.java
@@ -30,8 +30,6 @@ import de.fraunhofer.aisec.cpg.graph.Node;
 
 public class RecordScope extends NameScope {
 
-  enum Visiblity {}
-
   public RecordScope(Node node, String currentPrefix, String delimiter) {
     super(node, currentPrefix, delimiter);
   }

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManager.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManager.java
@@ -48,6 +48,7 @@ import de.fraunhofer.aisec.cpg.graph.Node;
 import de.fraunhofer.aisec.cpg.graph.RecordDeclaration;
 import de.fraunhofer.aisec.cpg.graph.Statement;
 import de.fraunhofer.aisec.cpg.graph.SwitchStatement;
+import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
 import de.fraunhofer.aisec.cpg.graph.TryStatement;
 import de.fraunhofer.aisec.cpg.graph.TypedefDeclaration;
 import de.fraunhofer.aisec.cpg.graph.ValueDeclaration;
@@ -442,9 +443,12 @@ public class ScopeManager {
     }
   }
 
-  public void resetToGlobal() {
+  public void resetToGlobal(TranslationUnitDeclaration declaration) {
     GlobalScope global = (GlobalScope) getFirstScopeThat(scope -> scope instanceof GlobalScope);
     if (global != null) {
+      // update the AST node to this translation unit declaration
+      global.astNode = declaration;
+
       currentScope = global;
     }
   }
@@ -452,9 +456,8 @@ public class ScopeManager {
   /**
    * Adds a declaration to the CPG by taking into account the currently active scope, and add the
    * Declaration to the appropriate node. This function will keep the declaration in the Scopes and
-   * allows the ScopeManager by himself to resolve ValueDeclarations through.
-   *
-   * <p>{@link ScopeManager#resolve(DeclaredReferenceExpression)}.
+   * allows the ScopeManager by himself to resolve ValueDeclarations through {@link
+   * ScopeManager#resolve(DeclaredReferenceExpression)}.
    *
    * @param declaration
    */
@@ -690,53 +693,37 @@ public class ScopeManager {
     return false;
   }
 
-  ///// Copied over for now - not used but maybe necessary at some point ///////
-
+  /**
+   * Retrieves the {@link RecordDeclaration} for the given name in the given scope.
+   *
+   * @param scope the scope
+   * @param name the name
+   * @return the declaration, or null if it does not exist
+   */
   @Nullable
-  @Deprecated
-  public Declaration getDeclarationForName(String name) {
-    // first, check locals
-    Declaration declaration;
-    if (isInBlock()) {
-      CompoundStatement currentBlock = getCurrentBlock();
-      declaration = getForName(currentBlock.getLocals(), name);
+  public RecordDeclaration getRecordForName(Scope scope, String name) {
+    Optional<RecordDeclaration> o = Optional.empty();
 
-      if (declaration != null) {
-        return declaration;
-      }
-    }
-    if (isInFunction()) {
-      FunctionDeclaration currentFunction = getCurrentFunction();
-      declaration = getForName(currentFunction.getParameters(), name);
-
-      if (declaration != null) {
-        return declaration;
-      }
-    }
-    if (isInRecord()) {
-      RecordDeclaration currentRecord = getCurrentRecord();
-      declaration = getForName(currentRecord.getFields(), name);
-
-      if (declaration != null) {
-        return declaration;
-      }
+    // check current scope first
+    if (scope instanceof StructureDeclarationScope) {
+      o =
+          ((StructureDeclarationScope) scope)
+              .getStructureDeclarations().stream()
+                  .filter(d -> d instanceof RecordDeclaration && Objects.equals(d.getName(), name))
+                  .map(d -> (RecordDeclaration) d)
+                  .findFirst();
     }
 
-    // lastly, check globals
-    declaration = getForName(getGlobals(), name);
+    if (o.isPresent()) {
+      return o.get();
+    }
 
-    return declaration;
+    // no parent left
+    if (scope.getParent() == null) {
+      return null;
+    }
 
-    // TODO: also check for function definitions?
-  }
-
-  @Nullable
-  @Deprecated
-  private <T extends ValueDeclaration> Declaration getForName(List<T> variables, String name) {
-    Optional<T> any =
-        variables.stream().filter(param -> Objects.equals(param.getName(), name)).findAny();
-
-    return any.orElse(null);
+    return getRecordForName(scope.getParent(), name);
   }
 
   ///// End copied over for now ///////

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManager.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManager.java
@@ -420,29 +420,7 @@ public class ScopeManager {
       toIterate = toIterate.getParent();
     } while (toIterate != null);
   }
-
-  /**
-   * Replaces the node inside of the scope manager. This is primarily used if we 'upgrade' a node in
-   * the hierarchy chain, i.e. if we construct a {@link
-   * de.fraunhofer.aisec.cpg.graph.ConstructorDeclaration} out of a {@link
-   * de.fraunhofer.aisec.cpg.graph.MethodDeclaration}.
-   *
-   * @param newNode the new node
-   * @param oldNode the old node
-   */
-  public void replaceNode(Node newNode, Node oldNode) {
-    Scope scope = scopeMap.get(oldNode);
-
-    // check, if old node has a scope
-    if (scope != null) {
-      // update ast node
-      scope.astNode = newNode;
-      // update key
-      scopeMap.remove(oldNode);
-      scopeMap.put(newNode, scope);
-    }
-  }
-
+  
   public void resetToGlobal(TranslationUnitDeclaration declaration) {
     GlobalScope global = (GlobalScope) getFirstScopeThat(scope -> scope instanceof GlobalScope);
     if (global != null) {

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManager.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManager.java
@@ -45,6 +45,7 @@ import de.fraunhofer.aisec.cpg.graph.IfStatement;
 import de.fraunhofer.aisec.cpg.graph.LabelStatement;
 import de.fraunhofer.aisec.cpg.graph.NamespaceDeclaration;
 import de.fraunhofer.aisec.cpg.graph.Node;
+import de.fraunhofer.aisec.cpg.graph.ProblemDeclaration;
 import de.fraunhofer.aisec.cpg.graph.RecordDeclaration;
 import de.fraunhofer.aisec.cpg.graph.Statement;
 import de.fraunhofer.aisec.cpg.graph.SwitchStatement;
@@ -440,7 +441,11 @@ public class ScopeManager {
    * @param declaration
    */
   public void addDeclaration(Declaration declaration) {
-    if (declaration instanceof ValueDeclaration) {
+    if (declaration instanceof ProblemDeclaration) {
+      // directly add problems to the global scope
+      var globalScope = (GlobalScope) getFirstScopeThat(scope -> scope instanceof GlobalScope);
+      globalScope.addDeclaration(declaration);
+    } else if (declaration instanceof ValueDeclaration) {
       ValueDeclarationScope scopeForValueDeclaration =
           (ValueDeclarationScope)
               getFirstScopeThat(scope -> scope instanceof ValueDeclarationScope);

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManager.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManager.java
@@ -420,7 +420,7 @@ public class ScopeManager {
       toIterate = toIterate.getParent();
     } while (toIterate != null);
   }
-  
+
   public void resetToGlobal(TranslationUnitDeclaration declaration) {
     GlobalScope global = (GlobalScope) getFirstScopeThat(scope -> scope instanceof GlobalScope);
     if (global != null) {

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/StructureDeclarationScope.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/StructureDeclarationScope.java
@@ -1,11 +1,11 @@
 package de.fraunhofer.aisec.cpg.passes.scopes;
 
 import de.fraunhofer.aisec.cpg.graph.Declaration;
-import de.fraunhofer.aisec.cpg.graph.FieldDeclaration;
 import de.fraunhofer.aisec.cpg.graph.FunctionDeclaration;
 import de.fraunhofer.aisec.cpg.graph.NamespaceDeclaration;
 import de.fraunhofer.aisec.cpg.graph.Node;
 import de.fraunhofer.aisec.cpg.graph.RecordDeclaration;
+import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
 import de.fraunhofer.aisec.cpg.graph.ValueDeclaration;
 import java.util.ArrayList;
 import java.util.List;
@@ -51,13 +51,10 @@ public class StructureDeclarationScope extends ValueDeclarationScope {
         RecordDeclaration recordD = (RecordDeclaration) astNode;
         if (declaration instanceof RecordDeclaration) {
           addIfNotContained(recordD.getRecords(), (RecordDeclaration) declaration);
-        } else if (declaration instanceof FieldDeclaration) {
-          addIfNotContained(recordD.getFields(), (FieldDeclaration) declaration);
         }
-
-      } else if (this instanceof GlobalScope) {
-        // Doe not have to be added in a declaration scope but could be added to the
-        // translationUnitDeclaration
+      } else if (astNode instanceof TranslationUnitDeclaration) {
+        TranslationUnitDeclaration tu = (TranslationUnitDeclaration) astNode;
+        addIfNotContained(tu.getDeclarations(), declaration);
       }
     }
   }

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/StructureDeclarationScope.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/StructureDeclarationScope.java
@@ -1,13 +1,11 @@
 package de.fraunhofer.aisec.cpg.passes.scopes;
 
 import de.fraunhofer.aisec.cpg.graph.Declaration;
-import de.fraunhofer.aisec.cpg.graph.FunctionDeclaration;
-import de.fraunhofer.aisec.cpg.graph.NamespaceDeclaration;
+import de.fraunhofer.aisec.cpg.graph.DeclarationHolder;
 import de.fraunhofer.aisec.cpg.graph.Node;
-import de.fraunhofer.aisec.cpg.graph.RecordDeclaration;
-import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
 import de.fraunhofer.aisec.cpg.graph.ValueDeclaration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -29,6 +27,18 @@ public class StructureDeclarationScope extends ValueDeclarationScope {
 
   private void addStructureDeclaration(@NonNull Declaration declaration) {
     structureDeclarations.add(declaration);
+
+    if (astNode instanceof DeclarationHolder) {
+      var holder = (DeclarationHolder) astNode;
+      var collection = holder.getContainerForDeclaration(declaration);
+
+      if (collection != null) {
+        addIfNotContained((Collection<Declaration>) collection, declaration);
+      }
+    } else {
+      log.error(
+          "Trying to add a value declaration to a scope which does not have a declaration holder AST node");
+    }
   }
 
   public void addDeclaration(@NonNull Declaration declaration) {
@@ -36,26 +46,6 @@ public class StructureDeclarationScope extends ValueDeclarationScope {
       addValueDeclaration((ValueDeclaration) declaration);
     } else {
       addStructureDeclaration(declaration);
-      if (astNode instanceof FunctionDeclaration) {
-        FunctionDeclaration functionD = (FunctionDeclaration) astNode;
-        if (declaration instanceof RecordDeclaration) {
-          addIfNotContained(functionD.getRecords(), (RecordDeclaration) declaration);
-        }
-
-      } else if (astNode instanceof NamespaceDeclaration) {
-        NamespaceDeclaration nameD = (NamespaceDeclaration) astNode;
-
-        addIfNotContained(nameD.getDeclarations(), declaration);
-
-      } else if (astNode instanceof RecordDeclaration) {
-        RecordDeclaration recordD = (RecordDeclaration) astNode;
-        if (declaration instanceof RecordDeclaration) {
-          addIfNotContained(recordD.getRecords(), (RecordDeclaration) declaration);
-        }
-      } else if (astNode instanceof TranslationUnitDeclaration) {
-        TranslationUnitDeclaration tu = (TranslationUnitDeclaration) astNode;
-        addIfNotContained(tu.getDeclarations(), declaration);
-      }
     }
   }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/StructureDeclarationScope.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/StructureDeclarationScope.java
@@ -5,7 +5,6 @@ import de.fraunhofer.aisec.cpg.graph.DeclarationHolder;
 import de.fraunhofer.aisec.cpg.graph.Node;
 import de.fraunhofer.aisec.cpg.graph.ValueDeclaration;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -30,17 +29,14 @@ public class StructureDeclarationScope extends ValueDeclarationScope {
 
     if (astNode instanceof DeclarationHolder) {
       var holder = (DeclarationHolder) astNode;
-      var collection = holder.getContainerForDeclaration(declaration);
-
-      if (collection != null) {
-        addIfNotContained((Collection<Declaration>) collection, declaration);
-      }
+      holder.addDeclaration(declaration);
     } else {
       log.error(
           "Trying to add a value declaration to a scope which does not have a declaration holder AST node");
     }
   }
 
+  @Override
   public void addDeclaration(@NonNull Declaration declaration) {
     if (declaration instanceof ValueDeclaration) {
       addValueDeclaration((ValueDeclaration) declaration);

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ValueDeclarationScope.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ValueDeclarationScope.java
@@ -32,7 +32,6 @@ import de.fraunhofer.aisec.cpg.graph.Node;
 import de.fraunhofer.aisec.cpg.graph.TypedefDeclaration;
 import de.fraunhofer.aisec.cpg.graph.ValueDeclaration;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
@@ -89,16 +88,12 @@ public class ValueDeclarationScope extends Scope {
    *
    * @param valueDeclaration
    */
-  public void addValueDeclaration(ValueDeclaration valueDeclaration) {
+  void addValueDeclaration(ValueDeclaration valueDeclaration) {
     this.valueDeclarations.add(valueDeclaration);
 
     if (astNode instanceof DeclarationHolder) {
       var holder = (DeclarationHolder) astNode;
-      var collection = holder.getContainerForDeclaration(valueDeclaration);
-
-      if (collection != null) {
-        addIfNotContained((Collection<Declaration>) collection, valueDeclaration);
-      }
+      holder.addDeclaration(valueDeclaration);
     } else {
       log.error(
           "Trying to add a value declaration to a scope which does not have a declaration holder AST node");
@@ -109,11 +104,5 @@ public class ValueDeclarationScope extends Scope {
      ForStatement, SwitchStatement; and others where the location of declaration is somewhere
      deeper in the AST-subtree: CompoundStatement, AssertStatement.
     */
-  }
-
-  protected void addIfNotContained(Collection<Declaration> collection, Declaration nodeToAdd) {
-    if (!collection.contains(nodeToAdd)) {
-      collection.add(nodeToAdd);
-    }
   }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ValueDeclarationScope.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ValueDeclarationScope.java
@@ -26,6 +26,8 @@
 
 package de.fraunhofer.aisec.cpg.passes.scopes;
 
+import static de.fraunhofer.aisec.cpg.helpers.Util.errorWithFileLocation;
+
 import de.fraunhofer.aisec.cpg.graph.Declaration;
 import de.fraunhofer.aisec.cpg.graph.DeclarationHolder;
 import de.fraunhofer.aisec.cpg.graph.Node;
@@ -78,7 +80,8 @@ public class ValueDeclarationScope extends Scope {
     if (declaration instanceof ValueDeclaration) {
       addValueDeclaration((ValueDeclaration) declaration);
     } else {
-      log.error("A non ValueDeclaration can not be added to a DeclarationScope");
+      errorWithFileLocation(
+          declaration, log, "A non ValueDeclaration can not be added to a DeclarationScope");
     }
   }
 
@@ -86,7 +89,7 @@ public class ValueDeclarationScope extends Scope {
    * THe value declarations are only set in the ast node if the handler of the ast node may not know
    * the outer
    *
-   * @param valueDeclaration
+   * @param valueDeclaration the {@link ValueDeclaration}
    */
   void addValueDeclaration(ValueDeclaration valueDeclaration) {
     this.valueDeclarations.add(valueDeclaration);
@@ -95,7 +98,9 @@ public class ValueDeclarationScope extends Scope {
       var holder = (DeclarationHolder) astNode;
       holder.addDeclaration(valueDeclaration);
     } else {
-      log.error(
+      errorWithFileLocation(
+          valueDeclaration,
+          log,
           "Trying to add a value declaration to a scope which does not have a declaration holder AST node");
     }
     /*

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ValueDeclarationScope.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ValueDeclarationScope.java
@@ -36,6 +36,7 @@ import de.fraunhofer.aisec.cpg.graph.NamespaceDeclaration;
 import de.fraunhofer.aisec.cpg.graph.Node;
 import de.fraunhofer.aisec.cpg.graph.ParamVariableDeclaration;
 import de.fraunhofer.aisec.cpg.graph.RecordDeclaration;
+import de.fraunhofer.aisec.cpg.graph.TranslationUnitDeclaration;
 import de.fraunhofer.aisec.cpg.graph.TypedefDeclaration;
 import de.fraunhofer.aisec.cpg.graph.ValueDeclaration;
 import de.fraunhofer.aisec.cpg.graph.VariableDeclaration;
@@ -124,8 +125,9 @@ public class ValueDeclarationScope extends Scope {
       if (valueDeclaration instanceof VariableDeclaration) {
         addIfNotContained(compoundStatement.getLocals(), (VariableDeclaration) valueDeclaration);
       }
-    } else if (this instanceof GlobalScope) {
-      // Here ther is no ast-node
+    } else if (astNode instanceof TranslationUnitDeclaration) {
+      var tu = (TranslationUnitDeclaration) astNode;
+      addIfNotContained(((TranslationUnitDeclaration) astNode).getDeclarations(), valueDeclaration);
     }
     /*
      There are nodes where we do not set the declaration when storing them in the scope,

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ValueDeclarationScope.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ValueDeclarationScope.java
@@ -104,7 +104,6 @@ public class ValueDeclarationScope extends Scope {
       NamespaceDeclaration namespaceD = (NamespaceDeclaration) astNode;
 
       addIfNotContained(namespaceD.getDeclarations(), valueDeclaration);
-
     } else if (astNode instanceof RecordDeclaration) {
       RecordDeclaration recordD = (RecordDeclaration) astNode;
       if (valueDeclaration instanceof ConstructorDeclaration) {
@@ -114,7 +113,6 @@ public class ValueDeclarationScope extends Scope {
       } else if (valueDeclaration instanceof FieldDeclaration) {
         addIfNotContained(recordD.getFields(), (FieldDeclaration) valueDeclaration);
       }
-
     } else if (astNode instanceof FunctionDeclaration) {
       FunctionDeclaration functionD = (FunctionDeclaration) astNode;
       if (valueDeclaration instanceof ParamVariableDeclaration) {
@@ -126,7 +124,6 @@ public class ValueDeclarationScope extends Scope {
         addIfNotContained(compoundStatement.getLocals(), (VariableDeclaration) valueDeclaration);
       }
     } else if (astNode instanceof TranslationUnitDeclaration) {
-      var tu = (TranslationUnitDeclaration) astNode;
       addIfNotContained(((TranslationUnitDeclaration) astNode).getDeclarations(), valueDeclaration);
     }
     /*


### PR DESCRIPTION
Declarations in the translation units where the only ones not added by the scope manager. This PR fixes that, leaving the scope manager the singular place to add new declarations. This is necessary to implement things like re-declarables (see #231).

It also contains some cleaner handling of fields, functions, methods and constructors, i.e. checking based on the current scope if it is a function or method. This should remove the need to create function declarations, which are then later on "upgraded" to methods or constructors, effectively removing the need for `ScopeManager::replaceNode` (and #226)

# API Changes

I have added a new interface `DeclarationHolder`, which CPG nodes can implement, which denotes that this node holds further declarations. It basically consists of one method, `addDeclaration`, which the holder needs to implement and this controls how and to which field (i.e. methods, constructors, etc. in the case of a record decl) the declaration is added to.