### PR TITLE
Smart guessing of a cast expression vs. call expression, if the type is known

### DIFF
--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.java
@@ -446,12 +446,14 @@ public class DeclarationHandler extends Handler<Declaration, IASTDeclaration, CX
       handleTemplateUsage((CPPASTNamedTypeSpecifier) declSpecifier, ctx, sequence);
     } else {
       for (IASTDeclarator declarator : ctx.getDeclarators()) {
+        String typeString = getTypeStringFromDeclarator(declarator, ctx.getDeclSpecifier());
+
+        // make sure, the type manager knows about this type before parsing the declarator
+        Type result = TypeParser.createFrom(typeString, true, lang);
+
         ValueDeclaration declaration =
             (ValueDeclaration) this.lang.getDeclaratorHandler().handle(declarator);
 
-        String typeString = getTypeStringFromDeclarator(declarator, ctx.getDeclSpecifier());
-
-        Type result = TypeParser.createFrom(typeString, true, lang);
         declaration.setType(result);
 
         // cache binding

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/TypeManager.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/TypeManager.java
@@ -240,6 +240,10 @@ public class TypeManager {
     return secondOrderTypes;
   }
 
+  public boolean typeExists(String name) {
+    return firstOrderTypes.stream().anyMatch(type -> type.getRoot().getName().equals(name));
+  }
+
   private TypeManager() {}
 
   public static TypeManager getInstance() {

--- a/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
+++ b/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
@@ -1310,5 +1310,7 @@ class CXXLanguageFrontendTest extends BaseTest {
 
     var initializer = decl.getInitializer();
     assertNotNull(initializer);
+    assertTrue(initializer instanceof CastExpression);
+    assertEquals("size_t", ((CastExpression) initializer).getCastType().getName());
   }
 }


### PR DESCRIPTION
C/C++ has some ambuigities, for example in the expression `(size_t)(42)`. If CDT has not seen the type, it will guess, that this is a call expression. We try to be a little bit smarter than CDT and check our type manager, if the type is already known, for example because it was used as a type in a LHS of an assignment. This would also allow us to pre-fill the `TypeManager` with some common types.

Fixes #474
