### PR TITLE
Somehow `@BeforeAll` stopped working in Kotlin tests

### DIFF
--- a/cpg-neo4j/src/test/java/de/fraunhofer/aisec/cpg_vis_neo4j/ApplicationTest.kt
+++ b/cpg-neo4j/src/test/java/de/fraunhofer/aisec/cpg_vis_neo4j/ApplicationTest.kt
@@ -31,19 +31,35 @@ import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import java.io.File
 import java.nio.file.Paths
-import java.util.concurrent.ExecutionException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
 @Tag("integration")
 class ApplicationTest {
 
+    private var translationResult: TranslationResult? = null
+
     @Test
     @Throws(InterruptedException::class)
     fun testPush() {
+        val topLevel = Paths.get("src").resolve("test").resolve("resources").toAbsolutePath()
+        val path = topLevel.resolve("client.cpp").toAbsolutePath()
+        val file = File(path.toString())
+        assert(file.exists() && !file.isDirectory && !file.isHidden)
+        val translationConfiguration =
+            TranslationConfiguration.builder()
+                .sourceLocations(file)
+                .topLevel(topLevel.toFile())
+                .defaultPasses()
+                .defaultLanguages()
+                .debugParser(true)
+                .build()
+        val translationManager =
+            TranslationManager.builder().config(translationConfiguration).build()
+        translationResult = translationManager.analyze().get()
+
         val application = Application()
 
         application.pushToNeo4j(translationResult!!)
@@ -62,30 +78,5 @@ class ApplicationTest {
 
         session.clear()
         sessionAndSessionFactoryPair.second.close()
-    }
-
-    companion object {
-        private var translationResult: TranslationResult? = null
-
-        @BeforeAll
-        @JvmStatic
-        @Throws(ExecutionException::class, InterruptedException::class)
-        private fun init() {
-            val topLevel = Paths.get("src").resolve("test").resolve("resources").toAbsolutePath()
-            val path = topLevel.resolve("client.cpp").toAbsolutePath()
-            val file = File(path.toString())
-            assert(file.exists() && !file.isDirectory && !file.isHidden)
-            val translationConfiguration =
-                TranslationConfiguration.builder()
-                    .sourceLocations(file)
-                    .topLevel(topLevel.toFile())
-                    .defaultPasses()
-                    .defaultLanguages()
-                    .debugParser(true)
-                    .build()
-            val translationManager =
-                TranslationManager.builder().config(translationConfiguration).build()
-            translationResult = translationManager.analyze().get()
-        }
     }
 }


### PR DESCRIPTION
Somehow, magically, the `@BeforeAll` annotation stopped working in the `cpg-neo4j` test. This is a hot fix. We should investigate this further.