### PR TITLE
Fixed various crashes in the CPG

### DIFF
--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.kt
@@ -420,13 +420,15 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
                 // make sure, the type manager knows about this type before parsing the declarator
                 val result = TypeParser.createFrom(typeString, true, lang)
 
-                val declaration = lang.declaratorHandler.handle(declarator) as ValueDeclaration
+                val declaration = lang.declaratorHandler.handle(declarator) as? ValueDeclaration
 
-                declaration.type = result
+                if (declaration != null) {
+                    declaration.type = result
 
-                // process attributes
-                lang.processAttributes(declaration, ctx)
-                sequence.addDeclaration(declaration)
+                    // process attributes
+                    lang.processAttributes(declaration, ctx)
+                    sequence.addDeclaration(declaration)
+                }
             }
         }
 

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.kt
@@ -223,14 +223,14 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
             if ((declSpecifier as CPPASTNamedTypeSpecifier).name is CPPASTTemplateId) {
                 templateParameters = getTemplateArguments(declSpecifier.name as CPPASTTemplateId)
                 assert(t.root is ObjectType)
-                val objectType = t.root as ObjectType
+                val objectType = t.root as? ObjectType
                 val generics =
                     templateParameters
                         .stream()
                         .filter { obj: Node? -> TypeExpression::class.java.isInstance(obj) }
                         .map { e: Node? -> (e as TypeExpression?)!!.type }
                         .collect(Collectors.toList())
-                objectType.generics = generics
+                objectType?.generics = generics
             }
 
             // new returns a pointer, so we need to reference the type by pointer
@@ -591,11 +591,11 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
             TypeParser.createFrom(
                 (proxy as CPPClassInstance).templateDefinition.toString(),
                 true
-            ) as
+            ) as?
                 ObjectType
         for (templateArgument in proxy.templateArguments) {
             if (templateArgument is CPPTemplateTypeArgument) {
-                type.addGeneric(TypeParser.createFrom(templateArgument.toString(), true))
+                type?.addGeneric(TypeParser.createFrom(templateArgument.toString(), true))
             }
         }
         declaredReferenceExpression.type = type

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.kt
@@ -598,7 +598,7 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
                 type?.addGeneric(TypeParser.createFrom(templateArgument.toString(), true))
             }
         }
