### PR TITLE
Add test cases for CXX ambiguities

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The following authors have contributed to this project (in alphabetical order):
 * [maximiliankaul](https://github.com/maximiliankaul)
 * [obraunsdorf](https://github.com/obraunsdorf)
 * [oxisto](https://github.com/oxisto)
+* [peckto](https://github.com/peckto)
 * [titze](https://github.com/titze)
 * [vfsrfs](https://github.com/vfsrfs)
 

--- a/cpg-core/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXAmbiguitiesTest.kt
+++ b/cpg-core/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXAmbiguitiesTest.kt
@@ -35,6 +35,7 @@ import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.DeclarationStatement
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CastExpression
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberCallExpression
 import java.io.File
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -111,5 +112,29 @@ class CXXAmbiguitiesTest {
 
         val s4 = mainFunc.getBodyStatementAs(4, CastExpression::class.java)
         assertNotNull(s4)
+    }
+
+    /**
+     * In CXX there is an ambiguity with the statement: "(A.B)(C);" 1) If B is a method, this is a
+     * [MemberCallExpression] 2) if B is a function pointer, this is a [CallExpression].
+     *
+     * Function pointer as a struct member are currently not supported in the cpg. This test case
+     * will just ensure that there will be no crash when parsing such a statement. When adding this
+     * functionality in the cpg, this test case must be adapted accordingly.
+     */
+    @Test
+    fun testMethodOrFunction() {
+        val file = File("src/test/resources/method_or_function_call.cpp")
+        val tu = TestUtils.analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true)
+        assertNotNull(tu)
+
+        val mainFunc = tu.byNameOrNull<FunctionDeclaration>("main")
+        assertNotNull(mainFunc)
+
+        val classA = tu.byNameOrNull<RecordDeclaration>("A")
+        assertNotNull(classA)
+
+        val structB = tu.byNameOrNull<RecordDeclaration>("B")
+        assertNotNull(structB)
     }
 }

--- a/cpg-core/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXAmbiguitiesTest.kt
+++ b/cpg-core/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXAmbiguitiesTest.kt
@@ -28,10 +28,13 @@ package de.fraunhofer.aisec.cpg.frontends.cpp
 import de.fraunhofer.aisec.cpg.TestUtils
 import de.fraunhofer.aisec.cpg.graph.bodyOrNull
 import de.fraunhofer.aisec.cpg.graph.byNameOrNull
+import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.ProblemDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.DeclarationStatement
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.CastExpression
 import java.io.File
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -75,5 +78,38 @@ class CXXAmbiguitiesTest {
         val problem = crazy.singleDeclaration as? ProblemDeclaration
         assertNotNull(problem)
         assertContains(problem.problem, "CDT")
+    }
+
+    /**
+     * In CXX there is an ambiguity with the statement: "(A)(B);" 1) If A is a function pointer,
+     * this is a [CallExpression] 2) If A is a type, this is a [CastExpression]
+     */
+    @Test
+    fun testFunctionCallOrTypeCast() {
+        val file = File("src/test/resources/function_ptr_or_type_cast.c")
+        val tu = TestUtils.analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true)
+        assertNotNull(tu)
+
+        val mainFunc = tu.byNameOrNull<FunctionDeclaration>("main")
+        assertNotNull(mainFunc)
+
+        val fooFunc = tu.byNameOrNull<FunctionDeclaration>("foo")
+        assertNotNull(fooFunc)
+
+        // First two Statements are CallExpressions
+        val s1 = mainFunc.getBodyStatementAs(1, CallExpression::class.java)
+        assertNotNull(s1)
+        assertEquals(s1.invokes.iterator().next(), fooFunc)
+
+        val s2 = mainFunc.getBodyStatementAs(2, CallExpression::class.java)
+        assertNotNull(s2)
+        assertEquals(s2.invokes.iterator().next(), fooFunc)
+
+        // Last two Statements are CastExpressions
+        val s3 = mainFunc.getBodyStatementAs(3, CastExpression::class.java)
+        assertNotNull(s3)
+
+        val s4 = mainFunc.getBodyStatementAs(4, CastExpression::class.java)
+        assertNotNull(s4)
     }
 }

--- a/cpg-core/src/test/resources/function_ptr_or_type_cast.c
+++ b/cpg-core/src/test/resources/function_ptr_or_type_cast.c
@@ -1,0 +1,22 @@
+void foo(int i) {
+}
+
+struct S {
+    int a;
+} typedef s_t;
+
+typedef s_t* s_t_p;
+
+int main() {
+    void (*ptr)(int) = &foo;
+
+    // this is a function call
+    (*ptr)(1);
+    (ptr)(2);
+
+    // this is a type case
+    (int)(3);
+    (s_t_p)(4);
+
+    return 0;
+}

--- a/cpg-core/src/test/resources/method_or_function_call.cpp
+++ b/cpg-core/src/test/resources/method_or_function_call.cpp
@@ -1,0 +1,27 @@
+struct A {
+    void foo(int i) {
+    }
+};
+
+struct B {
+    void (*bar)(int);
+};
+
+void bar(int i) {
+}
+
+int main() {
+    A a;
+    B b;
+    b.bar = &bar;
+
+    // foo is a method
+    (a.foo)(1);
+    a.foo(2);
+
+    // bar is a function
+    (b.bar)(3);
+    (*b.bar)(3);
+
+    return 0;
+}


### PR DESCRIPTION
In CXX there is an ambiguity with the statement `(A.B)(C)`.
`B` can either be a method or a function pointer.

Example:
```cpp
struct A {
        void foo(int i) {
        }
};

struct B {
        void (*bar)(int);
};

void bar(int i) {
}

int main() {
        A a;
        a.j = 1;
        B b;
        b.bar = &bar;

        // foo is a method
        (a.foo)(1);     // Crash
        a.foo(2);       // OK

        // bar is a function pointer
        (b.bar)(3);     // Crash
        (*b.bar)(4);    // MemberExpression is missing

        return 0;
}
```

Loading the example code into the cpg will result in a crash for the `(A.B)(C)` statements:
```
java.util.concurrent.ExecutionException: java.lang.ClassCastException: class org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTUnaryExpression cannot be cast to class org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTFieldReference (org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTUnaryExpression and org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTFieldReference are in unnamed module of loader 'app')
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1999)
	at de.fraunhofer.aisec.cpg_vis_neo4j.Application.call(Application.kt:345)
	at de.fraunhofer.aisec.cpg_vis_neo4j.Application.call(Application.kt:72)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1953)
	at picocli.CommandLine.access$1300(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2352)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2346)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2311)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
	at picocli.CommandLine.execute(CommandLine.java:2078)
	at de.fraunhofer.aisec.cpg_vis_neo4j.ApplicationKt.main(Application.kt:372)
Caused by: java.lang.ClassCastException: class org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTUnaryExpression cannot be cast to class org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTFieldReference (org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTUnaryExpression and org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTFieldReference are in unnamed module of loader 'app')
	at de.fraunhofer.aisec.cpg.frontends.cpp.ExpressionHandler.handleFunctionCallExpression(ExpressionHandler.kt:488)
	at de.fraunhofer.aisec.cpg.frontends.cpp.ExpressionHandler._init_$lambda-7(ExpressionHandler.kt:91)
	at de.fraunhofer.aisec.cpg.frontends.Handler.handle(Handler.java:111)
	at de.fraunhofer.aisec.cpg.frontends.cpp.StatementHandler.handleExpressionStatement(StatementHandler.kt:255)
	at de.fraunhofer.aisec.cpg.frontends.cpp.StatementHandler._init_$lambda-4(StatementHandler.kt:56)
	at de.fraunhofer.aisec.cpg.frontends.Handler.handle(Handler.java:111)
	at de.fraunhofer.aisec.cpg.frontends.cpp.StatementHandler.handleCompoundStatement(StatementHandler.kt:289)
	at de.fraunhofer.aisec.cpg.frontends.cpp.StatementHandler._init_$lambda-1(StatementHandler.kt:50)
	at de.fraunhofer.aisec.cpg.frontends.Handler.handle(Handler.java:111)
	at de.fraunhofer.aisec.cpg.frontends.cpp.DeclarationHandler.handleFunctionDefinition(DeclarationHandler.kt:162)
	at de.fraunhofer.aisec.cpg.frontends.cpp.DeclarationHandler._init_$lambda-3(DeclarationHandler.kt:60)
	at de.fraunhofer.aisec.cpg.frontends.Handler.handle(Handler.java:111)
	at de.fraunhofer.aisec.cpg.frontends.cpp.DeclarationHandler.handleTranslationUnit(DeclarationHandler.kt:529)
	at de.fraunhofer.aisec.cpg.frontends.cpp.CXXLanguageFrontend.parse(CXXLanguageFrontend.kt:226)
	at de.fraunhofer.aisec.cpg.TranslationManager.parse(TranslationManager.kt:340)
	at de.fraunhofer.aisec.cpg.TranslationManager.parseSequentially(TranslationManager.kt:284)
	at de.fraunhofer.aisec.cpg.TranslationManager.runFrontends(TranslationManager.kt:204)
	at de.fraunhofer.aisec.cpg.TranslationManager.analyze$lambda-2(TranslationManager.kt:86)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1692)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```

I wrote a hot fix to prevent the cpg from crashing, but the resulting graph does not reconstruct the `MemberExpression` and does not distinguish the ambiguity:
![cpg-member-function](https://user-images.githubusercontent.com/2060591/150589253-dbcc5c07-c250-40e0-a661-94895c035d4f.png)


I see two main questions:
1) How (and at which point) can we distinguish the ambiguity?
2) How should the graph look like for `(A.B)(C)` when `B` is a function pointer?

Clang AST looks for the above example as follows:
```
    |-CXXMemberCallExpr 0x55dd05798630 <line:19:9, col:18> 'void'
    | |-ParenExpr 0x55dd057985f0 <col:9, col:15> '<bound member function type>'
    | | `-MemberExpr 0x55dd057985c0 <col:10, col:12> '<bound member function type>' .foo 0x55dd05769fd8
    | |   `-DeclRefExpr 0x55dd057985a0 <col:10> 'A' lvalue Var 0x55dd0576a708 'a' 'A'
    | `-IntegerLiteral 0x55dd05798610 <col:17> 'int' 1
    |-CXXMemberCallExpr 0x55dd057986c8 <line:20:9, col:16> 'void'
    | |-MemberExpr 0x55dd05798678 <col:9, col:11> '<bound member function type>' .foo 0x55dd05769fd8
    | | `-DeclRefExpr 0x55dd05798658 <col:9> 'A' lvalue Var 0x55dd0576a708 'a' 'A'
    | `-IntegerLiteral 0x55dd057986a8 <col:15> 'int' 2
    |-CallExpr 0x55dd05798798 <line:22:9, col:18> 'void'
    | |-ImplicitCastExpr 0x55dd05798780 <col:9, col:15> 'void (*)(int)' <LValueToRValue>
    | | `-ParenExpr 0x55dd05798740 <col:9, col:15> 'void (*)(int)' lvalue
    | |   `-MemberExpr 0x55dd05798710 <col:10, col:12> 'void (*)(int)' lvalue .bar 0x55dd0576a3d0
    | |     `-DeclRefExpr 0x55dd057986f0 <col:10> 'B' lvalue Var 0x55dd05797f08 'b' 'B'
    | `-IntegerLiteral 0x55dd05798760 <col:17> 'int' 3
    |-CallExpr 0x55dd05798898 <line:23:9, col:19> 'void'
    | |-ImplicitCastExpr 0x55dd05798880 <col:9, col:16> 'void (*)(int)' <FunctionToPointerDecay>
    | | `-ParenExpr 0x55dd05798840 <col:9, col:16> 'void (int)':'void (int)' lvalue
    | |   `-UnaryOperator 0x55dd05798828 <col:10, col:13> 'void (int)':'void (int)' lvalue prefix '*' cannot overflow
    | |     `-ImplicitCastExpr 0x55dd05798810 <col:11, col:13> 'void (*)(int)' <LValueToRValue>
    | |       `-MemberExpr 0x55dd057987e0 <col:11, col:13> 'void (*)(int)' lvalue .bar 0x55dd0576a3d0
    | |         `-DeclRefExpr 0x55dd057987c0 <col:11> 'B' lvalue Var 0x55dd05797f08 'b' 'B'
    | `-IntegerLiteral 0x55dd05798860 <col:18> 'int' 4
```