### PR TITLE
Add Annotation Handling for Variables and Parameters

### DIFF
--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.java
@@ -205,6 +205,9 @@ public class DeclarationHandler
 
       functionDeclaration.addParameter(param);
       lang.setCodeAndRegion(param, parameter);
+
+      lang.processAnnotations(param, parameter);
+
       lang.getScopeManager().addDeclaration(param);
     }
 
@@ -418,7 +421,7 @@ public class DeclarationHandler
   }
 
   public Declaration /* TODO refine return type*/ handleAnnotationDeclaration(
-      AnnotationDeclaration annotationConstDecl) {
+          AnnotationDeclaration annotationConstDecl) {
     return new Declaration();
   }
 

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java
@@ -262,6 +262,8 @@ public class ExpressionHandler extends Handler<Statement, Expression, JavaLangua
       lang.setCodeAndRegion(declaration, variable);
       declarationStatement.addToPropertyEdgeDeclaration(declaration);
 
+      lang.processAnnotations(declaration, variableDeclarationExpr);
+
       lang.getScopeManager().addDeclaration(declaration);
     }
 


### PR DESCRIPTION
Closes #502 

In the Local Variable case, the Annotation is Attached to each Variable Declaration, although the originally Annotated AST-Element is the `VariableDeclarationExpr`