### PR TITLE
Fix detection of multiple typedef statement

### DIFF
--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/helpers/Util.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/helpers/Util.java
@@ -300,12 +300,17 @@ public class Util {
 
   public static boolean containsOnOuterLevel(String input, char marker) {
     int openParentheses = 0;
+    int openTemplate = 0;
     for (char c : input.toCharArray()) {
       if (c == '(') {
         openParentheses++;
       } else if (c == ')') {
         openParentheses--;
-      } else if (c == marker && openParentheses == 0) {
+      } else if (c == '<') {
+        openTemplate++;
+      } else if (c == '>') {
+        openTemplate--;
+      } else if (c == marker && openParentheses == 0 && openTemplate == 0) {
         return true;
       }
     }

--- a/cpg-core/src/test/java/de/fraunhofer/aisec/cpg/enhancements/TypedefTest.java
+++ b/cpg-core/src/test/java/de/fraunhofer/aisec/cpg/enhancements/TypedefTest.java
@@ -32,7 +32,9 @@ import de.fraunhofer.aisec.cpg.TestUtils;
 import de.fraunhofer.aisec.cpg.graph.TypeManager;
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration;
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration;
+import de.fraunhofer.aisec.cpg.graph.declarations.TypedefDeclaration;
 import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration;
+import de.fraunhofer.aisec.cpg.graph.types.ObjectType;
 import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -116,6 +118,7 @@ class TypedefTest extends BaseTest {
   void testMultiple() throws Exception {
     List<TranslationUnitDeclaration> result = TestUtils.analyze("cpp", topLevel, true);
     List<ValueDeclaration> variables = TestUtils.subnodesOfType(result, ValueDeclaration.class);
+    List<ObjectType> types = TestUtils.subnodesOfType(result, ObjectType.class);
 
     // simple type
     ValueDeclaration i1 = TestUtils.findByUniqueName(variables, "i1");
@@ -136,6 +139,13 @@ class TypedefTest extends BaseTest {
     ValueDeclaration fPtr1 = TestUtils.findByUniqueName(variables, "intFptr1");
     ValueDeclaration fPtr2 = TestUtils.findByUniqueName(variables, "intFptr2");
     assertEquals(fPtr1.getType(), fPtr2.getType());
+
+    // template, not to be confused with multiple typedef
+    TypedefDeclaration template =
+        TestUtils.findByUniquePredicate(
+            result.get(0).getTypedefs(),
+            (n) -> n.getType().getTypeName().equals("template_class_A"));
+    assertEquals(template.getAlias().getTypeName(), "type_B");
   }
 
   @Test

--- a/cpg-core/src/test/resources/typedefs/typedefs.cpp
+++ b/cpg-core/src/test/resources/typedefs/typedefs.cpp
@@ -83,6 +83,9 @@ struct add_const {
     type typeMember2;
 };
 
+// template, not to be confused with multiple typedef
+typedef template_class_A<int, int> type_B;
+
 
 int main() {
   typedef char *type;


### PR DESCRIPTION
This PR fixes a bug in the handling of the "multiple typedef statement":
```cpp
      typedef int myIntA, intIntB;
```

We detect this by splitting at `,`
In c++ and templates, this gets more complicated:
```cpp
      typedef T<int, int> B;
```

I fixed this inside the `Util.containsOnOuterLevel` function.
The solution is not optimal and there might be even more corner cases.
But for now this prevents the cpg from crashing.
Additionally, we do not fully support template classes yet.