### PR TITLE
CallResolver Refinement for Calls with Implicit Cast

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/Node.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/Node.java
@@ -89,7 +89,8 @@ public class Node implements IVisitable<Node>, Persistable {
 
   /**
    * outgoing control flow edges.
-   * @deprecated  This Edge-Type is deprecated as it is less precise then the {@link Node#nextEOG}
+   *
+   * @deprecated This Edge-Type is deprecated as it is less precise then the {@link Node#nextEOG}
    */
   @Deprecated(since = "3.4", forRemoval = true)
   @NonNull
@@ -142,11 +143,12 @@ public class Node implements IVisitable<Node>, Persistable {
     this.name = name;
   }
 
+  @Nullable
   public String getFile() {
     return file;
   }
 
-  public void setFile(String file) {
+  public void setFile(@Nullable String file) {
     this.file = file;
   }
 
@@ -243,7 +245,7 @@ public class Node implements IVisitable<Node>, Persistable {
   }
 
   /**
-   * @deprecated  This Edge-Type is deprecated as it is less precise then the {@link Node#nextEOG}n
+   * @deprecated This Edge-Type is deprecated as it is less precise then the {@link Node#nextEOG}n
    */
   @NonNull
   @Deprecated(since = "3.4", forRemoval = true)
@@ -252,7 +254,7 @@ public class Node implements IVisitable<Node>, Persistable {
   }
 
   /**
-   * @deprecated  This Edge-Type is deprecated as it is less precise then the {@link Node#nextEOG}
+   * @deprecated This Edge-Type is deprecated as it is less precise then the {@link Node#nextEOG}
    */
   @Deprecated(since = "3.4", forRemoval = true)
   public void addNextCFG(Node node) {
@@ -263,7 +265,8 @@ public class Node implements IVisitable<Node>, Persistable {
 
   /**
    * outgoing control flow edges.
-   * @deprecated  This Edge-Type is deprecated as it is less precise then the {@link Node#nextEOG}
+   *
+   * @deprecated This Edge-Type is deprecated as it is less precise then the {@link Node#nextEOG}
    */
   @Deprecated(since = "3.4", forRemoval = true)
   public void addNextCFG(Collection<? extends Node> collection) {

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/declarations/FunctionDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/declarations/FunctionDeclaration.java
@@ -236,6 +236,14 @@ public class FunctionDeclaration extends ValueDeclaration implements Declaration
     return unwrap(this.parameters);
   }
 
+  public List<Type> getSignatureTypes() {
+    List<Type> signatureTypes = new ArrayList<>();
+    for (ParamVariableDeclaration paramVariableDeclaration : unwrap(this.parameters)) {
+      signatureTypes.add(paramVariableDeclaration.getType());
+    }
+    return signatureTypes;
+  }
+
   public List<PropertyEdge<ParamVariableDeclaration>> getParametersPropertyEdge() {
     return this.parameters;
   }

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/edge/PropertyEdge.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/edge/PropertyEdge.java
@@ -84,6 +84,14 @@ public class PropertyEdge<T extends Node> implements Persistable {
     return start;
   }
 
+  public void setEnd(T end) {
+    this.end = end;
+  }
+
+  public void setStart(Node start) {
+    this.start = start;
+  }
+
   /**
    * Add/Update index element of list of PropertyEdges
    *

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.java
@@ -90,6 +90,10 @@ public class CallExpression extends Expression implements TypeListener {
     return Collections.unmodifiableList(targets);
   }
 
+  public void setArgument(int index, Expression argument) {
+    this.arguments.get(index).setEnd(argument);
+  }
+
   @NonNull
   public List<PropertyEdge<Expression>> getArgumentsPropertyEdge() {
     return this.arguments;

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/types/ObjectType.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/types/ObjectType.java
@@ -52,7 +52,6 @@ public class ObjectType extends Type {
   }
 
   private final Modifier modifier;
-  private final boolean primitive;
   // Reference from the ObjectType to its class (RecordDeclaration) only if the class is available
   private RecordDeclaration recordDeclaration = null;
 

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/types/Type.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/types/Type.java
@@ -51,6 +51,8 @@ public abstract class Type extends Node {
    */
   @NonNull protected Storage storage = Storage.AUTO;
 
+  protected boolean primitive = false;
+
   @Convert(QualifierConverter.class)
   protected Qualifier qualifier;
 
@@ -133,6 +135,10 @@ public abstract class Type extends Node {
 
   public void setTypeOrigin(Origin origin) {
     this.origin = origin;
+  }
+
+  public boolean isPrimitive() {
+    return primitive;
   }
 
   /** Type Origin describes where the Type information came from */

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
@@ -329,6 +329,8 @@ public class CallResolver extends Pass {
           implicitCast.setExpression(call.getArguments().get(i));
           implicitCasts.add(implicitCast);
         } else {
+          // If no cast is needed we add null to be able to access the function signature list and
+          // the implicit cast list with the same index.
           implicitCasts.add(null);
         }
       }
@@ -337,7 +339,6 @@ public class CallResolver extends Pass {
     }
     return new ArrayList<>();
   }
-
 
   /**
    * modifies: call arguments by applying implicit casts
@@ -425,7 +426,8 @@ public class CallResolver extends Pass {
               .collect(Collectors.toList());
 
       if (invocationCandidates.isEmpty() && this.getLang() instanceof CXXLanguageFrontend) {
-        // If we don't find any candidate and our current language is c/c++ we check if there is a candidate with an implicit cast
+        // If we don't find any candidate and our current language is c/c++ we check if there is a
+        // candidate with an implicit cast
         invocationCandidates.addAll(resolveWithImplicitCast(call));
       }
 

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
@@ -34,6 +34,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.*;
 import de.fraunhofer.aisec.cpg.graph.types.FunctionPointerType;
 import de.fraunhofer.aisec.cpg.graph.types.Type;
 import de.fraunhofer.aisec.cpg.graph.types.TypeParser;
+import de.fraunhofer.aisec.cpg.graph.types.UnknownType;
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker.ScopedWalker;
 import de.fraunhofer.aisec.cpg.helpers.Util;
 import de.fraunhofer.aisec.cpg.processing.strategy.Strategy;
@@ -278,6 +279,129 @@ public class CallResolver extends Pass {
     }
   }
 
+  /**
+   * @param callSignature Type signature of the CallExpression
+   * @param functionSignature Type signature of the FunctionDeclaration
+   * @return true if the CallExpression signature can be transformed into the FunctionDeclaration
+   *     signature by means of casting
+   */
+  private boolean compatibleSignatures(List<Type> callSignature, List<Type> functionSignature) {
+    if (callSignature.size() == functionSignature.size()) {
+      for (int i = 0; i < callSignature.size(); i++) {
+        if ((callSignature.get(i).isPrimitive() != functionSignature.get(i).isPrimitive())
+            && !TypeManager.getInstance()
+                .isSupertypeOf(functionSignature.get(i), callSignature.get(i))) {
+          return false;
+        }
+      }
+    } else {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Computes the implicit casts that are necessary to reach the
+   *
+   * @param call we want to find invocation targets for by performing implicit casts
+   * @param functionSignature Types of the signature of the possible invocation candidate
+   * @return List containing either null on the i-th position (if the type of i-th argument of the
+   *     call equals the type of the i-th argument of the FunctionDeclaration) or a CastExpression
+   *     on the i-th position (if the argument of the call can be casted to match the type of the
+   *     argument at the i-th position of the FunctionDeclaration). If the list is empty the
+   *     signature of the FunctionDeclaration cannot be reached through implicit casts
+   */
+  private List<CastExpression> signatureWithImplicitCastTransformation(
+      CallExpression call, List<Type> functionSignature) {
+    List<Type> callSignature = call.getSignature();
+    if (callSignature.size() == functionSignature.size()) {
+      List<CastExpression> implicitCasts = new ArrayList<>();
+
+      for (int i = 0; i < callSignature.size(); i++) {
+        Type callType = callSignature.get(i);
+        Type funcType = functionSignature.get(i);
+        if (callType.isPrimitive() && callType.isPrimitive() && !(callType.equals(funcType))) {
+          CastExpression implicitCast = new CastExpression();
+          implicitCast.setImplicit(true);
+          implicitCast.setCastType(funcType);
+          implicitCast.setExpression(call.getArguments().get(i));
+          implicitCasts.add(implicitCast);
+        } else {
+          implicitCasts.add(null);
+        }
+      }
+
+      return implicitCasts;
+    }
+    return new ArrayList<>();
+  }
+
+  /**
+   * modifies: call arguments by applying implicit casts
+   *
+   * @param call we want to find invocation targets for by performing implicit casts
+   * @return list of invocation candidates by applying
+   */
+  private List<FunctionDeclaration> resolveWithImplicitCast(CallExpression call) {
+    // Get possible invocation targets based on the function name
+    List<FunctionDeclaration> matchingFunctionName =
+        currentTU.getDeclarations().stream()
+            .filter(FunctionDeclaration.class::isInstance)
+            .map(FunctionDeclaration.class::cast)
+            .filter(f -> f.getName().equals(call.getName()))
+            .collect(Collectors.toList());
+
+    // Output list for invocationTargets obtaining a valid signature by performing implicit casts
+    List<FunctionDeclaration> invocationTargetsWithImplicitCast = new ArrayList<>();
+
+    List<CastExpression> implicitCasts = null;
+    List<Type> callSignature = call.getSignature();
+
+    // Iterate through all possible invocation candidates
+    for (FunctionDeclaration functionDeclaration : matchingFunctionName) {
+      // Check if the signatures match by implicit casts
+      if (compatibleSignatures(callSignature, functionDeclaration.getSignatureTypes())) {
+        List<CastExpression> implicitCastTargets =
+            signatureWithImplicitCastTransformation(call, functionDeclaration.getSignatureTypes());
+        if (implicitCasts == null) {
+          implicitCasts = implicitCastTargets;
+        } else {
+          // Since we can have multiple possible invocation targets the cast must all be to the same
+          // target type
+          for (int i = 0; i < implicitCasts.size(); i++) {
+            CastExpression currentCast = implicitCasts.get(i);
+            CastExpression otherCast = implicitCasts.get(i);
+            if (currentCast == null || otherCast == null) {
+              continue;
+            }
+            if (!(currentCast.equals(otherCast))) {
+              // If we have multiple function targets with different implicit casts we have an
+              // ambiguous call and we can't have a single cast
+              CastExpression contradictoryCast = new CastExpression();
+              contradictoryCast.setImplicit(true);
+              contradictoryCast.setCastType(UnknownType.getUnknownType());
+              contradictoryCast.setExpression(currentCast.getExpression());
+              implicitCasts.set(i, contradictoryCast);
+            }
+          }
+        }
+        invocationTargetsWithImplicitCast.add(functionDeclaration);
+      }
+    }
+
+    // Apply implicit casts to call arguments
+    if (implicitCasts != null) {
+      for (int i = 0; i < implicitCasts.size(); i++) {
+        if (implicitCasts.get(i) != null) {
+          call.setArgument(i, implicitCasts.get(i));
+        }
+      }
+    }
+
+    return invocationTargetsWithImplicitCast;
+  }
+
   private void handleNormalCalls(RecordDeclaration curClass, CallExpression call) {
     if (curClass == null && this.currentTU != null) {
       // Handle function (not method) calls
@@ -289,7 +413,14 @@ public class CallResolver extends Pass {
               .filter(
                   f -> f.getName().equals(call.getName()) && f.hasSignature(call.getSignature()))
               .collect(Collectors.toList());
+
       if (invocationCandidates.isEmpty()) {
+        // If we don't find any candidate we check if there is a candidate with an implicit cast
+        invocationCandidates.addAll(resolveWithImplicitCast(call));
+      }
+
+      if (invocationCandidates.isEmpty()) {
+        // If we still have no candidates we create dummy FunctionDeclaration
         invocationCandidates =
             List.of(createDummy(null, call.getName(), call.getCode(), false, call.getSignature()));
       }

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
@@ -352,7 +352,7 @@ public class CallResolver extends Pass {
         currentTU.getDeclarations().stream()
             .filter(FunctionDeclaration.class::isInstance)
             .map(FunctionDeclaration.class::cast)
-            .filter(f -> f.getName().equals(call.getName()))
+            .filter(f -> f.getName().equals(call.getName()) && !f.isImplicit())
             .collect(Collectors.toList());
 
     // Output list for invocationTargets obtaining a valid signature by performing implicit casts

--- a/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
@@ -27,6 +27,7 @@
 package de.fraunhofer.aisec.cpg.passes;
 
 import de.fraunhofer.aisec.cpg.TranslationResult;
+import de.fraunhofer.aisec.cpg.frontends.cpp.CXXLanguageFrontend;
 import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguageFrontend;
 import de.fraunhofer.aisec.cpg.graph.*;
 import de.fraunhofer.aisec.cpg.graph.declarations.*;
@@ -423,8 +424,8 @@ public class CallResolver extends Pass {
                   f -> f.getName().equals(call.getName()) && f.hasSignature(call.getSignature()))
               .collect(Collectors.toList());
 
-      if (invocationCandidates.isEmpty()) {
-        // If we don't find any candidate we check if there is a candidate with an implicit cast
+      if (invocationCandidates.isEmpty() && this.getLang() instanceof CXXLanguageFrontend) {
+        // If we don't find any candidate and our current language is c/c++ we check if there is a candidate with an implicit cast
         invocationCandidates.addAll(resolveWithImplicitCast(call));
       }
 

--- a/src/test/resources/calls/implicitcast/ambiguouscall.cpp
+++ b/src/test/resources/calls/implicitcast/ambiguouscall.cpp
@@ -1,0 +1,15 @@
+#include <iostream>
+using namespace std;
+
+int ambiguous_multiply (int val)
+{
+  return val * 3;
+}
+
+int ambiguous_multiply (float val) {
+    return val * 5;
+}
+
+int main() {
+  std::cout << ambiguous_multiply(10.0) << '\n';
+}

--- a/src/test/resources/calls/implicitcast/implicitcast.cpp
+++ b/src/test/resources/calls/implicitcast/implicitcast.cpp
@@ -1,0 +1,12 @@
+#include <iostream>
+using namespace std;
+
+int multiply (int val)
+{
+  return val * 3;
+}
+
+
+int main() {
+  std::cout << multiply(10.0) << '\n';
+}


### PR DESCRIPTION
This PR closes #325.

## Features
- The CallResolver is now able to resolve CallExpression, where an implicit cast is necessary to match the signature of the corresponding FunctionDeclaration

## Graph Changes
- An implicit CastExpression node is added when a CallExpression needs to perform a cast to be resolved
