### PR TITLE
Add option `--topLevel` to cpg-neo4j application

### DIFF
--- a/cpg-neo4j/src/main/java/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
+++ b/cpg-neo4j/src/main/java/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
@@ -183,6 +183,14 @@ class Application : Callable<Int> {
     )
     private var noPurgeDb: Boolean = false
 
+    @CommandLine.Option(
+        names = ["--top-level"],
+        description =
+            [
+                "Set top level directory of project structure. Default: Largest common path of all source files"]
+    )
+    private var topLevel: File? = null
+
     /**
      * Pushes the whole translationResult to the neo4j db.
      *
@@ -274,7 +282,6 @@ class Application : Callable<Int> {
     private fun setupTranslationConfiguration(): TranslationConfiguration {
         assert(mutuallyExclusiveParameters.files.isNotEmpty())
         val filePaths = arrayOfNulls<File>(mutuallyExclusiveParameters.files.size)
-        var topLevel: File? = null
 
         for (index in mutuallyExclusiveParameters.files.indices) {
             val path =
@@ -283,12 +290,6 @@ class Application : Callable<Int> {
             require(file.exists() && (!file.isHidden)) {
                 "Please use a correct path. It was: $path"
             }
-            val currentTopLevel = if (file.isDirectory) file else file.parentFile
-            if (topLevel == null) topLevel = currentTopLevel
-            require(topLevel.toString() == currentTopLevel.toString()) {
-                "All files should have the same top level path."
-            }
-            filePaths[index] = file
         }
 
         val translationConfiguration =

--- a/cpg-neo4j/src/main/java/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
+++ b/cpg-neo4j/src/main/java/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
@@ -201,7 +201,7 @@ class Application : Callable<Int> {
      */
     @Throws(InterruptedException::class, ConnectException::class)
     fun pushToNeo4j(translationResult: TranslationResult) {
-        var bench = Benchmark(this.javaClass, "Push cpg to neo4j", false, translationResult)
+        val bench = Benchmark(this.javaClass, "Push cpg to neo4j", false, translationResult)
         log.info("Using import depth: $depth")
         log.info(
             "Count base nodes to save: " +
@@ -280,21 +280,19 @@ class Application : Callable<Int> {
      */
     @OptIn(ExperimentalPython::class, ExperimentalGolang::class, ExperimentalTypeScript::class)
     private fun setupTranslationConfiguration(): TranslationConfiguration {
-        assert(mutuallyExclusiveParameters.files.isNotEmpty())
-        val filePaths = arrayOfNulls<File>(mutuallyExclusiveParameters.files.size)
-
-        for (index in mutuallyExclusiveParameters.files.indices) {
-            val path =
-                Paths.get(mutuallyExclusiveParameters.files[index]).toAbsolutePath().normalize()
-            val file = File(path.toString())
-            require(file.exists() && (!file.isHidden)) {
-                "Please use a correct path. It was: $path"
+        val filePaths =
+            mutuallyExclusiveParameters.files.map {
+                Paths.get(it).toAbsolutePath().normalize().toFile()
+            }
+        filePaths.forEach {
+            require(it.exists() && (!it.isHidden)) {
+                "Please use a correct path. It was: ${it.path}"
             }
         }
 
         val translationConfiguration =
             TranslationConfiguration.builder()
-                .sourceLocations(*filePaths)
+                .sourceLocations(filePaths)
                 .topLevel(topLevel)
                 .defaultLanguages()
                 .loadIncludes(loadIncludes)


### PR DESCRIPTION
This PR adds the option `--topLevel` to the `cpg-neo4j` application, to specify the topLevel directory of the source code to be analyzed. The topLevel attribute of the `TranslationConfiguration` is optional and is mainly/only used by the java language frontend. If no topLevel is given, the java language frontend calculates it based on the largest common path over all source files.
See: 
https://github.com/Fraunhofer-AISEC/cpg/blob/599b44aa57b74a17b7d68356eada2faebaa35e0b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt#L494-L497

The second commit does some smaller clean up and refactor.