### PR TITLE
Catching nested JavaParser exception in resolve()

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java
@@ -670,7 +670,10 @@ public class ExpressionHandler extends Handler<Statement, Expression, JavaLangua
       resolved = methodCallExpr.resolve();
       isStatic = resolved.isStatic();
       typeString = resolved.getReturnType().describe();
-    } catch (UnsolvedSymbolException | NoClassDefFoundError ignored) {
+    } catch (NoClassDefFoundError | RuntimeException ignored) {
+      // Unfortunately, JavaParser also throws a simple RuntimeException instead of an
+      // UnsolvedSymbolException within resolve() if it fails to resolve it under certain
+      // circumstances, we catch all that and continue on our own
       log.debug("Could not resolve method {}", methodCallExpr);
     }
 


### PR DESCRIPTION
One does not simple catch a `RuntimeException` apparently.

Fixes #308 