### PR TITLE
Add option to not purge db before pushing nodes to neo4j

### DIFF
--- a/cpg-neo4j/src/main/java/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
+++ b/cpg-neo4j/src/main/java/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
@@ -53,7 +53,6 @@ private const val MAX_COUNT_OF_FAILS = 10
 private const val EXIT_SUCCESS = 0
 private const val EXIT_FAILURE = 1
 private const val VERIFY_CONNECTION = true
-private const val PURGE_DB = true
 private const val DEBUG_PARSER = true
 private const val AUTO_INDEX = "none"
 private const val PROTOCOL = "bolt://"
@@ -178,6 +177,12 @@ class Application : Callable<Int> {
     )
     private var noNeo4j: Boolean = false
 
+    @CommandLine.Option(
+        names = ["--no-purge-db"],
+        description = ["Do no purge neo4j database before pushing the cpg"]
+    )
+    private var noPurgeDb: Boolean = false
+
     /**
      * Pushes the whole translationResult to the neo4j db.
      *
@@ -200,7 +205,7 @@ class Application : Callable<Int> {
 
         val session = sessionAndSessionFactoryPair.first
         session.beginTransaction().use { transaction ->
-            if (PURGE_DB) session.purgeDatabase()
+            if (!noPurgeDb) session.purgeDatabase()
             session.save(translationResult.translationUnits, depth)
             session.save(translationResult.additionalNodes, depth)
             transaction.commit()


### PR DESCRIPTION
This PR adds an option to the cpg-neo4j application to not purge the database before pushing the nodes.
This can be useful, if you want to load multiple projects into one database.