### PR TITLE
Python: handle expression for first decorator argument

### DIFF
--- a/cpg-library/src/main/python/CPGPython/_statements.py
+++ b/cpg-library/src/main/python/CPGPython/_statements.py
@@ -400,7 +400,7 @@ def handle_function_or_method(self, node, record=None):
         # add first arg as value
         if len(decorator.args) > 0:
             arg0 = decorator.args[0]
-            value = self.visit(arg0)
+            value = self.handle_expression(arg0)
 
             member = NodeBuilder.newAnnotationMember(
                 "value", value, self.get_src_code(arg0))


### PR DESCRIPTION
This PR fixes an issue identified by @immqu
The first argument of an annotation / decorator was visited using the old CPG/Python implementation. Annotation arguments are now parsed using the correct `handle_expression` function.