### PR TITLE
Fixed missing DFG edges in Go frontend

### DIFF
--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -158,3 +158,24 @@ fun Node.followPrevEOG(predicate: (PropertyEdge<*>) -> Boolean): List<PropertyEd
 
     return null
 }
+
+fun Node.followPrevDFG(predicate: (Node) -> Boolean): MutableList<Node>? {
+    val path = mutableListOf<Node>()
+
+    for (prev in this.prevDFG) {
+        path.add(prev)
+
+        if (predicate(prev)) {
+            return path
+        }
+
+        val subPath = prev.followPrevDFG(predicate)
+        if (subPath != null) {
+            path.addAll(subPath)
+        }
+
+        return path
+    }
+
+    return null
+}

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/InitializerListExpression.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/InitializerListExpression.java
@@ -62,6 +62,9 @@ public class InitializerListExpression extends Expression implements TypeListene
     var edge = new PropertyEdge<>(this, initializer);
     edge.addProperty(Properties.INDEX, this.initializers.size());
 
+    initializer.registerTypeListener(this);
+    this.addPrevDFG(initializer);
+
     this.initializers.add(edge);
   }
 

--- a/cpg-language-go/src/main/golang/expressions.go
+++ b/cpg-language-go/src/main/golang/expressions.go
@@ -339,6 +339,10 @@ func (c *ConstructExpression) AddArgument(e *Expression) {
 	(*jnigi.ObjectRef)(c).CallMethod(env, "addArgument", jnigi.Void, (*jnigi.ObjectRef)(e).Cast("de/fraunhofer/aisec/cpg/graph/statements/expressions/Expression"))
 }
 
+func (c *ConstructExpression) AddPrevDFG(n *Node) {
+	(*jnigi.ObjectRef)(c).CallMethod(env, "addPrevDFG", jnigi.Void, (*jnigi.ObjectRef)(n).Cast("de/fraunhofer/aisec/cpg/graph/Node"))
+}
+
 func (n *NewExpression) SetInitializer(e *Expression) (err error) {
 	_, err = (*jnigi.ObjectRef)(n).CallMethod(env, "setInitializer", jnigi.Void, (*jnigi.ObjectRef)(e).Cast("de/fraunhofer/aisec/cpg/graph/statements/expressions/Expression"))
 

--- a/cpg-language-go/src/main/golang/frontend/handler.go
+++ b/cpg-language-go/src/main/golang/frontend/handler.go
@@ -1110,6 +1110,11 @@ func (this *GoLanguageFrontend) handleCompositeLit(fset *token.FileSet, lit *ast
 
 	c.AddArgument((*cpg.Expression)(l))
 
+	// Normally, the construct expression would not have DFG edge, but in this case we are mis-using it
+	// to simulate an object literal, so we need to add a DFG here, otherwise a declaration is disconnected
+	// from its initialization.
+	c.AddPrevDFG((*cpg.Node)(l))
+
 	for _, elem := range lit.Elts {
 		expr := this.handleExpr(fset, elem)
 

--- a/cpg-language-go/src/main/golang/frontend/handler.go
+++ b/cpg-language-go/src/main/golang/frontend/handler.go
@@ -1098,13 +1098,12 @@ func (this *GoLanguageFrontend) handleCompositeLit(fset *token.FileSet, lit *ast
 	c := cpg.NewConstructExpression(fset, lit)
 
 	// parse the type field, to see which kind of expression it is
-	var reference = this.handleExpr(fset, lit.Type)
+	var typ = this.handleType(lit.Type)
 
-	if reference == nil {
-		return nil
+	if typ != nil {
+		(*cpg.Node)(c).SetName((*cpg.Node)(typ).GetName())
+		(*cpg.Expression)(c).SetType(typ)
 	}
-
-	(*cpg.Node)(c).SetName(reference.GetName())
 
 	l := cpg.NewInitializerListExpression(fset, lit)
 

--- a/cpg-language-go/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
+++ b/cpg-language-go/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
@@ -43,6 +43,47 @@ import kotlin.test.assertTrue
 class GoLanguageFrontendTest : BaseTest() {
 
     @Test
+    fun testArrayCompositeLiteral() {
+        val topLevel = Path.of("src", "test", "resources", "golang")
+        val tu =
+            TestUtils.analyzeAndGetFirstTU(
+                listOf(topLevel.resolve("values.go").toFile()),
+                topLevel,
+                true
+            ) {
+                it.registerLanguage(
+                    GoLanguageFrontend::class.java,
+                    GoLanguageFrontend.GOLANG_EXTENSIONS
+                )
+            }
+        assertNotNull(tu)
+
+        val p = tu.byNameOrNull<NamespaceDeclaration>("p")
+        assertNotNull(p)
+
+        val main = p.byNameOrNull<FunctionDeclaration>("main")
+
+        assertNotNull(main)
+
+        val message =
+            main.bodyOrNull<DeclarationStatement>(2)?.singleDeclaration as? VariableDeclaration
+
+        assertNotNull(message)
+
+        val map =
+            ((message.initializer as? ConstructExpression)?.arguments?.firstOrNull() as?
+                InitializerListExpression)
+
+        assertNotNull(map)
+
+        val nameEntry = map.initializers.firstOrNull() as? KeyValueExpression
+
+        assertNotNull(nameEntry)
+
+        assertEquals("string[]", (nameEntry.value as? ConstructExpression)?.name)
+    }
+
+    @Test
     fun testDFG() {
         val topLevel = Path.of("src", "test", "resources", "golang")
         val tu =

--- a/cpg-language-go/src/test/resources/golang/dfg.go
+++ b/cpg-language-go/src/test/resources/golang/dfg.go
@@ -1,0 +1,6 @@
+package p
+
+func main() int {
+    data := &Data{Name: name}
+    db.Create(data)
+}

--- a/cpg-language-go/src/test/resources/golang/values.go
+++ b/cpg-language-go/src/test/resources/golang/values.go
@@ -1,0 +1,13 @@
+package p
+
+import "net/url"
+
+func main() {
+	name := "firstname lastname"
+	data := "data"
+
+	message := url.Values{
+		"Name": []string{name},
+		"Data": []string{data},
+	}
+}


### PR DESCRIPTION
Currently, the declaration of a variable and the expression that represents an object literal, e.g., `d := &Data{}` were not connected with a DFG edge. This was due to the fact that there is not real object literal expression in the CPG and we need to "emulate" it with a combination of a `ConstructExpression` and a `InitializerListExpression`.

Furthermore, a DFG edge was missing in `InitializerListExpression::addInitializer`, it was only set in `setInitializers`.