### PR TITLE
Add option to export benchmark result as json

### DIFF
--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/TranslationConfiguration.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/TranslationConfiguration.java
@@ -557,25 +557,35 @@ public class TranslationConfiguration {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, ToStringStyle.JSON_STYLE)
-        .append("debugParser", debugParser)
-        .append("loadIncludes", loadIncludes)
-        .append("includePaths", includePaths)
-        .append("includeWhitelist", includeWhitelist)
-        .append("includeBlacklist", includeBlacklist)
-        .append("frontends", frontends)
-        .append("disableCleanup", disableCleanup)
-        .append("codeInNodes", codeInNodes)
-        .append("processAnnotations", processAnnotations)
-        .append("failOnError", failOnError)
-        .append("symbols", symbols)
-        .append("sourceLocations", sourceLocations)
-        .append("topLevel", topLevel)
-        .append("useUnityBuild", useUnityBuild)
-        .append("useParallelFrontends", useParallelFrontends)
-        .append("typeSystemActiveInFrontend", typeSystemActiveInFrontend)
-        .append("passes", passes)
-        .append("inferenceConfiguration", inferenceConfiguration)
-        .toString();
+    return ToStringBuilder.reflectionToString(this, ToStringStyle.JSON_STYLE);
+  }
+
+  public Map<String, Object> getConfigAsHashMap() {
+    // We first need to convert the passes to string, otherwise the serialisation will fail
+    List<String> passes_names = new ArrayList<String>();
+    for (Pass p : passes) {
+      passes_names.add(p.toString());
+    }
+
+    Map<String, Object> conf = new HashMap<String, Object>();
+    conf.put("debugParser", debugParser);
+    conf.put("loadIncludes", loadIncludes);
+    conf.put("includePaths", includePaths);
+    conf.put("includeWhitelist", includeWhitelist);
+    conf.put("includeBlacklist", includeBlacklist);
+    conf.put("frontends", frontends);
+    conf.put("disableCleanup", disableCleanup);
+    conf.put("codeInNodes", codeInNodes);
+    conf.put("processAnnotations", processAnnotations);
+    conf.put("failOnError", failOnError);
+    conf.put("symbols", symbols);
+    conf.put("sourceLocations", sourceLocations);
+    conf.put("topLevel", topLevel);
+    conf.put("useUnityBuild", useUnityBuild);
+    conf.put("useParallelFrontends", useParallelFrontends);
+    conf.put("typeSystemActiveInFrontend", typeSystemActiveInFrontend);
+    conf.put("passes", passes_names);
+    conf.put("inferenceConfiguration", inferenceConfiguration);
+    return conf;
   }
 }

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/TranslationConfiguration.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/TranslationConfiguration.java
@@ -28,6 +28,9 @@ package de.fraunhofer.aisec.cpg;
 import static de.fraunhofer.aisec.cpg.frontends.cpp.CXXLanguageFrontend.CXX_EXTENSIONS;
 import static de.fraunhofer.aisec.cpg.frontends.cpp.CXXLanguageFrontend.CXX_HEADER_EXTENSIONS;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import de.fraunhofer.aisec.cpg.frontends.CompilationDatabase;
@@ -222,6 +225,8 @@ public class TranslationConfiguration {
     return topLevel;
   }
 
+  @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "name")
+  @JsonIdentityReference(alwaysAsId = true)
   public List<Pass> getRegisteredPasses() {
     return this.passes;
   }
@@ -558,34 +563,5 @@ public class TranslationConfiguration {
   @Override
   public String toString() {
     return ToStringBuilder.reflectionToString(this, ToStringStyle.JSON_STYLE);
-  }
-
-  public Map<String, Object> getConfigAsHashMap() {
-    // We first need to convert the passes to string, otherwise the serialisation will fail
-    List<String> passes_names = new ArrayList<String>();
-    for (Pass p : passes) {
-      passes_names.add(p.toString());
-    }
-
-    Map<String, Object> conf = new HashMap<String, Object>();
-    conf.put("debugParser", debugParser);
-    conf.put("loadIncludes", loadIncludes);
-    conf.put("includePaths", includePaths);
-    conf.put("includeWhitelist", includeWhitelist);
-    conf.put("includeBlacklist", includeBlacklist);
-    conf.put("frontends", frontends);
-    conf.put("disableCleanup", disableCleanup);
-    conf.put("codeInNodes", codeInNodes);
-    conf.put("processAnnotations", processAnnotations);
-    conf.put("failOnError", failOnError);
-    conf.put("symbols", symbols);
-    conf.put("sourceLocations", sourceLocations);
-    conf.put("topLevel", topLevel);
-    conf.put("useUnityBuild", useUnityBuild);
-    conf.put("useParallelFrontends", useParallelFrontends);
-    conf.put("typeSystemActiveInFrontend", typeSystemActiveInFrontend);
-    conf.put("passes", passes_names);
-    conf.put("inferenceConfiguration", inferenceConfiguration);
-    return conf;
   }
 }

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/TranslationResult.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/TranslationResult.java
@@ -29,6 +29,7 @@ import de.fraunhofer.aisec.cpg.graph.Node;
 import de.fraunhofer.aisec.cpg.graph.SubGraph;
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration;
 import de.fraunhofer.aisec.cpg.helpers.Benchmark;
