### PR TITLE
Added null safety checks for language frontend in passes

### DIFF
--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
@@ -525,6 +525,8 @@ public class CallResolver extends Pass {
     if (lang == null) {
       Util.errorWithFileLocation(
           templateCall, log, "Could not handle template function call: language frontend is null");
+
+      return false;
     }
 
     List<FunctionTemplateDeclaration> instantiationCandidates =
@@ -896,6 +898,8 @@ public class CallResolver extends Pass {
     if (lang == null) {
       Util.errorWithFileLocation(
           call, log, "Could not resolve implicit casts: language frontend is null");
+
+      return Collections.emptyList();
     }
 
     List<FunctionDeclaration> initialInvocationCandidates =
@@ -997,6 +1001,8 @@ public class CallResolver extends Pass {
     if (lang == null) {
       Util.errorWithFileLocation(
           call, log, "Could not resolve default arguments: language frontend is null");
+
+      return Collections.emptyList();
     }
 
     List<FunctionDeclaration> invocationCandidates =
@@ -1032,6 +1038,8 @@ public class CallResolver extends Pass {
     if (lang == null) {
       Util.errorWithFileLocation(
           call, log, "Could not handle normal CXX calls: language frontend is null");
+
+      return;
     }
 
     List<FunctionDeclaration> invocationCandidates =
@@ -1137,6 +1145,8 @@ public class CallResolver extends Pass {
     if (lang == null) {
       Util.errorWithFileLocation(
           call, log, "Could not handle method CXX calls: language frontend is null");
+
+      return Collections.emptyList();
     }
 
     List<FunctionDeclaration> invocationCandidates =
@@ -1198,6 +1208,8 @@ public class CallResolver extends Pass {
     if (lang == null) {
       Util.errorWithFileLocation(
           call, log, "Could not search for invokes in parent: language frontend is null");
+
+      return false;
     }
 
     return lang.getScopeManager().resolveFunctionStopScopeTraversalOnDefinition(call).isEmpty();

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
@@ -522,6 +522,10 @@ public class CallResolver extends Pass {
       @Nullable RecordDeclaration curClass,
       @NonNull CallExpression templateCall,
       boolean applyInference) {
+    if (lang == null) {
+      Util.errorWithFileLocation(
+          templateCall, log, "Could not handle template function call: language frontend is null");
+    }
 
     List<FunctionTemplateDeclaration> instantiationCandidates =
         lang.getScopeManager().resolveFunctionTemplateDeclaration(templateCall);
@@ -889,7 +893,11 @@ public class CallResolver extends Pass {
    * @return list of invocation candidates by applying implicit casts
    */
   private List<FunctionDeclaration> resolveWithImplicitCastFunc(CallExpression call) {
-    assert lang != null;
+    if (lang == null) {
+      Util.errorWithFileLocation(
+          call, log, "Could not resolve implicit casts: language frontend is null");
+    }
+
     List<FunctionDeclaration> initialInvocationCandidates =
         new ArrayList<>(lang.getScopeManager().resolveFunctionStopScopeTraversalOnDefinition(call));
     return resolveWithImplicitCast(call, initialInvocationCandidates);
@@ -986,7 +994,11 @@ public class CallResolver extends Pass {
    *     arguments
    */
   private List<FunctionDeclaration> resolveWithDefaultArgsFunc(CallExpression call) {
-    assert lang != null;
+    if (lang == null) {
+      Util.errorWithFileLocation(
+          call, log, "Could not resolve default arguments: language frontend is null");
+    }
+
     List<FunctionDeclaration> invocationCandidates =
         lang.getScopeManager().resolveFunctionStopScopeTraversalOnDefinition(call).stream()
             .filter(
@@ -1017,6 +1029,11 @@ public class CallResolver extends Pass {
   }
 
   private void handleNormalCallCXX(RecordDeclaration curClass, CallExpression call) {
+    if (lang == null) {
+      Util.errorWithFileLocation(
+          call, log, "Could not handle normal CXX calls: language frontend is null");
+    }
+
     List<FunctionDeclaration> invocationCandidates =
         lang.getScopeManager().resolveFunctionStopScopeTraversalOnDefinition(call).stream()
             .filter(f -> f.hasSignature(call.getSignature()))
@@ -1117,6 +1134,11 @@ public class CallResolver extends Pass {
    */
   private List<FunctionDeclaration> handleCXXMethodCall(
       RecordDeclaration curClass, CallExpression call) {
+    if (lang == null) {
+      Util.errorWithFileLocation(
+          call, log, "Could not handle method CXX calls: language frontend is null");
+    }
+
     List<FunctionDeclaration> invocationCandidates =
         lang.getScopeManager().resolveFunctionStopScopeTraversalOnDefinition(call).stream()
             .filter(f -> f.hasSignature(call.getSignature()))
@@ -1173,6 +1195,11 @@ public class CallResolver extends Pass {
    * @return true if we should stop searching parent, false otherwise
    */
   private boolean shouldSearchForInvokesInParent(CallExpression call) {
+    if (lang == null) {
+      Util.errorWithFileLocation(
+          call, log, "Could not search for invokes in parent: language frontend is null");
+    }
+
     return lang.getScopeManager().resolveFunctionStopScopeTraversalOnDefinition(call).isEmpty();
   }
 

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.java
@@ -167,6 +167,8 @@ public class EvaluationOrderGraphPass extends Pass {
     if (lang == null) {
       Util.errorWithFileLocation(
               result, log, "Could not create EOG: language frontend is null");
+
+      return;
     }
 
     for (TranslationUnitDeclaration tu : result.getTranslationUnits()) {

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.java
@@ -164,6 +164,11 @@ public class EvaluationOrderGraphPass extends Pass {
 
   @Override
   public void accept(TranslationResult result) {
+    if (lang == null) {
+      Util.errorWithFileLocation(
+              result, log, "Could not create EOG: language frontend is null");
+    }
+
     for (TranslationUnitDeclaration tu : result.getTranslationUnits()) {
       createEOG(tu);
       removeUnreachableEOGEdges(tu);

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.java
@@ -341,7 +341,7 @@ public class VariableUsageResolver extends Pass {
       Util.errorWithFileLocation(
           reference, log, "Could not resolve base: language frontend is null");
 
-      return;
+      return null;
     }
 
     Declaration declaration = lang.getScopeManager().resolveReference(reference);

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.java
@@ -190,6 +190,8 @@ public class VariableUsageResolver extends Pass {
     if (lang == null) {
       Util.errorWithFileLocation(
           current, log, "Could not resolve local variable usage: language frontend is null");
+
+      return;
     }
 
     if (current instanceof DeclaredReferenceExpression && !(current instanceof MemberExpression)) {
@@ -338,6 +340,8 @@ public class VariableUsageResolver extends Pass {
     if (lang == null) {
       Util.errorWithFileLocation(
           reference, log, "Could not resolve base: language frontend is null");
+
+      return;
     }
 
     Declaration declaration = lang.getScopeManager().resolveReference(reference);

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.java
@@ -187,6 +187,11 @@ public class VariableUsageResolver extends Pass {
   }
 
   private void resolveLocalVarUsage(RecordDeclaration currentClass, Node parent, Node current) {
+    if (lang == null) {
+      Util.errorWithFileLocation(
+          current, log, "Could not resolve local variable usage: language frontend is null");
+    }
+
     if (current instanceof DeclaredReferenceExpression && !(current instanceof MemberExpression)) {
       DeclaredReferenceExpression ref = (DeclaredReferenceExpression) current;
       if (parent instanceof MemberCallExpression
@@ -330,6 +335,10 @@ public class VariableUsageResolver extends Pass {
 
   @Nullable
   private Declaration resolveBase(DeclaredReferenceExpression reference) {
+    if (lang == null) {
+      Util.errorWithFileLocation(
+          reference, log, "Could not resolve base: language frontend is null");
+    }
 
     Declaration declaration = lang.getScopeManager().resolveReference(reference);
     if (declaration != null) {


### PR DESCRIPTION
This PR adds some additional null safety checks that are needed because of the way passes currently work. Hopefully, this will also make it a little bit easier to identify why under certain conditions the language frontend of a pass is `null`.