### PR TITLE
Add this field to cpp struct as they are classes

### DIFF
--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.kt
@@ -368,7 +368,8 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
                 lang.scopeManager.currentNamePrefixWithDelimiter + ctx.name.toString(),
                 kind,
                 ctx.rawSignature,
-                true
+                true,
+                lang
             )
         recordDeclaration.superClasses =
             Arrays.stream(ctx.baseSpecifiers)

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -660,7 +660,8 @@ object NodeBuilder {
             node.code = code
         }
 
-        if (kind == "class" && createThis) {
+        // In cpp, structs are also classes
+        if ((kind == "class" || kind == "struct") && createThis) {
             val thisDeclaration =
                 newFieldDeclaration(
                     "this",

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.graph
 
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
+import de.fraunhofer.aisec.cpg.frontends.cpp.CXXLanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.NodeBuilder.setCodeAndRegion
 import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.statements.*
@@ -661,7 +662,7 @@ object NodeBuilder {
         }
 
         // In cpp, structs are also classes
-        if ((kind == "class" || kind == "struct") && createThis) {
+        if ((kind == "class" || (lang is CXXLanguageFrontend && kind == "struct")) && createThis) {
             val thisDeclaration =
                 newFieldDeclaration(
                     "this",

--- a/cpg-core/src/test/java/de/fraunhofer/aisec/cpg/enhancements/templates/ClassTemplateTest.java
+++ b/cpg-core/src/test/java/de/fraunhofer/aisec/cpg/enhancements/templates/ClassTemplateTest.java
@@ -393,9 +393,9 @@ class ClassTemplateTest extends BaseTest {
     assertEquals(type1ParameterizedType, pairType.getGenerics().get(0));
     assertEquals(type2ParameterizedType, pairType.getGenerics().get(1));
 
-    assertEquals(2, pair.getFields().size());
-    assertEquals(first, pair.getFields().get(0));
-    assertEquals(second, pair.getFields().get(1));
+    assertEquals(3, pair.getFields().size()); // cpp has implicit `this` field
+    assertEquals(first, pair.getFields().get(1));
+    assertEquals(second, pair.getFields().get(2));
 
     assertEquals(type1ParameterizedType, first.getType());
     assertEquals(type2ParameterizedType, second.getType());

--- a/cpg-core/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
+++ b/cpg-core/src/test/java/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.java
@@ -1336,4 +1336,42 @@ class CXXLanguageFrontendTest extends BaseTest {
     assertTrue(initializer instanceof CastExpression);
     assertEquals("size_t", ((CastExpression) initializer).getCastType().getName());
   }
+
+  @Test
+  void testCppThisField() throws Exception {
+    var file = new File("src/test/resources/cpp-this-field.cpp");
+    var tu = TestUtils.analyzeAndGetFirstTU(List.of(file), file.getParentFile().toPath(), true);
+
+    var main = tu.getDeclarationsByName("main", FunctionDeclaration.class).iterator().next();
+    assertNotNull(main);
+
+    var classT = tu.getDeclarationsByName("T", RecordDeclaration.class).iterator().next();
+    assertNotNull(classT);
+    var classTFoo = classT.getMethods().iterator().next();
+    assertNotNull(classTFoo);
+    var classTThis = classT.getThis();
+    assertNotNull(classTThis);
+    var classTReturn = classTFoo.getBodyStatementAs(0, ReturnStatement.class);
+    assertNotNull(classTReturn);
+    var classTReturnMember = (MemberExpression) classTReturn.getReturnValue();
+    assertNotNull(classTReturnMember);
+    var classTThisExpression = (DeclaredReferenceExpression) classTReturnMember.getBase();
+    assertEquals(classTThisExpression.getRefersTo(), classTThis);
+
+    var classS = tu.getDeclarationsByName("S", RecordDeclaration.class).iterator().next();
+    assertNotNull(classS);
+    var classSFoo = classS.getMethods().iterator().next();
+    assertNotNull(classSFoo);
+    var classSThis = classS.getThis();
+    assertNotNull(classSThis);
+    var classSReturn = classSFoo.getBodyStatementAs(0, ReturnStatement.class);
+    assertNotNull(classSReturn);
+    var classSReturnMember = (MemberExpression) classSReturn.getReturnValue();
+    assertNotNull(classSReturnMember);
+    var classSThisExpression = (DeclaredReferenceExpression) classSReturnMember.getBase();
+    assertEquals(classSThisExpression.getRefersTo(), classSThis);
+
+    assertNotEquals(classTFoo, classSFoo);
+    assertNotEquals(classTThis, classSThis);
+  }
 }

--- a/cpg-core/src/test/resources/cpp-this-field.cpp
+++ b/cpg-core/src/test/resources/cpp-this-field.cpp
@@ -1,0 +1,18 @@
+class T {
+	int i=0;
+	int foo() {
+		return this->i;
+	}
+};
+
+struct S {
+	int i=0;
+	int foo() {
+		return this->i;
+	}
+};
+
+int main() {
+  T t;
+  S s;
+}


### PR DESCRIPTION
This PR adds the `this` field to `RecordDeclarations` with type struct, as in cpp structs are classes.
Because we currently make no difference between a c struct and a cpp struct/class, this does also apply to c structs.
This is nothing new, as we create an implicit constructor for structs already.

Additionally, test-cases are added.