### PR TITLE
Build go language frontend on jitpack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -2,7 +2,7 @@ jdk:
   - openjdk11
 before_install:
   mkdir -p ~/go
-  wget -q https://go.dev/dl/go1.18.3.linux-amd64.tar.gz && tar -C ~/go -xzf go1.18.3.linux-amd64.tar.gz
+  wget -Q https://go.dev/dl/go1.18.3.linux-amd64.tar.gz && tar -C ~/go -xzf go1.18.3.linux-amd64.tar.gz
   export PATH=$PATH:~/go
 install:
   go version

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,9 +1,9 @@
 jdk:
   - openjdk11
 before_install:
-  mkdir -p ~/go
-  wget -Q https://go.dev/dl/go1.18.3.linux-amd64.tar.gz && tar -C ~/go -xzf go1.18.3.linux-amd64.tar.gz
-  export PATH=$PATH:~/go
+  - mkdir -p ~/go
+  - wget -q https://go.dev/dl/go1.18.3.linux-amd64.tar.gz && tar -C ~/go -xzf go1.18.3.linux-amd64.tar.gz
+  - export PATH=$PATH:~/go
 install:
   go version
   #- ./gradlew build -xtest -Pgroup=com.github.Fraunhofer-AISEC -PnodeDownload=true -PskipGoBuild publishToMavenLocal

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,7 @@
 jdk:
   - openjdk11
+before_install:
+  wget https://go.dev/dl/go1.18.3.linux-amd64.tar.gz && tar -C /usr/local -xzf gogo1.18.3.linux-amd64.tar.gz
+  go version
 install:
   - ./gradlew build -xtest -Pgroup=com.github.Fraunhofer-AISEC -PnodeDownload=true -PskipGoBuild publishToMavenLocal

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -3,7 +3,8 @@ jdk:
 before_install:
   - mkdir -p ~/go
   - wget -q https://go.dev/dl/go1.18.3.linux-amd64.tar.gz && tar -C ~/go -xzf go1.18.3.linux-amd64.tar.gz
+  - ls -l ~/go
 install:
-  - export PATH="$PATH:$HOME/go"
+  - export PATH="$PATH:$HOME/go/bin"
   - go version
   #- ./gradlew build -xtest -Pgroup=com.github.Fraunhofer-AISEC -PnodeDownload=true -PskipGoBuild publishToMavenLocal

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -3,7 +3,7 @@ jdk:
 before_install:
   - mkdir -p ~/go
   - wget -q https://go.dev/dl/go1.18.3.linux-amd64.tar.gz && tar -C ~/go -xzf go1.18.3.linux-amd64.tar.gz
-  - export PATH=$PATH:~/go
 install:
-  go version
+  - export PATH="$PATH:$HOME/go"
+  - go version
   #- ./gradlew build -xtest -Pgroup=com.github.Fraunhofer-AISEC -PnodeDownload=true -PskipGoBuild publishToMavenLocal

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,7 +1,9 @@
 jdk:
   - openjdk11
 before_install:
-  wget -q https://go.dev/dl/go1.18.3.linux-amd64.tar.gz && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz
+  mkdir -p ~/go
+  wget -q https://go.dev/dl/go1.18.3.linux-amd64.tar.gz && tar -C ~/go -xzf go1.18.3.linux-amd64.tar.gz
+  export PATH=$PATH:~/go
 install:
   go version
   #- ./gradlew build -xtest -Pgroup=com.github.Fraunhofer-AISEC -PnodeDownload=true -PskipGoBuild publishToMavenLocal

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -6,5 +6,4 @@ before_install:
   - ls -l ~/go
 install:
   - export PATH="$PATH:$HOME/go/bin"
-  - go version
-  #- ./gradlew build -xtest -Pgroup=com.github.Fraunhofer-AISEC -PnodeDownload=true -PskipGoBuild publishToMavenLocal
+  - ./gradlew build -xtest -Pgroup=com.github.Fraunhofer-AISEC -PnodeDownload=true publishToMavenLocal

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,7 +1,7 @@
 jdk:
   - openjdk11
 before_install:
-  wget https://go.dev/dl/go1.18.3.linux-amd64.tar.gz && tar -C /usr/local -xzf gogo1.18.3.linux-amd64.tar.gz
-  go version
+  wget -q https://go.dev/dl/go1.18.3.linux-amd64.tar.gz && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz
 install:
-  - ./gradlew build -xtest -Pgroup=com.github.Fraunhofer-AISEC -PnodeDownload=true -PskipGoBuild publishToMavenLocal
+  go version
+  #- ./gradlew build -xtest -Pgroup=com.github.Fraunhofer-AISEC -PnodeDownload=true -PskipGoBuild publishToMavenLocal


### PR DESCRIPTION
This finally enables the build of the `go` language frontend on jitpack builds. Note however, due to the nature of the go library, only the native libraries for linux are included in the jar. This is due to the fact that we need to use `cgo` in order to interface with JNI and `cgo` does not allow cross-compiling the library to other platforms.