### PR TITLE
Handling typedefs with tabs

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/TypeManager.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/TypeManager.java
@@ -396,7 +396,7 @@ public class TypeManager {
     } else if (Util.containsOnOuterLevel(cleaned, ',')) {
       handleMultipleAliases(rawCode, cleaned);
     } else {
-      List<String> parts = Util.splitLeavingParenthesisContents(cleaned, " \r\n");
+      List<String> parts = Util.splitLeavingParenthesisContents(cleaned, " \t\r\n");
       if (parts.size() < 2) {
         log.error("Typedef contains no whitespace to split on: {}", rawCode);
         return;

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/TypedefTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/TypedefTest.java
@@ -40,6 +40,16 @@ class TypedefTest extends BaseTest {
     ValueDeclaration uintfp1 = TestUtils.findByUniqueName(variables, "uintfp1");
     ValueDeclaration uintfp2 = TestUtils.findByUniqueName(variables, "uintfp2");
     assertEquals(uintfp1.getType(), uintfp2.getType());
+
+    var frontend = TypeManager.getInstance().getFrontend();
+
+    assertNotNull(frontend);
+
+    var typedefs = frontend.getScopeManager().getCurrentTypedefs();
+    var def =
+        typedefs.stream().filter(d -> d.getAlias().getName().equals("test")).findAny().orElse(null);
+
+    assertNotNull(def);
   }
 
   @Test

--- a/src/test/resources/typedefs/typedefs.cpp
+++ b/src/test/resources/typedefs/typedefs.cpp
@@ -74,6 +74,9 @@ ullong someUllong2;
 typedef long type;
 type typeMemberOutside;
 
+// sample typedef with tabs
+typedef uint8		test;
+
 struct add_const {
     typedef const int type;
     const int typeMember1;


### PR DESCRIPTION
Fixes #320 

I am still not a big fan of the fact that the type manager does some C++ specific AST handling, but at least this fixes a problem with tab white spaces.