### PR TITLE
openCypher integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -165,6 +165,9 @@ dependencies {
     // CDT
     api("org.eclipse.cdt:core:6.11.1.202006011430")
 
+    // openCypher
+    api("org.opencypher:front-end-9.0:9.0.20190305")
+
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -166,7 +166,7 @@ dependencies {
     api("org.eclipse.cdt:core:6.11.1.202006011430")
 
     // openCypher
-    api("org.opencypher:front-end-9.0:9.0.20190305")
+    api("org.opencypher:parser-9.0:9.0.20190305")
 
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib")

--- a/src/main/java/de/fraunhofer/aisec/cpg/ExperimentalGraph.kt
+++ b/src/main/java/de/fraunhofer/aisec/cpg/ExperimentalGraph.kt
@@ -1,4 +1,7 @@
 package de.fraunhofer.aisec.cpg
 
+/**
+ * This annotation marks the use an experimental graph feature.
+ */
 @RequiresOptIn
 annotation class ExperimentalGraph()

--- a/src/main/java/de/fraunhofer/aisec/cpg/ExperimentalGraph.kt
+++ b/src/main/java/de/fraunhofer/aisec/cpg/ExperimentalGraph.kt
@@ -1,0 +1,4 @@
+package de.fraunhofer.aisec.cpg
+
+@RequiresOptIn
+annotation class ExperimentalGraph()

--- a/src/main/java/de/fraunhofer/aisec/cpg/TranslationResult.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/TranslationResult.java
@@ -26,6 +26,8 @@
 
 package de.fraunhofer.aisec.cpg;
 
+import de.fraunhofer.aisec.cpg.graph.Node;
+import de.fraunhofer.aisec.cpg.graph.SubGraph;
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -37,11 +39,13 @@ import java.util.Map;
  * de.fraunhofer.aisec.cpg.frontends.LanguageFrontend} will initially populate it and a {@link
  * de.fraunhofer.aisec.cpg.passes.Pass} can extend it.
  */
-public class TranslationResult {
+public class TranslationResult extends Node {
   public static final String SOURCE_LOCATIONS_TO_FRONTEND = "sourceLocationsToFrontend";
   private final TranslationManager translationManager;
+
   /** Entry points to the CPG: "TranslationUnits" refer to source files. */
-  private List<TranslationUnitDeclaration> translationUnits = new ArrayList<>();
+  @SubGraph("AST")
+  private final List<TranslationUnitDeclaration> translationUnits = new ArrayList<>();
 
   /** A free-for-use HashMap where passes can store whatever they want. */
   private Map<String, Object> scratch = new HashMap<>();

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/Graph.kt
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/Graph.kt
@@ -68,9 +68,6 @@ class QueryContext constructor(val graph: Graph) {
     }
 
     internal fun handleMatch(match: Match) {
-        // keep track of bound variables
-        val variables = mutableSetOf<LogicalVariable>()
-
         // find out which class we need (only first pattern for now)
         val pattern = match.pattern().patternParts().head()
         if (pattern is EveryPath) {
@@ -89,7 +86,6 @@ class QueryContext constructor(val graph: Graph) {
     }
 
     private fun handleRelationshipChain(chain: RelationshipChain, nodes: List<Node>, where: Option<Where>) {
-        // TODO: support relationships based on 'any' label
         // relationship = we need the label for now
         val relationship = chain.relationship()
 
@@ -129,10 +125,6 @@ class QueryContext constructor(val graph: Graph) {
 
     private fun handleNodePattern(element: NodePattern, nodes: List<Node>, where: Option<Where>, predicate: Predicate<in Node>?): List<Node> {
         var stream = nodes.parallelStream()
-
-        if (predicate != null) {
-            stream = stream.filter(predicate)
-        }
 
         val labels = element.labels()
 
@@ -178,6 +170,10 @@ class QueryContext constructor(val graph: Graph) {
                     }
                 }
             }
+        }
+
+        if (predicate != null) {
+            stream = stream.filter(predicate)
         }
 
         val list = stream.collect(Collectors.toList())
@@ -307,7 +303,7 @@ class Graph(var nodes: List<Node>) {
 
     @OptIn(ExperimentalTime::class)
     fun executeQuery(query: Query): List<Node> {
-        var ctx = QueryContext(this)
+        val ctx = QueryContext(this)
 
         var list: List<Node> = listOf()
         val b = QueryBenchmark(this, query)

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/Graph.kt
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/Graph.kt
@@ -1,0 +1,346 @@
+package de.fraunhofer.aisec.cpg.graph
+
+import de.fraunhofer.aisec.cpg.ExperimentalGraph
+import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
+import de.fraunhofer.aisec.cpg.helpers.Benchmark
+import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
+import org.neo4j.ogm.annotation.Relationship
+import org.opencypher.v9_0.ast.*
+import org.opencypher.v9_0.expressions.*
+import org.opencypher.v9_0.parser.CypherParser
+import scala.Option
+import java.util.*
+import java.util.stream.Collectors
+import java.util.stream.Stream
+import kotlin.time.ExperimentalTime
+import kotlin.time.milliseconds
+
+@ExperimentalGraph
+class QueryBenchmark constructor(db: Graph, query: Query) :
+        Benchmark(db.javaClass,
+                "totalNodes: " + db.size() + " query: " + query.toString()), AutoCloseable {
+    override fun close() {
+        stop()
+    }
+}
+
+/**
+ * Returns a {@link Graph} object starting from this translation result.
+ */
+@ExperimentalGraph
+val TranslationResult.graph: Graph
+    get() {
+        // TODO: retrieve ALL nodes, not just AST, i.e. we are missing type nodes
+        val nodes = SubgraphWalker.flattenAST(this)
+
+        return Graph(nodes)
+    }
+
+
+/**
+ * Represents a graph consisting of the specified nodes. It can be queried using openCypher queries.
+ */
+@ExperimentalGraph
+class Graph(var nodes: List<Node>) {
+
+    private val parser = CypherParser()
+
+    fun size(): Int {
+        return nodes.size
+    }
+
+    operator fun plusAssign(node: Node) {
+        nodes += node
+    }
+
+    fun query(queryText: String): List<Node> {
+        val query = parser.parse(queryText, null) as Query
+
+        return executeQuery(query)
+    }
+
+    @OptIn(ExperimentalTime::class)
+    fun executeQuery(query: Query): List<Node> {
+        var list: List<Node> = listOf()
+        val b = QueryBenchmark(this, query)
+        b.use {
+            // very hacky for now
+            val singleQuery = query.part() as SingleQuery
+
+            lateinit var stream: Stream<Node>
+            for (clause in singleQuery.clauses()) {
+                // TODO: have a map of streams for the variables?
+                if (clause is Match) {
+                    stream = handleMatch(clause)
+                } else if (clause is Return) {
+                    list = handleReturn(clause, stream)
+                }
+            }
+        }
+
+        println("Query took ${b.duration.milliseconds}")
+
+        return list
+    }
+
+    private fun handleReturn(`return`: Return, streamIn: Stream<Node>): List<Node> {
+        var stream = streamIn
+
+        val limit: Limit? = `return`.limit().getOrElse { null }
+        if (limit != null) {
+            val expression = limit.expression()
+
+            if (expression is IntegerLiteral) {
+                stream = stream.limit(expression.value())
+            } else {
+                throw RuntimeException("Only non-negative integers are allowed")
+            }
+        }
+
+        return stream.collect(Collectors.toList())
+    }
+
+    private fun handleMatch(match: Match): Stream<Node> {
+        var stream = nodes.parallelStream()
+
+        // keep track of bound variables
+        val variables = mutableSetOf<LogicalVariable>()
+
+        // find out which class we need (only first pattern for now)
+        val pattern = match.pattern().patternParts().head()
+        if (pattern is EveryPath) {
+            stream = handleEveryPath(pattern, stream, variables, match.where())
+        }
+
+        return stream
+    }
+
+    private fun handleEveryPath(pattern: PatternPart, streamIn: Stream<Node>, variables: MutableSet<LogicalVariable>, where: Option<Where>): Stream<Node> {
+        var stream = streamIn
+        val element = pattern.element()
+
+        if (element is NodePattern) {
+            stream = handleNodePattern(element, stream, variables, where)
+        } else if (element is RelationshipChain) {
+            stream = handleRelationshipChain(element, stream, variables, where)
+        }
+
+        return stream
+    }
+
+    private fun handleRelationshipChain(chain: RelationshipChain, streamIn: Stream<Node>, variables: MutableSet<LogicalVariable>, where: Option<Where>): Stream<Node> {
+        var stream = streamIn
+
+        // first, handle it like a normal node
+        stream = handleNodePattern(chain.element() as NodePattern, stream, variables, where)
+
+        // TODO: support relationships based on 'any' label
+        // relationship = we need the label for now
+        val relationship = chain.relationship()
+
+        if (relationship.direction() is SemanticDirection.`BOTH$`) {
+            TODO("Not supporting relationships with both directions yet")
+        }
+
+        if (relationship.types().isEmpty) {
+            TODO("Not supporting relationships without type yet")
+        } else {
+            val type = relationship.types().head()
+
+            stream = stream.filter {
+                var relationshipProperty = it[type.name().toLowerCase(), relationship.direction().toString()]
+
+                // check for the existence of the edge
+                if (relationshipProperty is Collection<*>) {
+                    // TODO: check if it really needs unwrapping, not all our nodes are modelled this way
+                    relationshipProperty = PropertyEdge.unwrap(relationshipProperty as MutableList<PropertyEdge<Node>>)
+
+                    // TODO: save these sub streams somehow or use flatmap?
+                    var subStream = relationshipProperty.stream() as Stream<Node>
+                    if (chain.rightNode() is NodePattern) {
+                        subStream = handleNodePattern(chain.rightNode(), subStream, variables, where)
+                    } else {
+                        TODO()
+                    }
+
+                    subStream.count() > 0
+                } else {
+                    relationshipProperty != null
+                }
+            }
+        }
+
+        return stream
+    }
+
+    private fun handleNodePattern(element: NodePattern, streamIn: Stream<Node>, variables: MutableSet<LogicalVariable>, where: Option<Where>): Stream<Node> {
+        var stream = streamIn
+        val labels = element.labels()
+
+        // only one label for now
+        if (!labels.isEmpty) {
+            val label = labels.head()
+
+            stream = stream.filter {
+                it.labels.contains(label.name())
+            }
+        }
+
+        // lets do the where
+        if (where.isDefined) {
+            val inner = where.get()
+
+            val expression = inner.expression()
+            if (expression is Equals) {
+                // check for variables
+                val list = getVariables(expression)
+
+                if (list.size > 1) {
+                    TODO("Cannot handle comparison between two variables yet")
+                }
+
+                // variable seems optional
+                val o = element.variable()
+                val variable: Variable? = o.getOrElse { null }
+
+                // add to variables
+                variable?.let { variables += it }
+
+                /*list.forEach {
+                    if (!variables.contains(it)) {
+                        throw RuntimeException("Variable ${it.name()} is not defined")
+                    }
+                }*/
+
+                // only select it, if contains a variable bound for this node pattern; or no variables are present
+                if (list.isEmpty() || list.contains(variable)) {
+                    stream = handleEquals(expression, stream)
+                }
+            }
+        }
+
+        return stream
+    }
+
+    private fun handleEquals(expression: Equals, stream: Stream<Node>): Stream<Node> {
+        return stream.filter {
+            val lhs = handleExpression(it, expression.lhs())
+            val rhs = handleExpression(it, expression.rhs())
+
+            if (lhs is Number && rhs is Number) {
+                lhs.toLong() == rhs.toLong()
+            } else {
+                lhs == rhs
+            }
+        }
+    }
+
+    private fun handleExpression(node: Node, expression: Expression): Any? {
+        if (expression is Literal) {
+            return handleLiteral(expression)
+        } else if (expression is Property) {
+            return handleProperty(node, expression)
+        }
+
+        return null
+    }
+
+    private fun handleProperty(node: Node, property: Property): Any? {
+        // it seems, that non-valid properties are silently ignored, need to check
+        // that in the openCypher specification
+        return node[property.propertyKey().name()]
+    }
+
+    private fun handleLiteral(literal: Literal): Any {
+        return literal.value()
+    }
+
+    fun getVariables(equals: Equals): List<Variable> {
+        val list = mutableListOf<Variable>()
+
+        list.addAll(getVariables(equals.lhs()))
+        list.addAll(getVariables(equals.rhs()))
+
+        return list
+    }
+
+    private fun getVariables(expression: Expression): List<Variable> {
+        if (expression is Property) {
+            return getVariables(expression)
+        }
+
+        return emptyList()
+    }
+
+    private fun getVariables(property: Property): List<Variable> {
+        return listOf(property.map() as Variable)
+    }
+
+    operator fun Node.get(key: String): Any? {
+        return getProperty(this.javaClass, key)
+    }
+
+    operator fun Node.get(key: String, direction: String): Any? {
+        return getRelationship(this.javaClass, key, direction)
+    }
+
+    private fun Node.getRelationship(clazz: Class<*>, key: String, direction: String): Any? {
+        return try {
+            val field = clazz.getDeclaredField(key)
+
+            if (field.trySetAccessible()) {
+                val annotation = field.getAnnotation(Relationship::class.java)
+
+                if (annotation.direction == direction) {
+                    field.get(this)
+                } else {
+                    null
+                }
+            } else {
+                // TODO: throw exception?
+                null
+            }
+        } catch (e: NoSuchFieldException) {
+            if (clazz.superclass != null) {
+                getRelationship(clazz.superclass, key, direction)
+            } else {
+                null
+            }
+        }
+    }
+
+    private fun Node.getProperty(clazz: Class<*>, key: String): Any? {
+        // TODO: cache fields somehow?
+        return try {
+            val field = clazz.getDeclaredField(key)
+
+            if (field.trySetAccessible()) {
+                field.get(this)
+            } else {
+                // TODO: throw exception?
+                null
+            }
+        } catch (e: NoSuchFieldException) {
+            if (clazz.superclass != null) {
+                getProperty(clazz.superclass, key)
+            } else {
+                null
+            }
+        }
+    }
+}
+
+// TODO: do this once and cache it
+val Node.labels: List<String>
+    get() {
+        // for now, just the class itself
+        // TODO: hierarchy
+
+        val labels = mutableListOf<String>()
+
+        labels += this.javaClass.simpleName
+
+        return labels
+    }
+

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/Graph.kt
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/Graph.kt
@@ -327,6 +327,23 @@ class Graph(var nodes: List<Node>) {
     }
 }
 
+/**
+ * Returns the node's label based on its class hierarchy. It might seem like a good idea to cache this somehow
+ * but for some reason, it is faster to do it this way. An example query run almost twice as fast this way.
+ * So it looks like Kotlin optimizes the heck out of this.
+ */
+val Node.labels: List<String>
+    get() {
+        val labels = mutableListOf<String>()
+
+        var clazz: Class<*>? = this.javaClass
+        while (clazz != null && clazz != Object::class.java) {
+            labels += clazz.simpleName
+            clazz = clazz.superclass
+        }
+
+        return labels
+    }
 
 operator fun Node.get(key: String): Any? {
     return getProperty(this.javaClass, key)
@@ -381,16 +398,5 @@ private fun Node.getProperty(clazz: Class<*>, key: String): Any? {
     }
 }
 
-// TODO: do this once and cache it
-val Node.labels: List<String>
-    get() {
-        // for now, just the class itself
-        // TODO: hierarchy
 
-        val labels = mutableListOf<String>()
-
-        labels += this.javaClass.simpleName
-
-        return labels
-    }
 

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/Graph.kt
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/Graph.kt
@@ -5,10 +5,12 @@ import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.helpers.Benchmark
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
+import de.fraunhofer.aisec.cpg.passes.CallResolver
 import org.neo4j.ogm.annotation.Relationship
 import org.opencypher.v9_0.ast.*
 import org.opencypher.v9_0.expressions.*
 import org.opencypher.v9_0.parser.CypherParser
+import org.slf4j.LoggerFactory
 import scala.Option
 import java.io.Closeable
 import java.util.function.Predicate
@@ -38,7 +40,15 @@ val TranslationResult.graph: Graph
         return Graph(nodes)
     }
 
-
+/**
+ * A query context represents an interface between an openCypher query and the actual graph.
+ * It contains of different handler functions, belonging to different language constructs in
+ * the openCypher language, such as MATCH or RETURN. These handler functions basically execute
+ * the query on the graph.
+ *
+ * Please see https://github.com/Fraunhofer-AISEC/cpg/pull/276 for an overview of currently
+ * supported openCypher features.
+ */
 @ExperimentalGraph
 class QueryContext constructor(val graph: Graph) {
     val results = mutableMapOf<Variable, MutableList<Node>>()
@@ -285,6 +295,8 @@ class QueryContext constructor(val graph: Graph) {
 @ExperimentalGraph
 class Graph(var nodes: List<Node>) {
 
+    private val logger = LoggerFactory.getLogger(Graph::class.java)
+
     private val parser = CypherParser()
 
     fun size(): Int {
@@ -321,7 +333,7 @@ class Graph(var nodes: List<Node>) {
             }
         }
 
-        println("Query took ${b.duration.milliseconds}")
+        logger.info("Query took ${b.duration.milliseconds}")
 
         return list
     }

--- a/src/test/java/de/fraunhofer/aisec/cpg/graph/QueryTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/cpg/graph/QueryTest.kt
@@ -77,8 +77,6 @@ class QueryTest {
 
         b.stop()
         println("Experimental query2 took: ${b.duration.milliseconds}")
-
-
     }
 
     @Test

--- a/src/test/java/de/fraunhofer/aisec/cpg/graph/QueryTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/cpg/graph/QueryTest.kt
@@ -25,14 +25,13 @@ class QueryTest {
         val query = parser.parse("MATCH (n:FunctionDeclaration)-[:PARAMETERS]->(m:ParamVariableDeclaration) RETURN n", null) as Query
         var nodes = listOf<Node>()
 
-        var b: Benchmark
         var variables = mutableMapOf<String, MutableList<Node>>()
 
         nodes = db.executeQuery(query)
 
         assertEquals(2, nodes.size)
 
-        b = Benchmark(QueryTest::class.java, "something else - stream version")
+        var b: Benchmark = Benchmark(QueryTest::class.java, "something else - stream version")
         variables = mutableMapOf()
         variables["n"] = mutableListOf()
         variables["m"] = mutableListOf()
@@ -42,7 +41,7 @@ class QueryTest {
                 .filter {
                     val parameters = PropertyEdge.unwrap(it["parameters", "OUTGOING"] as List<PropertyEdge<Node>>)
 
-                    var params = parameters.parallelStream().filter { it is ParamVariableDeclaration }.collect(Collectors.toList())
+                    val params = parameters.parallelStream().filter { it is ParamVariableDeclaration }.collect(Collectors.toList())
 
                     variables["m"]?.addAll(params)
                     !params.isEmpty()
@@ -56,7 +55,6 @@ class QueryTest {
         println("Experimental query2 took: ${b.duration.milliseconds}")
 
         b = Benchmark(QueryTest::class.java, "something else")
-        nodes = mutableListOf()
         variables["n"] = mutableListOf()
         variables["m"] = mutableListOf()
 

--- a/src/test/java/de/fraunhofer/aisec/cpg/graph/QueryTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/cpg/graph/QueryTest.kt
@@ -1,0 +1,127 @@
+package de.fraunhofer.aisec.cpg.graph
+
+import de.fraunhofer.aisec.cpg.ExperimentalGraph
+import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
+import de.fraunhofer.aisec.cpg.graph.types.UnknownType
+import org.junit.jupiter.api.BeforeAll
+import org.opencypher.v9_0.ast.Query
+import org.opencypher.v9_0.parser.CypherParser
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.ExperimentalTime
+
+@ExperimentalGraph
+@ExperimentalTime
+class QueryTest {
+    @Test
+    fun testQueryExistenceOfEdge() {
+        val query = parser.parse("MATCH (n:FunctionDeclaration)-[:PARAMETERS]->(:ParamVariableDeclaration) RETURN n", null) as Query
+
+        val nodes = db.executeQuery(query)
+
+        assertEquals(2, nodes.size)
+    }
+
+    @Test
+    fun testQueryExistenceOfEdgeWithEquals() {
+        val query = parser.parse("MATCH (n:FunctionDeclaration)-[:PARAMETERS]->(m:ParamVariableDeclaration) WHERE m.name = 'paramB' RETURN n", null) as Query
+
+        val nodes = db.executeQuery(query)
+
+        assertEquals(1, nodes.size)
+        assertEquals(func2, nodes[0])
+    }
+
+    @Test
+    fun testQueryWithSimpleProperty() {
+        val query = parser.parse("MATCH (n:VariableDeclaration) WHERE n.name = 'myVar' RETURN n", null) as Query
+        println(query)
+
+        val nodes = db.executeQuery(query)
+
+        assertEquals(1, nodes.size)
+    }
+
+    @Test
+    fun testQueryAllNodes() {
+        // should return all nodes
+        val query = parser.parse("MATCH (n) RETURN n", null) as Query
+        println(query)
+
+        val nodes = db.executeQuery(query)
+
+        assertEquals(db.size(), nodes.size)
+    }
+
+    @Test
+    fun testQueryAllNodesWithEquals() {
+        // should return all nodes
+        val query = parser.parse("MATCH (n) WHERE 1=1 RETURN n", null) as Query
+        println(query)
+
+        val nodes = db.executeQuery(query)
+
+        assertEquals(db.size(), nodes.size)
+    }
+
+    @Test
+    fun testQueryLimit() {
+        // should return all nodes
+        val query = parser.parse("MATCH (n) RETURN n LIMIT 25", null) as Query
+        println(query)
+
+        val nodes = db.executeQuery(query)
+
+        assertEquals(25, nodes.size)
+    }
+
+    @Test
+    fun testQueryNoResult() {
+        // should return no nodes
+        val query = parser.parse("MATCH (n) WHERE 1='a' RETURN n", null) as Query
+        println(query)
+
+        val nodes = db.executeQuery(query)
+        println(nodes)
+
+        assertTrue(nodes.isEmpty())
+    }
+
+    companion object {
+        lateinit var db: Graph
+        val parser = CypherParser()
+
+        lateinit var func1: FunctionDeclaration
+        lateinit var func2: FunctionDeclaration
+        lateinit var func3: FunctionDeclaration
+
+        @ExperimentalGraph
+        @BeforeAll
+        @JvmStatic
+        fun before() {
+            db = Graph(mutableListOf())
+            db += NodeBuilder.newVariableDeclaration("myVar", UnknownType.getUnknownType(), "myVar", false)
+
+            func1 = NodeBuilder.newFunctionDeclaration("func1", "private int func1() { return 1; }")
+            func2 = NodeBuilder.newFunctionDeclaration("func2", "private int func2() { return 1; }")
+            func3 = NodeBuilder.newFunctionDeclaration("func3", "private int func2() { return 1; }")
+            val paramA = NodeBuilder.newMethodParameterIn("paramA", UnknownType.getUnknownType(), false, "paramA");
+            val paramB = NodeBuilder.newMethodParameterIn("paramB", UnknownType.getUnknownType(), false, "paramB");
+            func1.addParameter(paramA)
+            func2.addParameter(paramB)
+
+            // create some dummy nodes to make queries a little bit slower
+            for (i in 0..10000) {
+                db += NodeBuilder.newVariableDeclaration("var${i}", UnknownType.getUnknownType(), "var${i}", true)
+            }
+
+            db += func1
+            db += func2
+            db += func3
+            db += paramA
+            db += paramB
+        }
+    }
+
+}

--- a/src/test/java/de/fraunhofer/aisec/cpg/graph/QueryTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/cpg/graph/QueryTest.kt
@@ -88,6 +88,30 @@ class QueryTest {
         assertTrue(nodes.isEmpty())
     }
 
+    @Test
+    fun testQueryLesser() {
+        // should return no nodes
+        val query = parser.parse("MATCH (n) WHERE 1<0 RETURN n", null) as Query
+        println(query)
+
+        val nodes = db.executeQuery(query)
+        println(nodes)
+
+        assertTrue(nodes.isEmpty())
+    }
+
+    @Test
+    fun testQueryGreaterThan() {
+        // should return no nodes
+        val query = parser.parse("MATCH (n) WHERE 0>1 RETURN n", null) as Query
+        println(query)
+
+        val nodes = db.executeQuery(query)
+        println(nodes)
+
+        assertTrue(nodes.isEmpty())
+    }
+
     companion object {
         lateinit var db: Graph
         val parser = CypherParser()

--- a/src/test/java/de/fraunhofer/aisec/cpg/graph/QueryTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/cpg/graph/QueryTest.kt
@@ -23,16 +23,13 @@ class QueryTest {
     @Test
     fun testQueryExistenceOfEdge() {
         val query = parser.parse("MATCH (n:FunctionDeclaration)-[:PARAMETERS]->(m:ParamVariableDeclaration) RETURN n", null) as Query
-        var nodes = listOf<Node>()
 
-        var variables = mutableMapOf<String, MutableList<Node>>()
-
-        nodes = db.executeQuery(query)
+        var nodes: List<Node> = db.executeQuery(query)
 
         assertEquals(2, nodes.size)
 
         var b: Benchmark = Benchmark(QueryTest::class.java, "something else - stream version")
-        variables = mutableMapOf()
+        val variables: MutableMap<String, MutableList<Node>> = mutableMapOf()
         variables["n"] = mutableListOf()
         variables["m"] = mutableListOf()
 
@@ -44,7 +41,7 @@ class QueryTest {
                     val params = parameters.parallelStream().filter { it is ParamVariableDeclaration }.collect(Collectors.toList())
 
                     variables["m"]?.addAll(params)
-                    !params.isEmpty()
+                    params.isNotEmpty()
                 }
                 .collect(Collectors.toList())
 
@@ -91,9 +88,6 @@ class QueryTest {
         val nodes = db.executeQuery(query)
 
         assertEquals(2, nodes.size)
-
-
-
     }
 
     @Test

--- a/src/test/java/de/fraunhofer/aisec/cpg/graph/TranslationResultTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/cpg/graph/TranslationResultTest.kt
@@ -1,0 +1,39 @@
+package de.fraunhofer.aisec.cpg.graph
+
+import de.fraunhofer.aisec.cpg.BaseTest
+import de.fraunhofer.aisec.cpg.ExperimentalGraph
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationManager
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@ExperimentalGraph
+class TranslationResultTest : BaseTest() {
+    @Test
+    fun testFromTranslationUnit() {
+        val file = File("src/test/resources/compiling/RecordDeclaration.java")
+
+        val config = TranslationConfiguration.builder()
+                .sourceLocations(listOf(file))
+                .topLevel(file.parentFile)
+                .defaultPasses()
+                .debugParser(true)
+                .failOnError(true)
+                .build()
+
+        val analyzer = TranslationManager.builder().config(config).build()
+
+        val result = analyzer.analyze().get()
+
+        val graph = result.graph
+        assertNotNull(graph)
+
+        var nodes = graph.query("MATCH (m:MethodDeclaration) RETURN m")
+        assertEquals(1, nodes.size)
+
+        nodes = graph.query("MATCH (l:Literal) WHERE l.value = 0 RETURN l")
+        assertEquals(2, nodes.size)
+    }
+}

--- a/src/test/java/de/fraunhofer/aisec/cpg/graph/TranslationResultTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/cpg/graph/TranslationResultTest.kt
@@ -31,7 +31,8 @@ class TranslationResultTest : BaseTest() {
         assertNotNull(graph)
 
         var nodes = graph.query("MATCH (m:MethodDeclaration) RETURN m")
-        assertEquals(1, nodes.size)
+        // returns the method declaration as well as the constructor declaration
+        assertEquals(2, nodes.size)
 
         nodes = graph.query("MATCH (l:Literal) WHERE l.value = 0 RETURN l")
         assertEquals(2, nodes.size)


### PR DESCRIPTION
This is work in progress. This adds a `Graph` class, which offers a simple interface to query its content with openCypher (https://opencypher.org). It is tied to the translation results using a Kotlin extension  `TranslationResult.graph` and can be used like this:

```Kotlin
val graph = result.graph

var nodes = graph.query("MATCH (m:MethodDeclaration) RETURN m")
```

Only a very limited subset of openCypher is supported for now. This includes

- Simple `MATCH` for nodes with a simple `WHERE` query, such as `MATCH (n) WHERE n.name = "myName" RETURN n`
- Very basic relationship queries, such as `MATCH (n:SomeType)-[:SOME_EDGE]->(m:OtherType) RETURN n`, also including simple `WHERE` constrains on the nodes, but not on the edge
- Can now either return the left or ride side variable of a relationship query, i.e. `MATCH (n:FunctionDeclaration)-[:PARAMETERS]->(m:ParamVariableDeclaration) RETURN m`
- Labels on multiple hierarchy levels are supported, i.e. looking for a `VariableDeclaration` should also find `ParamVariableDeclarations`

BEWARE: This is not optimised at all. It just stupidly uses the Java Stream API. I guess there is huge potential in optimising things, but this is not in scope at the moment.

The unit test https://github.com/Fraunhofer-AISEC/cpg/blob/opencypher-support/src/test/java/de/fraunhofer/aisec/cpg/graph/QueryTest.kt should give you an indication of what is supported.

Definitely NOT working (yet) is:
- `WHERE` conditions on edge properties
- an edge `MATCH` without specifying the edge label, such as `-[]->`. This is potentially not that easy, since it means that we need to gather all edge properties in a class. Also probably pretty slow without any optimisation
- Undirected edges or edges specifying both directions
- everything else in the openCypher language