-        type?.let {  declaredReferenceExpression.type = it }
+        type?.let { declaredReferenceExpression.type = it }
     }
 
     private fun handleExpressionList(exprList: CPPASTExpressionList): ExpressionList {

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.kt
@@ -219,8 +219,8 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
         } else {
             // Resolve possible templates
             var templateParameters: List<Node?> = emptyList<Node>()
-            val declSpecifier = ctx.typeId.declSpecifier
-            if ((declSpecifier as CPPASTNamedTypeSpecifier).name is CPPASTTemplateId) {
+            val declSpecifier = ctx.typeId.declSpecifier as? CPPASTNamedTypeSpecifier
+            if (declSpecifier?.name is CPPASTTemplateId) {
                 templateParameters = getTemplateArguments(declSpecifier.name as CPPASTTemplateId)
                 assert(t.root is ObjectType)
                 val objectType = t.root as? ObjectType
@@ -598,7 +598,7 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
                 type?.addGeneric(TypeParser.createFrom(templateArgument.toString(), true))
             }
         }
-        declaredReferenceExpression.type = type
+        type?.let {  declaredReferenceExpression.type = it }
     }
 
     private fun handleExpressionList(exprList: CPPASTExpressionList): ExpressionList {

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/TypeManager.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/TypeManager.java
@@ -480,10 +480,18 @@ public class TypeManager {
     typeToRecord =
         frontend
             .getScopeManager()
-            .filterScopesDistinctBy(RecordScope.class::isInstance, s -> s.getAstNode().getName())
+            .filterScopesDistinctBy(
+                scope -> {
+                  // It seems that somehow other node types get mixed into the ast node of a record
+                  // scope sometimes. So we need to be extra sure that our ast node is a record
+                  // declaration
+                  return scope instanceof RecordScope
+                      && scope.getAstNode() instanceof RecordDeclaration;
+                },
+                s -> s.getAstNode().getName())
             .stream()
             .map(s -> (RecordDeclaration) s.getAstNode())
-            .collect(Collectors.toMap(RecordDeclaration::getName, Function.identity()));
+            .collect(Collectors.toMap(Node::getName, Function.identity()));
 
     List<Set<Ancestor>> allAncestors =
         types.stream()

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/TypeManager.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/TypeManager.java
@@ -237,10 +237,16 @@ public class TypeManager {
   public ParameterizedType searchTemplateScopeForDefinedParameterizedTypes(
       Scope scope, String name) {
     if (scope instanceof TemplateScope) {
-      TemplateDeclaration template = (TemplateDeclaration) scope.getAstNode();
-      ParameterizedType parameterizedType = getTypeParameter(template, name);
-      if (parameterizedType != null) {
-        return parameterizedType;
+      var node = scope.getAstNode();
+
+      // We need an additional check here, because of parsing or other errors, the AST node might
+      // not necessarily be a template declaration.
+      if (node instanceof TemplateDeclaration) {
+        TemplateDeclaration template = (TemplateDeclaration) node;
+        ParameterizedType parameterizedType = getTypeParameter(template, name);
+        if (parameterizedType != null) {
+          return parameterizedType;
+        }
       }
     }
 

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/declarations/ClassTemplateDeclaration.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/declarations/ClassTemplateDeclaration.java
@@ -86,7 +86,7 @@ public class ClassTemplateDeclaration extends TemplateDeclaration {
     if (o == null || getClass() != o.getClass()) return false;
     if (!super.equals(o)) return false;
     ClassTemplateDeclaration that = (ClassTemplateDeclaration) o;
-    return realization.equals(that.realization) && parameters.equals(that.parameters);
+    return realization.equals(that.realization) && PropertyEdge.propertyEqualsList(parameters, that.parameters);
   }
 
   // Do NOT add parameters to hashcode, as they are added incrementally to the list. If the

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/declarations/ClassTemplateDeclaration.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/declarations/ClassTemplateDeclaration.java
@@ -86,7 +86,10 @@ public class ClassTemplateDeclaration extends TemplateDeclaration {
     if (o == null || getClass() != o.getClass()) return false;
     if (!super.equals(o)) return false;
     ClassTemplateDeclaration that = (ClassTemplateDeclaration) o;
-    return realization.equals(that.realization) && PropertyEdge.propertyEqualsList(parameters, that.parameters);
+    return Objects.equals(getRealization(), that.getRealization())
+        && PropertyEdge.propertyEqualsList(realization, that.realization)
+        && Objects.equals(getParameters(), that.getParameters())
+        && PropertyEdge.propertyEqualsList(parameters, that.parameters);
   }
 
   // Do NOT add parameters to hashcode, as they are added incrementally to the list. If the

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/declarations/TemplateDeclaration.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/declarations/TemplateDeclaration.java
@@ -134,7 +134,7 @@ public abstract class TemplateDeclaration extends Declaration implements Declara
     if (o == null || getClass() != o.getClass()) return false;
     if (!super.equals(o)) return false;
     TemplateDeclaration that = (TemplateDeclaration) o;
-    return Objects.equals(parameters, that.parameters)
+    return Objects.equals(getParameters(), that.getParameters())
         && PropertyEdge.propertyEqualsList(parameters, that.parameters);
   }
 

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/ArrayCreationExpression.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/ArrayCreationExpression.java
@@ -105,8 +105,8 @@ public class ArrayCreationExpression extends Expression implements TypeListener 
     ArrayCreationExpression that = (ArrayCreationExpression) o;
     return super.equals(that)
         && Objects.equals(initializer, that.initializer)
-        && Objects.equals(dimensions, that.dimensions)
-        && Objects.equals(this.getDimensions(), that.getDimensions());
+        && Objects.equals(this.getDimensions(), that.getDimensions())
+        && PropertyEdge.propertyEqualsList(dimensions, that.dimensions);
   }
 
   @Override

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.java
@@ -396,11 +396,9 @@ public class CallExpression extends Expression
         && Objects.equals(this.getInvokes(), that.getInvokes())
         && PropertyEdge.propertyEqualsList(invokes, that.invokes)
         && Objects.equals(base, that.base)
-        && ((templateParameters == that.templateParameters)
-            || (templateParameters.equals(that.templateParameters)
-                && PropertyEdge.propertyEqualsList(templateParameters, that.templateParameters)))
-        && ((templateInstantiation == that.templateInstantiation)
-            || (templateInstantiation.equals(that.templateInstantiation)))
+        && Objects.equals(getTemplateParameters(), that.getTemplateParameters())
+        && PropertyEdge.propertyEqualsList(templateParameters, that.templateParameters)
+        && Objects.equals(templateInstantiation, that.templateInstantiation)
         && template == that.template;
   }
 

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.java
@@ -733,15 +733,23 @@ public class CallResolver extends Pass {
     List<Type> templateCallSignature = new ArrayList<>();
     for (ParamVariableDeclaration argument : function.getParameters()) {
       if (argument.getType() instanceof ParameterizedType) {
-        templateCallSignature.add(
-            ((TypeExpression)
-                    initializationSignature.get(
-                        parameterizedTypeResolution.get(argument.getType())))
-                .getType());
+        Type type = UnknownType.getUnknownType();
+
+        var typeParamDeclaration = parameterizedTypeResolution.get(argument.getType());
+
+        if (typeParamDeclaration != null) {
+          Node node = initializationSignature.get(typeParamDeclaration);
+          if (node instanceof TypeExpression) {
+            type = ((TypeExpression) node).getType();
+          }
+        }
+
+        templateCallSignature.add(type);
       } else {
         templateCallSignature.add(argument.getType());
       }
     }
+
     return templateCallSignature;
   }
 


### PR DESCRIPTION
* Fixed stack overflow in `ClassTemplateDeclaration::equals`
* Fixed stack overflow in `ArrayCreationExpression::equals`
* Fixed stack overflow in `CallExpression::equals`
* Fixed class cast exception in `TypeManager::getCommonType`
* Fixed NPE in `CallResolver::getCallSignature`
