### PR TITLE
Add support for -isystem and -D

### DIFF
--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontend.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontend.kt
@@ -185,11 +185,14 @@ class CXXLanguageFrontend(config: TranslationConfiguration, scopeManager: ScopeM
             includePaths.add(config.topLevel.toPath().toAbsolutePath().toString())
         }
 
+        val symbols: HashMap<String, String> = HashMap()
+        symbols.putAll(config.symbols)
         includePaths.addAll(listOf(*config.includePaths))
 
-        config.compilationDatabase?.get(file)?.let { includePaths.addAll(it) }
+        config.compilationDatabase?.getIncludePaths(file)?.let { includePaths.addAll(it) }
+        config.compilationDatabase?.getSymbols(file)?.let { symbols.putAll(it) }
 
-        val scannerInfo = ScannerInfo(config.symbols, includePaths.toTypedArray())
+        val scannerInfo = ScannerInfo(symbols, includePaths.toTypedArray())
         val log = DefaultLogService()
         val opts = ILanguage.OPTION_PARSE_INACTIVE_CODE // | ILanguage.OPTION_ADD_COMMENTS;
         return try {

--- a/cpg-core/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXCompilationDatabaseTest.kt
+++ b/cpg-core/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXCompilationDatabaseTest.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2022, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.frontends.cpp
+
+import de.fraunhofer.aisec.cpg.TestUtils
+import de.fraunhofer.aisec.cpg.graph.byNameOrNull
+import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
+import de.fraunhofer.aisec.cpg.graph.statements.ReturnStatement
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.Literal
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import org.junit.jupiter.api.Test
+
+class CXXCompilationDatabaseTest {
+    @Test
+    fun testCompilationDatabaseWithIncludes() {
+        val ccs =
+            listOf(
+                "src/test/resources/cxxCompilationDatabase/compile_commands_arguments.json",
+                "src/test/resources/cxxCompilationDatabase/compile_commands_commands.json"
+            )
+        for (path in ccs) {
+            val cc = File(path)
+            val tus = TestUtils.analyzeWithCompilationDatabase(cc, true)
+            val tu = tus.stream().findFirst().orElseThrow()
+            assertNotNull(tu)
+
+            val mainFunc = tu.byNameOrNull<FunctionDeclaration>("main")
+            assertNotNull(mainFunc)
+
+            val func1 = tu.byNameOrNull<FunctionDeclaration>("func1")
+            assertNotNull(func1)
+            assertEquals(func1.isInferred, false)
+            val func2 = tu.byNameOrNull<FunctionDeclaration>("func2")
+            assertNotNull(func2)
+            assertEquals(func2.isInferred, false)
+            val sysFunc = tu.byNameOrNull<FunctionDeclaration>("sys_func")
+            assertNotNull(sysFunc)
+            assertEquals(sysFunc.isInferred, false)
+
+            val s0 = mainFunc.getBodyStatementAs(0, CallExpression::class.java)
+            assertNotNull(s0)
+            val arg1 = s0.arguments[1]
+            assert(arg1 is Literal<*>)
+            val lit = arg1 as Literal<*>
+            assertEquals(lit.value, "hi")
+
+            val s1 = mainFunc.getBodyStatementAs(1, CallExpression::class.java)
+            assertNotNull(s1)
+            assertEquals(s1.invokes.iterator().next(), func1)
+
+            val s2 = mainFunc.getBodyStatementAs(2, CallExpression::class.java)
+            assertNotNull(s2)
+            assertEquals(s2.invokes.iterator().next(), func2)
+
+            val s3 = mainFunc.getBodyStatementAs(3, CallExpression::class.java)
+            assertNotNull(s3)
+            assertEquals(s3.invokes.iterator().next(), sysFunc)
+
+            val s4 = mainFunc.getBodyStatementAs(4, Literal::class.java)
+            assertNotNull(s4)
+            assertEquals(s4.value, 1)
+
+            val s5 = mainFunc.getBodyStatementAs(5, Literal::class.java)
+            assertNotNull(s5)
+            assertEquals(s5.value, 2)
+        }
+    }
+
+    @Test
+    fun testCompilationDatabaseSimple() {
+        val cc = File("src/test/resources/cxxCompilationDatabase/compile_commands_simple.json")
+        val tus = TestUtils.analyzeWithCompilationDatabase(cc, true)
+        val tu = tus.stream().findFirst().orElseThrow()
+        assertNotNull(tu)
+        assertNotNull(tu)
+
+        val mainFunc = tu.byNameOrNull<FunctionDeclaration>("main")
+        assertNotNull(mainFunc)
+
+        val s0 = mainFunc.getBodyStatementAs(0, ReturnStatement::class.java)
+        assertNotNull(s0)
+        val retVal = s0.returnValue as Literal<*>
+        assertEquals(retVal.value, 1)
+    }
+
+    @Test
+    fun testCompilationDatabaseMultiTUs() {
+        val cc = File("src/test/resources/cxxCompilationDatabase/compile_commands_multi_tus.json")
+        val tus = TestUtils.analyzeWithCompilationDatabase(cc, true)
+        assertEquals(tus.size, 2)
+
+        val ref = mapOf("main_tu_1.c" to 1, "main_tu_2.c" to 2)
+
+        for (i in tus.indices) {
+            val tu = tus[i]
+            val value = ref[File(tu.name).name]
+            val mainFunc = tu.byNameOrNull<FunctionDeclaration>("main")
+            assertNotNull(mainFunc)
+
+            val s0 = mainFunc.getBodyStatementAs(0, Literal::class.java)
+            assertNotNull(s0)
+            assertEquals(s0.value, value)
+
+            val s1 = mainFunc.getBodyStatementAs(1, Literal::class.java)
+            assertNotNull(s1)
+            assertEquals(s1.value, value)
+        }
+    }
+}

--- a/cpg-core/src/test/resources/cxxCompilationDatabase/compile_commands_arguments.json
+++ b/cpg-core/src/test/resources/cxxCompilationDatabase/compile_commands_arguments.json
@@ -1,0 +1,20 @@
+[
+  {
+    "arguments": [
+      "/usr/bin/gcc",
+      "-c",
+      "-I",
+      "includes_1",
+      "-Iincludes_2",
+      "-Isys_includes/",
+      "-DFOO=1",
+      "-D",
+      "BAR=2",
+      "-DINFO=\"hi\"",
+      "-DDEBUG=1",
+      "main.c"
+    ],
+    "directory": "src/test/resources/cxxCompilationDatabase",
+    "file": "src/test/resources/cxxCompilationDatabase/main.c"
+  }
+]

--- a/cpg-core/src/test/resources/cxxCompilationDatabase/compile_commands_commands.json
+++ b/cpg-core/src/test/resources/cxxCompilationDatabase/compile_commands_commands.json
@@ -1,0 +1,8 @@
+[
+  {
+    "command": "/usr/bin/gcc -c -I includes_1 -Iincludes_2 -Isys_includes/ -DFOO=1 -D BAR=2 -DINFO=\"hi\" -DDEBUG=1 main.c -o main",
+    "directory": "src/test/resources/cxxCompilationDatabase",
+    "file": "src/test/resources/cxxCompilationDatabase/main.c",
+    "output": "src/test/resources/cxxCompilationDatabase/main"
+  }
+]

--- a/cpg-core/src/test/resources/cxxCompilationDatabase/compile_commands_multi_tus.json
+++ b/cpg-core/src/test/resources/cxxCompilationDatabase/compile_commands_multi_tus.json
@@ -1,0 +1,36 @@
+[
+  {
+    "arguments": [
+      "/usr/bin/gcc",
+      "-c",
+      "-Iincludes_1",
+      "-D",
+      "FOO=1",
+      "main_tu_1.c"
+    ],
+    "directory": "src/test/resources/cxxCompilationDatabase",
+    "file": "src/test/resources/cxxCompilationDatabase/main_tu_1.c"
+  },
+  {
+    "arguments": [
+      "/usr/bin/gcc",
+      "-c",
+      "-Iincludes_2",
+      "-D",
+      "FOO=2",
+      "main_tu_2.c"
+    ],
+    "directory": "src/test/resources/cxxCompilationDatabase",
+    "file": "src/test/resources/cxxCompilationDatabase/main_tu_2.c"
+  },
+  {
+    "arguments": [
+      "/usr/bin/gcc",
+      "-c",
+      "missing_file.c"
+    ],
+    "directory": "src/test/resources/cxxCompilationDatabase",
+    "file": "src/test/resources/cxxCompilationDatabase/missing_file.c"
+  }
+
+]

--- a/cpg-core/src/test/resources/cxxCompilationDatabase/compile_commands_simple.json
+++ b/cpg-core/src/test/resources/cxxCompilationDatabase/compile_commands_simple.json
@@ -1,0 +1,7 @@
+[
+  {
+    "command": "/usr/bin/gcc -c main_simple.c -o main_simple",
+    "directory": "src/test/resources/cxxCompilationDatabase",
+    "file": "src/test/resources/cxxCompilationDatabase/main_simple.c"
+  }
+]

--- a/cpg-core/src/test/resources/cxxCompilationDatabase/includes_1/config.h
+++ b/cpg-core/src/test/resources/cxxCompilationDatabase/includes_1/config.h
@@ -1,0 +1,1 @@
+#define VERSION 1

--- a/cpg-core/src/test/resources/cxxCompilationDatabase/includes_1/header_1.h
+++ b/cpg-core/src/test/resources/cxxCompilationDatabase/includes_1/header_1.h
@@ -1,0 +1,3 @@
+int func1() {
+	return 2;
+}

--- a/cpg-core/src/test/resources/cxxCompilationDatabase/includes_2/config.h
+++ b/cpg-core/src/test/resources/cxxCompilationDatabase/includes_2/config.h
@@ -1,0 +1,1 @@
+#define VERSION 2

--- a/cpg-core/src/test/resources/cxxCompilationDatabase/includes_2/header_2.h
+++ b/cpg-core/src/test/resources/cxxCompilationDatabase/includes_2/header_2.h
@@ -1,0 +1,3 @@
+int func2() {
+	return 2;
+}

--- a/cpg-core/src/test/resources/cxxCompilationDatabase/main.c
+++ b/cpg-core/src/test/resources/cxxCompilationDatabase/main.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "header_1.h"
+#include "header_2.h"
+#include <sys_header.h>
+
+int main() {
+#ifdef DEBUG
+	printf("%s\n", INFO);
+#endif
+	func1();
+	func2();
+	sys_func();
+	FOO;
+	BAR;
+	return 0;
+}

--- a/cpg-core/src/test/resources/cxxCompilationDatabase/main_simple.c
+++ b/cpg-core/src/test/resources/cxxCompilationDatabase/main_simple.c
@@ -1,0 +1,3 @@
+int main() {
+	return 1;
+}

--- a/cpg-core/src/test/resources/cxxCompilationDatabase/main_tu_1.c
+++ b/cpg-core/src/test/resources/cxxCompilationDatabase/main_tu_1.c
@@ -1,0 +1,7 @@
+#include "config.h"
+
+int main() {
+	VERSION;
+	FOO;
+	return 0;
+}

--- a/cpg-core/src/test/resources/cxxCompilationDatabase/main_tu_2.c
+++ b/cpg-core/src/test/resources/cxxCompilationDatabase/main_tu_2.c
@@ -1,0 +1,7 @@
+#include "config.h"
+
+int main() {
+	VERSION;
+	FOO;
+	return 0;
+}

--- a/cpg-core/src/test/resources/cxxCompilationDatabase/sys_includes/sys_header.h
+++ b/cpg-core/src/test/resources/cxxCompilationDatabase/sys_includes/sys_header.h
@@ -1,0 +1,3 @@
+int sys_func() {
+	return 4;
+}

--- a/cpg-core/src/testFixtures/java/de/fraunhofer/aisec/cpg/TestUtils.kt
+++ b/cpg-core/src/testFixtures/java/de/fraunhofer/aisec/cpg/TestUtils.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg
 
+import de.fraunhofer.aisec.cpg.frontends.CompilationDatabase
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.TypeManager
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
@@ -33,7 +34,6 @@ import de.fraunhofer.aisec.cpg.helpers.Util
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
-import java.util.*
 import java.util.function.Consumer
 import java.util.function.Predicate
 import java.util.stream.Collectors
@@ -189,6 +189,21 @@ object TestUtils {
     ): TranslationUnitDeclaration {
         val translationUnits = analyze(files, topLevel, usePasses, configModifier)
         return translationUnits.stream().findFirst().orElseThrow()
+    }
+
+    @JvmStatic
+    @Throws(Exception::class)
+    fun analyzeWithCompilationDatabase(
+        jsonCompilationDatabase: File,
+        usePasses: Boolean,
+    ): List<TranslationUnitDeclaration> {
+        return analyze(listOf(), jsonCompilationDatabase.parentFile.toPath(), usePasses) {
+            val db = CompilationDatabase.fromFile(jsonCompilationDatabase)
+            if (db.isNotEmpty()) {
+                it.useCompilationDatabase(db)
+                it.sourceLocations(db.sourceFiles)
+            }
+        }
     }
 
     @JvmStatic


### PR DESCRIPTION
This PR extends the `CompilationDatabase` by the following compiler options:
* `-isystem` (system include path)
* `-D` (define symbols)

Additionally, test-cases for the current feature set of the  `CompilationDatabase` are added.