### PR TITLE
ForEachStatement: `variable` is now a `Statement` instead of a `Declaration`

### DIFF
--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/StatementHandler.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/StatementHandler.java
@@ -25,6 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.frontends.cpp;
 
+import static de.fraunhofer.aisec.cpg.graph.NodeBuilder.newDeclarationStatement;
+
 import de.fraunhofer.aisec.cpg.frontends.Handler;
 import de.fraunhofer.aisec.cpg.graph.NodeBuilder;
 import de.fraunhofer.aisec.cpg.graph.TypeManager;
@@ -272,7 +274,7 @@ class StatementHandler extends Handler<Statement, IASTStatement, CXXLanguageFron
     lang.getScopeManager().enterScope(statement);
 
     Declaration decl = this.lang.getDeclarationHandler().handle(ctx.getDeclaration());
-    DeclarationStatement var = new DeclarationStatement();
+    DeclarationStatement var = newDeclarationStatement(decl.getCode());
     var.setSingleDeclaration(decl);
     Statement iterable = this.lang.getExpressionHandler().handle(ctx.getInitializerClause());
 
@@ -305,8 +307,7 @@ class StatementHandler extends Handler<Statement, IASTStatement, CXXLanguageFron
       TypeManager.getInstance().handleTypedef(ctx.getRawSignature());
       return null;
     } else {
-      DeclarationStatement declarationStatement =
-          NodeBuilder.newDeclarationStatement(ctx.getRawSignature());
+      DeclarationStatement declarationStatement = newDeclarationStatement(ctx.getRawSignature());
 
       Declaration declaration = this.lang.getDeclarationHandler().handle(ctx.getDeclaration());
 

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/StatementHandler.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/StatementHandler.java
@@ -271,7 +271,9 @@ class StatementHandler extends Handler<Statement, IASTStatement, CXXLanguageFron
     ForEachStatement statement = NodeBuilder.newForEachStatement(ctx.getRawSignature());
     lang.getScopeManager().enterScope(statement);
 
-    Declaration var = this.lang.getDeclarationHandler().handle(ctx.getDeclaration());
+    Declaration decl = this.lang.getDeclarationHandler().handle(ctx.getDeclaration());
+    DeclarationStatement var = new DeclarationStatement();
+    var.setSingleDeclaration(decl);
     Statement iterable = this.lang.getExpressionHandler().handle(ctx.getInitializerClause());
 
     statement.setVariable(var);

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.java
@@ -421,7 +421,7 @@ public class DeclarationHandler
   }
 
   public Declaration /* TODO refine return type*/ handleAnnotationDeclaration(
-          AnnotationDeclaration annotationConstDecl) {
+      AnnotationDeclaration annotationConstDecl) {
     return new Declaration();
   }
 

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/StatementAnalyzer.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/StatementAnalyzer.java
@@ -179,16 +179,16 @@ public class StatementAnalyzer
     lang.getScopeManager().enterScope(statement);
 
     ForEachStmt forEachStmt = stmt.asForEachStmt();
-    de.fraunhofer.aisec.cpg.graph.statements.Statement var =
+    de.fraunhofer.aisec.cpg.graph.statements.Statement variable =
         lang.getExpressionHandler().handle(forEachStmt.getVariable());
     de.fraunhofer.aisec.cpg.graph.statements.Statement iterable =
         lang.getExpressionHandler().handle(forEachStmt.getIterable());
 
-    if (!(var instanceof DeclarationStatement))
-      log.error("Expected a DeclarationStatement but received: {}", var.getName());
-    else if (!((DeclarationStatement) var).isSingleDeclaration())
-      log.error("Expected a single DeclarationStatement.");
-    else statement.setVariable(var);
+    if (!(variable instanceof DeclarationStatement)) {
+      log.error("Expected a DeclarationStatement but received: {}", variable.getName());
+    } else {
+      statement.setVariable(variable);
+    }
 
     statement.setIterable(iterable);
     statement.setStatement(handle(forEachStmt.getBody()));

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/StatementAnalyzer.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/StatementAnalyzer.java
@@ -184,12 +184,7 @@ public class StatementAnalyzer
     de.fraunhofer.aisec.cpg.graph.statements.Statement iterable =
         lang.getExpressionHandler().handle(forEachStmt.getIterable());
 
