### PR TITLE
Adapting visibility modifiers in passes to allow extendabillity

### DIFF
--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.kt
@@ -485,7 +485,8 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
                     reference.operatorCode,
                     ctx.rawSignature
                 )
-            if ((ctx.functionNameExpression as? CPPASTFieldReference)?.fieldName is CPPASTTemplateId) {
+            if ((ctx.functionNameExpression as? CPPASTFieldReference)?.fieldName is CPPASTTemplateId
+            ) {
                 // Make necessary adjustments if we are handling a function template
                 val name =
                     ((ctx.functionNameExpression as CPPASTFieldReference).fieldName as

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
@@ -1251,7 +1251,7 @@ public class CallResolver extends Pass {
 
   /**
    * Adds the resolved default template arguments recursively to the templateParameter list of the
-   * ConstructExpression until a fixpoint is reached e.g. template<class Type1, class Type2 = Type1>
+   * ConstructExpression until a fixpoint is reached e.g. template&lt;class Type1, class Type2 = Type1&gt;
    *
    * @param constructExpression
    * @param template

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
@@ -64,11 +64,11 @@ public class CallResolver extends Pass {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CallResolver.class);
 
-  private final Map<String, RecordDeclaration> recordMap = new HashMap<>();
-  private final List<TemplateDeclaration> templateList = new ArrayList<>();
-  private final Map<FunctionDeclaration, Type> containingType = new HashMap<>();
-  @Nullable private TranslationUnitDeclaration currentTU;
-  private ScopedWalker walker;
+  protected final Map<String, RecordDeclaration> recordMap = new HashMap<>();
+  protected final List<TemplateDeclaration> templateList = new ArrayList<>();
+  protected final Map<FunctionDeclaration, Type> containingType = new HashMap<>();
+  @Nullable protected TranslationUnitDeclaration currentTU;
+  protected ScopedWalker walker;
 
   @Override
   public void cleanup() {
@@ -103,7 +103,7 @@ public class CallResolver extends Pass {
     }
   }
 
-  private void findRecords(@NonNull Node node, RecordDeclaration curClass) {
+  protected void findRecords(@NonNull Node node, RecordDeclaration curClass) {
     if (node instanceof RecordDeclaration) {
       recordMap.putIfAbsent(node.getName(), (RecordDeclaration) node);
     }
@@ -115,13 +115,13 @@ public class CallResolver extends Pass {
    * @param node
    * @param curClass
    */
-  private void findTemplates(@NonNull Node node, RecordDeclaration curClass) {
+  protected void findTemplates(@NonNull Node node, RecordDeclaration curClass) {
     if (node instanceof TemplateDeclaration) {
       templateList.add((TemplateDeclaration) node);
     }
   }
 
-  private void registerMethods(
+  protected void registerMethods(
       RecordDeclaration currentClass, Node parent, @NonNull Node currentNode) {
     if (currentNode instanceof MethodDeclaration && currentClass != null) {
       containingType.put(
@@ -129,7 +129,7 @@ public class CallResolver extends Pass {
     }
   }
 
-  private void fixInitializers(@NonNull Node node, RecordDeclaration curClass) {
+  protected void fixInitializers(@NonNull Node node, RecordDeclaration curClass) {
     if (node instanceof VariableDeclaration) {
       VariableDeclaration declaration = ((VariableDeclaration) node);
       // check if we have the corresponding class for this type
@@ -190,7 +190,7 @@ public class CallResolver extends Pass {
    * @param curClass The class containing the call
    * @param call The call to be resolved
    */
-  private void handleSuperCall(RecordDeclaration curClass, CallExpression call) {
+  protected void handleSuperCall(RecordDeclaration curClass, CallExpression call) {
     RecordDeclaration target = null;
     if (call.getBase().getName().equals("super")) {
       // direct superclass, either defined explicitly or java.lang.Object by default
@@ -214,7 +214,7 @@ public class CallResolver extends Pass {
     }
   }
 
-  private RecordDeclaration handleSpecificSupertype(
+  protected RecordDeclaration handleSpecificSupertype(
       RecordDeclaration curClass, CallExpression call) {
     String baseName =
         call.getBase().getName().substring(0, call.getBase().getName().lastIndexOf(".super"));
@@ -239,7 +239,7 @@ public class CallResolver extends Pass {
     return null;
   }
 
-  private void resolve(@NonNull Node node, RecordDeclaration curClass) {
+  protected void resolve(@NonNull Node node, RecordDeclaration curClass) {
     if (node instanceof TranslationUnitDeclaration) {
       this.currentTU = (TranslationUnitDeclaration) node;
     } else if (node instanceof ExplicitConstructorInvocation) {
@@ -261,7 +261,7 @@ public class CallResolver extends Pass {
     }
   }
 
-  private void handleCallExpression(RecordDeclaration curClass, CallExpression call) {
+  protected void handleCallExpression(RecordDeclaration curClass, CallExpression call) {
     if (lang instanceof JavaLanguageFrontend
         && call.getBase() instanceof DeclaredReferenceExpression
         && call.getBase().getName().matches("(?<class>.+\\.)?super")) {
@@ -310,7 +310,7 @@ public class CallResolver extends Pass {
    *     callParamerter must be an Expression and its type must match the type of the
    *     ParamVariableDeclaration (same type or subtype) => returns true Otherwise return false
    */
-  private boolean isInstantiated(Node callParameter, Declaration templateParameter) {
+  protected boolean isInstantiated(Node callParameter, Declaration templateParameter) {
     if (callParameter instanceof TypeExpression) {
       callParameter = ((TypeExpression) callParameter).getType();
     }
@@ -338,8 +338,8 @@ public class CallResolver extends Pass {
    * @return mapping of the parameterizedtypes to the corresponding TypeParamDeclaration in the
    *     template
    */
-  private Map<ParameterizedType, TypeParamDeclaration> getParameterizedSignaturesFromInitialization(
-      Map<Declaration, Node> intialization) {
+  protected Map<ParameterizedType, TypeParamDeclaration>
+      getParameterizedSignaturesFromInitialization(Map<Declaration, Node> intialization) {
     Map<ParameterizedType, TypeParamDeclaration> parameterizedSignature = new HashMap<>();
     for (Declaration templateParam : intialization.keySet()) {
       if (templateParam instanceof TypeParamDeclaration) {
@@ -363,7 +363,7 @@ public class CallResolver extends Pass {
    *     on resolution {@link TemplateDeclaration.TemplateInitialization}
    * @param orderedInitializationSignature mapping of the ordering of the template parameters
    */
-  private void handleImplicitTemplateParameter(
+  protected void handleImplicitTemplateParameter(
       FunctionTemplateDeclaration functionTemplateDeclaration,
       int index,
       Map<Declaration, Node> instantiationSignature,
@@ -413,7 +413,7 @@ public class CallResolver extends Pass {
    *     initialization -> initialization not possible
    */
   @Nullable
-  private Map<Declaration, Node> constructTemplateInitializationSignatureFromTemplateParameters(
+  protected Map<Declaration, Node> constructTemplateInitializationSignatureFromTemplateParameters(
       FunctionTemplateDeclaration functionTemplateDeclaration,
       CallExpression templateCall,
       Map<Node, TemplateDeclaration.TemplateInitialization> instantiationType,
@@ -470,7 +470,7 @@ public class CallResolver extends Pass {
    *     the {ParamVariableDeclaration, TypeParamDeclaration} do not match the provided value for
    *     initialization -> initialization not possible
    */
-  private Map<Declaration, Node> getTemplateInitializationSignature(
+  protected Map<Declaration, Node> getTemplateInitializationSignature(
       FunctionTemplateDeclaration functionTemplateDeclaration,
       CallExpression templateCall,
       Map<Node, TemplateDeclaration.TemplateInitialization> instantiationType,
@@ -518,7 +518,7 @@ public class CallResolver extends Pass {
    *     will resolve to a instantiation/invocation of an inferred template
    * @return true if resolution was successful, false if not
    */
-  private boolean handleTemplateFunctionCalls(
+  protected boolean handleTemplateFunctionCalls(
       @Nullable RecordDeclaration curClass,
       @NonNull CallExpression templateCall,
       boolean applyInference) {
@@ -609,7 +609,7 @@ public class CallResolver extends Pass {
    *     on resolution {@link TemplateDeclaration.TemplateInitialization}
    * @param orderedInitializationSignature mapping of the ordering of the template parameters
    */
-  private void applyTemplateInstantiation(
+  protected void applyTemplateInstantiation(
       CallExpression templateCall,
       FunctionTemplateDeclaration functionTemplateDeclaration,
       FunctionDeclaration function,
@@ -677,7 +677,7 @@ public class CallResolver extends Pass {
    * @return true if the instantiation of the template is compatible with the templatedeclaration,
    *     false otherwise
    */
-  private boolean checkArgumentValidity(
+  protected boolean checkArgumentValidity(
       FunctionDeclaration functionDeclaration,
       List<Type> functionDeclarationSignature,
       CallExpression templateCallExpression,
@@ -719,7 +719,7 @@ public class CallResolver extends Pass {
    *     ParameterizedTypes (which depend on the specific instantiation of the template) are
    *     resolved to the values the Template is instantiated with.
    */
-  private List<Type> getCallSignature(
+  protected List<Type> getCallSignature(
       FunctionDeclaration function,
       Map<ParameterizedType, TypeParamDeclaration> parameterizedTypeResolution,
       Map<Declaration, Node> initializationSignature) {
@@ -738,7 +738,7 @@ public class CallResolver extends Pass {
     return templateCallSignature;
   }
 
-  private void resolveArguments(CallExpression call, RecordDeclaration curClass) {
+  protected void resolveArguments(CallExpression call, RecordDeclaration curClass) {
     Deque<Node> worklist = new ArrayDeque<>();
     call.getArguments().forEach(worklist::push);
     while (!worklist.isEmpty()) {
@@ -763,7 +763,7 @@ public class CallResolver extends Pass {
    * @return true if the CallExpression signature can be transformed into the FunctionDeclaration
    *     signature by means of casting
    */
-  private boolean compatibleSignatures(List<Type> callSignature, List<Type> functionSignature) {
+  protected boolean compatibleSignatures(List<Type> callSignature, List<Type> functionSignature) {
     if (callSignature.size() == functionSignature.size()) {
       for (int i = 0; i < callSignature.size(); i++) {
         if ((callSignature.get(i).isPrimitive() != functionSignature.get(i).isPrimitive())
@@ -791,7 +791,7 @@ public class CallResolver extends Pass {
    *     argument at the i-th position of the FunctionDeclaration). If the list is empty the
    *     signature of the FunctionDeclaration cannot be reached through implicit casts
    */
-  private List<CastExpression> signatureWithImplicitCastTransformation(
+  protected List<CastExpression> signatureWithImplicitCastTransformation(
       List<Type> callSignature, List<Expression> arguments, List<Type> functionSignature) {
     if (callSignature.size() == functionSignature.size()) {
       List<CastExpression> implicitCasts = new ArrayList<>();
@@ -823,7 +823,7 @@ public class CallResolver extends Pass {
    * @return list containing the signature containing all argument types including the default
    *     arguments
    */
-  private List<Type> getCallSignatureWithDefaults(
+  protected List<Type> getCallSignatureWithDefaults(
       CallExpression call, FunctionDeclaration functionDeclaration) {
     List<Type> callSignature = new ArrayList<>(call.getSignature());
     if (call.getSignature().size() < functionDeclaration.getParameters().size()) {
@@ -844,7 +844,7 @@ public class CallResolver extends Pass {
    * @param call we want to find invocation targets for by performing implicit casts
    * @return list of invocation candidates by applying implicit casts
    */
-  private List<FunctionDeclaration> resolveWithImplicitCast(
+  protected List<FunctionDeclaration> resolveWithImplicitCast(
       CallExpression call, List<FunctionDeclaration> initialInvocationCandidates) {
 
     // Output list for invocationTargets obtaining a valid signature by performing implicit casts
@@ -894,7 +894,7 @@ public class CallResolver extends Pass {
    * @param call we want to find invocation targets for by performing implicit casts
    * @return list of invocation candidates by applying implicit casts
    */
-  private List<FunctionDeclaration> resolveWithImplicitCastFunc(CallExpression call) {
+  protected List<FunctionDeclaration> resolveWithImplicitCastFunc(CallExpression call) {
     if (lang == null) {
       Util.errorWithFileLocation(
           call, log, "Could not resolve implicit casts: language frontend is null");
@@ -915,7 +915,7 @@ public class CallResolver extends Pass {
    * @param implicitCasts current Cast
    * @param implicitCastTargets new Cast
    */
-  private void checkMostCommonImplicitCast(
+  protected void checkMostCommonImplicitCast(
       List<CastExpression> implicitCasts, List<CastExpression> implicitCastTargets) {
     for (int i = 0; i < implicitCasts.size(); i++) {
       CastExpression currentCast = implicitCasts.get(i);
@@ -941,7 +941,7 @@ public class CallResolver extends Pass {
    * @param call CallExpression
    * @param implicitCasts Casts
    */
-  private void applyImplicitCastToArguments(
+  protected void applyImplicitCastToArguments(
       CallExpression call, List<CastExpression> implicitCasts) {
     if (implicitCasts != null) {
       for (int i = 0; i < implicitCasts.size(); i++) {
@@ -958,7 +958,7 @@ public class CallResolver extends Pass {
    * @param constructExpression ConstructExpression
    * @param implicitCasts Casts
    */
-  private void applyImplicitCastToArguments(
+  protected void applyImplicitCastToArguments(
       ConstructExpression constructExpression, List<CastExpression> implicitCasts) {
     if (implicitCasts != null) {
       for (int i = 0; i < implicitCasts.size(); i++) {
@@ -977,7 +977,7 @@ public class CallResolver extends Pass {
    * @return List of FunctionDeclarations that are the target of the CallExpression (will be
    *     connected with an invokes edge)
    */
-  private List<FunctionDeclaration> resolveWithDefaultArgs(
+  protected List<FunctionDeclaration> resolveWithDefaultArgs(
       CallExpression call, List<FunctionDeclaration> initialInvocationCandidates) {
 
     List<FunctionDeclaration> invocationCandidatesDefaultArgs = new ArrayList<>();
@@ -997,7 +997,7 @@ public class CallResolver extends Pass {
    * @return list of invocation candidates that have matching signature when considering default
    *     arguments
    */
-  private List<FunctionDeclaration> resolveWithDefaultArgsFunc(CallExpression call) {
+  protected List<FunctionDeclaration> resolveWithDefaultArgsFunc(CallExpression call) {
     if (lang == null) {
       Util.errorWithFileLocation(
           call, log, "Could not resolve default arguments: language frontend is null");
@@ -1014,7 +1014,7 @@ public class CallResolver extends Pass {
     return resolveWithDefaultArgs(call, invocationCandidates);
   }
 
-  private void handleNormalCalls(RecordDeclaration curClass, CallExpression call) {
+  protected void handleNormalCalls(RecordDeclaration curClass, CallExpression call) {
     if (curClass == null && lang != null) {
       // Handle function (not method) calls
       // C++ allows function overloading. Make sure we have at least the same number of arguments
@@ -1034,7 +1034,7 @@ public class CallResolver extends Pass {
     }
   }
 
-  private void handleNormalCallCXX(RecordDeclaration curClass, CallExpression call) {
+  protected void handleNormalCallCXX(RecordDeclaration curClass, CallExpression call) {
     if (lang == null) {
       Util.errorWithFileLocation(
           call, log, "Could not handle normal CXX calls: language frontend is null");
@@ -1075,7 +1075,7 @@ public class CallResolver extends Pass {
     call.setInvokes(invocationCandidates);
   }
 
-  private void createInferredFunction(
+  protected void createInferredFunction(
       List<FunctionDeclaration> invocationCandidates, CallExpression call) {
     if (invocationCandidates.isEmpty()) {
       // If we still have no candidates and our current language is c++ we create an inferred
@@ -1086,7 +1086,7 @@ public class CallResolver extends Pass {
     }
   }
 
-  private void handleMethodCall(RecordDeclaration curClass, CallExpression call) {
+  protected void handleMethodCall(RecordDeclaration curClass, CallExpression call) {
     Set<Type> possibleContainingTypes = getPossibleContainingTypes(call, curClass);
 
     // Find overridden invokes
@@ -1131,7 +1131,7 @@ public class CallResolver extends Pass {
    * @return FunctionDeclarations that are invocation candidates for the MethodCall call using C++
    *     resolution techniques
    */
-  private List<FunctionDeclaration> handleCXXMethodCall(
+  protected List<FunctionDeclaration> handleCXXMethodCall(
       RecordDeclaration curClass, CallExpression call) {
     if (lang == null) {
       Util.errorWithFileLocation(
@@ -1172,7 +1172,7 @@ public class CallResolver extends Pass {
    * @param possibleContainingTypes
    * @param call
    */
-  private void createMethodDummies(
+  protected void createMethodDummies(
       List<FunctionDeclaration> invocationCandidates,
       Set<Type> possibleContainingTypes,
       CallExpression call) {
@@ -1195,7 +1195,7 @@ public class CallResolver extends Pass {
    * @param call
    * @return true if we should stop searching parent, false otherwise
    */
-  private boolean shouldSearchForInvokesInParent(CallExpression call) {
+  protected boolean shouldSearchForInvokesInParent(CallExpression call) {
     if (lang == null) {
       Util.errorWithFileLocation(
           call, log, "Could not search for invokes in parent: language frontend is null");
@@ -1206,7 +1206,7 @@ public class CallResolver extends Pass {
     return lang.getScopeManager().resolveFunctionStopScopeTraversalOnDefinition(call).isEmpty();
   }
 
-  private void resolveConstructExpression(ConstructExpression constructExpression) {
+  protected void resolveConstructExpression(ConstructExpression constructExpression) {
     String typeName = constructExpression.getType().getTypeName();
     RecordDeclaration recordDeclaration = recordMap.get(typeName);
     constructExpression.setInstantiates(recordDeclaration);
@@ -1256,7 +1256,7 @@ public class CallResolver extends Pass {
    * @param constructExpression
    * @param template
    */
-  private void addRecursiveDefaultTemplateArgs(
+  protected void addRecursiveDefaultTemplateArgs(
       ConstructExpression constructExpression, ClassTemplateDeclaration template) {
     int templateParameters;
     do {
@@ -1291,7 +1291,7 @@ public class CallResolver extends Pass {
    * @param templateParameterRealDefaultInitialization mapping of template parameter to its real
    *     default (no recursive)
    */
-  private void applyMissingParams(
+  protected void applyMissingParams(
       ClassTemplateDeclaration template,
       ConstructExpression constructExpression,
       Map<Node, Node> templateParametersExplicitInitialization,
@@ -1343,7 +1343,7 @@ public class CallResolver extends Pass {
    * @param templateParametersExplicitInitialization mapping of the template parameter to the
    *     explicit instantiation
    */
-  private void handleExplicitTemplateParameters(
+  protected void handleExplicitTemplateParameters(
       ConstructExpression constructExpression,
       ClassTemplateDeclaration template,
       Map<Node, Node> templateParametersExplicitInitialization) {
@@ -1366,7 +1366,7 @@ public class CallResolver extends Pass {
    * @param templateParameterRealDefaultInitialization mapping of template parameter to its real
    *     default (no recursive)
    */
-  private void handleDefaultTemplateParameters(
+  protected void handleDefaultTemplateParameters(
       ClassTemplateDeclaration template,
       Map<Node, Node> templateParameterRealDefaultInitialization) {
     List<Type> declaredTemplateTypes = new ArrayList<>();
@@ -1398,7 +1398,7 @@ public class CallResolver extends Pass {
     }
   }
 
-  private void handleFunctionPointerCall(CallExpression call, Node pointer) {
+  protected void handleFunctionPointerCall(CallExpression call, Node pointer) {
     if (!(pointer instanceof HasType
         && ((HasType) pointer).getType() instanceof FunctionPointerType)) {
       LOGGER.error("Can't handle a function pointer call without function pointer type");
@@ -1432,7 +1432,7 @@ public class CallResolver extends Pass {
     call.setInvokes(invocationCandidates);
   }
 
-  private void resolveExplicitConstructorInvocation(ExplicitConstructorInvocation eci) {
+  protected void resolveExplicitConstructorInvocation(ExplicitConstructorInvocation eci) {
     if (eci.getContainingClass() != null) {
       RecordDeclaration recordDeclaration = recordMap.get(eci.getContainingClass());
       List<Type> signature =
@@ -1447,7 +1447,7 @@ public class CallResolver extends Pass {
     }
   }
 
-  private boolean handlePossibleStaticImport(
+  protected boolean handlePossibleStaticImport(
       @Nullable CallExpression call, RecordDeclaration curClass) {
     if (call == null || curClass == null) {
       return false;
@@ -1479,7 +1479,7 @@ public class CallResolver extends Pass {
     }
   }
 
-  private void generateInferredStaticallyImportedMethods(
+  protected void generateInferredStaticallyImportedMethods(
       @NonNull CallExpression call,
       @NonNull String name,
       @NonNull List<FunctionDeclaration> invokes,
@@ -1517,7 +1517,7 @@ public class CallResolver extends Pass {
    * @param call
    * @return inferred FunctionTemplateDeclaration which can be invoked by the call
    */
-  private FunctionTemplateDeclaration createInferredFunctionTemplate(
+  protected FunctionTemplateDeclaration createInferredFunctionTemplate(
       RecordDeclaration containingRecord, CallExpression call) {
     String name = call.getName();
     String code = call.getCode();
@@ -1573,7 +1573,7 @@ public class CallResolver extends Pass {
   }
 
   @NonNull
-  private FunctionDeclaration createInferredFunctionDeclaration(
+  protected FunctionDeclaration createInferredFunctionDeclaration(
       RecordDeclaration containingRecord,
       String name,
       String code,
@@ -1622,7 +1622,7 @@ public class CallResolver extends Pass {
     }
   }
 
-  private ConstructorDeclaration createInferredConstructor(
+  protected ConstructorDeclaration createInferredConstructor(
       @NonNull RecordDeclaration containingRecord, List<Type> signature) {
     ConstructorDeclaration inferred =
         NodeBuilder.newConstructorDeclaration(containingRecord.getName(), "", containingRecord);
@@ -1632,7 +1632,7 @@ public class CallResolver extends Pass {
     return inferred;
   }
 
-  private Set<Type> getPossibleContainingTypes(Node node, RecordDeclaration curClass) {
+  protected Set<Type> getPossibleContainingTypes(Node node, RecordDeclaration curClass) {
     Set<Type> possibleTypes = new HashSet<>();
     if (node instanceof MemberCallExpression) {
       MemberCallExpression memberCall = (MemberCallExpression) node;
@@ -1652,7 +1652,7 @@ public class CallResolver extends Pass {
     return possibleTypes;
   }
 
-  private List<FunctionDeclaration> getInvocationCandidatesFromRecord(
+  protected List<FunctionDeclaration> getInvocationCandidatesFromRecord(
       RecordDeclaration recordDeclaration, String name, CallExpression call) {
     List<Type> signature = call.getSignature();
     Pattern namePattern =
@@ -1703,7 +1703,7 @@ public class CallResolver extends Pass {
     }
   }
 
-  private List<FunctionDeclaration> getInvocationCandidatesFromParents(
+  protected List<FunctionDeclaration> getInvocationCandidatesFromParents(
       String name, CallExpression call, Set<RecordDeclaration> possibleTypes) {
     Set<RecordDeclaration> workingPossibleTypes = new HashSet<>(possibleTypes);
 
@@ -1746,7 +1746,7 @@ public class CallResolver extends Pass {
    * @return true if there is no method in the recordDeclaration where the name of the method
    *     matches with the provided name. false otherwise
    */
-  private boolean shouldContinueSearchInParent(RecordDeclaration recordDeclaration, String name) {
+  protected boolean shouldContinueSearchInParent(RecordDeclaration recordDeclaration, String name) {
     Pattern namePattern =
         Pattern.compile(
             "(" + Pattern.quote(recordDeclaration.getName()) + "\\.)?" + Pattern.quote(name));
@@ -1760,7 +1760,7 @@ public class CallResolver extends Pass {
     return invocationCandidate.isEmpty();
   }
 
-  private Set<FunctionDeclaration> getOverridingCandidates(
+  protected Set<FunctionDeclaration> getOverridingCandidates(
       Set<Type> possibleSubTypes, FunctionDeclaration declaration) {
     return declaration.getOverriddenBy().stream()
         .filter(f -> possibleSubTypes.contains(containingType.get(f)))
@@ -1772,7 +1772,7 @@ public class CallResolver extends Pass {
    * @param recordDeclaration matching the class the ConstructExpression wants to construct
    * @return ConstructorDeclaration that matches the provided signature
    */
-  private ConstructorDeclaration getConstructorDeclarationDirectMatch(
+  protected ConstructorDeclaration getConstructorDeclarationDirectMatch(
       List<Type> signature, RecordDeclaration recordDeclaration) {
     for (ConstructorDeclaration constructor : recordDeclaration.getConstructors()) {
       if (constructor.hasSignature(signature)) {
@@ -1790,7 +1790,7 @@ public class CallResolver extends Pass {
    *     added default arguments. The default arguments are added to the arguments edge of the
    *     ConstructExpression
    */
-  private ConstructorDeclaration resolveConstructorWithDefaults(
+  protected ConstructorDeclaration resolveConstructorWithDefaults(
       ConstructExpression constructExpression,
       List<Type> signature,
       RecordDeclaration recordDeclaration) {
@@ -1815,7 +1815,7 @@ public class CallResolver extends Pass {
    *     ConstructExpressions. The arguments are proxied through a CastExpression to the type
    *     required by the ConstructDeclaration.
    */
-  private ConstructorDeclaration resolveConstructorWithImplicitCast(
+  protected ConstructorDeclaration resolveConstructorWithImplicitCast(
       ConstructExpression constructExpression, RecordDeclaration recordDeclaration) {
     for (ConstructorDeclaration constructorDeclaration : recordDeclaration.getConstructors()) {
       var workingSignature = new ArrayList<>(constructExpression.getSignature());
@@ -1859,7 +1859,7 @@ public class CallResolver extends Pass {
    *     matches the ConstructExpression.
    */
   @NonNull
-  private ConstructorDeclaration getConstructorDeclaration(
+  protected ConstructorDeclaration getConstructorDeclaration(
       ConstructExpression constructExpression, RecordDeclaration recordDeclaration) {
     List<Type> signature = constructExpression.getSignature();
     ConstructorDeclaration constructorCandidate =
@@ -1886,7 +1886,7 @@ public class CallResolver extends Pass {
   }
 
   @NonNull
-  private ConstructorDeclaration getConstructorDeclarationForExplicitInvocation(
+  protected ConstructorDeclaration getConstructorDeclarationForExplicitInvocation(
       List<Type> signature, RecordDeclaration recordDeclaration) {
     return recordDeclaration.getConstructors().stream()
         .filter(f -> f.hasSignature(signature))

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.java
@@ -463,11 +463,11 @@ public class ControlFlowSensitiveDFGPass extends Pass {
 
     /**
      * Merges two states asusming that both states come from valid paths. All the definition for
-     * variables are collected into the current state represented by {@ref currentJoinpoint}
+     * variables are collected into the current state represented by {@code currentJoinpoint}
      *
      * @param currentJoinpoint - The state we are merging into
      * @param variables - tje state we are merging from
-     * @return - whether or not the merging resulted into an update to {@ref currentJoinpoint}
+     * @return - whether or not the merging resulted into an update to {@code currentJoinpoint}
      */
     protected boolean mergeStates(
         Map<VariableDeclaration, Set<Node>> currentJoinpoint,

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.java
@@ -80,7 +80,7 @@ public class ControlFlowSensitiveDFGPass extends Pass {
    *
    * @param fixDFGs ControlFlowSensitiveDFG of entire Method
    */
-  private void removeValues(ControlFlowSensitiveDFGPass.FunctionLevelFixpointIterator fixDFGs) {
+  protected void removeValues(ControlFlowSensitiveDFGPass.FunctionLevelFixpointIterator fixDFGs) {
     for (Node currNode : fixDFGs.getRemoves().keySet()) {
       for (Node prev : fixDFGs.getRemoves().get(currNode)) {
         currNode.removePrevDFG(prev);
@@ -93,7 +93,7 @@ public class ControlFlowSensitiveDFGPass extends Pass {
    *
    * @param node every node in the TranslationResult
    */
-  public void handle(Node node) {
+  protected void handle(Node node) {
     if (node instanceof FunctionDeclaration || node instanceof StatementHolder) {
       ControlFlowSensitiveDFGPass.FunctionLevelFixpointIterator flfIterator =
           new ControlFlowSensitiveDFGPass.FunctionLevelFixpointIterator();
@@ -102,20 +102,20 @@ public class ControlFlowSensitiveDFGPass extends Pass {
     }
   }
 
-  private interface IterationFunction {
+  protected interface IterationFunction {
     Map<VariableDeclaration, Set<Node>> iterate(
         Node node, Map<VariableDeclaration, Set<Node>> variables, Node endNode, boolean stopBefore);
   }
 
-  private class FunctionLevelFixpointIterator {
+  protected class FunctionLevelFixpointIterator {
 
     /**
      * A Node with refined DFG edges (key) is mapped to a set of nodes that were the previous
      * (unrefined) DFG edges and need to be removed later on
      */
-    private Map<Node, Set<Node>> removes = new HashMap<>();
+    protected Map<Node, Set<Node>> removes = new HashMap<>();
 
-    private final Map<Node, Map<VariableDeclaration, Set<Node>>> joinPoints = new HashMap<>();
+    protected final Map<Node, Map<VariableDeclaration, Set<Node>>> joinPoints = new HashMap<>();
 
     public void handle(Node functionRoot) {
       iterateTillFixpoint(functionRoot, new HashMap<>(), null, false);
@@ -128,7 +128,7 @@ public class ControlFlowSensitiveDFGPass extends Pass {
       return removes;
     }
 
-    private void addToRemoves(Node curr, Node prev) {
+    protected void addToRemoves(Node curr, Node prev) {
       if (!this.removes.containsKey(curr)) {
         this.removes.put(curr, new HashSet<>());
       }
@@ -142,7 +142,7 @@ public class ControlFlowSensitiveDFGPass extends Pass {
      * @param node starting node
      * @return set containing all nodes that have been reached
      */
-    private Set<Node> eogTraversal(Node node) {
+    protected Set<Node> eogTraversal(Node node) {
       Set<Node> eogReachableNodes = new HashSet<>();
       Set<Node> checkRechable = new HashSet<>();
       checkRechable.add(node);
@@ -163,7 +163,7 @@ public class ControlFlowSensitiveDFGPass extends Pass {
      *
      * @param currNode node that is analyzed
      */
-    private void setIngoingDFG(Node currNode, Map<VariableDeclaration, Set<Node>> variables) {
+    protected void setIngoingDFG(Node currNode, Map<VariableDeclaration, Set<Node>> variables) {
       Set<Node> prevDFGs = new HashSet<>(currNode.getPrevDFG());
       for (Node prev : prevDFGs) {
         if (prev instanceof VariableDeclaration && variables.containsKey(prev)) {
@@ -181,7 +181,8 @@ public class ControlFlowSensitiveDFGPass extends Pass {
      *
      * @param currNode Node that is being analyzed
      */
-    private void registerOutgoingDFG(Node currNode, Map<VariableDeclaration, Set<Node>> variables) {
+    protected void registerOutgoingDFG(
+        Node currNode, Map<VariableDeclaration, Set<Node>> variables) {
       Set<Node> nextDFG = new HashSet<>(currNode.getNextDFG());
       for (Node next : nextDFG) {
         if (next instanceof VariableDeclaration && variables.containsKey(next)) {
@@ -197,7 +198,7 @@ public class ControlFlowSensitiveDFGPass extends Pass {
      * @param node start node of the assignment LHS DeclaredReferenceExpression
      * @return return the last (in eog order) node of the assignment
      */
-    private Node obtainAssignmentNode(Node node) {
+    protected Node obtainAssignmentNode(Node node) {
       Set<Node> nextEOG = new HashSet<>(node.getNextEOG());
       Set<Node> rechableEOGs = new HashSet<>();
       for (Node next : nextEOG) {
@@ -219,7 +220,7 @@ public class ControlFlowSensitiveDFGPass extends Pass {
      *
      * @param currNode node whose dfg edges have to be replaced
      */
-    private void modifyDFGEdges(Node currNode, Map<VariableDeclaration, Set<Node>> variables) {
+    protected void modifyDFGEdges(Node currNode, Map<VariableDeclaration, Set<Node>> variables) {
       // A DeclaredReferenceExpression makes use of one of the VariableDeclaration we are
       // tracking. Therefore we must modify the outgoing and ingoing DFG edges
       // Check for outgoing DFG edges
@@ -250,7 +251,7 @@ public class ControlFlowSensitiveDFGPass extends Pass {
      *     reached node.
      * @return The state after reaching on of the terminating conditions
      */
-    public Map<VariableDeclaration, Set<Node>> iterateTillFixpoint(
+    protected Map<VariableDeclaration, Set<Node>> iterateTillFixpoint(
         Node node,
         Map<VariableDeclaration, Set<Node>> variables,
         Node endNode,
@@ -321,7 +322,7 @@ public class ControlFlowSensitiveDFGPass extends Pass {
      * @param currNode DeclaredReferenceExpression that is found in
      * @return Node where the EOG traversal should continue
      */
-    private Node handleDeclaredReferenceExpression(
+    protected Node handleDeclaredReferenceExpression(
         DeclaredReferenceExpression currNode,
         Map<VariableDeclaration, Set<Node>> variables,
         IterationFunction iterationFunction) {
@@ -361,7 +362,7 @@ public class ControlFlowSensitiveDFGPass extends Pass {
      * Iterates over all join-points and propagates the state that is valid for the sum of incoming
      * eog-Paths to refine the dfg edges at variable usage points.
      */
-    public void propagateValues() {
+    protected void propagateValues() {
       for (Map.Entry<Node, Map<VariableDeclaration, Set<Node>>> joinPoint :
           this.joinPoints.entrySet()) {
         propagateFromJoinPoints(joinPoint.getKey(), joinPoint.getValue(), null, true);
@@ -380,7 +381,7 @@ public class ControlFlowSensitiveDFGPass extends Pass {
      *     reached node.
      * @return The state after reaching on of the terminating conditions
      */
-    public Map<VariableDeclaration, Set<Node>> propagateFromJoinPoints(
+    protected Map<VariableDeclaration, Set<Node>> propagateFromJoinPoints(
         Node node,
         Map<VariableDeclaration, Set<Node>> variables,
         Node endNode,
@@ -443,7 +444,7 @@ public class ControlFlowSensitiveDFGPass extends Pass {
      * @param prev - the defining expression to the variable
      * @param variables - the state that is updated by the DFG edge
      */
-    private void addDFGToMap(
+    protected void addDFGToMap(
         VariableDeclaration variableDeclaration,
         Node prev,
         Map<VariableDeclaration, Set<Node>> variables) {
@@ -468,7 +469,7 @@ public class ControlFlowSensitiveDFGPass extends Pass {
      * @param variables - tje state we are merging from
      * @return - whether or not the merging resulted into an update to {@ref currentJoinpoint}
      */
-    public boolean mergeStates(
+    protected boolean mergeStates(
         Map<VariableDeclaration, Set<Node>> currentJoinpoint,
         Map<VariableDeclaration, Set<Node>> variables) {
       boolean changed = false;
@@ -504,7 +505,7 @@ public class ControlFlowSensitiveDFGPass extends Pass {
      * @param state
      * @return
      */
-    public Map<VariableDeclaration, Set<Node>> createShallowCopy(
+    protected Map<VariableDeclaration, Set<Node>> createShallowCopy(
         Map<VariableDeclaration, Set<Node>> state) {
       Map<VariableDeclaration, Set<Node>> shallowCopy = new LinkedHashMap<>();
       for (Map.Entry<VariableDeclaration, Set<Node>> entry : state.entrySet()) {

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.java
@@ -77,12 +77,12 @@ public class EvaluationOrderGraphPass extends Pass {
   protected final Map<Class<? extends Node>, CallableInterface<? extends Node>> map =
       new HashMap<>();
 
-  private List<Node> currentEOG = new ArrayList<>();
-  private final EnumMap<Properties, Object> currentProperties = new EnumMap<>(Properties.class);
+  protected List<Node> currentEOG = new ArrayList<>();
+  protected final EnumMap<Properties, Object> currentProperties = new EnumMap<>(Properties.class);
 
   // Some nodes will have no incoming nor outgoing edges but still need to be associated to the next
   // eog relevant node.
-  private final List<Node> intermediateNodes = new ArrayList<>();
+  protected final List<Node> intermediateNodes = new ArrayList<>();
 
   public EvaluationOrderGraphPass() {
     map.put(TranslationUnitDeclaration.class, this::handleTranslationUnitDeclaration);
@@ -137,7 +137,7 @@ public class EvaluationOrderGraphPass extends Pass {
    * @param node - That lies on the reachable or unreachable path
    * @return true if the node can bea reached from a function declaration
    */
-  private static boolean reachableFromValidEOGRoot(@NonNull Node node) {
+  protected static boolean reachableFromValidEOGRoot(@NonNull Node node) {
     Set<Node> passedBy = new HashSet<>();
     List<Node> workList = new ArrayList<>(node.getPrevEOG());
     while (!workList.isEmpty()) {
@@ -236,7 +236,7 @@ public class EvaluationOrderGraphPass extends Pass {
    * Removes EOG edges by first building the negative set of nodes that cannot be visited and then
    * remove there outgoing edges.In contrast to truncateLooseEdges this also removes cycles.
    */
-  private void removeUnreachableEOGEdges(@NonNull TranslationUnitDeclaration tu) {
+  protected void removeUnreachableEOGEdges(@NonNull TranslationUnitDeclaration tu) {
     List<Node> eognodes =
         SubgraphWalker.flattenAST(tu).stream()
             .filter(node -> !(node.getPrevEOG().isEmpty() && node.getNextEOG().isEmpty()))
@@ -267,7 +267,7 @@ public class EvaluationOrderGraphPass extends Pass {
     }
   }
 
-  private void handleTranslationUnitDeclaration(@NonNull Node node) {
+  protected void handleTranslationUnitDeclaration(@NonNull Node node) {
     TranslationUnitDeclaration declaration = (TranslationUnitDeclaration) node;
 
     handleStatementHolder((StatementHolder) node);
@@ -279,7 +279,7 @@ public class EvaluationOrderGraphPass extends Pass {
     lang.clearProcessed();
   }
 
-  private void handleNamespaceDeclaration(@NonNull Node node) {
+  protected void handleNamespaceDeclaration(@NonNull Node node) {
     NamespaceDeclaration declaration = (NamespaceDeclaration) node;
 
     handleStatementHolder(declaration);
@@ -291,14 +291,14 @@ public class EvaluationOrderGraphPass extends Pass {
     lang.clearProcessed();
   }
 
-  private void handleVariableDeclaration(@NonNull Node node) {
+  protected void handleVariableDeclaration(@NonNull Node node) {
     Declaration declaration = (Declaration) node;
     // analyze the initializer
     createEOG(((VariableDeclaration) declaration).getInitializer());
     pushToEOG(declaration);
   }
 
-  private void handleRecordDeclaration(@NonNull Node node) {
+  protected void handleRecordDeclaration(@NonNull Node node) {
     RecordDeclaration declaration = (RecordDeclaration) node;
     lang.getScopeManager().enterScope(declaration);
 
@@ -320,7 +320,7 @@ public class EvaluationOrderGraphPass extends Pass {
     lang.getScopeManager().leaveScope(declaration);
   }
 
-  private void handleStatementHolder(StatementHolder statementHolder) {
+  protected void handleStatementHolder(StatementHolder statementHolder) {
     // separate code into static and non-static parts as they are executed in different moments
     // although they can be
     // be placed in the same enclosing declaration.
@@ -355,7 +355,7 @@ public class EvaluationOrderGraphPass extends Pass {
     currentEOG.clear();
   }
 
-  private void handleFunctionDeclaration(@NonNull Node node) {
+  protected void handleFunctionDeclaration(@NonNull Node node) {
     FunctionDeclaration funcDecl = (FunctionDeclaration) node;
 
     // reset EOG
@@ -439,7 +439,7 @@ public class EvaluationOrderGraphPass extends Pass {
     this.currentEOG.clear();
   }
 
-  public void createEOG(@Nullable Node node) {
+  protected void createEOG(@Nullable Node node) {
     if (node == null) {
       return;
     }
@@ -458,11 +458,11 @@ public class EvaluationOrderGraphPass extends Pass {
     }
   }
 
-  private void handleDefault(@NonNull Node node) {
+  protected void handleDefault(@NonNull Node node) {
     pushToEOG(node);
   }
 
-  private void handleCallExpression(@NonNull Node node) {
+  protected void handleCallExpression(@NonNull Node node) {
     CallExpression callExpression = (CallExpression) node;
 
     // Todo add call as throwexpression to outer scope of call can throw (which is trivial to find
@@ -482,13 +482,13 @@ public class EvaluationOrderGraphPass extends Pass {
     pushToEOG(callExpression);
   }
 
-  private void handleMemberExpression(@NonNull Node node) {
+  protected void handleMemberExpression(@NonNull Node node) {
     MemberExpression memberExpression = (MemberExpression) node;
     createEOG(memberExpression.getBase());
     pushToEOG(memberExpression);
   }
 
-  private void handleArraySubscriptionExpression(@NonNull Node node) {
+  protected void handleArraySubscriptionExpression(@NonNull Node node) {
     ArraySubscriptionExpression arraySubs = (ArraySubscriptionExpression) node;
 
     // Connect according to evaluation order, first the array reference, then the contained index.
@@ -498,7 +498,7 @@ public class EvaluationOrderGraphPass extends Pass {
     pushToEOG(arraySubs);
   }
 
-  private void handleArrayCreationExpression(@NonNull Node node) {
+  protected void handleArrayCreationExpression(@NonNull Node node) {
     ArrayCreationExpression arrayCreate = (ArrayCreationExpression) node;
 
     for (Expression dimension : arrayCreate.getDimensions()) {
@@ -511,7 +511,7 @@ public class EvaluationOrderGraphPass extends Pass {
     pushToEOG(arrayCreate);
   }
 
-  private void handleDeclarationStatement(@NonNull Node node) {
+  protected void handleDeclarationStatement(@NonNull Node node) {
     DeclarationStatement declarationStatement = (DeclarationStatement) node;
     // loop through declarations
     for (Declaration declaration : declarationStatement.getDeclarations()) {
@@ -536,7 +536,7 @@ public class EvaluationOrderGraphPass extends Pass {
     pushToEOG(declarationStatement);
   }
 
-  private void handleReturnStatement(@NonNull Node node) {
+  protected void handleReturnStatement(@NonNull Node node) {
     ReturnStatement returnStatement = (ReturnStatement) node;
     // analyze the return value
     createEOG(returnStatement.getReturnValue());
@@ -548,7 +548,7 @@ public class EvaluationOrderGraphPass extends Pass {
     currentEOG.clear();
   }
 
-  private void handleBinaryOperator(@NonNull Node node) {
+  protected void handleBinaryOperator(@NonNull Node node) {
     BinaryOperator binOp = (BinaryOperator) node;
     createEOG(binOp.getLhs());
 
@@ -568,7 +568,7 @@ public class EvaluationOrderGraphPass extends Pass {
     pushToEOG(binOp);
   }
 
-  private void handleCompoundStatement(@NonNull Node node) {
+  protected void handleCompoundStatement(@NonNull Node node) {
     CompoundStatement compoundStatement = (CompoundStatement) node;
 
     // not all language handle compound statements as scoping blocks, so we need to avoid creating
@@ -587,7 +587,7 @@ public class EvaluationOrderGraphPass extends Pass {
     pushToEOG(compoundStatement);
   }
 
-  private void handleUnaryOperator(@NonNull Node node) {
+  protected void handleUnaryOperator(@NonNull Node node) {
     UnaryOperator unaryOperator = (UnaryOperator) node;
     Expression input = unaryOperator.getInput();
     createEOG(input);
@@ -635,12 +635,12 @@ public class EvaluationOrderGraphPass extends Pass {
     }
   }
 
-  private void handleCompoundStatementExpression(@NonNull Node node) {
+  protected void handleCompoundStatementExpression(@NonNull Node node) {
     createEOG(((CompoundStatementExpression) node).getStatement());
     pushToEOG(node);
   }
 
-  private void handleAssertStatement(@NonNull Node node) {
+  protected void handleAssertStatement(@NonNull Node node) {
     AssertStatement ifs = (AssertStatement) node;
     createEOG(ifs.getCondition());
     List<Node> openConditionEOGs = new ArrayList<>(currentEOG);
@@ -649,7 +649,7 @@ public class EvaluationOrderGraphPass extends Pass {
     pushToEOG(node);
   }
 
-  private void handleTryStatement(@NonNull Node node) {
+  protected void handleTryStatement(@NonNull Node node) {
     TryStatement tryStatement = (TryStatement) node;
     lang.getScopeManager().enterScope(tryStatement);
     TryScope tryScope = (TryScope) lang.getScopeManager().getCurrentScope();
@@ -728,30 +728,30 @@ public class EvaluationOrderGraphPass extends Pass {
     pushToEOG(tryStatement);
   }
 
-  private void handleContinueStatement(@NonNull Node node) {
+  protected void handleContinueStatement(@NonNull Node node) {
     pushToEOG(node);
     lang.getScopeManager().addContinueStatement((ContinueStatement) node);
     currentEOG.clear();
   }
 
-  private void handleDeleteExpression(@NonNull Node node) {
+  protected void handleDeleteExpression(@NonNull Node node) {
     createEOG(((DeleteExpression) node).getOperand());
     pushToEOG(node);
   }
 
-  private void handleBreakStatement(@NonNull Node node) {
+  protected void handleBreakStatement(@NonNull Node node) {
     pushToEOG(node);
     lang.getScopeManager().addBreakStatement((BreakStatement) node);
     currentEOG.clear();
   }
 
-  private void handleLabelStatement(@NonNull Node node) {
+  protected void handleLabelStatement(@NonNull Node node) {
     LabelStatement labelStatement = (LabelStatement) node;
     lang.getScopeManager().addLabelStatement(labelStatement);
     createEOG(labelStatement.getSubStatement());
   }
 
-  private void handleGotoStatement(@NonNull Node node) {
+  protected void handleGotoStatement(@NonNull Node node) {
     GotoStatement gotoStatement = (GotoStatement) node;
     pushToEOG(gotoStatement);
     if (gotoStatement.getTargetLabel() != null) {
@@ -761,25 +761,25 @@ public class EvaluationOrderGraphPass extends Pass {
     currentEOG.clear();
   }
 
-  private void handleCaseStatement(@NonNull Node node) {
+  protected void handleCaseStatement(@NonNull Node node) {
     createEOG(((CaseStatement) node).getCaseExpression());
     pushToEOG(node);
   }
 
-  private void handleNewExpression(@NonNull Node node) {
+  protected void handleNewExpression(@NonNull Node node) {
     NewExpression newStmt = (NewExpression) node;
     createEOG(newStmt.getInitializer());
 
     pushToEOG(node);
   }
 
-  private void handleCastExpression(@NonNull Node node) {
+  protected void handleCastExpression(@NonNull Node node) {
     CastExpression castExpr = (CastExpression) node;
     createEOG(castExpr.getExpression());
     pushToEOG(castExpr);
   }
 
-  private void handleExpressionList(@NonNull Node node) {
+  protected void handleExpressionList(@NonNull Node node) {
     ExpressionList exprList = (ExpressionList) node;
     for (Statement expr : exprList.getExpressions()) {
       createEOG(expr);
@@ -788,7 +788,7 @@ public class EvaluationOrderGraphPass extends Pass {
     pushToEOG(exprList);
   }
 
-  private void handleInitializerListExpression(@NonNull Node node) {
+  protected void handleInitializerListExpression(@NonNull Node node) {
     InitializerListExpression initList = (InitializerListExpression) node;
 
     // first the arguments
@@ -799,7 +799,7 @@ public class EvaluationOrderGraphPass extends Pass {
     pushToEOG(initList);
   }
 
-  private void handleConstructExpression(@NonNull Node node) {
+  protected void handleConstructExpression(@NonNull Node node) {
     ConstructExpression constructExpr = (ConstructExpression) node;
     // first the arguments
     for (Expression arg : constructExpr.getArguments()) {
@@ -860,7 +860,7 @@ public class EvaluationOrderGraphPass extends Pass {
    * @param loopStatement the loop statement
    * @param loopScope the loop scope
    */
-  public void exitLoop(@NonNull Statement loopStatement, @NonNull LoopScope loopScope) {
+  protected void exitLoop(@NonNull Statement loopStatement, @NonNull LoopScope loopScope) {
     // Breaks are connected to the NEXT EOG node and therefore temporarily stored after the loop
     // context is destroyed
     this.currentEOG.addAll(loopScope.getBreakStatements());
@@ -887,7 +887,7 @@ public class EvaluationOrderGraphPass extends Pass {
   /**
    * Connects current EOG nodes to the previously saved loop start to mimic control flow of loops
    */
-  public void connectCurrentToLoopStart() {
+  protected void connectCurrentToLoopStart() {
     if (lang == null) {
       // Avoid null checks in every if/else branch
       LOGGER.warn(
@@ -914,7 +914,7 @@ public class EvaluationOrderGraphPass extends Pass {
    * @param prev the previous node
    * @param next the next node
    */
-  public void addEOGEdge(Node prev, Node next) {
+  protected void addEOGEdge(Node prev, Node next) {
     PropertyEdge<Node> propertyEdge = new PropertyEdge<>(prev, next);
     propertyEdge.addProperties(this.currentProperties);
     propertyEdge.addProperty(Properties.INDEX, prev.getNextEOG().size());
@@ -923,18 +923,18 @@ public class EvaluationOrderGraphPass extends Pass {
     next.addPrevEOG(propertyEdge);
   }
 
-  public void addMultipleIncomingEOGEdges(List<Node> prevs, Node next) {
+  protected void addMultipleIncomingEOGEdges(List<Node> prevs, Node next) {
     prevs.forEach(prev -> addEOGEdge(prev, next));
   }
 
-  private void handleSynchronizedStatement(@NonNull Node node) {
+  protected void handleSynchronizedStatement(@NonNull Node node) {
     SynchronizedStatement synch = (SynchronizedStatement) node;
     createEOG(synch.getExpression());
     pushToEOG(synch);
     createEOG(synch.getBlockStatement());
   }
 
-  private void handleConditionalExpression(@NonNull Node node) {
+  protected void handleConditionalExpression(@NonNull Node node) {
     ConditionalExpression conditionalExpression = (ConditionalExpression) node;
     List<Node> openBranchNodes = new ArrayList<>();
     createEOG(conditionalExpression.getCondition());
@@ -950,7 +950,7 @@ public class EvaluationOrderGraphPass extends Pass {
     setCurrentEOGs(openBranchNodes);
   }
 
-  private void handleDoStatement(@NonNull Node node) {
+  protected void handleDoStatement(@NonNull Node node) {
     DoStatement doStatement = (DoStatement) node;
     lang.getScopeManager().enterScope(doStatement);
 
@@ -970,7 +970,7 @@ public class EvaluationOrderGraphPass extends Pass {
     }
   }
 
-  private void handleForEachStatement(@NonNull Node node) {
+  protected void handleForEachStatement(@NonNull Node node) {
     ForEachStatement forEachStatement = (ForEachStatement) node;
     lang.getScopeManager().enterScope(forEachStatement);
 
@@ -996,7 +996,7 @@ public class EvaluationOrderGraphPass extends Pass {
     currentEOG.addAll(tmpEOGNodes);
   }
 
-  private void handleForStatement(@NonNull Node node) {
+  protected void handleForStatement(@NonNull Node node) {
 
     ForStatement forStatement = (ForStatement) node;
     lang.getScopeManager().enterScope(forStatement);
@@ -1028,7 +1028,7 @@ public class EvaluationOrderGraphPass extends Pass {
     currentEOG.addAll(tmpEOGNodes);
   }
 
-  private void handleIfStatement(@NonNull Node node) {
+  protected void handleIfStatement(@NonNull Node node) {
     IfStatement ifStatement = (IfStatement) node;
     List<Node> openBranchNodes = new ArrayList<>();
     lang.getScopeManager().enterScopeIfExists(ifStatement);
@@ -1059,7 +1059,7 @@ public class EvaluationOrderGraphPass extends Pass {
     setCurrentEOGs(openBranchNodes);
   }
 
-  private void handleSwitchStatement(@NonNull Node node) {
+  protected void handleSwitchStatement(@NonNull Node node) {
     SwitchStatement switchStatement = (SwitchStatement) node;
     lang.getScopeManager().enterScopeIfExists(switchStatement);
 
@@ -1100,7 +1100,7 @@ public class EvaluationOrderGraphPass extends Pass {
     }
   }
 
-  private void handleWhileStatement(@NonNull Node node) {
+  protected void handleWhileStatement(@NonNull Node node) {
     WhileStatement whileStatement = (WhileStatement) node;
     lang.getScopeManager().enterScope(whileStatement);
 

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/ImportResolver.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/ImportResolver.java
@@ -40,8 +40,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class ImportResolver extends Pass {
 
-  private final List<RecordDeclaration> records = new ArrayList<>();
-  private final Map<String, Declaration> importables = new HashMap<>();
+  protected final List<RecordDeclaration> records = new ArrayList<>();
+  protected final Map<String, Declaration> importables = new HashMap<>();
 
   @Override
   @Nullable
@@ -72,7 +72,7 @@ public class ImportResolver extends Pass {
     }
   }
 
-  private Set<ValueDeclaration> getStaticImports(RecordDeclaration record) {
+  protected Set<ValueDeclaration> getStaticImports(RecordDeclaration record) {
     Map<Boolean, List<String>> partitioned =
         record.getStaticImportStatements().stream()
             .collect(Collectors.partitioningBy(i -> i.endsWith("*")));
@@ -119,14 +119,14 @@ public class ImportResolver extends Pass {
     return staticImports;
   }
 
-  private Set<Declaration> getDeclarationsForTypeNames(List<String> targetTypes) {
+  protected Set<Declaration> getDeclarationsForTypeNames(List<String> targetTypes) {
     return targetTypes.stream()
         .map(importables::get)
         .filter(Objects::nonNull)
         .collect(Collectors.toSet());
   }
 
-  private Set<ValueDeclaration> getOrCreateMembers(EnumDeclaration base, String name) {
+  protected Set<ValueDeclaration> getOrCreateMembers(EnumDeclaration base, String name) {
     Set<ValueDeclaration> entries =
         base.getEntries().stream()
             .filter(e -> e.getName().equals(name))
@@ -134,7 +134,7 @@ public class ImportResolver extends Pass {
     return entries;
   }
 
-  private Set<ValueDeclaration> getOrCreateMembers(RecordDeclaration base, String name) {
+  protected Set<ValueDeclaration> getOrCreateMembers(RecordDeclaration base, String name) {
     Set<MethodDeclaration> memberMethods =
         base.getMethods().stream()
             .filter(m -> m.getName().endsWith(name))
@@ -181,7 +181,7 @@ public class ImportResolver extends Pass {
     return result;
   }
 
-  private void findImportables(Node node) {
+  protected void findImportables(Node node) {
     if (node instanceof RecordDeclaration) {
       records.add((RecordDeclaration) node);
       importables.putIfAbsent(node.getName(), (RecordDeclaration) node);

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/TypeHierarchyResolver.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/TypeHierarchyResolver.java
@@ -54,8 +54,8 @@ import java.util.stream.Collectors;
  */
 public class TypeHierarchyResolver extends Pass {
 
-  private final Map<String, RecordDeclaration> recordMap = new HashMap<>();
-  private final List<EnumDeclaration> enums = new ArrayList<>();
+  protected final Map<String, RecordDeclaration> recordMap = new HashMap<>();
+  protected final List<EnumDeclaration> enums = new ArrayList<>();
 
   @Override
   public LanguageFrontend getLang() {
@@ -95,7 +95,7 @@ public class TypeHierarchyResolver extends Pass {
     translationResult.getTranslationUnits().forEach(SubgraphWalker::refreshType);
   }
 
-  private void findRecordsAndEnums(Node node) {
+  protected void findRecordsAndEnums(Node node) {
     if (node instanceof RecordDeclaration) {
       recordMap.putIfAbsent(node.getName(), (RecordDeclaration) node);
     } else if (node instanceof EnumDeclaration) {
@@ -106,7 +106,7 @@ public class TypeHierarchyResolver extends Pass {
     }
   }
 
-  private List<MethodDeclaration> getAllMethodsFromSupertypes(
+  protected List<MethodDeclaration> getAllMethodsFromSupertypes(
       Set<RecordDeclaration> supertypeRecords) {
     return supertypeRecords.stream()
         .map(RecordDeclaration::getMethods)
@@ -114,7 +114,7 @@ public class TypeHierarchyResolver extends Pass {
         .collect(Collectors.toList());
   }
 
-  private Set<RecordDeclaration> findSupertypeRecords(RecordDeclaration record) {
+  protected Set<RecordDeclaration> findSupertypeRecords(RecordDeclaration record) {
     Set<RecordDeclaration> superTypeDeclarations =
         record.getSuperTypes().stream()
             .map(Type::getTypeName)
@@ -126,7 +126,7 @@ public class TypeHierarchyResolver extends Pass {
     return superTypeDeclarations;
   }
 
-  private void analyzeOverridingMethods(
+  protected void analyzeOverridingMethods(
       RecordDeclaration declaration, List<MethodDeclaration> allMethodsFromSupertypes) {
     for (MethodDeclaration superMethod : allMethodsFromSupertypes) {
       List<MethodDeclaration> overrideCandidates =

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/TypeResolver.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/TypeResolver.java
@@ -34,8 +34,8 @@ import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker;
 import java.util.*;
 
 public class TypeResolver extends Pass {
-  private final Set<Type> firstOrderTypes = new HashSet<>();
-  private final Map<Type, List<Type>> typeState = new HashMap<>();
+  protected final Set<Type> firstOrderTypes = new HashSet<>();
+  protected final Map<Type, List<Type>> typeState = new HashMap<>();
 
   /**
    * Reduce the SecondOrderTypes to store only the unique SecondOrderTypes
@@ -43,7 +43,7 @@ public class TypeResolver extends Pass {
    * @param type SecondOrderType that is to be eliminated if an equal is already in typeState or is
    *     added if not
    */
-  private void processSecondOrderTypes(Type type) {
+  protected void processSecondOrderTypes(Type type) {
     Type root = type.getRoot();
 
     if (typeState.get(root).contains(type)) {
@@ -116,7 +116,7 @@ public class TypeResolver extends Pass {
    *
    * @param type new type
    */
-  private void addType(Type type) {
+  protected void addType(Type type) {
     Type root = type.getRoot();
     if (root.equals(type) && !typeState.containsKey(type)) {
       // This is a rootType and is included in the map as key with empty references
@@ -137,7 +137,7 @@ public class TypeResolver extends Pass {
     }
   }
 
-  private void removeDuplicateTypes() {
+  protected void removeDuplicateTypes() {
     TypeManager typeManager = TypeManager.getInstance();
     // Remove duplicate firstOrderTypes
     firstOrderTypes.addAll(typeManager.getFirstOrderTypes());
@@ -178,7 +178,7 @@ public class TypeResolver extends Pass {
    *
    * @param t FirstOrderType
    */
-  private void removeDuplicatesInFields(Type t) {
+  protected void removeDuplicatesInFields(Type t) {
     // Remove duplicates from fields
     if (t instanceof FunctionPointerType) {
       ((FunctionPointerType) t)
@@ -217,7 +217,7 @@ public class TypeResolver extends Pass {
     }
   }
 
-  public Set<Type> ensureUniqueSubTypes(Set<Type> subTypes) {
+  protected Set<Type> ensureUniqueSubTypes(Set<Type> subTypes) {
     Set<Type> uniqueTypes = new HashSet<>();
     for (Type subType : subTypes) {
       Collection<Type> trackedTypes;
@@ -238,7 +238,7 @@ public class TypeResolver extends Pass {
     return uniqueTypes;
   }
 
-  public void ensureUniqueType(Node node) {
+  protected void ensureUniqueType(Node node) {
     // Avoid handling of ParameterizedType as they should be unique to each class and not globally
     // unique
     if (node instanceof HasType && !(((HasType) node).getType() instanceof ParameterizedType)) {
@@ -264,7 +264,7 @@ public class TypeResolver extends Pass {
    *
    * @param node implementing {@link HasType.SecondaryTypeEdge}
    */
-  public void ensureUniqueSecondaryTypeEdge(Node node) {
+  protected void ensureUniqueSecondaryTypeEdge(Node node) {
     if (node instanceof HasType.SecondaryTypeEdge) {
       ((HasType.SecondaryTypeEdge) node).updateType(typeState.keySet());
     } else if (node instanceof HasType
@@ -278,7 +278,7 @@ public class TypeResolver extends Pass {
     }
   }
 
-  private void updateType(Node node, Collection<Type> types) {
+  protected void updateType(Node node, Collection<Type> types) {
     for (Type t : types) {
       if (t.equals(((HasType) node).getType())) {
         ((HasType) node).updateType(t);

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.java
@@ -68,11 +68,11 @@ import org.slf4j.LoggerFactory;
 public class VariableUsageResolver extends Pass {
 
   private static final Logger log = LoggerFactory.getLogger(VariableUsageResolver.class);
-  private final Map<Type, List<Type>> superTypesMap = new HashMap<>();
-  private final Map<Type, RecordDeclaration> recordMap = new HashMap<>();
-  private final Map<Type, EnumDeclaration> enumMap = new HashMap<>();
-  private TranslationUnitDeclaration currTu;
-  private ScopedWalker walker;
+  protected final Map<Type, List<Type>> superTypesMap = new HashMap<>();
+  protected final Map<Type, RecordDeclaration> recordMap = new HashMap<>();
+  protected final Map<Type, EnumDeclaration> enumMap = new HashMap<>();
+  protected TranslationUnitDeclaration currTu;
+  protected ScopedWalker walker;
 
   @Override
   public void cleanup() {
@@ -115,7 +115,7 @@ public class VariableUsageResolver extends Pass {
     }
   }
 
-  private void findRecordsAndEnums(Node node, RecordDeclaration curClass) {
+  protected void findRecordsAndEnums(Node node, RecordDeclaration curClass) {
     if (node instanceof RecordDeclaration) {
       Type type = TypeParser.createFrom(node.getName(), true);
       recordMap.putIfAbsent(type, (RecordDeclaration) node);
@@ -125,7 +125,7 @@ public class VariableUsageResolver extends Pass {
     }
   }
 
-  private Optional<? extends ValueDeclaration> resolveFunctionPtr(
+  protected Optional<? extends ValueDeclaration> resolveFunctionPtr(
       Type containingClass, DeclaredReferenceExpression reference) {
     FunctionPointerType fptrType;
     if (reference.getType() instanceof FunctionPointerType) {
@@ -186,7 +186,7 @@ public class VariableUsageResolver extends Pass {
     return target;
   }
 
-  private void resolveLocalVarUsage(RecordDeclaration currentClass, Node parent, Node current) {
+  protected void resolveLocalVarUsage(RecordDeclaration currentClass, Node parent, Node current) {
     if (lang == null) {
       Util.errorWithFileLocation(
           current, log, "Could not resolve local variable usage: language frontend is null");
@@ -262,7 +262,7 @@ public class VariableUsageResolver extends Pass {
     }
   }
 
-  private void resolveFieldUsages(Node current, RecordDeclaration curClass) {
+  protected void resolveFieldUsages(Node current, RecordDeclaration curClass) {
     if (current instanceof MemberExpression) {
       MemberExpression memberExpression = (MemberExpression) current;
       Declaration baseTarget = null;
@@ -336,7 +336,7 @@ public class VariableUsageResolver extends Pass {
   }
 
   @Nullable
-  private Declaration resolveBase(DeclaredReferenceExpression reference) {
+  protected Declaration resolveBase(DeclaredReferenceExpression reference) {
     if (lang == null) {
       Util.errorWithFileLocation(
           reference, log, "Could not resolve base: language frontend is null");
@@ -372,7 +372,7 @@ public class VariableUsageResolver extends Pass {
     }
   }
 
-  private ValueDeclaration resolveMember(
+  protected ValueDeclaration resolveMember(
       Type containingClass, DeclaredReferenceExpression reference) {
     if (lang instanceof JavaLanguageFrontend
         && reference.getName().matches("(?<class>.+\\.)?super")) {
@@ -406,7 +406,7 @@ public class VariableUsageResolver extends Pass {
         () -> handleUnknownField(containingClass, reference.getName(), reference.getType()));
   }
 
-  private FieldDeclaration handleUnknownField(Type base, String name, Type type) {
+  protected FieldDeclaration handleUnknownField(Type base, String name, Type type) {
     // unwrap a potential pointer-type
     if (base instanceof PointerType) {
       return handleUnknownField(((PointerType) base).getElementType(), name, type);
@@ -451,7 +451,7 @@ public class VariableUsageResolver extends Pass {
     }
   }
 
-  private MethodDeclaration handleUnknownClassMethod(
+  protected MethodDeclaration handleUnknownClassMethod(
       Type base, String name, Type returnType, List<Type> signature) {
     if (!recordMap.containsKey(base)) {
       return null;
@@ -477,7 +477,7 @@ public class VariableUsageResolver extends Pass {
     }
   }
 
-  private FunctionDeclaration handleUnknownMethod(
+  protected FunctionDeclaration handleUnknownMethod(
       String name, Type returnType, List<Type> signature) {
     Optional<FunctionDeclaration> target =
         currTu.getDeclarations().stream()
@@ -500,7 +500,7 @@ public class VariableUsageResolver extends Pass {
     }
   }
 
-  private RecordDeclaration inferRecordDeclaration(Type type) {
+  protected RecordDeclaration inferRecordDeclaration(Type type) {
     if (type instanceof ObjectType) {
       log.debug(
           "Encountered an unknown record type {} during a field access. We are going to infer that record",


### PR DESCRIPTION
This PR modifies many of the private functions in the default passes to open them up for modification through subclassing. Members and member functions of the passes are now `protected` instead of `private`. Some functions were `public` and had no purpose in being, therefore, I made them protected as well.