### PR TITLE
Fixed CI errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,24 +92,24 @@ jobs:
           name: test
           path: "**/build/reports/tests"
       - name: JavaDoc
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'beta')
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
-          FOLDER: build/docs/javadoc
+          FOLDER: cpg-library/build/docs/javadoc
       - name: Publish
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'beta')      
         run: |
           export ORG_GRADLE_PROJECT_signingKey=`echo ${{ secrets.GPG_PRIVATE_KEY }} | base64 -d`
           ./gradlew -Dorg.gradle.internal.publish.checksums.insecure=true --parallel -Pversion=$VERSION build signMavenPublication publish
-        if: startsWith(github.ref, 'refs/tags/v')
         env:
           VERSION: ${{ steps.determine_version.outputs.version }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSWORD }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
       - name: "Create Release"
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'beta')
         id: create_release
         uses: actions/create-release@latest
         env:


### PR DESCRIPTION
* Only really publish, when tag does not contain `beta`
* Fixed javadoc path