### PR TITLE
Increased timeout for regression test to 20s

### DIFF
--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/PerformanceRegressionTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/PerformanceRegressionTest.kt
@@ -63,9 +63,9 @@ class PerformanceRegressionTest {
         val tmp = kotlin.io.path.createTempFile("c_range", ".c")
         tmp.writeText(string)
 
-        // this should not exceed 10-15 seconds (it takes about 2800ms on a good machine, about
-        // 8000ms on GitHub)
-        assertTimeout(Duration.of(15, ChronoUnit.SECONDS)) {
+        // this should not exceed 20 seconds (it takes about 2800ms on a good machine, about
+        // 10-20s on GitHub, depending on the slowness of the runner)
+        assertTimeout(Duration.of(20, ChronoUnit.SECONDS)) {
             val tu = analyzeAndGetFirstTU(listOf(tmp.toFile()), tmp.parent, true)
             assertNotNull(tu)
         }


### PR DESCRIPTION
It seems the GitHub runners are getting slower and sometimes they do not hit the 15s target. Performance is still good locally, so we increase the timeout to 20s for less flaky tests.