### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ dependencies {
 
 The library can be used on the command line using `jshell`, the Java shell to try out some basic queries.
 
-First, a jar consisting all the necessary dependencies should be created with `./gradlew shadowJar`. Afterwards, the shell can be launched using `jshell --class-path build/libs/cpg-*-all.jar`.
+First, a jar consisting all the necessary dependencies should be created with `./gradlew shadowJar`. Afterwards, the shell can be launched using `jshell --class-path build/libs/cpg-all.jar`.
 
 The following snippet creates a basic `TranslationManager` with default settings to analyze a sample file in `src/test/resources/openssl/client.cpp`:
 


### PR DESCRIPTION
Fixed a typo in a command (**cpg-*-all.jar** to **cpg-all.jar**).