### PR TITLE
Fixed potential stack overflow in `Statement::equals`

### DIFF
--- a/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/Statement.java
+++ b/cpg-library/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/Statement.java
@@ -78,7 +78,7 @@ public class Statement extends Node implements DeclarationHolder {
     Statement statement = (Statement) o;
     return super.equals(statement)
         && Objects.equals(this.getLocals(), statement.getLocals())
-        && Objects.equals(this.locals, statement.locals);
+        && PropertyEdge.propertyEqualsList(this.locals, statement.locals);
   }
 
   @Override


### PR DESCRIPTION
`Statement::equals` was using `equals` for its `locals` field instead of the appropriate property edge equal function. This lead to a stack overflow in some cases
