### PR TITLE
Getting rid of `definedBefore` in `CallResolver`

### DIFF
--- a/cpg-console/src/main/kotlin/de/fraunhofer/aisec/cpg/console/TranslatePlugin.kt
+++ b/cpg-console/src/main/kotlin/de/fraunhofer/aisec/cpg/console/TranslatePlugin.kt
@@ -75,7 +75,9 @@ class TranslatePlugin : Plugin {
                         path +
                         "\"))\n" +
                         "                    .defaultLanguages()\n" +
-//                      "                    .registerLanguage(GoLanguageFrontend::class.java, GoLanguageFrontend.GOLANG_EXTENSIONS)" +
+                        //                      "
+                        // .registerLanguage(GoLanguageFrontend::class.java,
+                        // GoLanguageFrontend.GOLANG_EXTENSIONS)" +
                         "                    .defaultPasses()\n" +
                         "                    .build()",
                     "val analyzer = TranslationManager.builder().config(config).build()",

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/edge/PropertyEdgeConverterManager.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/edge/PropertyEdgeConverterManager.java
@@ -50,7 +50,8 @@ public class PropertyEdgeConverterManager {
         TemplateDeclaration.TemplateInitialization.class.getName(), Object::toString);
 
     this.addDeserializer(
-        "INSTANTIATION", (s -> s != null ? TemplateDeclaration.TemplateInitialization.valueOf(s.toString()) : null));
+        "INSTANTIATION",
+        (s -> s != null ? TemplateDeclaration.TemplateInitialization.valueOf(s.toString()) : null));
   }
 
   public static PropertyEdgeConverterManager getInstance() {

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/UnaryOperator.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/UnaryOperator.java
@@ -116,7 +116,8 @@ public class UnaryOperator extends Expression implements TypeListener {
 
   private boolean getsDataFromInput(TypeListener listener) {
     checked.clear();
-    return input != null && input.getTypeListeners().stream().anyMatch(l -> getsDataFromInput(l, listener));
+    return input != null
+        && input.getTypeListeners().stream().anyMatch(l -> getsDataFromInput(l, listener));
   }
 
   public String getOperatorCode() {
@@ -170,8 +171,9 @@ public class UnaryOperator extends Expression implements TypeListener {
         newType = src.getPropagationType().dereference();
       }
 
-      // We are a fuzzy parser, so while this should not happen, there is no guarantee that input is not null
-      if(input != null) {
+      // We are a fuzzy parser, so while this should not happen, there is no guarantee that input is
+      // not null
+      if (input != null) {
         input.setType(newType, this);
       }
     }

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
@@ -37,7 +37,6 @@ import de.fraunhofer.aisec.cpg.graph.types.*;
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker.ScopedWalker;
 import de.fraunhofer.aisec.cpg.helpers.Util;
 import de.fraunhofer.aisec.cpg.processing.strategy.Strategy;
-import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
@@ -999,27 +999,6 @@ public class CallResolver extends Pass {
     return resolveWithDefaultArgs(call, invocationCandidates);
   }
 
-  /**
-   * Methods can be defined inline and then they can be used even if they are declared below.
-   * Currently we cannot distinguish between inline methods and method definitions outside of the
-   * class block. This will be considered when we have a language dependent call resolver
-   *
-   * @param call we want to find invocation targets for by adding the default arguments to the
-   *     signature
-   * @return list of invocation candidates that have matching signature when considering default
-   *     arguments
-   */
-  private List<FunctionDeclaration> resolveWithDefaultArgsMethod(CallExpression call) {
-    assert lang != null;
-    List<FunctionDeclaration> invocationCandidates =
-        lang.getScopeManager().resolveFunctionStopScopeTraversalOnDefinition(call).stream()
-            .filter(
-                f -> !f.isImplicit() && call.getSignature().size() < f.getSignatureTypes().size())
-            .collect(Collectors.toList());
-
-    return resolveWithDefaultArgs(call, invocationCandidates);
-  }
-
   private void handleNormalCalls(RecordDeclaration curClass, CallExpression call) {
     if (curClass == null && lang != null) {
       // Handle function (not method) calls
@@ -1147,7 +1126,7 @@ public class CallResolver extends Pass {
 
     if (invocationCandidates.isEmpty()) {
       // Check for usage of default args
-      invocationCandidates.addAll(resolveWithDefaultArgsMethod(call));
+      invocationCandidates.addAll(resolveWithDefaultArgsFunc(call));
     }
 
     if (invocationCandidates.isEmpty()) {

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
@@ -903,24 +903,6 @@ public class CallResolver extends Pass {
   }
 
   /**
-   * Methods can be defined inline and then they can be used even if they are declared below.
-   * Currently we cannot distinguish between inline methods and method definitions outside of the
-   * class block. This will be considered when we have a language dependent call resolver
-   *
-   * @param call we want to find invocation targets for by performing implicit casts
-   * @return list of invocation candidates by applying implicit casts
-   */
-  private List<FunctionDeclaration> resolveWithImplicitCastMethod(CallExpression call) {
-    assert lang != null;
-    List<FunctionDeclaration> initialInvocationCandidates =
-        lang.getScopeManager().resolveFunctionStopScopeTraversalOnDefinition(call).stream()
-            .filter(f -> !f.isImplicit())
-            .collect(Collectors.toList());
-
-    return resolveWithImplicitCast(call, initialInvocationCandidates);
-  }
-
-  /**
    * Checks if the current casts are compatible with the casts necessary to match with a new
    * FunctionDeclaration. If a one argument would need to be casted in two different types it would
    * be modified to a cast to UnknownType
@@ -1178,7 +1160,7 @@ public class CallResolver extends Pass {
 
     if (invocationCandidates.isEmpty()) {
       // Check for usage of implicit cast
-      invocationCandidates.addAll(resolveWithImplicitCastMethod(call));
+      invocationCandidates.addAll(resolveWithImplicitCastFunc(call));
     }
     return invocationCandidates;
   }

--- a/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/enhancements/calls/CallResolverTest.java
+++ b/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/enhancements/calls/CallResolverTest.java
@@ -286,7 +286,8 @@ public class CallResolverTest extends BaseTest {
     assertEquals("10.0", castExpression.getExpression().getCode());
   }
 
-  private void testDefaultArgumentsInDeclaration() throws Exception {
+  @Test
+  void testDefaultArgumentsInDeclaration() throws Exception {
     List<TranslationUnitDeclaration> result =
         TestUtils.analyze(
             List.of(
@@ -388,7 +389,8 @@ public class CallResolverTest extends BaseTest {
     assertEquals("int", ((CastExpression) display10.getArguments().get(0)).getCastType().getName());
   }
 
-  private void testDefaultArgumentsInDefinition() throws Exception {
+  @Test
+  void testDefaultArgumentsInDefinition() throws Exception {
     List<TranslationUnitDeclaration> result =
         TestUtils.analyze(
             List.of(
@@ -471,7 +473,8 @@ public class CallResolverTest extends BaseTest {
     assertEquals("count", display$Count.getArguments().get(1).getName());
   }
 
-  private void testPartialDefaultArguments() throws Exception {
+  @Test
+  void testPartialDefaultArguments() throws Exception {
     List<TranslationUnitDeclaration> result =
         TestUtils.analyze(
             List.of(Path.of(topLevel.toString(), "defaultargs", "partialDefaults.cpp").toFile()),
@@ -608,13 +611,6 @@ public class CallResolverTest extends BaseTest {
   }
 
   @Test
-  void testDefaultArgumentsCallResolution() throws Exception {
-    testDefaultArgumentsInDeclaration();
-    testDefaultArgumentsInDefinition();
-    testPartialDefaultArguments();
-  }
-
-  @Test
   void testScopedFunctionResolutionUndefined() throws Exception {
     List<TranslationUnitDeclaration> result =
         TestUtils.analyze(
@@ -679,7 +675,7 @@ public class CallResolverTest extends BaseTest {
             calls, c -> c.getLocation().getRegion().getStartLine() == 8);
 
     assertEquals(1, fm1.getInvokes().size());
-    assertTrue(fm1.getInvokes().get(0).isImplicit());
+
     assertEquals(1, fm1.getArguments().size());
     assertEquals(8, ((Literal) fm1.getArguments().get(0)).getValue());
 
@@ -692,7 +688,7 @@ public class CallResolverTest extends BaseTest {
             TestUtils.subnodesOfType(result, Literal.class), l -> l.getValue().equals(5));
 
     assertEquals(1, fm2.getInvokes().size());
-    assertFalse(fm2.getInvokes().get(0).isImplicit());
+
     assertEquals(9, fm2.getInvokes().get(0).getLocation().getRegion().getStartLine());
     assertEquals(1, fm2.getArguments().size());
     assertEquals(4, ((Literal) fm2.getArguments().get(0)).getValue());

--- a/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/enhancements/calls/CallResolverTest.java
+++ b/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/enhancements/calls/CallResolverTest.java
@@ -323,7 +323,10 @@ public class CallResolverTest extends BaseTest {
               return c.getCode().equals("display(1);");
             });
 
-    assertEquals(1, display1.getInvokes().size());
+    // it will contain two nodes: the definition and the declaration. this is a general
+    // problem, that we need to tackle in the future, how to combine those two. See
+    // https://github.com/Fraunhofer-AISEC/cpg/issues/194
+    assertEquals(2, display1.getInvokes().size());
     assertTrue(display1.getInvokes().contains(displayDeclaration));
 
     assertEquals("1", display1.getArguments().get(0).getCode());
@@ -352,7 +355,7 @@ public class CallResolverTest extends BaseTest {
               return c.getCode().equals("display();");
             });
 
-    assertEquals(1, display.getInvokes().size());
+    assertEquals(2, display.getInvokes().size());
     assertTrue(display.getInvokes().contains(displayDeclaration));
 
     assertEquals(0, display.getArguments().size());
@@ -365,7 +368,7 @@ public class CallResolverTest extends BaseTest {
               return c.getCode().equals("display(count, '$');");
             });
 
-    assertEquals(1, display.getInvokes().size());
+    assertEquals(2, display.getInvokes().size());
     assertTrue(display.getInvokes().contains(displayDeclaration));
 
     assertEquals("count", displayCount$.getArguments().get(0).getName());
@@ -379,7 +382,7 @@ public class CallResolverTest extends BaseTest {
               return c.getCode().equals("display(10.0);");
             });
 
-    assertEquals(1, display10.getInvokes().size());
+    assertEquals(2, display10.getInvokes().size());
     assertTrue(display.getInvokes().contains(displayDeclaration));
 
     assertEquals(1, display10.getArguments().size());
@@ -622,10 +625,10 @@ public class CallResolverTest extends BaseTest {
     assertEquals(1, calls.size());
     List<FunctionDeclaration> functionDeclarations =
         TestUtils.subnodesOfType(result, FunctionDeclaration.class);
-    assertEquals(3, functionDeclarations.size());
+    assertEquals(2, functionDeclarations.size());
 
     assertEquals(1, calls.get(0).getInvokes().size());
-    assertTrue(calls.get(0).getInvokes().get(0).isImplicit());
+
     assertEquals("f", calls.get(0).getInvokes().get(0).getName());
   }
 

--- a/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
+++ b/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
@@ -285,8 +285,8 @@ class CXXLanguageFrontendTest extends BaseTest {
     TranslationUnitDeclaration declaration =
         TestUtils.analyzeAndGetFirstTU(List.of(file), file.getParentFile().toPath(), true);
 
-    // should be six function nodes
-    assertEquals(8, declaration.getDeclarations().size());
+    // should be seven function nodes
+    assertEquals(7, declaration.getDeclarations().size());
 
     FunctionDeclaration method = declaration.getDeclarationAs(0, FunctionDeclaration.class);
     assertEquals("function0(int)void", method.getSignature());

--- a/cpg-library/src/test/resources/calls/ignore-return.cpp
+++ b/cpg-library/src/test/resources/calls/ignore-return.cpp
@@ -1,0 +1,8 @@
+int main() {
+    Object o1;
+    someFunction(o1); // intentionally ignore the return value
+}
+
+Object someFunction(Object x) {
+    return x;
+}


### PR DESCRIPTION
The CPG aims to be a fuzzy parser and not a compiler. We therefore have more leeway when parsing declarations than a compiler. We therefore, explicitly should NOT check, whether a declaration is really before its usage. The simple reason for that is that we want to be able to analyze code fragments, i.e. if the definition was in a header file that we did not see.

A discussion point might be whether, we want to introduce a flag that enables a more "stricter" compiler-like way in the call resolver. But somehow, I am not sure, whether this makes too much sense, given the use cases we mostly serve.

Closes #457

Addresses the WPDS issue in https://github.com/Fraunhofer-AISEC/codyze/pull/184