### PR TITLE
Revert "Update dependency com.github.javaparser:javaparser-symbol-solver-core to v3.18.0"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -156,7 +156,7 @@ dependencies {
     api("org.neo4j:neo4j-ogm-core:3.2.10")
     api("org.apache.logging.log4j:log4j-slf4j18-impl:2.14.0")
     api("org.slf4j:jul-to-slf4j:1.8.0-beta4")
-    api("com.github.javaparser:javaparser-symbol-solver-core:3.18.0")
+    api("com.github.javaparser:javaparser-symbol-solver-core:3.17.0")
 
     // Eclipse dependencies
     api("org.eclipse.platform:org.eclipse.core.runtime:3.18.0")


### PR DESCRIPTION
Reverts Fraunhofer-AISEC/cpg#282

Fixes #304 