### PR TITLE
DFG Hotfix

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java
@@ -254,12 +254,17 @@ public class ExpressionHandler extends Handler<Statement, Expression, JavaLangua
 
       if (oInitializer.isPresent()) {
         de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression initializer =
-            (de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression)
-                handle(oInitializer.get());
+                (de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression)
+                        handle(oInitializer.get());
         if (initializer instanceof ArrayCreationExpression) {
           declaration.setIsArray(true);
         }
         declaration.setInitializer(initializer);
+      } else {
+        de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression uninitialzedInitializer =
+                new UninitializedValue();
+        declaration.setInitializer(uninitialzedInitializer);
+        declaration.getNextEOG();
       }
       lang.setCodeAndRegion(declaration, variable);
       declarationStatement.getDeclarations().add(declaration);

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/UninitializedValue.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/UninitializedValue.java
@@ -1,0 +1,7 @@
+package de.fraunhofer.aisec.cpg.graph.statements.expressions;
+
+public class UninitializedValue extends Expression {
+  public UninitializedValue() {
+    setName("Uninitialized Value");
+  }
+}

--- a/src/main/java/de/fraunhofer/aisec/cpg/helpers/ControlFlowSensitiveDFG.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/helpers/ControlFlowSensitiveDFG.java
@@ -290,7 +290,7 @@ public class ControlFlowSensitiveDFG {
     }
 
     this.variables = joinVariables(dfgs);
