### PR TITLE
Added AST annotation for receiver property

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/declarations/MethodDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/declarations/MethodDeclaration.java
@@ -26,6 +26,7 @@
 
 package de.fraunhofer.aisec.cpg.graph.declarations;
 
+import de.fraunhofer.aisec.cpg.graph.SubGraph;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/declarations/MethodDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/declarations/MethodDeclaration.java
@@ -48,6 +48,7 @@ public class MethodDeclaration extends FunctionDeclaration {
    *
    * <p>It can be empty, i.e., for pure function definitions as part as an interface.
    */
+  @SubGraph("AST")
   @Nullable private VariableDeclaration receiver;
 
   public boolean isStatic() {

--- a/src/main/java/de/fraunhofer/aisec/cpg/graph/declarations/MethodDeclaration.java
+++ b/src/main/java/de/fraunhofer/aisec/cpg/graph/declarations/MethodDeclaration.java
@@ -50,7 +50,8 @@ public class MethodDeclaration extends FunctionDeclaration {
    * <p>It can be empty, i.e., for pure function definitions as part as an interface.
    */
   @SubGraph("AST")
-  @Nullable private VariableDeclaration receiver;
+  @Nullable
+  private VariableDeclaration receiver;
 
   public boolean isStatic() {
     return isStatic;

--- a/src/test/java/de/fraunhofer/aisec/cpg/enhancements/VisitorTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/enhancements/VisitorTest.java
@@ -112,7 +112,7 @@ class VisitorTest extends BaseTest {
           }
         });
 
-    assertEquals(34, nodeList.size());
+    assertEquals(35, nodeList.size());
   }
 
   /** Visits only ReturnStatement nodes. */

--- a/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
+++ b/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
@@ -576,6 +576,13 @@ class JavaLanguageFrontendTest extends BaseTest {
     var record = (RecordDeclaration) tu.getDeclarationAs(0, RecordDeclaration.class);
     assertNotNull(record);
 
+    var func = record.getMethods().stream().findFirst().orElse(null);
+    assertNotNull(func);
+    assertNotNull(func.getReceiver());
+
+    // make sure, that the type system correctly cleans up these duplicate types
+    assertSame(record.getThis().getType(), func.getReceiver().getType());
+
     var nodes = SubgraphWalker.flattenAST(record);
 
     var request =


### PR DESCRIPTION
Adding the AST annotation to the receiver property of a method declaration to help the type resolver clean up duplicate types.

Fixes #387 