### PR TITLE
compatibility to neo4j ogm

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/helpers/LocationConverter.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/helpers/LocationConverter.java
@@ -33,19 +33,26 @@ import de.fraunhofer.aisec.cpg.sarif.Region;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.neo4j.ogm.typeconversion.CompositeAttributeConverter;
 
 public class LocationConverter implements CompositeAttributeConverter<PhysicalLocation> {
+
+  public static final String START_LINE = "startLine";
+  public static final String END_LINE = "endLine";
+  public static final String START_COLUMN = "startColumn";
+  public static final String END_COLUMN = "endColumn";
+  public static final String ARTIFACT = "artifact";
 
   @Override
   public Map<String, ?> toGraphProperties(PhysicalLocation value) {
     Map<String, Object> properties = new HashMap<>();
     if (value != null) {
-      properties.put("artifact", value.getArtifactLocation().getUri().toString());
-      properties.put("startLine", value.getRegion().getStartLine());
-      properties.put("endLine", value.getRegion().getEndLine());
-      properties.put("startColumn", value.getRegion().getStartColumn());
-      properties.put("endColumn", value.getRegion().getEndColumn());
+      properties.put(ARTIFACT, value.getArtifactLocation().getUri().toString());
+      properties.put(START_LINE, value.getRegion().getStartLine());
+      properties.put(END_LINE, value.getRegion().getEndLine());
+      properties.put(START_COLUMN, value.getRegion().getStartColumn());
+      properties.put(END_COLUMN, value.getRegion().getEndColumn());
     }
     return properties;
   }
@@ -53,15 +60,20 @@ public class LocationConverter implements CompositeAttributeConverter<PhysicalLo
   @Override
   public PhysicalLocation toEntityAttribute(Map<String, ?> value) {
     try {
-      int startLine = toIntExact((Integer) value.get("startLine"));
-      int endLine = toIntExact((Integer) value.get("endLine"));
-      int startColumn = toIntExact((Integer) value.get("startColumn"));
-      int endColumn = toIntExact((Integer) value.get("endColumn"));
-      URI uri = URI.create((String) value.get("artifact"));
+      final int startLine = toInt(value.get(START_LINE));
+      final int endLine = toInt(value.get(END_LINE));
+      final int startColumn = toInt(value.get(START_COLUMN));
+      final int endColumn = toInt(value.get(END_COLUMN));
+      final URI uri = URI.create((String) value.get(ARTIFACT));
 
       return new PhysicalLocation(uri, new Region(startLine, startColumn, endLine, endColumn));
     } catch (NullPointerException e) {
       return null;
     }
+  }
+
+  private int toInt(final Object objectToMap) {
+    final long value = Long.parseLong(objectToMap.toString());
+    return toIntExact(value);
   }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/sarif/PhysicalLocation.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/sarif/PhysicalLocation.java
@@ -27,6 +27,8 @@
 package de.fraunhofer.aisec.cpg.sarif;
 
 import java.net.URI;
+
+import com.google.common.base.Objects;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -63,6 +65,19 @@ public class PhysicalLocation {
     public String toString() {
       return uri.getPath().substring(uri.getPath().lastIndexOf('/') + 1);
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof ArtifactLocation)) return false;
+      ArtifactLocation that = (ArtifactLocation) o;
+      return Objects.equal(uri, that.uri);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(uri);
+    }
   }
 
   @NonNull private final ArtifactLocation artifactLocation;
@@ -91,5 +106,19 @@ public class PhysicalLocation {
   @Override
   public String toString() {
     return artifactLocation.toString() + "(" + region.toString() + ")";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof PhysicalLocation)) return false;
+    PhysicalLocation that = (PhysicalLocation) o;
+    return Objects.equal(artifactLocation, that.artifactLocation)
+            && Objects.equal(region, that.region);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(artifactLocation, region);
   }
 }

--- a/src/test/java/de/fraunhofer/aisec/cpg/helpers/BaseAttributeConverterTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/helpers/BaseAttributeConverterTest.java
@@ -1,0 +1,8 @@
+package de.fraunhofer.aisec.cpg.helpers;
+
+import de.fraunhofer.aisec.cpg.BaseTest;
+import org.neo4j.ogm.typeconversion.CompositeAttributeConverter;
+
+abstract class BaseAttributeConverterTest<T> extends BaseTest {
+  abstract CompositeAttributeConverter<T> getSut();
+}

