### PR TITLE
Prolongs dfg graphs to the root of a language feature 

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/helpers/Util.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/helpers/Util.java
@@ -491,7 +491,7 @@ public class Util {
     List<Node> conditionNodes = new ArrayList<>();
 
     if (branchingExp != null) {
-      conditionNodes = new ArrayList<Node>();
+      conditionNodes = new ArrayList<>();
       conditionNodes.add(branchingExp);
     } else if (branchingDecl != null) {
       conditionNodes = getAdjacentDFGNodes(branchingDecl, true);

--- a/src/main/java/de/fraunhofer/aisec/cpg/helpers/Util.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/helpers/Util.java
@@ -451,4 +451,51 @@ public class Util {
     ENTRIES,
     EXITS;
   }
+
+  /**
+   * This function returns the set of adjacent DFG nodes that is contained in the nodes subgraph.
+   *
+   * @param n Node of interest
+   * @param incoming whether the node connected by an incoming or, if false, outgoing DFG edge
+   * @return
+   */
+  public static List<Node> getAdjacentDFGNodes(final Node n, boolean incoming) {
+
+    Set<Node> subnodes = SubgraphWalker.getAstChildren(n);
+    List<Node> adjacentNodes;
+    if (incoming) {
+      adjacentNodes =
+          subnodes.stream()
+              .filter(prevCandidate -> prevCandidate.getNextDFG().contains(n))
+              .collect(Collectors.toList());
+    } else {
+      adjacentNodes =
+          subnodes.stream()
+              .filter(nextCandidate -> nextCandidate.getPrevDFG().contains(n))
+              .collect(Collectors.toList());
+    }
+    return adjacentNodes;
+  }
+
+  /**
+   * Connects the node <code>n</code> with the node <code>branchingExp</code> if present or with the
+   * node <node>branchingDecl</node>. The assumption is that only <code>branchingExp</code> or
+   * <code>branchingDecl</code> are present, e.g. C++.
+   *
+   * @param n
+   * @param branchingExp
+   * @param branchingDecl
+   */
+  public static void addDFGEdgesForMutuallyExclusiveBranchingExpression(
+      Node n, Node branchingExp, Node branchingDecl) {
+    List<Node> conditionNodes = new ArrayList<>();
+
+    if (branchingExp != null) {
+      conditionNodes = new ArrayList<Node>();
+      conditionNodes.add(branchingExp);
+    } else if (branchingDecl != null) {
+      conditionNodes = getAdjacentDFGNodes(branchingDecl, true);
+    }
+    conditionNodes.forEach(c -> n.addPrevDFG(c));
+  }
 }

--- a/src/main/java/de/fraunhofer/aisec/cpg/helpers/Util.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/helpers/Util.java
@@ -479,7 +479,7 @@ public class Util {
 
   /**
    * Connects the node <code>n</code> with the node <code>branchingExp</code> if present or with the
-   * node <node>branchingDecl</node>. The assumption is that only <code>branchingExp</code> or
+   * node <code>branchingDecl</code>. The assumption is that only <code>branchingExp</code> or
    * <code>branchingDecl</code> are present, e.g. C++.
    *
    * @param n

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.java
@@ -37,6 +37,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.*;
 import de.fraunhofer.aisec.cpg.graph.types.Type;
 import de.fraunhofer.aisec.cpg.graph.types.TypeParser;
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker;
+import de.fraunhofer.aisec.cpg.helpers.Util;
 import de.fraunhofer.aisec.cpg.passes.scopes.*;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -781,7 +782,10 @@ public class EvaluationOrderGraphPass extends Pass {
     createEOG(doStatement.getStatement());
 
     createEOG(doStatement.getCondition());
+
+    doStatement.addPrevDFG(doStatement.getCondition());
     pushToEOG(doStatement); // To have semantic information after the condition evaluation
+
     connectCurrentToLoopStart();
     LoopScope currentLoopScope = (LoopScope) lang.getScopeManager().leaveScope(doStatement);
     if (currentLoopScope != null) {
@@ -798,6 +802,7 @@ public class EvaluationOrderGraphPass extends Pass {
     createEOG(forEachStatement.getIterable());
     createEOG(forEachStatement.getVariable());
 
+    forEachStatement.addPrevDFG(forEachStatement.getVariable());
     pushToEOG(forEachStatement); // To have semantic information after the variable declaration
 
     List<Node> tmpEOGNodes = new ArrayList<>(currentEOG);
@@ -818,6 +823,7 @@ public class EvaluationOrderGraphPass extends Pass {
   }
 
   private void handleForStatement(@NonNull Node node) {
+
     ForStatement forStatement = (ForStatement) node;
     lang.getScopeManager().enterScope(forStatement);
     ForStatement forStmt = forStatement;
@@ -825,6 +831,9 @@ public class EvaluationOrderGraphPass extends Pass {
     createEOG(forStmt.getInitializerStatement());
     createEOG(forStmt.getConditionDeclaration());
     createEOG(forStmt.getCondition());
+
+    Util.addDFGEdgesForMutuallyExclusiveBranchingExpression(
+        forStatement, forStatement.getCondition(), forStatement.getConditionDeclaration());
 
     pushToEOG(forStatement); // To have semantic information after the condition evaluation
 
@@ -852,6 +861,9 @@ public class EvaluationOrderGraphPass extends Pass {
     createEOG(ifStatement.getInitializerStatement());
     createEOG(ifStatement.getConditionDeclaration());
     createEOG(ifStatement.getCondition());
+
+    Util.addDFGEdgesForMutuallyExclusiveBranchingExpression(
+        ifStatement, ifStatement.getCondition(), ifStatement.getConditionDeclaration());
 
     pushToEOG(ifStatement); // To have semantic information after the condition evaluation
     List<Node> openConditionEOGs = new ArrayList<>(currentEOG);
@@ -882,6 +894,9 @@ public class EvaluationOrderGraphPass extends Pass {
     createEOG(switchStatement.getSelectorDeclaration());
 
     createEOG(switchStatement.selector);
+
+    Util.addDFGEdgesForMutuallyExclusiveBranchingExpression(
+        switchStatement, switchStatement.getSelector(), switchStatement.getSelectorDeclaration());
 
     pushToEOG(switchStatement); // To have semantic information after the condition evaluation
 
@@ -919,6 +934,9 @@ public class EvaluationOrderGraphPass extends Pass {
     createEOG(whileStatement.getConditionDeclaration());
 
     createEOG(whileStatement.getCondition());
+
+    Util.addDFGEdgesForMutuallyExclusiveBranchingExpression(
+        whileStatement, whileStatement.getCondition(), whileStatement.getConditionDeclaration());
 
     pushToEOG(whileStatement); // To have semantic information after the condition evaluation
 


### PR DESCRIPTION
Currently we have the root node as branching node to keep the semantic information of the language-feature that branches while traversing the EOG. To keep EOG and DFG coherent and later build a propper PDG we prolong the dfg paths to the branching node.

I added the DFG edges where I added the EOG-Edges to the root node: in the EOG-pass- A strategy pattern would be nice to make the root node configurable for EOG and DFG but so far I could not find an easy way to integrate one for the EOG pass.

Root node of language feature if is a sink for the EOG of the condition and then branches out. For certain applications this rootnode allows traversals to use the root node like a jumpi 
![eog_root_node](https://user-images.githubusercontent.com/12885000/105500200-dc0a3780-5cc2-11eb-90ec-b8c70b8f65a9.png)

DFG edge from condition to the language-feature root node that acts as branching condition.
![dfg_root_node](https://user-images.githubusercontent.com/12885000/105500198-db71a100-5cc2-11eb-876c-26af83ca867b.png)

