### PR TITLE
LLVM-CPG: Fix handling of `LLVMConstantVectorValueKind`

### DIFF
--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -52,6 +52,15 @@ class LLVMIRLanguageFrontendTest {
     }
 
     @Test
+    fun testVectorPoison() {
+        val topLevel = Path.of("src", "test", "resources", "llvm")
+
+        val frontend =
+            LLVMIRLanguageFrontend(TranslationConfiguration.builder().build(), ScopeManager())
+        frontend.parse(topLevel.resolve("vector_poison.ll").toFile())
+    }
+
+    @Test
     fun testIntegerOps() {
         val topLevel = Path.of("src", "test", "resources", "llvm")
         val tu =

--- a/cpg-language-llvm/src/test/resources/llvm/vector_poison.ll
+++ b/cpg-language-llvm/src/test/resources/llvm/vector_poison.ll
@@ -1,0 +1,4 @@
+define i32 @main() {   ; i32()*
+  %vec = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 5, i32 0
+  ret i32 0
+}


### PR DESCRIPTION
Closes #736 