### PR TITLE
Added `HasInitializer` interface for fields and variable declarations

### DIFF
--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/HasInitializer.kt
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/HasInitializer.kt
@@ -5,6 +5,6 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 /** Specifies that a certain node has an initializer. */
 interface HasInitializer {
 
-    val initializer: Expression?
+    var initializer: Expression?
 
 }

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/HasInitializer.kt
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/HasInitializer.kt
@@ -1,0 +1,10 @@
+package de.fraunhofer.aisec.cpg.graph
+
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
+
+/** Specifies that a certain node has an initializer. */
+interface HasInitializer {
+
+    val initializer: Expression?
+
+}

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/declarations/FieldDeclaration.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/declarations/FieldDeclaration.java
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.graph.declarations;
 
+import de.fraunhofer.aisec.cpg.graph.HasInitializer;
 import de.fraunhofer.aisec.cpg.graph.HasType;
 import de.fraunhofer.aisec.cpg.graph.HasType.TypeListener;
 import de.fraunhofer.aisec.cpg.graph.Node;
@@ -35,7 +36,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.InitializerListExpre
 import de.fraunhofer.aisec.cpg.graph.types.Type;
 import java.util.*;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Nullable;
 import org.neo4j.ogm.annotation.Relationship;
 
 /**
@@ -43,7 +44,7 @@ import org.neo4j.ogm.annotation.Relationship;
  * with the field as well as an initializer {@link Expression} which provides an initial value for
  * the field.
  */
-public class FieldDeclaration extends ValueDeclaration implements TypeListener {
+public class FieldDeclaration extends ValueDeclaration implements TypeListener, HasInitializer {
 
   @SubGraph("AST")
   @Nullable

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/declarations/VariableDeclaration.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/declarations/VariableDeclaration.java
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.graph.declarations;
 
+import de.fraunhofer.aisec.cpg.graph.HasInitializer;
 import de.fraunhofer.aisec.cpg.graph.HasType;
 import de.fraunhofer.aisec.cpg.graph.HasType.TypeListener;
 import de.fraunhofer.aisec.cpg.graph.Node;
@@ -35,11 +36,11 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.InitializerListExpre
 import de.fraunhofer.aisec.cpg.graph.types.Type;
 import java.util.*;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.Nullable;
 import org.neo4j.ogm.annotation.Relationship;
 
 /** Represents the declaration of a variable. */
-public class VariableDeclaration extends ValueDeclaration implements TypeListener {
+public class VariableDeclaration extends ValueDeclaration implements TypeListener, HasInitializer {
 
   /** The (optional) initializer of the declaration. */
   @SubGraph("AST")

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/NewExpression.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/NewExpression.java
@@ -25,16 +25,18 @@
  */
 package de.fraunhofer.aisec.cpg.graph.statements.expressions;
 
+import de.fraunhofer.aisec.cpg.graph.HasInitializer;
 import de.fraunhofer.aisec.cpg.graph.Node;
 import de.fraunhofer.aisec.cpg.graph.SubGraph;
 import java.util.List;
 import java.util.Objects;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
 import org.neo4j.ogm.annotation.Relationship;
 
 /** Represents the creation of a new object through the <code>new</code> keyword. */
-public class NewExpression extends Expression {
+public class NewExpression extends Expression implements HasInitializer {
 
   /** The initializer expression. */
   @SubGraph("AST")


### PR DESCRIPTION
Mainly needed for better in-memory graph traversal in Codyze.
