### PR TITLE
Improvements to the Go language frontend

### DIFF
--- a/cpg-library/src/main/golang/expressions.go
+++ b/cpg-library/src/main/golang/expressions.go
@@ -234,6 +234,10 @@ func (m *MemberExpression) GetBase() *Expression {
 	return (*Expression)(i.(*jnigi.ObjectRef))
 }
 
+func (e *Expression) GetName() string {
+	return (*Node)(e).GetName()
+}
+
 func (r *DeclaredReferenceExpression) Expression() *Expression {
 	return (*Expression)(r)
 }

--- a/cpg-library/src/main/golang/frontend/frontend.go
+++ b/cpg-library/src/main/golang/frontend/frontend.go
@@ -34,6 +34,7 @@ import (
 	"go/token"
 	"log"
 
+	"golang.org/x/mod/modfile"
 	"tekao.net/jnigi"
 )
 
@@ -41,7 +42,8 @@ var env *jnigi.Env
 
 type GoLanguageFrontend struct {
 	*jnigi.ObjectRef
-	File *ast.File
+	File   *ast.File
+	Module *modfile.File
 }
 
 func InitEnv(e *jnigi.Env) {

--- a/cpg-library/src/main/golang/frontend/handler.go
+++ b/cpg-library/src/main/golang/frontend/handler.go
@@ -638,9 +638,12 @@ func (this *GoLanguageFrontend) handleIfStmt(fset *token.FileSet, ifStmt *ast.If
 
 	var scope = this.GetScopeManager()
 
-	// TODO: initializer
-
 	scope.EnterScope((*cpg.Node)(stmt))
+
+	init := this.handleStmt(fset, ifStmt.Init)
+	if init != nil {
+		stmt.SetInitializerStatement(init)
+	}
 
 	cond := this.handleExpr(fset, ifStmt.Cond)
 	if cond != nil {

--- a/cpg-library/src/main/golang/frontend/handler.go
+++ b/cpg-library/src/main/golang/frontend/handler.go
@@ -479,24 +479,24 @@ func (this *GoLanguageFrontend) handleForStmt(fset *token.FileSet, forStmt *ast.
 
 	f := cpg.NewForStatement(fset, forStmt)
 
-	if statement := this.handleStmt(fset, forStmt.Init); statement != nil {
-		f.SetInitializerStatement(statement)
+	var scope = this.GetScopeManager()
+
+	scope.EnterScope((*cpg.Node)(f))
+
+	if initStatement := this.handleStmt(fset, forStmt.Init); initStatement != nil {
+		f.SetInitializerStatement(initStatement)
 	}
 
 	if condition := this.handleExpr(fset, forStmt.Cond); condition != nil {
 		f.SetCondition(condition)
 	}
 
-	var scope = this.GetScopeManager()
-
-	scope.EnterScope((*cpg.Node)(f))
+	if iter := this.handleStmt(fset, forStmt.Post); iter != nil {
+		f.SetIterationStatement(iter)
+	}
 
 	if body := this.handleStmt(fset, forStmt.Body); body != nil {
 		f.SetStatement(body)
-	}
-
-	if iter := this.handleStmt(fset, forStmt.Post); iter != nil {
-		f.SetIterationStatement(iter)
 	}
 
 	scope.LeaveScope((*cpg.Node)(f))

--- a/cpg-library/src/main/golang/go.mod
+++ b/cpg-library/src/main/golang/go.mod
@@ -2,4 +2,7 @@ module cpg
 
 go 1.16
 
-require tekao.net/jnigi v0.0.0-20201212091834-f7b899046676
+require (
+	golang.org/x/mod v0.4.2
+	tekao.net/jnigi v0.0.0-20201212091834-f7b899046676
+)

--- a/cpg-library/src/main/golang/go.sum
+++ b/cpg-library/src/main/golang/go.sum
@@ -1,2 +1,16 @@
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 tekao.net/jnigi v0.0.0-20201212091834-f7b899046676 h1:ZEkhDs0eKEynaUD1XX/WnQCD5/zoEUyMkDx5DbvVq7g=
 tekao.net/jnigi v0.0.0-20201212091834-f7b899046676/go.mod h1:SmVvXetJ8N0ov5c2eOC+IxmkdYGEyuXghTuBq5HWZ/Y=

--- a/cpg-library/src/main/golang/statements.go
+++ b/cpg-library/src/main/golang/statements.go
@@ -41,6 +41,7 @@ type IfStatement Statement
 type SwitchStatement Statement
 type CaseStatement Statement
 type DefaultStatement Statement
+type ForStatement Statement
 
 func NewCompoundStatement(fset *token.FileSet, astNode ast.Node) *CompoundStatement {
 	s, err := env.NewObject("de/fraunhofer/aisec/cpg/graph/statements/CompoundStatement")
@@ -92,6 +93,19 @@ func NewIfStatement(fset *token.FileSet, astNode ast.Node) *IfStatement {
 	updateLocation(fset, (*Node)(s), astNode)
 
 	return (*IfStatement)(s)
+}
+
+func NewForStatement(fset *token.FileSet, astNode ast.Node) *ForStatement {
+	s, err := env.NewObject("de/fraunhofer/aisec/cpg/graph/statements/ForStatement")
+	if err != nil {
+		log.Fatal(err)
+
+	}
+
+	updateCode(fset, (*Node)(s), astNode)
+	updateLocation(fset, (*Node)(s), astNode)
+
+	return (*ForStatement)(s)
 }
 
 func NewSwitchStatement(fset *token.FileSet, astNode ast.Node) *SwitchStatement {
@@ -163,6 +177,22 @@ func (sw *SwitchStatement) SetStatement(s *Statement) {
 
 func (sw *SwitchStatement) SetInitializerStatement(s *Statement) {
 	(*jnigi.ObjectRef)(sw).SetField(env, "initializerStatement", (*jnigi.ObjectRef)(s).Cast("de/fraunhofer/aisec/cpg/graph/statements/Statement"))
+}
+
+func (fw *ForStatement) SetInitializerStatement(s *Statement) {
+	(*jnigi.ObjectRef)(fw).SetField(env, "initializerStatement", (*jnigi.ObjectRef)(s).Cast("de/fraunhofer/aisec/cpg/graph/statements/Statement"))
+}
+
+func (fw *ForStatement) SetCondition(e *Expression) {
+	(*jnigi.ObjectRef)(fw).SetField(env, "condition", (*jnigi.ObjectRef)(e).Cast("de/fraunhofer/aisec/cpg/graph/statements/expressions/Expression"))
+}
+
+func (fw *ForStatement) SetStatement(s *Statement) {
+	(*jnigi.ObjectRef)(fw).SetField(env, "statement", (*jnigi.ObjectRef)(s).Cast("de/fraunhofer/aisec/cpg/graph/statements/Statement"))
+}
+
+func (fw *ForStatement) SetIterationStatement(s *Statement) {
+	(*jnigi.ObjectRef)(fw).SetField(env, "iterationStatement", (*jnigi.ObjectRef)(s).Cast("de/fraunhofer/aisec/cpg/graph/statements/Statement"))
 }
 
 func (r *ReturnStatement) SetReturnValue(e *Expression) {

--- a/cpg-library/src/main/golang/statements.go
+++ b/cpg-library/src/main/golang/statements.go
@@ -167,6 +167,10 @@ func (m *IfStatement) SetCondition(e *Expression) {
 	(*jnigi.ObjectRef)(m).SetField(env, "condition", (*jnigi.ObjectRef)(e).Cast("de/fraunhofer/aisec/cpg/graph/statements/expressions/Expression"))
 }
 
+func (i *IfStatement) SetInitializerStatement(s *Statement) {
+	(*jnigi.ObjectRef)(i).SetField(env, "initializerStatement", (*jnigi.ObjectRef)(s).Cast("de/fraunhofer/aisec/cpg/graph/statements/Statement"))
+}
+
 func (s *SwitchStatement) SetCondition(e *Expression) {
 	(*jnigi.ObjectRef)(s).SetField(env, "selector", (*jnigi.ObjectRef)(e).Cast("de/fraunhofer/aisec/cpg/graph/statements/expressions/Expression"))
 }

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/StatementHandler.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/StatementHandler.java
@@ -259,7 +259,7 @@ class StatementHandler extends Handler<Statement, IASTStatement, CXXLanguageFron
       statement.setCondition(literal);
     }
     if (ctx.getIterationExpression() != null)
-      statement.setIterationExpression(
+      statement.setIterationStatement(
           this.lang.getExpressionHandler().handle(ctx.getIterationExpression()));
     statement.setStatement(handle(ctx.getBody()));
     lang.getScopeManager().leaveScope(statement);

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontend.kt
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontend.kt
@@ -33,7 +33,6 @@ import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 import java.io.File
-import java.nio.file.Paths
 import kotlin.Throws
 
 @ExperimentalGolang

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontend.kt
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontend.kt
@@ -37,7 +37,7 @@ import kotlin.Throws
 
 @ExperimentalGolang
 class GoLanguageFrontend(config: TranslationConfiguration, scopeManager: ScopeManager?) :
-    LanguageFrontend(config, scopeManager, "/") {
+    LanguageFrontend(config, scopeManager, ".") {
     companion object {
         @kotlin.jvm.JvmField var GOLANG_EXTENSIONS: List<String> = listOf(".go")
 

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontend.kt
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontend.kt
@@ -50,7 +50,7 @@ class GoLanguageFrontend(config: TranslationConfiguration, scopeManager: ScopeMa
     @Throws(TranslationException::class)
     override fun parse(file: File): TranslationUnitDeclaration {
         TypeManager.getInstance().setLanguageFrontend(this)
-        
+
         return parseInternal(file.readText(Charsets.UTF_8), file.path, config.topLevel.absolutePath)
     }
 

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontend.kt
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontend.kt
@@ -33,11 +33,12 @@ import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 import java.io.File
+import java.nio.file.Paths
 import kotlin.Throws
 
 @ExperimentalGolang
 class GoLanguageFrontend(config: TranslationConfiguration, scopeManager: ScopeManager?) :
-    LanguageFrontend(config, scopeManager, ".") {
+    LanguageFrontend(config, scopeManager, "/") {
     companion object {
         @kotlin.jvm.JvmField var GOLANG_EXTENSIONS: List<String> = listOf(".go")
 
@@ -48,7 +49,7 @@ class GoLanguageFrontend(config: TranslationConfiguration, scopeManager: ScopeMa
 
     @Throws(TranslationException::class)
     override fun parse(file: File): TranslationUnitDeclaration {
-        return parseInternal(file.readText(Charsets.UTF_8), file.path)
+        return parseInternal(file.readText(Charsets.UTF_8), file.path, config.topLevel.absolutePath)
     }
 
     override fun <T> getCodeFromRawNode(astNode: T): String? {
@@ -63,5 +64,9 @@ class GoLanguageFrontend(config: TranslationConfiguration, scopeManager: ScopeMa
 
     override fun <S, T> setComment(s: S, ctx: T) {}
 
-    private external fun parseInternal(s: String?, path: String): TranslationUnitDeclaration
+    private external fun parseInternal(
+        s: String?,
+        path: String,
+        topLevel: String
+    ): TranslationUnitDeclaration
 }

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/StatementAnalyzer.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/StatementAnalyzer.java
@@ -302,9 +302,9 @@ public class StatementAnalyzer
         iterationExprList.setLocation(ofExprList);
         iterationExprList.setCode(updateCode);
       }
-      statement.setIterationExpression(iterationExprList);
+      statement.setIterationStatement(iterationExprList);
     } else if (forStmt.getUpdate().size() == 1) {
-      statement.setIterationExpression(
+      statement.setIterationStatement(
           (Expression) lang.getExpressionHandler().handle(forStmt.getUpdate().get(0)));
     }
 

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/StatementAnalyzer.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/StatementAnalyzer.java
@@ -305,7 +305,7 @@ public class StatementAnalyzer
       statement.setIterationStatement(iterationExprList);
     } else if (forStmt.getUpdate().size() == 1) {
       statement.setIterationStatement(
-          (Expression) lang.getExpressionHandler().handle(forStmt.getUpdate().get(0)));
+          lang.getExpressionHandler().handle(forStmt.getUpdate().get(0)));
     }
 
     statement.setStatement(handle(forStmt.getBody()));

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/typescript/DeclarationHandler.kt
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/typescript/DeclarationHandler.kt
@@ -58,7 +58,9 @@ class DeclarationHandler(lang: TypeScriptLanguageFrontend) :
 
     private fun handlePropertySignature(node: TypeScriptNode): FieldDeclaration {
         val name = this.lang.getIdentifierName(node)
-        val type = node.typeChildNode?.let { this.lang.typeHandler.handle(it) } ?: UnknownType.getUnknownType()
+        val type =
+            node.typeChildNode?.let { this.lang.typeHandler.handle(it) }
+                ?: UnknownType.getUnknownType()
 
         val field =
             NodeBuilder.newFieldDeclaration(
@@ -111,7 +113,9 @@ class DeclarationHandler(lang: TypeScriptLanguageFrontend) :
 
     private fun handleParameter(node: TypeScriptNode): Declaration {
         val name = this.lang.getIdentifierName(node)
-        val type = node.typeChildNode?.let { this.lang.typeHandler.handle(it) } ?: UnknownType.getUnknownType()
+        val type =
+            node.typeChildNode?.let { this.lang.typeHandler.handle(it) }
+                ?: UnknownType.getUnknownType()
 
         val param =
             NodeBuilder.newMethodParameterIn(name, type, false, this.lang.getCodeFromRawNode(node))

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/ForStatement.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/ForStatement.java
@@ -45,7 +45,7 @@ public class ForStatement extends Statement {
   private Expression condition;
 
   @SubGraph("AST")
-  private Expression iterationExpression;
+  private Statement iterationStatement;
 
   public Statement getStatement() {
     return statement;
@@ -79,12 +79,12 @@ public class ForStatement extends Statement {
     this.condition = condition;
   }
 
-  public Expression getIterationExpression() {
-    return iterationExpression;
+  public Statement getIterationStatement() {
+    return iterationStatement;
   }
 
-  public void setIterationExpression(Expression iterationExpression) {
-    this.iterationExpression = iterationExpression;
+  public void setIterationStatement(Statement iterationStatement) {
+    this.iterationStatement = iterationStatement;
   }
 
   @Override
@@ -101,7 +101,7 @@ public class ForStatement extends Statement {
         && Objects.equals(initializerStatement, that.initializerStatement)
         && Objects.equals(conditionDeclaration, that.conditionDeclaration)
         && Objects.equals(condition, that.condition)
-        && Objects.equals(iterationExpression, that.iterationExpression);
+        && Objects.equals(iterationStatement, that.iterationStatement);
   }
 
   @Override

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.java
@@ -966,7 +966,7 @@ public class EvaluationOrderGraphPass extends Pass {
     List<Node> tmpEOGNodes = new ArrayList<>(currentEOG);
 
     createEOG(forStmt.getStatement());
-    createEOG(forStmt.getIterationExpression());
+    createEOG(forStmt.getIterationStatement());
 
     connectCurrentToLoopStart();
     currentEOG.clear();

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManager.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManager.java
@@ -576,31 +576,29 @@ public class ScopeManager {
     // First, we need to check, whether we have some kind of scoping. this is currently only limited
     // to the Go frontend,
     // but should work for other languages as well - but is not tested.
-    if (lang instanceof GoLanguageFrontend) {
-      if (call.getFqn() != null && call.getFqn().contains(lang.getNamespaceDelimiter())) {
-        // extract the scope name, it is usually a name space, but could probably be something else
-        // as well in other languages
-        var scopeName =
-            call.getFqn().substring(0, call.getFqn().lastIndexOf(lang.getNamespaceDelimiter()));
+    if (lang instanceof GoLanguageFrontend
+        && call.getFqn() != null
+        && call.getFqn().contains(lang.getNamespaceDelimiter())) {
+      // extract the scope name, it is usually a name space, but could probably be something else
+      // as well in other languages
+      var scopeName =
+          call.getFqn().substring(0, call.getFqn().lastIndexOf(lang.getNamespaceDelimiter()));
 
-        var globalScope =
-            (GlobalScope) getFirstScopeThat(predicate -> predicate instanceof GlobalScope);
-        // this is a scoped call. we need to explicitly jump to that particular scope
-        var scopes =
-            this.getScopesThat(
-                (predicate) ->
-                    (predicate instanceof NameScope)
-                        && Objects.equals(predicate.scopedName, scopeName));
+      // this is a scoped call. we need to explicitly jump to that particular scope
+      var scopes =
+          this.getScopesThat(
+              predicate ->
+                  (predicate instanceof NameScope)
+                      && Objects.equals(predicate.scopedName, scopeName));
 
-        if (scopes == null || scopes.isEmpty()) {
-          LOGGER.error(
-              "Could not find the scope {} needed to resolve the call {}. Falling back to the current scope",
-              scopeName,
-              call.getFqn());
-          scope = currentScope;
-        } else {
-          scope = scopes.get(0);
-        }
+      if (scopes == null || scopes.isEmpty()) {
+        LOGGER.error(
+            "Could not find the scope {} needed to resolve the call {}. Falling back to the current scope",
+            scopeName,
+            call.getFqn());
+        scope = currentScope;
+      } else {
+        scope = scopes.get(0);
       }
     }
 

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManager.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManager.java
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.passes.scopes;
 import static de.fraunhofer.aisec.cpg.helpers.Util.errorWithFileLocation;
 
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend;
+import de.fraunhofer.aisec.cpg.frontends.golang.GoLanguageFrontend;
 import de.fraunhofer.aisec.cpg.graph.HasType;
 import de.fraunhofer.aisec.cpg.graph.Node;
 import de.fraunhofer.aisec.cpg.graph.declarations.*;
@@ -536,8 +537,47 @@ public class ScopeManager {
     return resolve(currentScope, ref);
   }
 
+  /**
+   * Tries to resolve a function in a call expression.
+   *
+   * @param call the call expression
+   * @return a list of possible functions
+   */
   public List<FunctionDeclaration> resolveFunction(CallExpression call) {
-    return resolveFunction(currentScope, call);
+    var scope = currentScope;
+
+    // First, we need to check, whether we have some kind of scoping. this is currently only limited
+    // to the Go frontend,
+    // but should work for other languages as well - but is not tested.
+    if (lang instanceof GoLanguageFrontend) {
+      if (call.getFqn() != null && call.getFqn().contains(lang.getNamespaceDelimiter())) {
+        // extract the scope name, it is usually a name space, but could probably be something else
+        // as well in other languages
+        var scopeName =
+            call.getFqn().substring(0, call.getFqn().lastIndexOf(lang.getNamespaceDelimiter()));
+
+        var globalScope =
+            (GlobalScope) getFirstScopeThat(predicate -> predicate instanceof GlobalScope);
+        // this is a scoped call. we need to explicitly jump to that particular scope
+        var scopes =
+            this.getScopesThat(
+                (predicate) ->
+                    (predicate instanceof NameScope)
+                        && Objects.equals(predicate.scopedName, scopeName));
+
+        if (scopes == null || scopes.isEmpty()) {
+          LOGGER.error(
+              "Could not find the scope {} needed to resolve the call {}. Falling back to the current scope",
+              scopeName,
+              call.getFqn());
+          scope = currentScope;
+        } else {
+          scope = scopes.get(0);
+        }
+      }
+    }
+
+    return resolveFunction(scope, call);
   }
 
   public List<FunctionTemplateDeclaration> resolveFunctionTemplateDeclaration(CallExpression call) {

--- a/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/enhancements/EOGTest.java
+++ b/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/enhancements/EOGTest.java
@@ -204,16 +204,16 @@ class EOGTest extends BaseTest {
     assertTrue(Util.eogConnect(EXITS, fs.getCondition(), NODE, fs));
     assertTrue(Util.eogConnect(NODE, EXITS, fs, SUBTREE, fs.getStatement(), prints.get(1)));
 
-    assertTrue(Util.eogConnect(EXITS, fs.getStatement(), SUBTREE, fs.getIterationExpression()));
-    assertTrue(Util.eogConnect(EXITS, fs.getIterationExpression(), SUBTREE, fs.getCondition()));
+    assertTrue(Util.eogConnect(EXITS, fs.getStatement(), SUBTREE, fs.getIterationStatement()));
+    assertTrue(Util.eogConnect(EXITS, fs.getIterationStatement(), SUBTREE, fs.getCondition()));
 
     fs = fstat.get(1);
     assertTrue(Util.eogConnect(NODE, EXITS, prints.get(1), SUBTREE, fs));
     assertTrue(Util.eogConnect(NODE, EXITS, prints.get(1), SUBTREE, fs.getInitializerStatement()));
     assertTrue(Util.eogConnect(EXITS, fs.getInitializerStatement(), SUBTREE, fs.getCondition()));
     assertTrue(Util.eogConnect(EXITS, fs.getCondition(), NODE, fs));
-    assertTrue(Util.eogConnect(EXITS, fs.getStatement(), SUBTREE, fs.getIterationExpression()));
-    assertTrue(Util.eogConnect(EXITS, fs.getIterationExpression(), SUBTREE, fs.getCondition()));
+    assertTrue(Util.eogConnect(EXITS, fs.getStatement(), SUBTREE, fs.getIterationStatement()));
+    assertTrue(Util.eogConnect(EXITS, fs.getIterationStatement(), SUBTREE, fs.getCondition()));
     assertTrue(Util.eogConnect(SUBTREE, EXITS, fs, SUBTREE, prints.get(2)));
   }
 
@@ -233,9 +233,9 @@ class EOGTest extends BaseTest {
         Util.eogConnect(
             EXITS, fs.getInitializerStatement(), SUBTREE, fs.getConditionDeclaration()));
     assertTrue(Util.eogConnect(EXITS, fs.getConditionDeclaration(), NODE, fs));
-    assertTrue(Util.eogConnect(EXITS, fs.getStatement(), SUBTREE, fs.getIterationExpression()));
+    assertTrue(Util.eogConnect(EXITS, fs.getStatement(), SUBTREE, fs.getIterationStatement()));
     assertTrue(
-        Util.eogConnect(EXITS, fs.getIterationExpression(), SUBTREE, fs.getConditionDeclaration()));
+        Util.eogConnect(EXITS, fs.getIterationStatement(), SUBTREE, fs.getConditionDeclaration()));
     assertTrue(Util.eogConnect(SUBTREE, EXITS, fs, SUBTREE, prints.get(1)));
 
     fs = fstat.get(1);
@@ -243,8 +243,8 @@ class EOGTest extends BaseTest {
     assertTrue(Util.eogConnect(NODE, EXITS, prints.get(1), SUBTREE, fs.getInitializerStatement()));
     assertTrue(Util.eogConnect(EXITS, fs.getInitializerStatement(), SUBTREE, fs.getCondition()));
     assertTrue(Util.eogConnect(EXITS, fs.getCondition(), NODE, fs));
-    assertTrue(Util.eogConnect(EXITS, fs.getStatement(), SUBTREE, fs.getIterationExpression()));
-    assertTrue(Util.eogConnect(EXITS, fs.getIterationExpression(), SUBTREE, fs.getCondition()));
+    assertTrue(Util.eogConnect(EXITS, fs.getStatement(), SUBTREE, fs.getIterationStatement()));
+    assertTrue(Util.eogConnect(EXITS, fs.getIterationStatement(), SUBTREE, fs.getCondition()));
     assertTrue(Util.eogConnect(SUBTREE, EXITS, fs, SUBTREE, prints.get(2)));
 
     fs = fstat.get(2);
@@ -252,8 +252,8 @@ class EOGTest extends BaseTest {
     assertTrue(Util.eogConnect(NODE, EXITS, prints.get(3), SUBTREE, fs.getInitializerStatement()));
     assertTrue(Util.eogConnect(EXITS, fs.getInitializerStatement(), SUBTREE, fs.getCondition()));
     assertTrue(Util.eogConnect(EXITS, fs.getCondition(), NODE, fs));
-    assertTrue(Util.eogConnect(EXITS, fs.getStatement(), SUBTREE, fs.getIterationExpression()));
-    assertTrue(Util.eogConnect(EXITS, fs.getIterationExpression(), SUBTREE, fs.getCondition()));
+    assertTrue(Util.eogConnect(EXITS, fs.getStatement(), SUBTREE, fs.getIterationStatement()));
+    assertTrue(Util.eogConnect(EXITS, fs.getIterationStatement(), SUBTREE, fs.getCondition()));
     assertTrue(Util.eogConnect(SUBTREE, EXITS, fs, SUBTREE, prints.get(4)));
   }
 

--- a/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
+++ b/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
@@ -246,15 +246,7 @@ class GoLanguageFrontendTest : BaseTest() {
         assertNotNull(callExpression)
 
         assertEquals("fmt.Printf", callExpression.fqn)
-
-        val base = callExpression.base as? DeclaredReferenceExpression
-
-        assertNotNull(base)
-
-        val include = base.refersTo as? IncludeDeclaration
-
-        assertNotNull(include)
-        assertEquals("fmt", include.name)
+        assertEquals("Printf", callExpression.name)
 
         val literal = callExpression.arguments.first() as? Literal<*>
         assertNotNull(literal)
@@ -463,11 +455,10 @@ class GoLanguageFrontendTest : BaseTest() {
         assertEquals("Field", lhs.name)
         assertEquals(TypeParser.createFrom("int", false), lhs.type)
 
-        val rhs = binOp.rhs as? MemberExpression
+        val rhs = binOp.rhs as? DeclaredReferenceExpression
 
         assertNotNull(rhs)
-        assertEquals("otherPackage", (rhs.base as? DeclaredReferenceExpression)?.name)
-        assertEquals("OtherField", rhs.name)
+        assertEquals("otherPackage.OtherField", rhs.name)
     }
 
     @Test
@@ -706,5 +697,40 @@ class GoLanguageFrontendTest : BaseTest() {
             }
 
         assertNotNull(tus)
+
+        val tu0 = tus.get(0)
+        assertNotNull(tu0)
+
+        val awesome =
+            tu0.getDeclarationsByName("awesome", NamespaceDeclaration::class.java).iterator().next()
+        assertNotNull(awesome)
+
+        val newAwesome =
+            awesome
+                .getDeclarationsByName("NewAwesome", FunctionDeclaration::class.java)
+                .iterator()
+                .next()
+        assertNotNull(newAwesome)
+
+        val tu1 = tus.get(1)
+        assertNotNull(tu1)
+
+        val mainNamespace =
+            tu1.getDeclarationsByName("main", NamespaceDeclaration::class.java).iterator().next()
+        assertNotNull(mainNamespace)
+
+        val main =
+            mainNamespace
+                .getDeclarationsByName("main", FunctionDeclaration::class.java)
+                .iterator()
+                .next()
+        assertNotNull(main)
+
+        val a = main.getBodyStatementAs(0, DeclarationStatement::class.java)
+        assertNotNull(a)
+
+        val call = (a.singleDeclaration as? VariableDeclaration)?.initializer as? CallExpression
+        assertNotNull(call)
+        assertTrue(call.invokes.contains(newAwesome))
     }
 }

--- a/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
+++ b/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
@@ -685,4 +685,26 @@ class GoLanguageFrontendTest : BaseTest() {
         assertTrue(f.initializerStatement is DeclarationStatement)
         assertTrue(f.iterationStatement is UnaryOperator)
     }
+
+    @Test
+    fun testModules() {
+        val topLevel = Path.of("src", "test", "resources", "golang-modules")
+        val tus =
+            TestUtils.analyze(
+                listOf(
+                    topLevel.resolve("awesome.go").toFile(),
+                    topLevel.resolve("cmd/awesome/main.go").toFile(),
+                    topLevel.resolve("util/stuff.go").toFile(),
+                ),
+                topLevel,
+                true
+            ) {
+                it.registerLanguage(
+                    GoLanguageFrontend::class.java,
+                    GoLanguageFrontend.GOLANG_EXTENSIONS
+                )
+            }
+
+        assertNotNull(tus)
+    }
 }

--- a/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
+++ b/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
@@ -648,4 +648,41 @@ class GoLanguageFrontendTest : BaseTest() {
         assertNotNull(base)
         assertEquals(c, base.refersTo)
     }
+
+    @Test
+    fun testFor() {
+        val topLevel = Path.of("src", "test", "resources", "golang")
+        val tus =
+            TestUtils.analyze(
+                listOf(
+                    topLevel.resolve("for.go").toFile(),
+                ),
+                topLevel,
+                true
+            ) {
+                it.registerLanguage(
+                    GoLanguageFrontend::class.java,
+                    GoLanguageFrontend.GOLANG_EXTENSIONS
+                )
+            }
+
+        assertNotNull(tus)
+
+        val tu = tus.first()
+
+        val p = tu.getDeclarationsByName("p", NamespaceDeclaration::class.java).iterator().next()
+
+        val main =
+            p.getDeclarationsByName("main", FunctionDeclaration::class.java).iterator().next()
+
+        assertNotNull(main)
+
+        val f = main.getBodyStatementAs(0, ForStatement::class.java)
+
+        assertNotNull(f)
+        assertTrue(f.condition is BinaryOperator)
+        assertTrue(f.statement is CompoundStatement)
+        assertTrue(f.initializerStatement is DeclarationStatement)
+        assertTrue(f.iterationStatement is UnaryOperator)
+    }
 }

--- a/cpg-library/src/test/resources/golang-modules/awesome.go
+++ b/cpg-library/src/test/resources/golang-modules/awesome.go
@@ -1,0 +1,8 @@
+package awesome
+
+type Awesome struct {
+}
+
+func NewAwesome() *Awesome {
+	return &Awesome{}
+}

--- a/cpg-library/src/test/resources/golang-modules/cmd/awesome/main.go
+++ b/cpg-library/src/test/resources/golang-modules/cmd/awesome/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"example.io/awesome"
+	"example.io/awesome/util"
+)
+
+func main() {
+	a := awesome.NewAwesome()
+
+	util.DoSomethingWith(a)
+	util.DoSomethingElse() // this function is part of a file we do not have
+}

--- a/cpg-library/src/test/resources/golang-modules/go.mod
+++ b/cpg-library/src/test/resources/golang-modules/go.mod
@@ -1,0 +1,3 @@
+module example.io/awesome
+
+go 1.16

--- a/cpg-library/src/test/resources/golang-modules/util/stuff.go
+++ b/cpg-library/src/test/resources/golang-modules/util/stuff.go
@@ -1,0 +1,7 @@
+package util
+
+import "example.io/awesome"
+
+func DoSomethingWith(a *awesome.Awesome) {
+
+}

--- a/cpg-library/src/test/resources/golang/for.go
+++ b/cpg-library/src/test/resources/golang/for.go
@@ -1,0 +1,7 @@
+package p
+
+func main() {
+    for i := 0; i < 5; i++ {
+        do()
+    }
+}


### PR DESCRIPTION
* Added support for parsing `ForStatement` in Go. This is also graph changing, as we needed to change the type of the iteration expression to `Statement`.
* Handling `IncDecStmt` as `UnaryOperator`.
* Preparing Go modules support. This is not active yet, just the prep work
* Proper resolution of calls across packages, based on package names. This could be re-used in other language frontends for scoped resolution, but is currently limited to Go