### PR TITLE
Fix issue when parsing functions whose name is in extra parentheses

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.java
@@ -170,15 +170,22 @@ class DeclaratorHandler extends Handler<Declaration, IASTNameOwner, CXXLanguageF
     // treats these levels as separate declarators, so we need to get to the bottom for the
     // actual name...
     IASTDeclarator nameDecl = ctx;
+    var hasPointer = false;
+
     while (nameDecl.getNestedDeclarator() != null) {
       nameDecl = nameDecl.getNestedDeclarator();
+      if (nameDecl.getPointerOperators().length > 0) {
+        hasPointer = true;
+      }
     }
+
+    String name = nameDecl.getName().toString();
+
     // Attention! This might actually be a function pointer (requires at least one level of
     // parentheses and a pointer operator)
-    if (nameDecl != ctx && nameDecl.getPointerOperators().length > 0) {
-      return handleFunctionPointer(ctx, nameDecl.getName().toString());
+    if (nameDecl != ctx && hasPointer) {
+      return handleFunctionPointer(ctx, name);
     }
-    String name = nameDecl.getName().toString();
 
     /*
      * As always, there are some special cases to consider and one of those are C++ operators.

--- a/src/test/resources/types/fptr_type.cpp
+++ b/src/test/resources/types/fptr_type.cpp
@@ -1,4 +1,4 @@
-void (*global_no_param_void)(void);
+void ((*global_no_param_void))(void);
 void (*global_no_param)();
 void ((*global_one_param)(int));
 int (*global_two_param)(int, unsigned long);


### PR DESCRIPTION
As found by @peckto when trying to parse the eLua library