### PR TITLE
Fixed NPE in ExpressionHandler

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.java
@@ -292,12 +292,15 @@ class ExpressionHandler extends Handler<Expression, IASTInitializerClause, CXXLa
   private Expression handleFieldReference(CPPASTFieldReference ctx) {
     Expression base = this.handle(ctx.getFieldOwner());
     // Replace Literal this with a reference pointing to this
-    if (base instanceof Literal && ((Literal) base).getValue().equals("this")) {
+    if (base instanceof Literal && ((Literal<?>) base).getValue().equals("this")) {
       PhysicalLocation location = base.getLocation();
+
+      var record = lang.getScopeManager().getCurrentRecord();
+
       base =
           NodeBuilder.newDeclaredReferenceExpression(
               "this",
-              lang.getScopeManager().getCurrentRecord().getThis().getType(),
+              record != null ? record.getThis().getType() : UnknownType.getUnknownType(),
               base.getCode());
       base.setLocation(location);
     }


### PR DESCRIPTION
Fixes #252: `ScopeManager::getCurrentRecord()` is declared as `@Nullable`, so one should not assume that it is safe to call `getThis()` on it.