-    this.removes = joinRemoves(dfgs);
+    mergeRemoves(joinRemoves(dfgs));
 
     for (ControlFlowSensitiveDFG dfg : dfgs) {
       this.visitedEOG.addAll(dfg.getVisitedEOG());
@@ -323,6 +323,16 @@ public class ControlFlowSensitiveDFG {
     setIngoingDFG(currNode);
   }
 
+  private void mergeRemoves(Map<Node, Set<Node>> newRemoves) {
+    for (Node n : newRemoves.keySet()) {
+      if (this.removes.containsKey(n)) {
+        this.removes.get(n).addAll(newRemoves.get(n));
+      } else {
+        this.removes.put(n, newRemoves.get(n));
+      }
+    }
+  }
+
   private Node handleDeclaredReferenceExpression(DeclaredReferenceExpression currNode) {
     if (currNode.getAccess().equals(AccessValues.WRITE)) {
       // This is an assignment
@@ -340,7 +350,7 @@ public class ControlFlowSensitiveDFG {
       dfg.handle();
 
       this.variables = joinVariables(dfgs);
-      this.removes = joinRemoves(dfgs);
+      mergeRemoves(joinRemoves(dfgs));
 
       this.visitedEOG.addAll(dfg.getVisitedEOG());
       modifyDFGEdges(currNode);

--- a/src/main/java/de/fraunhofer/aisec/cpg/helpers/ControlFlowSensitiveDFG.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/helpers/ControlFlowSensitiveDFG.java
@@ -315,7 +315,7 @@ public class ControlFlowSensitiveDFG {
             rechableEOGs.stream()
                     .filter(n -> n instanceof BinaryOperator && ((BinaryOperator) n).getLhs().equals(node))
                     .findAny()
-                    .get();
+                    .orElse(null);
     return binaryOperator;
   }
 

--- a/src/main/java/de/fraunhofer/aisec/cpg/helpers/ControlFlowSensitiveDFG.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/helpers/ControlFlowSensitiveDFG.java
@@ -311,12 +311,10 @@ public class ControlFlowSensitiveDFG {
       rechableEOGs.addAll(eogTraversal(next));
     }
 
-    Node binaryOperator =
-            rechableEOGs.stream()
-                    .filter(n -> n instanceof BinaryOperator && ((BinaryOperator) n).getLhs().equals(node))
-                    .findAny()
-                    .orElse(null);
-    return binaryOperator;
+    return rechableEOGs.stream()
+            .filter(n -> n instanceof BinaryOperator && ((BinaryOperator) n).getLhs().equals(node))
+            .findAny()
+            .orElse(null);
   }
 
   /**
@@ -340,11 +338,11 @@ public class ControlFlowSensitiveDFG {
    * @param newRemoves remove map of the other ControlFlowSensitiveDFG
    */
   private void mergeRemoves(Map<Node, Set<Node>> newRemoves) {
-    for (Node n : newRemoves.keySet()) {
-      if (this.removes.containsKey(n)) {
-        this.removes.get(n).addAll(newRemoves.get(n));
+    for (Map.Entry<Node, Set<Node>> entry : newRemoves.entrySet()) {
+      if (this.removes.containsKey(entry.getKey())) {
+        this.removes.get(entry.getKey()).addAll(entry.getValue());
       } else {
-        this.removes.put(n, newRemoves.get(n));
+        this.removes.put(entry.getKey(), entry.getValue());
       }
     }
   }

--- a/src/main/java/de/fraunhofer/aisec/cpg/helpers/ControlFlowSensitiveDFG.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/helpers/ControlFlowSensitiveDFG.java
@@ -318,7 +318,8 @@ public class ControlFlowSensitiveDFG {
   }
 
   /**
-   * Perform the actual modification of the DFG edges based on the values that are recorded in the variables map for every VariableDeclaration
+   * Perform the actual modification of the DFG edges based on the values that are recorded in the
+   * variables map for every VariableDeclaration
    *
    * @param currNode node whose dfg edges have to be replaced
    */
@@ -356,7 +357,9 @@ public class ControlFlowSensitiveDFG {
   private Node handleDeclaredReferenceExpression(DeclaredReferenceExpression currNode) {
     if (currNode.getAccess().equals(AccessValues.WRITE)) {
       // This is an assignment -> DeclaredReferenceExpression + Write Access
-      Node binaryOperator = obtainAssignmentNode(currNode); // Search for = BinaryOperator as it marks the end of the assignment
+      Node binaryOperator =
+              obtainAssignmentNode(
+                      currNode); // Search for = BinaryOperator as it marks the end of the assignment
 
       Node nextEOG =
               currNode
@@ -365,10 +368,13 @@ public class ControlFlowSensitiveDFG {
       List<ControlFlowSensitiveDFG> dfgs = new ArrayList<>();
 
       ControlFlowSensitiveDFG dfg =
-              new ControlFlowSensitiveDFG(nextEOG, binaryOperator, variables, this.visitedEOG); // Run DFG Pass until we reach the end of the assignment
+              new ControlFlowSensitiveDFG(
+                      nextEOG,
+                      binaryOperator,
+                      variables,
+                      this.visitedEOG); // Run DFG Pass until we reach the end of the assignment
       dfgs.add(dfg);
       dfg.handle();
-
 
       // Update values of DFG Pass until the end of the assignment
       this.variables = joinVariables(dfgs);
@@ -380,15 +386,14 @@ public class ControlFlowSensitiveDFG {
 
       return binaryOperator; // Continue the EOG traversal after the assignment
     } else {
-      // Other DeclaredReferenceExpression that do not have a write assignment we do not have to delay the replacement of the value in the VariableDeclaration
+      // Other DeclaredReferenceExpression that do not have a write assignment we do not have to
+      // delay the replacement of the value in the VariableDeclaration
       modifyDFGEdges(currNode);
       return getNextEOG(currNode);
     }
   }
 
-  /**
-   * Main method that performs the ControlFlowSensitveDFG analysis and transformation.
-   */
+  /** Main method that performs the ControlFlowSensitveDFG analysis and transformation. */
   public void handle() {
     Node currNode = startNode;
     while (!visitedEOG.contains(currNode) && currNode != null && !currNode.equals(endNode)) {

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.java
@@ -120,6 +120,7 @@ public class EvaluationOrderGraphPass extends Pass {
     map.put(ConstructExpression.class, this::handleConstructExpression);
     map.put(EmptyStatement.class, this::handleDefault);
     map.put(Literal.class, this::handleDefault);
+    map.put(UninitializedValue.class, this::handleDefault);
     map.put(DefaultStatement.class, this::handleDefault);
     map.put(TypeIdExpression.class, this::handleDefault);
     map.put(DeclaredReferenceExpression.class, this::handleDefault);

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/DFGTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/DFGTest.java
@@ -243,7 +243,7 @@ class DFGTest {
         TestUtils.analyze(List.of(topLevel.resolve("unaryoperator.cpp").toFile()), topLevel, true);
 
     UnaryOperator rwUnaryOperator =
-        TestUtils.findByUniqueName(TestUtils.subnodesOfType(result, UnaryOperator.class), "++");
+            TestUtils.findByUniqueName(TestUtils.subnodesOfType(result, UnaryOperator.class), "++");
     DeclaredReferenceExpression expression =
             TestUtils.findByUniqueName(
                     TestUtils.subnodesOfType(result, DeclaredReferenceExpression.class), "i");

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/DFGTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/DFGTest.java
@@ -245,13 +245,118 @@ class DFGTest {
     UnaryOperator rwUnaryOperator =
         TestUtils.findByUniqueName(TestUtils.subnodesOfType(result, UnaryOperator.class), "++");
     DeclaredReferenceExpression expression =
-        TestUtils.findByUniqueName(
-            TestUtils.subnodesOfType(result, DeclaredReferenceExpression.class), "i");
+            TestUtils.findByUniqueName(
+                    TestUtils.subnodesOfType(result, DeclaredReferenceExpression.class), "i");
 
     Set<Node> prevDFGOperator = rwUnaryOperator.getPrevDFG();
     Set<Node> nextDFGOperator = rwUnaryOperator.getNextDFG();
 
     assertTrue(prevDFGOperator.contains(expression));
     assertTrue(nextDFGOperator.contains(expression));
+  }
+
+  /**
+   * Ensures that if there is an assignment like a = a + b the replacement of the current value of
+   * the VariableDeclaration is delayed until the entire assignment has been traversed. This is
+   * necessary, since if the replacement was not delayed the rhs a would have an incoming dfg edge
+   * from a + b
+   *
+   * @throws Exception
+   */
+  @Test
+  void testDelayedAssignment() throws Exception {
+    Path topLevel = Path.of("src", "test", "resources", "dfg");
+    List<TranslationUnitDeclaration> result =
+            TestUtils.analyze(
+                    List.of(topLevel.resolve("DelayedAssignmentAfterRHS.java").toFile()), topLevel, true);
+
+    BinaryOperator binaryOperatorAssignment =
+            TestUtils.findByUniqueName(TestUtils.subnodesOfType(result, BinaryOperator.class), "=");
+
+    BinaryOperator binaryOperatorAddition =
+            TestUtils.findByUniqueName(TestUtils.subnodesOfType(result, BinaryOperator.class), "+");
+
+    VariableDeclaration varA =
+            TestUtils.findByUniqueName(
+                    TestUtils.subnodesOfType(result, VariableDeclaration.class), "a");
+    VariableDeclaration varB =
+            TestUtils.findByUniqueName(
+                    TestUtils.subnodesOfType(result, VariableDeclaration.class), "b");
+
+    DeclaredReferenceExpression lhsA =
+            (DeclaredReferenceExpression) binaryOperatorAssignment.getLhs();
+    DeclaredReferenceExpression rhsA =
+            (DeclaredReferenceExpression) binaryOperatorAddition.getLhs();
+
+    DeclaredReferenceExpression b =
+            TestUtils.findByUniqueName(
+                    TestUtils.subnodesOfType(result, DeclaredReferenceExpression.class), "b");
+
+    Literal<?> literal0 =
+            TestUtils.findByPredicate(
+                    TestUtils.subnodesOfType(result, Literal.class), l -> l.getValue().equals(0))
+                    .get(0);
+
+    Literal<?> literal1 =
+            TestUtils.findByPredicate(
+                    TestUtils.subnodesOfType(result, Literal.class), l -> l.getValue().equals(1))
+                    .get(0);
+
+    assertEquals(0, varA.getNextDFG().size()); // No outgoing DFG edges from VariableDeclaration a
+    assertEquals(0, varB.getNextDFG().size()); // No outgoing DFG edges from VariableDeclaration b
+
+    // Check that the replacement of the current value for VariableDeclaration a is delayed until
+    // the assignment is completed. This means that the DeclaredReferenceExpression on the rhs must
+    // contain a prev dfg edge to the previous valid value for VariableDeclaration a (literal 0)
+    assertEquals(1, rhsA.getPrevDFG().size());
+    assertTrue(rhsA.getPrevDFG().contains(literal0));
+
+    // Check outgoing dfg edges of literal 0 (VariableDeclaration a initializer and rhs expression
+    // of a = a + b
+    assertEquals(2, literal0.getNextDFG().size());
+    assertEquals(0, literal0.getPrevDFG().size());
+    assertTrue(literal0.getNextDFG().contains(varA));
+
+    // Check incoming dfg edges of VariableDeclaration a (lhs of a = a + b, 0 and expr a + b
+    assertEquals(3, varA.getPrevDFG().size());
+    assertTrue(varA.getPrevDFG().contains(lhsA));
+    assertTrue(varA.getPrevDFG().contains(binaryOperatorAddition));
+    assertTrue(varA.getPrevDFG().contains(literal0));
+
+    // Check incoming dfg edges in binaryOperator + (DeclaredReferenceExpression a and b)
+    assertEquals(2, binaryOperatorAddition.getPrevDFG().size());
+    assertTrue(binaryOperatorAddition.getPrevDFG().contains(b));
+    assertTrue(binaryOperatorAddition.getPrevDFG().contains(rhsA));
+
+    // Check outgoing dfg edges from binaryOperator + (lhs a from a = a + b and into
+    // VariableDeclaration a)
+    assertEquals(2, binaryOperatorAddition.getNextDFG().size());
+    assertTrue(binaryOperatorAddition.getNextDFG().contains(varA));
+    assertTrue(binaryOperatorAddition.getNextDFG().contains(lhsA));
+
+    // Check outgoing dfg edges of literal1 (VariableDeclaration b and DeclaredReferenceExpression
+    // b)
+    assertEquals(2, literal1.getNextDFG().size());
+    assertTrue(literal1.getNextDFG().contains(varB));
+    assertTrue(literal1.getNextDFG().contains(b));
+  }
+
+  /**
+   * Tests that there are no outgoing DFG edges from a VariableDeclaration
+   *
+   * @throws Exception
+   */
+  @Test
+  void testNoOutgoingDFGFromVariableDeclaration() throws Exception {
+    Path topLevel = Path.of("src", "test", "resources", "dfg");
+    List<TranslationUnitDeclaration> result =
+            TestUtils.analyze(List.of(topLevel.resolve("BasicSlice.java").toFile()), topLevel, true);
+
+    VariableDeclaration varA =
+            TestUtils.findByUniqueName(
+                    TestUtils.subnodesOfType(result, VariableDeclaration.class), "a");
+
+    assertEquals(0, varA.getNextDFG().size());
+    assertEquals(7, varA.getPrevDFG().size());
   }
 }

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/calls/ConstructorsTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/calls/ConstructorsTest.java
@@ -9,6 +9,8 @@ import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration;
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration;
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.ConstructExpression;
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.NewExpression;
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.UninitializedValue;
+
 import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -57,7 +59,7 @@ class ConstructorsTest extends BaseTest {
     assertEquals(twoArgs, a3Initializer.getConstructor());
 
     VariableDeclaration a4 = TestUtils.findByUniqueName(variables, "a4");
-    assertNull(a4.getInitializer());
+    assertTrue(a4.getInitializer() instanceof UninitializedValue);
   }
 
   @Test

--- a/src/test/resources/dfg/BasicSlice.java
+++ b/src/test/resources/dfg/BasicSlice.java
@@ -1,0 +1,48 @@
+public class BasicSlice {
+
+    public static void main(String[] args) {     // samples/BasicSlice.java:a:12:13 samples/BasicSlice.java
+        int a = 0;
+        int b = 1, c = 0, d = 0;
+        boolean sunShines = true; // and i am still inside :(
+
+        /*
+        if (b > 2) {
+            a +=2; // 3
+        } else {
+            a -=2; // 2
+        }
+        b = a; // 1
+        a -= 4; // 4
+
+         */
+
+        if (a > 0) {
+            d = 5;
+            c = 2;
+            if (b > 0) {
+                d = a * 2;
+                a = a + d * 2;
+            } else if (b < -2) {
+                a = a - 10;
+            }
+        } else {
+            b = -2;
+            d = -2;
+            a--;
+        }
+
+        a = a + b;
+
+        switch (sunShines) {
+            case True:
+                a = a * 2;
+                c = -2;
+                break;
+            case False:
+                a = 290;
+                d = -2;
+                b = -2;
+                break;
+        }
+    }
+}

--- a/src/test/resources/dfg/DelayedAssignmentAfterRHS.java
+++ b/src/test/resources/dfg/DelayedAssignmentAfterRHS.java
@@ -1,0 +1,9 @@
+public class DelayedAssignmentAfterRHS {
+
+    public static void main(String[] args) {
+        int a = 0;
+        int b = 1;
+        
+        a = a + b;
+    }
+}


### PR DESCRIPTION
Fixes multiple issues with incorrect DFG edges.
- VariableDeclaration should not contain any outgoing DFG edges.
- The replacement of DFG edges in an assignment must be delayed until the assignment has been completely processed, in order to avoid the issue that a rhs DeclaredReferenceExpression has a dfg edge from the las. E.g.: a = a + b.

## Graph Changes
None

## Interface Changes
None