--- a/src/test/java/de/fraunhofer/aisec/cpg/helpers/LocationConverterTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/helpers/LocationConverterTest.java
@@ -1,0 +1,217 @@
+package de.fraunhofer.aisec.cpg.helpers;
+
+import com.google.common.base.Objects;
+import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation;
+import de.fraunhofer.aisec.cpg.sarif.Region;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.neo4j.ogm.typeconversion.CompositeAttributeConverter;
+
+public class LocationConverterTest extends BaseAttributeConverterTest<PhysicalLocation> {
+
+  private static final String URI_STRING = "test://test:1234";
+  private static final URI URI_TO_TEST = URI.create(URI_STRING);
+
+  CompositeAttributeConverter<PhysicalLocation> getSut() {
+    return new LocationConverter();
+  }
+
+  @Test
+  void toEntityAttributeWithNullValueLine() {
+    // arrange
+    final CompositeAttributeConverter<PhysicalLocation> sut = getSut();
+    // act
+    final PhysicalLocation have = sut.toEntityAttribute(null);
+    // assert
+    Assertions.assertNull(have);
+  }
+
+  @Test
+  void toEntityAttributeWithNullStartLine() {
+    // arrange
+    final CompositeAttributeConverter<PhysicalLocation> sut = getSut();
+    final Map<String, ?> value = new HashMap<>();
+    value.put(LocationConverter.START_LINE, null);
+    // act
+    final PhysicalLocation have = sut.toEntityAttribute(value);
+    // assert
+    Assertions.assertNull(have);
+  }
+
+  @Test
+  void toEntityAttributeWithInteger() {
+    // arrange
+    final CompositeAttributeConverter<PhysicalLocation> sut = getSut();
+    final Map<String, Object> value = new HashMap<>();
+    final int startLineValue = 1;
+    value.put(LocationConverter.START_LINE, startLineValue); // autoboxing to Integer
+    final int endLineValue = 2;
+    value.put(LocationConverter.END_LINE, endLineValue);
+    final int startColumnValue = 3;
+    value.put(LocationConverter.START_COLUMN, startColumnValue);
+    final int endColumnValue = 4;
+    value.put(LocationConverter.END_COLUMN, endColumnValue);
+    value.put(LocationConverter.ARTIFACT, URI_STRING);
+    final Region region =
+        new Region(startLineValue, startColumnValue, endLineValue, endColumnValue);
+    final PhysicalLocation want = new PhysicalLocation(URI_TO_TEST, region);
+    // act
+    final PhysicalLocation have = sut.toEntityAttribute(value);
+    // assert
+    Assertions.assertEquals(want, have);
+  }
+
+  @Test
+  void toEntityAttributeWithLong() {
+    // arrange
+    final CompositeAttributeConverter<PhysicalLocation> sut = getSut();
+    final Map<String, Object> value = new HashMap<>();
+    final long startLineValue = 1;
+    value.put(LocationConverter.START_LINE, startLineValue); // autoboxing to Long
+    final long endLineValue = 2;
+    value.put(LocationConverter.END_LINE, endLineValue);
+    final long startColumnValue = 3;
+    value.put(LocationConverter.START_COLUMN, startColumnValue);
+    final long endColumnValue = 4;
+    value.put(LocationConverter.END_COLUMN, endColumnValue);
+    value.put(LocationConverter.ARTIFACT, URI_STRING);
+    final Region region =
+        new Region(
+            (int) startLineValue, (int) startColumnValue,
+            (int) endLineValue, (int) endColumnValue);
+    final PhysicalLocation want = new PhysicalLocation(URI_TO_TEST, region);
+    // act
+    final PhysicalLocation have = sut.toEntityAttribute(value);
+    // assert
+    Assertions.assertEquals(want, have);
+  }
+
+  @Test
+  void toEntityAttributeWithIntegerAndLong() {
+    // arrange
+    final CompositeAttributeConverter<PhysicalLocation> sut = getSut();
+    final Map<String, Object> value = new HashMap<>();
+    final int startLineValue = 1;
+    value.put(LocationConverter.START_LINE, startLineValue); // autoboxing to Integer
+    final int endLineValue = 2;
+    value.put(LocationConverter.END_LINE, endLineValue);
+    final long startColumnValue = 3;
+    value.put(LocationConverter.START_COLUMN, startColumnValue); // autoboxing to Long
+    final long endColumnValue = 4;
+    value.put(LocationConverter.END_COLUMN, endColumnValue);
+    value.put(LocationConverter.ARTIFACT, URI_STRING);
+    final Region region =
+        new Region(
+            startLineValue, (int) startColumnValue,
+            endLineValue, (int) endColumnValue);
+    final PhysicalLocation want = new PhysicalLocation(URI_TO_TEST, region);
+    // act
+    final PhysicalLocation have = sut.toEntityAttribute(value);
+    // assert
+    Assertions.assertEquals(want, have);
+  }
+
+  @Test
+  void toEntityAttributeWithStrings() {
+    // arrange
+    final CompositeAttributeConverter<PhysicalLocation> sut = getSut();
+    final Map<String, Object> value = new HashMap<>();
+    final String startLineValue = "1";
+    value.put(LocationConverter.START_LINE, startLineValue);
+    final String endLineValue = "2";
+    value.put(LocationConverter.END_LINE, endLineValue);
+    final String startColumnValue = "3";
+    value.put(LocationConverter.START_COLUMN, startColumnValue);
+    final String endColumnValue = "4";
+    value.put(LocationConverter.END_COLUMN, endColumnValue);
+    value.put(LocationConverter.ARTIFACT, URI_STRING);
+    final Region region =
+        new Region(
+            Integer.parseInt(startLineValue),
+            Integer.parseInt(startColumnValue),
+            Integer.parseInt(endLineValue),
+            Integer.parseInt(endColumnValue));
+    final PhysicalLocation want = new PhysicalLocation(URI_TO_TEST, region);
+    // act
+    final PhysicalLocation have = sut.toEntityAttribute(value);
+    // assert
+    Assertions.assertEquals(want, have);
+  }
+
+  @Test
+  void toEntityAttributeWithCustomTypes() {
+    // arrange
+    final CompositeAttributeConverter<PhysicalLocation> sut = getSut();
+    final Map<String, Object> value = new HashMap<>();
+    final Object startLineValue = new CustomNumber(1);
+    value.put(LocationConverter.START_LINE, startLineValue);
+    final Object endLineValue = new CustomNumber(2);
+    value.put(LocationConverter.END_LINE, endLineValue);
+    final Object startColumnValue = new CustomNumber(3);
+    value.put(LocationConverter.START_COLUMN, startColumnValue);
+    final Object endColumnValue = new CustomNumber(4);
+    value.put(LocationConverter.END_COLUMN, endColumnValue);
+    value.put(LocationConverter.ARTIFACT, URI_STRING);
+    final Region region =
+        new Region(
+            Integer.parseInt(startLineValue.toString()),
+            Integer.parseInt(startColumnValue.toString()),
+            Integer.parseInt(endLineValue.toString()),
+            Integer.parseInt(endColumnValue.toString()));
+    final PhysicalLocation want = new PhysicalLocation(URI_TO_TEST, region);
+    // act
+    final PhysicalLocation have = sut.toEntityAttribute(value);
+    // assert
+    Assertions.assertEquals(want, have);
+  }
+
+  private static class CustomNumber extends Number {
+
+    private final int value;
+
+    private CustomNumber(final int value) {
+      this.value = value;
+    }
+
+    @Override
+    public int intValue() {
+      return value;
+    }
+
+    @Override
+    public long longValue() {
+      return intValue();
+    }
+
+    @Override
+    public float floatValue() {
+      return longValue();
+    }
+
+    @Override
+    public double doubleValue() {
+      return floatValue();
+    }
+
+    @Override
+    public String toString() {
+      return Integer.toString(intValue());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof CustomNumber)) return false;
+      CustomNumber that = (CustomNumber) o;
+      return value == that.value;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(value);
+    }
+  }
+}


### PR DESCRIPTION
Loading a node from a Neo4j database that contains a PhysicalLocation throws a MappingException that is caused by a ClassCastException. 
The call:
session.query(Node::class.java,  "MATCH (n) RETURN n", HashMap<String, Any>())

The ClassCastException is caused by the conversion of a Long to a Integer in the LocationConverter and toIntExact expects a long value.
Therefore, I replaced the dangerous conversion with Long.parseLong and tested it.