-    if (!(var instanceof DeclarationStatement
-        && ((DeclarationStatement) var).isSingleDeclaration())) {
-      log.error("more or unknown decl in foreach");
-    } else {
-      statement.setVariable(((DeclarationStatement) var).getSingleDeclaration());
-    }
+    statement.setVariable(var);
 
     statement.setIterable(iterable);
     statement.setStatement(handle(forEachStmt.getBody()));

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/StatementAnalyzer.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/StatementAnalyzer.java
@@ -186,6 +186,8 @@ public class StatementAnalyzer
 
     if (!(var instanceof DeclarationStatement))
       log.error("Expected a DeclarationStatement but received: {}", var.getName());
+    else if (!((DeclarationStatement) var).isSingleDeclaration())
+      log.error("Expected a single DeclarationStatement.");
     else statement.setVariable(var);
 
     statement.setIterable(iterable);

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/StatementAnalyzer.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/StatementAnalyzer.java
@@ -184,7 +184,9 @@ public class StatementAnalyzer
     de.fraunhofer.aisec.cpg.graph.statements.Statement iterable =
         lang.getExpressionHandler().handle(forEachStmt.getIterable());
 
-    statement.setVariable(var);
+    if (!(var instanceof DeclarationStatement))
+      log.error("Expected a DeclarationStatement but received: {}", var.getName());
+    else statement.setVariable(var);
 
     statement.setIterable(iterable);
     statement.setStatement(handle(forEachStmt.getBody()));

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/typescript/DeclarationHandler.kt
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/typescript/DeclarationHandler.kt
@@ -58,7 +58,9 @@ class DeclarationHandler(lang: TypeScriptLanguageFrontend) :
 
     private fun handlePropertySignature(node: TypeScriptNode): FieldDeclaration {
         val name = this.lang.getIdentifierName(node)
-        val type = node.typeChildNode?.let { this.lang.typeHandler.handle(it) } ?: UnknownType.getUnknownType()
+        val type =
+            node.typeChildNode?.let { this.lang.typeHandler.handle(it) }
+                ?: UnknownType.getUnknownType()
 
         val field =
             NodeBuilder.newFieldDeclaration(
@@ -111,7 +113,9 @@ class DeclarationHandler(lang: TypeScriptLanguageFrontend) :
 
     private fun handleParameter(node: TypeScriptNode): Declaration {
         val name = this.lang.getIdentifierName(node)
-        val type = node.typeChildNode?.let { this.lang.typeHandler.handle(it) } ?: UnknownType.getUnknownType()
+        val type =
+            node.typeChildNode?.let { this.lang.typeHandler.handle(it) }
+                ?: UnknownType.getUnknownType()
 
         val param =
             NodeBuilder.newMethodParameterIn(name, type, false, this.lang.getCodeFromRawNode(node))

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/typescript/TypeHandler.kt
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/typescript/TypeHandler.kt
@@ -56,8 +56,10 @@ class TypeHandler(lang: TypeScriptLanguageFrontend?) :
     }
 
     private fun handleArrayType(node: TypeScriptNode): Type {
-        val type = node.firstChild("TypeReference")?.let { this.handle(it)  } ?: UnknownType.getUnknownType()
-        
+        val type =
+            node.firstChild("TypeReference")?.let { this.handle(it) }
+                ?: UnknownType.getUnknownType()
+
         return type.reference(PointerType.PointerOrigin.ARRAY)
     }
 

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/ForEachStatement.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/ForEachStatement.java
@@ -30,12 +30,18 @@ import java.util.Objects;
 
 public class ForEachStatement extends Statement {
 
+  /**
+   * This field contains the iteration variable of the loop. It can be either a new variable
+   * declaration or a reference to an existing variable.
+   */
   @SubGraph("AST")
   private Statement variable;
 
+  /** This field contains the iteration subject of the loop. */
   @SubGraph("AST")
   private Statement iterable;
 
+  /** This field contains the body of the loop. */
   @SubGraph("AST")
   private Statement statement;
 

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/ForEachStatement.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/ForEachStatement.java
@@ -26,13 +26,12 @@
 package de.fraunhofer.aisec.cpg.graph.statements;
 
 import de.fraunhofer.aisec.cpg.graph.SubGraph;
-import de.fraunhofer.aisec.cpg.graph.declarations.Declaration;
 import java.util.Objects;
 
 public class ForEachStatement extends Statement {
 
   @SubGraph("AST")
-  private Declaration variable;
+  private Statement variable;
 
   @SubGraph("AST")
   private Statement iterable;
@@ -48,11 +47,11 @@ public class ForEachStatement extends Statement {
     this.statement = statement;
   }
 
-  public Declaration getVariable() {
+  public Statement getVariable() {
     return variable;
   }
 
-  public void setVariable(Declaration variable) {
+  public void setVariable(Statement variable) {
     this.variable = variable;
   }
 

--- a/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
+++ b/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
@@ -104,9 +104,10 @@ class CXXLanguageFrontendTest extends BaseTest {
     assertEquals(ls, ((DeclaredReferenceExpression) forEachStatement.getIterable()).getRefersTo());
 
     // should declare auto i (so far no concrete type inferrable)
-    Statement stmt = (Statement) forEachStatement.getVariable();
+    Statement stmt = forEachStatement.getVariable();
     assertNotNull(stmt);
     assertTrue(stmt instanceof DeclarationStatement);
+    assertTrue(((DeclarationStatement) stmt).isSingleDeclaration());
     VariableDeclaration i =
         (VariableDeclaration) ((DeclarationStatement) stmt).getSingleDeclaration();
     assertNotNull(i);

--- a/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
+++ b/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
@@ -104,7 +104,11 @@ class CXXLanguageFrontendTest extends BaseTest {
     assertEquals(ls, ((DeclaredReferenceExpression) forEachStatement.getIterable()).getRefersTo());
 
     // should declare auto i (so far no concrete type inferrable)
-    VariableDeclaration i = (VariableDeclaration) forEachStatement.getVariable();
+    Statement stmt = (Statement) forEachStatement.getVariable();
+    assertNotNull(stmt);
+    assertTrue(stmt instanceof DeclarationStatement);
+    VariableDeclaration i =
+        (VariableDeclaration) ((DeclarationStatement) stmt).getSingleDeclaration();
     assertNotNull(i);
     assertEquals("i", i.getName());
     assertEquals(UnknownType.getUnknownType(), i.getType());

--- a/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
+++ b/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
@@ -137,7 +137,7 @@ class JavaLanguageFrontendTest extends BaseTest {
     assertEquals(ls, ((DeclaredReferenceExpression) forEachStatement.getIterable()).getRefersTo());
 
     // should declare String s
-    Statement s = forEachStatement.getVariable();
+    var s = forEachStatement.getVariable();
     assertNotNull(s);
     assertTrue(s instanceof DeclarationStatement);
     assertTrue(((DeclarationStatement) s).isSingleDeclaration());

--- a/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
+++ b/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
@@ -137,10 +137,13 @@ class JavaLanguageFrontendTest extends BaseTest {
     assertEquals(ls, ((DeclaredReferenceExpression) forEachStatement.getIterable()).getRefersTo());
 
     // should declare String s
-    VariableDeclaration s = (VariableDeclaration) forEachStatement.getVariable();
+    Statement s = forEachStatement.getVariable();
     assertNotNull(s);
-    assertEquals("s", s.getName());
-    assertEquals(TypeParser.createFrom("java.lang.String", true), s.getType());
+    assertTrue(s instanceof DeclarationStatement);
+    VariableDeclaration sDecl =
+        (VariableDeclaration) ((DeclarationStatement) s).getSingleDeclaration();
+    assertEquals("s", sDecl.getName());
+    assertEquals(TypeParser.createFrom("java.lang.String", true), sDecl.getType());
 
     // should contain a single statement
     var sce = (MemberCallExpression) forEachStatement.getStatement();

--- a/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
+++ b/cpg-library/src/test/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.java
@@ -140,8 +140,10 @@ class JavaLanguageFrontendTest extends BaseTest {
     Statement s = forEachStatement.getVariable();
     assertNotNull(s);
     assertTrue(s instanceof DeclarationStatement);
+    assertTrue(((DeclarationStatement) s).isSingleDeclaration());
     VariableDeclaration sDecl =
         (VariableDeclaration) ((DeclarationStatement) s).getSingleDeclaration();
+    assertNotNull(sDecl);
     assertEquals("s", sDecl.getName());
     assertEquals(TypeParser.createFrom("java.lang.String", true), sDecl.getType());
 


### PR DESCRIPTION
This PR changes the graph: `ForEachStamtents`'s `variable` field becomes a `Statement` (was a `Declaration`) to allow for languages that do not require new variables in for loops but also allow references.

Example:
```python
iter = 1
for iter in [1,2,3]:
  pass
# iter is now 3
```