### PR TITLE
Adding `DFG` edge from `value` to `KeyValueExpression`

### DIFF
--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/KeyValueExpression.kt
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/KeyValueExpression.kt
@@ -44,14 +44,13 @@ class KeyValueExpression : Expression() {
     @field:SubGraph("AST") var key: Expression? = null
 
     /** The value of this pair. It can be any expression */
-    @field:SubGraph("AST") var value: Expression? = null
+    @field:SubGraph("AST")
+    var value: Expression? = null
         set(value) {
-            if(this.value != null){
+            if (this.value != null) {
                 this.removePrevDFG(this.value)
             }
-            value?.let {
-                this.addPrevDFG(value);
-            }
+            value?.let { this.addPrevDFG(value) }
             field = value
         }
 

--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/KeyValueExpression.kt
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/KeyValueExpression.kt
@@ -45,6 +45,15 @@ class KeyValueExpression : Expression() {
 
     /** The value of this pair. It can be any expression */
     @field:SubGraph("AST") var value: Expression? = null
+        set(value) {
+            if(this.value != null){
+                this.removePrevDFG(this.value)
+            }
+            value?.let {
+                this.addPrevDFG(value);
+            }
+            field = value
+        }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) {


### PR DESCRIPTION
This should solve a non reported Issue where DFGs were incomplete. However we may have to look at other parts of the experimental typescript frontend and discuss how types are propagated as there is no current implementation for that logic.