### PR TITLE
Fixed #327 by removing unnecessary resolve() call

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java
@@ -681,21 +681,12 @@ public class ExpressionHandler extends Handler<Statement, Expression, JavaLangua
     // thus, only because the scope is present, this is not automatically a member call
     if (o.isPresent()) {
       Expression scope = o.get();
-      // We need to check if there is a value decl corresponding to the base. This cannot easily be
-      // done, but we can try to resolve the Expression, and if the JavaParser does not know about
-      // it, this could be a static call, but it could also be that the base is a further member
-      // call
       String scopeName = null;
 
-      try {
-        if (scope instanceof NameExpr) {
-          scopeName = ((NameExpr) scope).getNameAsString();
-          ((NameExpr) scope).resolve();
-        } else if (scope instanceof SuperExpr) {
-          scopeName = scope.toString();
-        }
-      } catch (UnsolvedSymbolException | NoClassDefFoundError ignored) {
-        // ignore
+      if (scope instanceof NameExpr) {
+        scopeName = ((NameExpr) scope).getNameAsString();
+      } else if (scope instanceof SuperExpr) {
+        scopeName = scope.toString();
       }
 
       Statement base = handle(scope);


### PR DESCRIPTION
This is a quick fix for #327.

There are many other `resolve()` calls, that are not really guarded at all. Seems like we need to be one crash at a time.