### PR TITLE
Support for Go 1.18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,11 +25,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of SonarQube analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of SonarQube analysis
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       - uses: actions/setup-java@v2
         with:
           distribution: "zulu"
@@ -56,18 +56,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of SonarQube analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of SonarQube analysis
       - uses: actions/setup-java@v2
         with:
           distribution: "zulu"
           java-version: "15"
-          cache: 'gradle'
+          cache: "gradle"
       - uses: actions/setup-python@v2
         with:
           python-version: "3.10"
       - uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: "16"
       - name: Setup neo4j
         run: |
           docker run -d --env NEO4J_AUTH=neo4j/password -p7474:7474 -p7687:7687 neo4j
@@ -97,10 +97,10 @@ jobs:
           find /opt/hostedtoolcache/Python/ -name libjep.so -exec sudo cp '{}' /usr/lib/ \;
       - name: Install pycodestyle
         run: |
-            pip3 install pycodestyle
+          pip3 install pycodestyle
       - name: Run pycodestyle
         run: |
-            find cpg-language-python/src/main/python -iname "*.py" -exec pycodestyle \{\} \;
+          find cpg-language-python/src/main/python -iname "*.py" -exec pycodestyle \{\} \;
       - uses: actions/download-artifact@v3
         with:
           name: libcpgo-arm64.dylib
@@ -133,7 +133,7 @@ jobs:
           name: test
           path: "**/build/reports/tests"
       - name: Publish
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'beta')      
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'beta')
         run: |
           export ORG_GRADLE_PROJECT_signingKey=`echo ${{ secrets.GPG_PRIVATE_KEY }} | base64 -d`
           ./gradlew --no-daemon -Dorg.gradle.internal.publish.checksums.insecure=true --parallel -Pversion=$VERSION -PexperimentalTypeScript signMavenPublication build publish javadoc

--- a/cpg-language-go/src/main/golang/go.mod
+++ b/cpg-language-go/src/main/golang/go.mod
@@ -6,3 +6,5 @@ require (
 	golang.org/x/mod v0.5.0
 	tekao.net/jnigi v0.0.0-20201212091834-f7b899046676
 )
+
+require golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect

--- a/cpg-language-go/src/main/golang/go.mod
+++ b/cpg-language-go/src/main/golang/go.mod
@@ -1,6 +1,6 @@
 module cpg
 
-go 1.16
+go 1.18
 
 require (
 	golang.org/x/mod v0.5.0

--- a/cpg-language-go/src/main/golang/go.sum
+++ b/cpg-language-go/src/main/golang/go.sum
@@ -1,15 +1,5 @@
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/mod v0.5.0 h1:UG21uOlmZabA4fW5i7ZX6bjw1xELEGg/ZLgZq9auk/Q=
 golang.org/x/mod v0.5.0/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
-golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 tekao.net/jnigi v0.0.0-20201212091834-f7b899046676 h1:ZEkhDs0eKEynaUD1XX/WnQCD5/zoEUyMkDx5DbvVq7g=


### PR DESCRIPTION
This PR adds support for parsing Go 1.18 files. The CPG does not yet translate Go generics into template nodes.