### PR TITLE
Added operatorCode to member expressions and member call expressions

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.java
@@ -310,6 +310,7 @@ class ExpressionHandler extends Handler<Expression, IASTInitializerClause, CXXLa
             base,
             UnknownType.getUnknownType(),
             ctx.getFieldName().toString(),
+            ctx.isPointerDereference() ? "->" : ".",
             ctx.getRawSignature());
 
     this.lang.expressionRefersToDeclaration(memberExpression, ctx);
@@ -415,6 +416,7 @@ class ExpressionHandler extends Handler<Expression, IASTInitializerClause, CXXLa
               baseTypename + "." + member.getName(),
               ((MemberExpression) reference).getBase(),
               member,
+              ((MemberExpression) reference).getOperatorCode(),
               ctx.getRawSignature());
     } else if (reference instanceof BinaryOperator
         && ((BinaryOperator) reference).getOperatorCode().equals(".")) {
@@ -426,18 +428,14 @@ class ExpressionHandler extends Handler<Expression, IASTInitializerClause, CXXLa
               "",
               ((BinaryOperator) reference).getLhs(),
               ((BinaryOperator) reference).getRhs(),
+              ((BinaryOperator) reference).getOperatorCode(),
               reference.getCode());
     } else if (reference instanceof UnaryOperator
         && ((UnaryOperator) reference).getOperatorCode().equals("*")) {
-      // Classic C-style function pointer call -> let's extract the target. For easy
-      // compatibility with C++-style function pointer calls, we create a member call without a base
+      // Classic C-style function pointer call -> let's extract the target
       callExpression =
-          NodeBuilder.newMemberCallExpression(
-              reference.getCode(),
-              "",
-              null,
-              ((UnaryOperator) reference).getInput(),
-              reference.getCode());
+          NodeBuilder.newCallExpression(
+              ((UnaryOperator) reference).getInput().getName(), "", reference.getCode());
     } else {
       String fqn = reference.getName();
       String name = fqn;

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java
@@ -379,6 +379,7 @@ public class ExpressionHandler extends Handler<Statement, Expression, JavaLangua
               base,
               fieldType,
               fieldAccessExpr.getName().getIdentifier(),
+              ".", // there is only "." in java
               fieldAccessExpr.toString());
       memberExpression.setStaticAccess(true);
       return memberExpression;
@@ -389,7 +390,11 @@ public class ExpressionHandler extends Handler<Statement, Expression, JavaLangua
     }
 
     return NodeBuilder.newMemberExpression(
-        base, fieldType, fieldAccessExpr.getName().getIdentifier(), fieldAccessExpr.toString());
+        base,
+        fieldType,
+        fieldAccessExpr.getName().getIdentifier(),
+        ".",
+        fieldAccessExpr.toString());
   }
 
   private Literal handleLiteralExpression(Expression expr) {
@@ -713,7 +718,7 @@ public class ExpressionHandler extends Handler<Statement, Expression, JavaLangua
             methodCallExpr); // This will also overwrite the code set to the empty string set above
         callExpression =
             NodeBuilder.newMemberCallExpression(
-                name, qualifiedName, base, member, methodCallExpr.toString());
+                name, qualifiedName, base, member, ".", methodCallExpr.toString());
       } else {
         String targetClass;
         if (resolved != null) {

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/NodeBuilder.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/NodeBuilder.java
@@ -239,11 +239,12 @@ public class NodeBuilder {
   }
 
   public static CallExpression newMemberCallExpression(
-      String name, String fqn, Node base, Node member, String code) {
+      String name, String fqn, Node base, Node member, String operatorCode, String code) {
     MemberCallExpression node = new MemberCallExpression();
     node.setName(name);
     node.setBase(base);
     node.setMember(member);
+    node.setOperatorCode(operatorCode);
     node.setCode(code);
     node.setFqn(fqn);
 
@@ -464,9 +465,10 @@ public class NodeBuilder {
   }
 
   public static MemberExpression newMemberExpression(
-      Expression base, Type memberType, String name, String code) {
+      Expression base, Type memberType, String name, String operatorCode, String code) {
     MemberExpression node = new MemberExpression();
     node.setBase(base);
+    node.setOperatorCode(operatorCode);
     node.setCode(code);
     node.setName(name);
     node.setType(memberType);

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/MemberCallExpression.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/MemberCallExpression.java
@@ -47,6 +47,8 @@ public class MemberCallExpression extends CallExpression {
     this.member = member;
   }
 
+  private String operatorCode;
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -65,5 +67,13 @@ public class MemberCallExpression extends CallExpression {
   @Override
   public int hashCode() {
     return super.hashCode();
+  }
+
+  public void setOperatorCode(String operatorCode) {
+    this.operatorCode = operatorCode;
+  }
+
+  public String getOperatorCode() {
+    return operatorCode;
   }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/MemberExpression.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/MemberExpression.java
@@ -51,6 +51,8 @@ public class MemberExpression extends DeclaredReferenceExpression {
     this.base = base;
   }
 
+  private String operatorCode;
+
   @Override
   public String toString() {
     return new ToStringBuilder(this, Node.TO_STRING_STYLE)
@@ -74,5 +76,13 @@ public class MemberExpression extends DeclaredReferenceExpression {
   @Override
   public int hashCode() {
     return super.hashCode();
+  }
+
+  public void setOperatorCode(String operatorCode) {
+    this.operatorCode = operatorCode;
+  }
+
+  public String getOperatorCode() {
+    return this.operatorCode;
   }
 }


### PR DESCRIPTION
This helps to differentiate between -> and . calls and field accesses. It currently is present on `MemberExpression` and `MemberCallExpression` until #298 is decided.

Fixes #297 