### PR TITLE
Improve Java FQN type guessing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ out
 .data/
 logs
 /lsp/*.log
+*.class
+

--- a/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.java
@@ -409,8 +409,18 @@ public class JavaLanguageFrontend extends LanguageFrontend {
           return TypeParser.createFrom(importDeclaration.getNameAsString(), true);
         }
       }
-      de.fraunhofer.aisec.cpg.graph.types.Type returnType =
-          TypeParser.createFrom(clazz.asString(), true);
+
+      var name = clazz.asString();
+
+      // no import found, so our last guess is that the type is in the same package
+      // as our current translation unit
+      var o = context.getPackageDeclaration();
+
+      if (o.isPresent()) {
+        name = o.get().getNameAsString() + getNamespaceDelimiter() + name;
+      }
+
+      de.fraunhofer.aisec.cpg.graph.types.Type returnType = TypeParser.createFrom(name, true);
       returnType.setTypeOrigin(de.fraunhofer.aisec.cpg.graph.types.Type.Origin.GUESSED);
       return returnType;
     }

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.java
@@ -254,8 +254,9 @@ public class VariableUsageResolver extends Pass {
 
             if (superRecord == null) {
               log.error(
-                  "Could not find referring super type {} for {} in the record map. This is a bit odd because they should have been parsed as well. Will set the super type to java.lang.Object",
-                  superType.getTypeName(), curClass.getName());
+                  "Could not find referring super type {} for {} in the record map. Will set the super type to java.lang.Object",
+                  superType.getTypeName(),
+                  curClass.getName());
               base.setType(TypeParser.createFrom(Object.class.getName(), true));
             } else {
               baseTarget = superRecord.getThis();

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
@@ -26,44 +26,15 @@
 
 package de.fraunhofer.aisec.cpg.frontends.java;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import de.fraunhofer.aisec.cpg.BaseTest;
 import de.fraunhofer.aisec.cpg.TestUtils;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.graph.Node;
-import de.fraunhofer.aisec.cpg.graph.declarations.ConstructorDeclaration;
-import de.fraunhofer.aisec.cpg.graph.declarations.FieldDeclaration;
-import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration;
-import de.fraunhofer.aisec.cpg.graph.declarations.NamespaceDeclaration;
-import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration;
-import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration;
-import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration;
-import de.fraunhofer.aisec.cpg.graph.statements.CaseStatement;
-import de.fraunhofer.aisec.cpg.graph.statements.CatchClause;
-import de.fraunhofer.aisec.cpg.graph.statements.CompoundStatement;
-import de.fraunhofer.aisec.cpg.graph.statements.DeclarationStatement;
-import de.fraunhofer.aisec.cpg.graph.statements.DefaultStatement;
-import de.fraunhofer.aisec.cpg.graph.statements.ForEachStatement;
-import de.fraunhofer.aisec.cpg.graph.statements.ForStatement;
-import de.fraunhofer.aisec.cpg.graph.statements.Statement;
-import de.fraunhofer.aisec.cpg.graph.statements.SwitchStatement;
-import de.fraunhofer.aisec.cpg.graph.statements.TryStatement;
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.ArrayCreationExpression;
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.ArraySubscriptionExpression;
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.CastExpression;
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.DeclaredReferenceExpression;
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.ExpressionList;
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.InitializerListExpression;
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.Literal;
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberCallExpression;
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberExpression;
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.StaticCallExpression;
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.UnaryOperator;
+import de.fraunhofer.aisec.cpg.graph.declarations.*;
+import de.fraunhofer.aisec.cpg.graph.statements.*;
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.*;
 import de.fraunhofer.aisec.cpg.graph.types.TypeParser;
 import de.fraunhofer.aisec.cpg.helpers.NodeComparator;
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker;
@@ -634,5 +605,34 @@ class JavaLanguageFrontendTest extends BaseTest {
     assertNotNull(staticCall);
 
     assertEquals("doSomethingStatic", staticCall.getName());
+  }
+
+  @Test
+  void testSuperFieldUsage() throws Exception {
+    var file1 = new File("src/test/resources/fix-328/Cat.java");
+    var file2 = new File("src/test/resources/fix-328/Animal.java");
+    var tu =
+        TestUtils.analyzeAndGetFirstTU(List.of(file1, file2), file1.getParentFile().toPath(), true);
+    var namespace = tu.getDeclarationAs(0, NamespaceDeclaration.class);
+
+    assertNotNull(namespace);
+
+    var record = namespace.getDeclarationAs(0, RecordDeclaration.class);
+
+    assertNotNull(record);
+
+    var constructor = record.getConstructors().get(0);
+    var op = constructor.getBodyStatementAs(0, BinaryOperator.class);
+
+    assertNotNull(op);
+
+    var lhs = (MemberExpression) op.getLhs();
+
+    var superThisField =
+        (FieldDeclaration) ((DeclaredReferenceExpression) lhs.getBase()).getRefersTo();
+
+    assertNotNull(superThisField);
+    assertEquals("this", superThisField.getName());
+    assertEquals(TypeParser.createFrom("my.Animal", false), superThisField.getType());
   }
 }

--- a/src/test/resources/fix-328/Animal.java
+++ b/src/test/resources/fix-328/Animal.java
@@ -1,0 +1,7 @@
+package my;
+
+public abstract class Animal implements Behavior<T> {
+
+    protected int myField;
+
+}

--- a/src/test/resources/fix-328/Cat.java
+++ b/src/test/resources/fix-328/Cat.java
@@ -1,0 +1,8 @@
+package my;
+
+public class Cat extends Animal implements OtherBehavior {
+
+    public Cat() {
+        super.myField = 2;
+    }
+}


### PR DESCRIPTION
This slightly changes the way types are "resolved" / guessed in Java. Mainly, it updates the type guessing in the following way:

- First, java parser is used to trying to resolve it
- If that fails, the type is check against the imports to find out the FQN
- NEW: If that fails, the current package name (if there is one), is prepended in front of the class name

This helps resolving types within the same package that do not have an import statement.

Fix for #328 