+import de.fraunhofer.aisec.cpg.helpers.BenchmarkResults;
 import de.fraunhofer.aisec.cpg.helpers.StatisticsHolder;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -118,11 +119,6 @@ public class TranslationResult extends Node implements StatisticsHolder {
     return benchmarks;
   }
 
-  @Override
-  public void printBenchmark() {
-    StatisticsHolder.DefaultImpls.printBenchmark(this);
-  }
-
   @NotNull
   @Override
   public List<String> getTranslatedFiles() {
@@ -138,8 +134,7 @@ public class TranslationResult extends Node implements StatisticsHolder {
   }
 
   @NotNull
-  @Override
-  public List<List<Object>> getBenchmarkResult() {
+  public BenchmarkResults getBenchmarkResult() {
     return StatisticsHolder.DefaultImpls.getBenchmarkResult(this);
   }
 }

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/TranslationResult.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/TranslationResult.java
@@ -93,10 +93,6 @@ public class TranslationResult extends Node implements StatisticsHolder {
    *
    * @return the scratch storage
    */
-  //  public Scene getScene() {
-  //    return this.scene;
-  //  }
-
   public Map<String, Object> getScratch() {
     return scratch;
   }
@@ -134,7 +130,7 @@ public class TranslationResult extends Node implements StatisticsHolder {
   }
 
   @NotNull
-  public BenchmarkResults getBenchmarkResult() {
-    return StatisticsHolder.DefaultImpls.getBenchmarkResult(this);
+  public BenchmarkResults getBenchmarkResults() {
+    return StatisticsHolder.DefaultImpls.getBenchmarkResults(this);
   }
 }

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/TranslationResult.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/TranslationResult.java
@@ -113,6 +113,7 @@ public class TranslationResult extends Node implements StatisticsHolder {
     this.benchmarks.add(b);
   }
 
+  @NotNull
   public List<Benchmark> getBenchmarks() {
     return benchmarks;
   }
@@ -134,5 +135,11 @@ public class TranslationResult extends Node implements StatisticsHolder {
   @Override
   public TranslationConfiguration getConfig() {
     return translationManager.getConfig();
+  }
+
+  @NotNull
+  @Override
+  public List<List<Object>> getBenchmarkResult() {
+    return StatisticsHolder.DefaultImpls.getBenchmarkResult(this);
   }
 }

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/helpers/Benchmark.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/helpers/Benchmark.kt
@@ -59,7 +59,7 @@ interface StatisticsHolder {
 
     fun addBenchmark(b: Benchmark)
 
-    val benchmarkResult: BenchmarkResults
+    val benchmarkResults: BenchmarkResults
         get() {
             return BenchmarkResults(
                 listOf(

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/helpers/Benchmark.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/helpers/Benchmark.kt
@@ -41,7 +41,7 @@ class BenchmarkResults(val entries: List<List<Any>>) {
         get() {
             val mapper = jacksonObjectMapper()
 
-            return mapper.writeValueAsString(entries)
+            return mapper.writeValueAsString(entries.associate { it[0] to it[1] })
         }
 
     /** Pretty-prints benchmark results for easy copying to GitHub issues. */

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/helpers/Benchmark.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/helpers/Benchmark.kt
@@ -105,13 +105,8 @@ fun printMarkdown(table: List<List<Any>>, headers: List<String>) {
 
     for (row in table) {
         var rowIndex = 0
-        val line =
-            row.joinToString(" | ", "| ", " |") {
-                val str =
-                    if (it is Map<*, *>) "`${it.toString().replace(",", ", ").replace(":", ": ")}`"
-                    else it.toString()
-                str.padEnd(lengths[rowIndex++])
-            }
+        // TODO: Add pretty printing for objects (e.g. List, Map)
+        val line = row.joinToString(" | ", "| ", " |") { it.toString().padEnd(lengths[rowIndex++]) }
         println(line)
     }
 

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/helpers/Benchmark.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/helpers/Benchmark.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.helpers
 
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import java.io.File
 import java.nio.file.Path
 import java.time.Duration
 import java.time.Instant
@@ -47,7 +48,7 @@ interface StatisticsHolder {
             listOf("Number of files translated", translatedFiles.size),
             listOf(
                 "Translated file(s)",
-                translatedFiles.map { relativeOrAbsolute(Path.of(it), config.topLevel.toPath()) }
+                translatedFiles.map { relativeOrAbsolute(Path.of(it), config.topLevel) }
             ),
             *benchmarks
                 .map { listOf("${it.caller}: ${it.message}", "${it.duration} ms") }
@@ -106,10 +107,14 @@ fun printMarkdown(table: List<List<Any>>, headers: List<String>) {
  * This function will shorten / relativize the [path], if it is relative to [topLevel]. Otherwise,
  * the full path will be returned.
  */
-fun relativeOrAbsolute(path: Path, topLevel: Path): Path {
-    return try {
-        topLevel.toAbsolutePath().relativize(path)
-    } catch (ex: IllegalArgumentException) {
+fun relativeOrAbsolute(path: Path, topLevel: File?): Path {
+    return if (topLevel != null) {
+        try {
+            topLevel.toPath().toAbsolutePath().relativize(path)
+        } catch (ex: IllegalArgumentException) {
+            path
+        }
+    } else {
         path
     }
 }

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/Pass.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/Pass.java
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.passes;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import de.fraunhofer.aisec.cpg.TranslationResult;
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend;
 import java.util.function.Consumer;
@@ -39,14 +40,24 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class Pass implements Consumer<TranslationResult> {
 
+  protected String name;
+
   protected static final Logger log = LoggerFactory.getLogger(Pass.class);
 
-  @Nullable protected LanguageFrontend lang;
+  Pass() {
+    name = this.getClass().getName();
+  }
+
+  @JsonIgnore @Nullable protected LanguageFrontend lang;
 
   /** @return May be null */
   @Nullable
   public LanguageFrontend getLang() {
     return lang;
+  }
+
+  public String getName() {
+    return name;
   }
 
   /**

--- a/cpg-core/src/test/java/de/fraunhofer/aisec/cpg/helpers/BenchmarkTest.kt
+++ b/cpg-core/src/test/java/de/fraunhofer/aisec/cpg/helpers/BenchmarkTest.kt
@@ -72,7 +72,7 @@ class BenchmarkTest {
         assertEquals(Path("foreachstmt.cpp"), files[0])
 
         val json = res.json
-        assertContains("{", json)
+        assertContains(json, "{")
     }
 
     @Test

--- a/cpg-core/src/test/java/de/fraunhofer/aisec/cpg/helpers/BenchmarkTest.kt
+++ b/cpg-core/src/test/java/de/fraunhofer/aisec/cpg/helpers/BenchmarkTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.helpers
+
+import de.fraunhofer.aisec.cpg.TestUtils
+import java.io.File
+import kotlin.io.path.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import org.junit.jupiter.api.Test
+
+class BenchmarkTest {
+
+    @Test
+    fun testRelativeOrAbsolute() {
+        val relPath = Path("./main.c")
+        val absPath = Path("/root/main.c")
+        val topLevelRoot = File("/root")
+        val topLevelFoo = File("/foo")
+
+        assertEquals(Path("./main.c"), relativeOrAbsolute(relPath, topLevelRoot))
+        assertEquals(Path("main.c"), relativeOrAbsolute(absPath, topLevelRoot))
+
+        // This is not what you would expect.
+        // But as topLevel is always the largest common path of all source files, this should not
+        // happen
+        assertEquals(Path("../root/main.c"), relativeOrAbsolute(absPath, topLevelFoo))
+
+        assertEquals(relPath, relativeOrAbsolute(relPath, null))
+        assertEquals(absPath, relativeOrAbsolute(absPath, null))
+    }
+
+    @Test
+    fun testGetBenchmarkResult() {
+        val file = File("src/test/resources/components/foreachstmt.cpp")
+        val tr = TestUtils.analyzeWithResult(listOf(file), file.parentFile.toPath(), true)
+
+        assertNotNull(tr)
+        val res = tr.getBenchmarkResult()
+        assertNotNull(res)
+
+        val resMap = res.associate { it[0] to it[1] }
+        assertEquals(1, resMap["Number of files translated"])
+        val files = resMap["Translated file(s)"] as List<*>
+        assertNotNull(files)
+        assertEquals(1, files.size)
+        assertEquals(Path("foreachstmt.cpp"), files[0])
+    }
+
+    @Test
+    fun testPrintBenchmark() {
+        val file = File("src/test/resources/components/foreachstmt.cpp")
+        val tr = TestUtils.analyzeWithResult(listOf(file), file.parentFile.toPath(), true)
+
+        assertNotNull(tr)
+        tr.printBenchmark()
+    }
+}

--- a/cpg-core/src/test/java/de/fraunhofer/aisec/cpg/helpers/BenchmarkTest.kt
+++ b/cpg-core/src/test/java/de/fraunhofer/aisec/cpg/helpers/BenchmarkTest.kt
@@ -60,7 +60,7 @@ class BenchmarkTest {
         val tr = TestUtils.analyzeWithResult(listOf(file), file.parentFile.toPath(), true)
 
         assertNotNull(tr)
-        val res = tr.benchmarkResult
+        val res = tr.benchmarkResults
         assertNotNull(res)
 
         val resMap = res.entries.associate { it[0] to it[1] }
@@ -81,6 +81,6 @@ class BenchmarkTest {
         val tr = TestUtils.analyzeWithResult(listOf(file), file.parentFile.toPath(), true)
 
         assertNotNull(tr)
-        tr.benchmarkResult.print()
+        tr.benchmarkResults.print()
     }
 }

--- a/cpg-core/src/test/java/de/fraunhofer/aisec/cpg/helpers/BenchmarkTest.kt
+++ b/cpg-core/src/test/java/de/fraunhofer/aisec/cpg/helpers/BenchmarkTest.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.helpers
 import de.fraunhofer.aisec.cpg.TestUtils
 import java.io.File
 import kotlin.io.path.Path
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import org.junit.jupiter.api.Test
@@ -59,15 +60,19 @@ class BenchmarkTest {
         val tr = TestUtils.analyzeWithResult(listOf(file), file.parentFile.toPath(), true)
 
         assertNotNull(tr)
-        val res = tr.getBenchmarkResult()
+        val res = tr.benchmarkResult
         assertNotNull(res)
 
-        val resMap = res.associate { it[0] to it[1] }
+        val resMap = res.entries.associate { it[0] to it[1] }
         assertEquals(1, resMap["Number of files translated"])
+
         val files = resMap["Translated file(s)"] as List<*>
         assertNotNull(files)
         assertEquals(1, files.size)
         assertEquals(Path("foreachstmt.cpp"), files[0])
+
+        val json = res.json
+        assertContains("{", json)
     }
 
     @Test
@@ -76,6 +81,6 @@ class BenchmarkTest {
         val tr = TestUtils.analyzeWithResult(listOf(file), file.parentFile.toPath(), true)
 
         assertNotNull(tr)
-        tr.printBenchmark()
+        tr.benchmarkResult.print()
     }
 }

--- a/cpg-neo4j/src/main/java/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
+++ b/cpg-neo4j/src/main/java/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
@@ -397,15 +397,15 @@ class Application : Callable<Int> {
         val pushTime = System.currentTimeMillis()
         log.info("Benchmark: push code in " + (pushTime - analyzingTime) / S_TO_MS_FACTOR + " s.")
 
+        val benchmarkResult = translationResult.benchmarkResult
+
         if (printBenchmark) {
-            translationResult.printBenchmark()
+            benchmarkResult.print()
         }
 
         benchmarkJson?.let { theFile ->
             log.info("Save benchmark results to file: $theFile")
-            val mapper = jacksonObjectMapper()
-            val json = translationResult.getBenchmarkResult().associate { it[0] to it[1] }
-            theFile.writeText(mapper.writeValueAsString(json))
+            theFile.writeText(benchmarkResult.json)
         }
 
         return EXIT_SUCCESS

--- a/cpg-neo4j/src/main/java/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
+++ b/cpg-neo4j/src/main/java/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
@@ -25,7 +25,6 @@
  */
 package de.fraunhofer.aisec.cpg_vis_neo4j
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import de.fraunhofer.aisec.cpg.*
 import de.fraunhofer.aisec.cpg.frontends.CompilationDatabase.Companion.fromFile
 import de.fraunhofer.aisec.cpg.frontends.golang.GoLanguageFrontend
@@ -397,7 +396,7 @@ class Application : Callable<Int> {
         val pushTime = System.currentTimeMillis()
         log.info("Benchmark: push code in " + (pushTime - analyzingTime) / S_TO_MS_FACTOR + " s.")
 
-        val benchmarkResult = translationResult.benchmarkResult
+        val benchmarkResult = translationResult.benchmarkResults
 
         if (printBenchmark) {
             benchmarkResult.print()

--- a/cpg-neo4j/src/main/java/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
+++ b/cpg-neo4j/src/main/java/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg_vis_neo4j
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import de.fraunhofer.aisec.cpg.*
 import de.fraunhofer.aisec.cpg.frontends.CompilationDatabase.Companion.fromFile
 import de.fraunhofer.aisec.cpg.frontends.golang.GoLanguageFrontend
@@ -190,6 +191,12 @@ class Application : Callable<Int> {
                 "Set top level directory of project structure. Default: Largest common path of all source files"]
     )
     private var topLevel: File? = null
+
+    @CommandLine.Option(
+        names = ["--benchmark-json"],
+        description = ["Save benchmark results to json file"]
+    )
+    private var benchmarkJson: File? = null
 
     /**
      * Pushes the whole translationResult to the neo4j db.
@@ -392,6 +399,13 @@ class Application : Callable<Int> {
 
         if (printBenchmark) {
             translationResult.printBenchmark()
+        }
+
+        benchmarkJson?.let { theFile ->
+            log.info("Save benchmark results to file: $theFile")
+            val mapper = jacksonObjectMapper()
+            val json = translationResult.getBenchmarkResult().associate { it[0] to it[1] }
+            theFile.writeText(mapper.writeValueAsString(json))
         }
 
         return EXIT_SUCCESS


### PR DESCRIPTION
This PR adds an option to export the benchmark result as json.

I'm not happy with the almost identical functions `getBenchmarkResult` and `printBenchmark`.
The only difference is the format of `Translation config`.
Do you have an idea how to unify this?

Benchmark json example:
```js
{
  "Translation config": {
    "inferenceConfiguration": {
      "guessCastExpressions": false,
      "inferRecords": false
    },
    "frontends": {
      "de.fraunhofer.aisec.cpg.frontends.java.JavaLanguageFrontend": [
        ".java"
      ],
      "de.fraunhofer.aisec.cpg.frontends.cpp.CXXLanguageFrontend": [
        ".c",
        ".cpp",
        ".cc",
        ".h",
        ".hpp"
      ],
      "de.fraunhofer.aisec.cpg.frontends.llvm.LLVMIRLanguageFrontend": [
        ".ll"
      ]
    },
    "processAnnotations": false,
    "includePaths": [],
    "codeInNodes": true,
    "failOnError": false,
    "disableCleanup": false,
    "symbols": {},
    "debugParser": true,
    "passes": [
      "de.fraunhofer.aisec.cpg.passes.CompressLLVMPass@3780a43",
      "de.fraunhofer.aisec.cpg.passes.TypeHierarchyResolver@11bdee44",
      "de.fraunhofer.aisec.cpg.passes.JavaExternalTypeHierarchyResolver@3e17b4a7",
      "de.fraunhofer.aisec.cpg.passes.ImportResolver@a1c8540",
      "de.fraunhofer.aisec.cpg.passes.VariableUsageResolver@781e47b2",
      "de.fraunhofer.aisec.cpg.passes.CallResolver@1d6e74c8",
      "de.fraunhofer.aisec.cpg.passes.EvaluationOrderGraphPass@a3ed67d",
      "de.fraunhofer.aisec.cpg.passes.TypeResolver@333122c2",
      "de.fraunhofer.aisec.cpg.passes.ControlFlowSensitiveDFGPass@46c79d59",
      "de.fraunhofer.aisec.cpg.passes.FilenameMapper@c4ee32f"
    ],
    "useUnityBuild": false,
    "topLevel": "/code",
    "loadIncludes": false,
    "includeBlacklist": [],
    "includeWhitelist": [],
    "sourceLocations": [
      "/code/main.c"
    ],
    "typeSystemActiveInFrontend": true,
    "useParallelFrontends": false
  },
  "Number of files translated": 1,
  "Translated file(s)": [
    "file:///code/main.c"
  ],
  "TranslationManager: Executing Language Frontend": "683 ms",
  "CompressLLVMPass: Executing Pass": "0 ms",
  "TypeHierarchyResolver: Executing Pass": "42 ms",
  "JavaExternalTypeHierarchyResolver: Executing Pass": "0 ms",
  "ImportResolver: Executing Pass": "2 ms",
  "VariableUsageResolver: Executing Pass": "26 ms",
  "CallResolver: Executing Pass": "16 ms",
  "EvaluationOrderGraphPass: Executing Pass": "6 ms",
  "TypeResolver: Executing Pass": "6 ms",
  "ControlFlowSensitiveDFGPass: Executing Pass": "10 ms",
  "FilenameMapper: Executing Pass": "2 ms",
  "TranslationManager: Translation into full graph": "808 ms"
}
```