### PR TITLE
LLVM-CPG: Improve parsing of types 

### DIFF
--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/DeclarationHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/DeclarationHandler.kt
@@ -267,6 +267,6 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
             name += "_${fieldType.typeName}"
         }
 
-        return name
+        return name.replace("[]", "Array").replace("*", "Ptr")
     }
 }

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/DeclarationHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/DeclarationHandler.kt
@@ -36,6 +36,7 @@ import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.CompoundStatement
+import de.fraunhofer.aisec.cpg.graph.types.Type
 import org.bytedeco.javacpp.Pointer
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.LLVM.LLVMValueRef
@@ -200,7 +201,7 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
      */
     fun handleStructureType(
         typeRef: LLVMTypeRef,
-        alreadyVisited: ArrayList<LLVMTypeRef> = ArrayList()
+        alreadyVisited: MutableMap<LLVMTypeRef, Type> = mutableMapOf()
     ): RecordDeclaration {
         // if this is a literal struct, we will give it a pseudo name
         val name =
@@ -254,7 +255,7 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
      */
     private fun getLiteralStructName(
         typeRef: LLVMTypeRef,
-        alreadyVisited: ArrayList<LLVMTypeRef>
+        alreadyVisited: MutableMap<LLVMTypeRef, Type>
     ): String {
         var name = "literal"
 

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/DeclarationHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/DeclarationHandler.kt
@@ -98,7 +98,6 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
      */
     private fun handleFunction(func: LLVMValueRef): FunctionDeclaration {
         val name = LLVMGetValueName(func)
-
         val functionDeclaration = newFunctionDeclaration(name.string, lang.getCodeFromRawNode(func))
 
         // return types are a bit tricky, because the type of the function is a pointer to the
@@ -257,6 +256,11 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
         typeRef: LLVMTypeRef,
         alreadyVisited: MutableMap<LLVMTypeRef, Type?>
     ): String {
+        val typeStr = LLVMPrintTypeToString(typeRef).string
+        if (typeStr in lang.typeCache && lang.typeCache[typeStr] != null) {
+            return lang.typeCache[typeStr]!!.name
+        }
+
         var name = "literal"
 
         val size = LLVMCountStructElementTypes(typeRef)

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/DeclarationHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/DeclarationHandler.kt
@@ -201,14 +201,14 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
      */
     fun handleStructureType(
         typeRef: LLVMTypeRef,
-        alreadyVisited: MutableMap<LLVMTypeRef, Type> = mutableMapOf()
+        alreadyVisited: MutableMap<LLVMTypeRef, Type?> = mutableMapOf()
     ): RecordDeclaration {
         // if this is a literal struct, we will give it a pseudo name
         val name =
             if (LLVMIsLiteralStruct(typeRef) == 1) {
                 getLiteralStructName(typeRef, alreadyVisited)
             } else {
-                LLVMGetStructName(typeRef).string
+                replaceCharsInName(LLVMGetStructName(typeRef).string)
             }
 
         // try to see, if the struct already exists as a record declaration
@@ -255,7 +255,7 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
      */
     private fun getLiteralStructName(
         typeRef: LLVMTypeRef,
-        alreadyVisited: MutableMap<LLVMTypeRef, Type>
+        alreadyVisited: MutableMap<LLVMTypeRef, Type?>
     ): String {
         var name = "literal"
 
@@ -268,6 +268,25 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
             name += "_${fieldType.typeName}"
         }
 
-        return name.replace("[]", "Array").replace("*", "Ptr")
+        return replaceCharsInName(name)
+    }
+
+    /**
+     * Replaces some "dangerous" characters in the name of structures as they can be misinterpreted
+     * by the [TypeParser].
+     */
+    private fun replaceCharsInName(name: String): String {
+        return name.replace("[]", "Array")
+            .replace("*", "Ptr")
+            .replace("+", "%2B")
+            .replace("&", "%26")
+            .replace("#", "%23")
+            .replace("<", "%3c")
+            .replace(">", "%3e")
+            .replace("@", "%40")
+            .replace("[", "%5b")
+            .replace("]", "%5d")
+            .replace("{", "%7b")
+            .replace("}", "%7d")
     }
 }

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/ExpressionHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/ExpressionHandler.kt
@@ -84,7 +84,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
             // we are only interested in its name and type.
             LLVMInstructionValueKind -> handleReference(value)
             LLVMFunctionValueKind -> handleFunction(value)
-            LLVMInlineAsmValueKind -> {
+            LLVMMetadataAsValueValueKind, LLVMInlineAsmValueKind -> {
                 // TODO
                 return Expression()
             }
@@ -120,7 +120,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
                 } else if (LLVMIsPoison(value) == 1) {
                     return newDeclaredReferenceExpression("poison", cpgType, "poison")
                 } else {
-                    log.error("Unknown expression")
+                    log.error("Unknown expression {}", kind)
                     return Expression()
                 }
             }

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/ExpressionHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/ExpressionHandler.kt
@@ -305,6 +305,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
             val expr: ConstructExpression = newConstructExpression(code)
             // map the construct expression to the record declaration of the type
             expr.instantiates = (type as? ObjectType)?.recordDeclaration
+            if (expr.instantiates == null) return expr
 
             // loop through the operands
             for (field in (expr.instantiates as RecordDeclaration).fields) {
@@ -329,6 +330,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
             val expr: ConstructExpression = newConstructExpression(code)
             // map the construct expression to the record declaration of the type
             expr.instantiates = (type as? ObjectType)?.recordDeclaration
+            if (expr.instantiates == null) return expr
 
             // loop through the operands
             for (field in (expr.instantiates as RecordDeclaration).fields) {

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/ExpressionHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/ExpressionHandler.kt
@@ -84,6 +84,10 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
             // we are only interested in its name and type.
             LLVMInstructionValueKind -> handleReference(value)
             LLVMFunctionValueKind -> handleFunction(value)
+            LLVMInlineAsmValueKind -> {
+                // TODO
+                return Expression()
+            }
             else -> {
                 log.info(
                     "Not handling value kind {} in handleValue yet. Falling back to the legacy way. Please change",

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontend.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontend.kt
@@ -52,6 +52,7 @@ class LLVMIRLanguageFrontend(config: TranslationConfiguration, scopeManager: Sco
     val statementHandler = StatementHandler(this)
     val declarationHandler = DeclarationHandler(this)
     val expressionHandler = ExpressionHandler(this)
+    val typeCache = mutableMapOf<String, Type>()
 
     val phiList = mutableListOf<LLVMValueRef>()
 
@@ -164,13 +165,11 @@ class LLVMIRLanguageFrontend(config: TranslationConfiguration, scopeManager: Sco
         return typeFrom(typeRef)
     }
 
-    private val typeCache = mutableMapOf<String, Type>()
-
     internal fun typeFrom(
         typeRef: LLVMTypeRef,
         alreadyVisited: MutableMap<LLVMTypeRef, Type?> = mutableMapOf()
     ): Type {
-        val typeStr = LLVMPrintTypeToString(typeRef).toString()
+        val typeStr = LLVMPrintTypeToString(typeRef).string
         if (typeStr in typeCache && typeCache[typeStr] != null) {
             return typeCache[typeStr]!!
         }

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/StatementHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/StatementHandler.kt
@@ -1117,8 +1117,7 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
 
         if (instr.opCode == LLVMInvoke) {
             // For the invoke instruction, the call is surrounded by a try statement which also
-            // contains a
-            // goto statement after the call.
+            // contains a goto statement after the call.
             val tryStatement = newTryStatement(instrStr!!)
             lang.scopeManager.enterScope(tryStatement)
             val tryBlock = newCompoundStatement(instrStr)

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/ExamplesTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/ExamplesTest.kt
@@ -34,6 +34,25 @@ import org.junit.jupiter.api.Test
 @Tag("llvm-examples")
 class ExamplesTest {
     @Test
+    fun testRust() {
+        val topLevel = Path.of("src", "test", "resources", "llvm", "examples")
+
+        val tu =
+            TestUtils.analyzeAndGetFirstTU(
+                listOf(topLevel.resolve("rust_sample.ll").toFile()),
+                topLevel,
+                true
+            ) {
+                it.registerLanguage(
+                    LLVMIRLanguageFrontend::class.java,
+                    LLVMIRLanguageFrontend.LLVM_EXTENSIONS
+                )
+            }
+
+        assertNotNull(tu)
+    }
+
+    @Test
     fun testIf() {
         val topLevel = Path.of("src", "test", "resources", "llvm", "examples", "llvm")
 

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/ExamplesTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/ExamplesTest.kt
@@ -53,25 +53,6 @@ class ExamplesTest {
     }
 
     @Test
-    fun testRust2() {
-        val topLevel = Path.of("src", "test", "resources", "llvm", "examples")
-
-        val tu =
-            TestUtils.analyzeAndGetFirstTU(
-                listOf(topLevel.resolve("all.ll").toFile()),
-                topLevel,
-                true
-            ) {
-                it.registerLanguage(
-                    LLVMIRLanguageFrontend::class.java,
-                    LLVMIRLanguageFrontend.LLVM_EXTENSIONS
-                )
-            }
-
-        assertNotNull(tu)
-    }
-
-    @Test
     fun testIf() {
         val topLevel = Path.of("src", "test", "resources", "llvm", "examples", "llvm")
 

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/ExamplesTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/ExamplesTest.kt
@@ -53,6 +53,25 @@ class ExamplesTest {
     }
 
     @Test
+    fun testRust2() {
+        val topLevel = Path.of("src", "test", "resources", "llvm", "examples")
+
+        val tu =
+            TestUtils.analyzeAndGetFirstTU(
+                listOf(topLevel.resolve("all.ll").toFile()),
+                topLevel,
+                true
+            ) {
+                it.registerLanguage(
+                    LLVMIRLanguageFrontend::class.java,
+                    LLVMIRLanguageFrontend.LLVM_EXTENSIONS
+                )
+            }
+
+        assertNotNull(tu)
+    }
+
+    @Test
     fun testIf() {
         val topLevel = Path.of("src", "test", "resources", "llvm", "examples", "llvm")
 

--- a/cpg-language-llvm/src/test/resources/llvm/examples/rust_sample.ll
+++ b/cpg-language-llvm/src/test/resources/llvm/examples/rust_sample.ll
@@ -1,0 +1,146 @@
+; ModuleID = 'cpg_rs_test.dbbe0041-cgu.0'
+source_filename = "cpg_rs_test.dbbe0041-cgu.0"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+%"core::fmt::Arguments" = type { { [0 x { [0 x i8]*, i64 }]*, i64 }, { i64*, i64 }, { [0 x { i8*, i64* }]*, i64 } }
+%"unwind::libunwind::_Unwind_Exception" = type { i64, void (i32, %"unwind::libunwind::_Unwind_Exception"*)*, [6 x i64] }
+%"unwind::libunwind::_Unwind_Context" = type { [0 x i8] }
+
+@vtable.0 = private unnamed_addr constant <{ i8*, [16 x i8], i8*, i8*, i8*, [0 x i8] }> <{ i8* bitcast (void (i64**)* @"_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h2182095d83600a8fE" to i8*), [16 x i8] c"\08\00\00\00\00\00\00\00\08\00\00\00\00\00\00\00", i8* bitcast (i32 (i64**)* @"_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h5efe6b9a0939581cE" to i8*), i8* bitcast (i32 (i64**)* @"_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h40bc64437f27ebd0E" to i8*), i8* bitcast (i32 (i64**)* @"_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h40bc64437f27ebd0E" to i8*), [0 x i8] zeroinitializer }>, align 8
+@alloc2 = private unnamed_addr constant <{ [14 x i8] }> <{ [14 x i8] c"Hello, world!\0A" }>, align 1
+@alloc3 = private unnamed_addr constant <{ i8*, [8 x i8] }> <{ i8* getelementptr inbounds (<{ [14 x i8] }>, <{ [14 x i8] }>* @alloc2, i32 0, i32 0, i32 0), [8 x i8] c"\0E\00\00\00\00\00\00\00" }>, align 8
+@alloc5 = private unnamed_addr constant <{ [0 x i8] }> zeroinitializer, align 8
+
+; std::sys_common::backtrace::__rust_begin_short_backtrace
+; Function Attrs: noinline nonlazybind uwtable
+define internal fastcc void @_ZN3std10sys_common9backtrace28__rust_begin_short_backtrace17h748911433efa822cE(void ()* nocapture nonnull %f) unnamed_addr #0 personality i32 (i32, i32, i64, %"unwind::libunwind::_Unwind_Exception"*, %"unwind::libunwind::_Unwind_Context"*)* @rust_eh_personality {
+start:
+  tail call void %f()
+  tail call void asm sideeffect "", "r,~{memory}"({}* undef) #6, !srcloc !3
+  ret void
+}
+
+; std::rt::lang_start
+; Function Attrs: nonlazybind uwtable
+define hidden i64 @_ZN3std2rt10lang_start17h4ce2d0d2984ce443E(void ()* nonnull %main, i64 %argc, i8** %argv) unnamed_addr #1 {
+start:
+  %_8 = alloca i64*, align 8
+  %0 = bitcast i64** %_8 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %0)
+  %1 = bitcast i64** %_8 to void ()**
+  store void ()* %main, void ()** %1, align 8
+  %_5.0 = bitcast i64** %_8 to {}*
+; call std::rt::lang_start_internal
+  %2 = call i64 @_ZN3std2rt19lang_start_internal17hd15a47be08101c28E({}* nonnull align 1 %_5.0, [3 x i64]* noalias readonly align 8 dereferenceable(24) bitcast (<{ i8*, [16 x i8], i8*, i8*, i8*, [0 x i8] }>* @vtable.0 to [3 x i64]*), i64 %argc, i8** %argv)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %0)
+  ret i64 %2
+}
+
+; std::rt::lang_start::{{closure}}
+; Function Attrs: inlinehint nonlazybind uwtable
+define internal i32 @"_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h40bc64437f27ebd0E"(i64** noalias nocapture readonly align 8 dereferenceable(8) %_1) unnamed_addr #2 {
+start:
+  %0 = bitcast i64** %_1 to void ()**
+  %_3 = load void ()*, void ()** %0, align 8, !nonnull !4
+; call std::sys_common::backtrace::__rust_begin_short_backtrace
+  tail call fastcc void @_ZN3std10sys_common9backtrace28__rust_begin_short_backtrace17h748911433efa822cE(void ()* nonnull %_3)
+  ret i32 0
+}
+
+; core::ops::function::FnOnce::call_once{{vtable.shim}}
+; Function Attrs: inlinehint nonlazybind uwtable
+define internal i32 @"_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h5efe6b9a0939581cE"(i64** nocapture readonly %_1) unnamed_addr #2 personality i32 (i32, i32, i64, %"unwind::libunwind::_Unwind_Exception"*, %"unwind::libunwind::_Unwind_Context"*)* @rust_eh_personality {
+start:
+  %0 = bitcast i64** %_1 to void ()**
+  %1 = load void ()*, void ()** %0, align 8, !nonnull !4
+; call std::sys_common::backtrace::__rust_begin_short_backtrace
+  tail call fastcc void @_ZN3std10sys_common9backtrace28__rust_begin_short_backtrace17h748911433efa822cE(void ()* nonnull %1), !noalias !5
+  ret i32 0
+}
+
+; core::ptr::drop_in_place<std::rt::lang_start<()>::{{closure}}>
+; Function Attrs: inlinehint mustprogress nofree norecurse nosync nounwind nonlazybind readnone uwtable willreturn
+define internal void @"_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h2182095d83600a8fE"(i64** nocapture %_1) unnamed_addr #3 {
+start:
+  ret void
+}
+
+; cpg_rs_test::main
+; Function Attrs: nonlazybind uwtable
+define internal void @_ZN11cpg_rs_test4main17h9e4ddb287fe877f0E() unnamed_addr #1 {
+start:
+  %_2 = alloca %"core::fmt::Arguments", align 8
+  %0 = bitcast %"core::fmt::Arguments"* %_2 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 48, i8* nonnull %0)
+  %1 = getelementptr inbounds %"core::fmt::Arguments", %"core::fmt::Arguments"* %_2, i64 0, i32 0, i32 0
+  store [0 x { [0 x i8]*, i64 }]* bitcast (<{ i8*, [8 x i8] }>* @alloc3 to [0 x { [0 x i8]*, i64 }]*), [0 x { [0 x i8]*, i64 }]** %1, align 8, !alias.scope !8
+  %2 = getelementptr inbounds %"core::fmt::Arguments", %"core::fmt::Arguments"* %_2, i64 0, i32 0, i32 1
+  store i64 1, i64* %2, align 8, !alias.scope !8
+  %3 = getelementptr inbounds %"core::fmt::Arguments", %"core::fmt::Arguments"* %_2, i64 0, i32 1, i32 0
+  store i64* null, i64** %3, align 8, !alias.scope !8
+  %4 = getelementptr inbounds %"core::fmt::Arguments", %"core::fmt::Arguments"* %_2, i64 0, i32 2, i32 0
+  store [0 x { i8*, i64* }]* bitcast (<{ [0 x i8] }>* @alloc5 to [0 x { i8*, i64* }]*), [0 x { i8*, i64* }]** %4, align 8, !alias.scope !8
+  %5 = getelementptr inbounds %"core::fmt::Arguments", %"core::fmt::Arguments"* %_2, i64 0, i32 2, i32 1
+  store i64 0, i64* %5, align 8, !alias.scope !8
+; call std::io::stdio::_print
+  call void @_ZN3std2io5stdio6_print17hd9c9dbd31aa97d70E(%"core::fmt::Arguments"* noalias nocapture nonnull dereferenceable(48) %_2)
+  call void @llvm.lifetime.end.p0i8(i64 48, i8* nonnull %0)
+  ret void
+}
+
+; Function Attrs: nonlazybind uwtable
+declare i32 @rust_eh_personality(i32, i32, i64, %"unwind::libunwind::_Unwind_Exception"*, %"unwind::libunwind::_Unwind_Context"*) unnamed_addr #1
+
+; Function Attrs: argmemonly mustprogress nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #4
+
+; Function Attrs: argmemonly mustprogress nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #4
+
+; std::rt::lang_start_internal
+; Function Attrs: nonlazybind uwtable
+declare i64 @_ZN3std2rt19lang_start_internal17hd15a47be08101c28E({}* nonnull align 1, [3 x i64]* noalias readonly align 8 dereferenceable(24), i64, i8**) unnamed_addr #1
+
+; std::io::stdio::_print
+; Function Attrs: nonlazybind uwtable
+declare void @_ZN3std2io5stdio6_print17hd9c9dbd31aa97d70E(%"core::fmt::Arguments"* noalias nocapture dereferenceable(48)) unnamed_addr #1
+
+; Function Attrs: nonlazybind
+define i32 @main(i32 %0, i8** %1) unnamed_addr #5 {
+top:
+  %_8.i = alloca i64*, align 8
+  %2 = sext i32 %0 to i64
+  %3 = bitcast i64** %_8.i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %3)
+  %4 = bitcast i64** %_8.i to void ()**
+  store void ()* @_ZN11cpg_rs_test4main17h9e4ddb287fe877f0E, void ()** %4, align 8
+  %_5.0.i = bitcast i64** %_8.i to {}*
+; call std::rt::lang_start_internal
+  %5 = call i64 @_ZN3std2rt19lang_start_internal17hd15a47be08101c28E({}* nonnull align 1 %_5.0.i, [3 x i64]* noalias readonly align 8 dereferenceable(24) bitcast (<{ i8*, [16 x i8], i8*, i8*, i8*, [0 x i8] }>* @vtable.0 to [3 x i64]*), i64 %2, i8** %1)
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %3)
+  %6 = trunc i64 %5 to i32
+  ret i32 %6
+}
+
+attributes #0 = { noinline nonlazybind uwtable "probe-stack"="__rust_probestack" "target-cpu"="x86-64" }
+attributes #1 = { nonlazybind uwtable "probe-stack"="__rust_probestack" "target-cpu"="x86-64" }
+attributes #2 = { inlinehint nonlazybind uwtable "probe-stack"="__rust_probestack" "target-cpu"="x86-64" }
+attributes #3 = { inlinehint mustprogress nofree norecurse nosync nounwind nonlazybind readnone uwtable willreturn "probe-stack"="__rust_probestack" "target-cpu"="x86-64" }
+attributes #4 = { argmemonly mustprogress nofree nosync nounwind willreturn }
+attributes #5 = { nonlazybind "probe-stack"="__rust_probestack" "target-cpu"="x86-64" }
+attributes #6 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !2}
+
+!0 = !{i32 7, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 2, !"RtLibUseGOT", i32 1}
+!3 = !{i32 3165991}
+!4 = !{}
+!5 = !{!6}
+!6 = distinct !{!6, !7, !"_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h40bc64437f27ebd0E: %_1"}
+!7 = distinct !{!7, !"_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h40bc64437f27ebd0E"}
+!8 = !{!9}
+!9 = distinct !{!9, !10, !"_ZN4core3fmt9Arguments6new_v117h28f78a49eb4e2f12E: argument 0"}
+!10 = distinct !{!10, !"_ZN4core3fmt9Arguments6new_v117h28f78a49eb4e2f12E"}


### PR DESCRIPTION
The parsing of structures was error prone for several reasons: Special characters in the names were parsed by the type parser in C-style and could lead to wrong types. Furthermore, some types were parsed over and over again. This is resolved by caching already known structures.

Closes #733 