### PR TITLE
Added support for `-arch` clang command in compilation database

### DIFF
--- a/cpg-core/build.gradle.kts
+++ b/cpg-core/build.gradle.kts
@@ -108,7 +108,11 @@ dependencies {
     api("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.3")
 
     // Eclipse dependencies
-    api("org.eclipse.platform:org.eclipse.core.runtime:3.24.100")
+    api("org.eclipse.platform:org.eclipse.core.runtime:3.24.100") {
+        // For some reason, this group name is wrong
+        exclude("org.osgi.service", "org.osgi.service.prefs")
+    }
+    api("org.osgi", "org.osgi.service.prefs", "1.1.2")
     api("com.ibm.icu:icu4j:71.1")
 
     // CDT

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXCompilationDatabaseTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXCompilationDatabaseTest.kt
@@ -32,9 +32,9 @@ import de.fraunhofer.aisec.cpg.graph.statements.ReturnStatement
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Literal
 import java.io.File
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import org.junit.jupiter.api.Test
 
 class CXXCompilationDatabaseTest {
     @Test
@@ -127,11 +127,20 @@ class CXXCompilationDatabaseTest {
 
             val s0 = mainFunc.getBodyStatementAs(0, Literal::class.java)
             assertNotNull(s0)
-            assertEquals(s0.value, value)
+            assertEquals(value, s0.value)
 
             val s1 = mainFunc.getBodyStatementAs(1, Literal::class.java)
             assertNotNull(s1)
-            assertEquals(s1.value, value)
+            assertEquals(value, s1.value)
         }
+    }
+
+    @Test
+    fun testCompilationDatabaseArch() {
+        val cc = File("src/test/resources/cxxCompilationDatabase/compile_commands_arch.json")
+        val result = TestUtils.analyzeWithCompilationDatabase(cc, true)
+
+        val main = result.translationUnits.firstOrNull()?.byNameOrNull<FunctionDeclaration>("main")
+        assertNotNull(main)
     }
 }

--- a/cpg-core/src/test/resources/cxxCompilationDatabase/compile_commands_arch.json
+++ b/cpg-core/src/test/resources/cxxCompilationDatabase/compile_commands_arch.json
@@ -1,0 +1,7 @@
+[
+  {
+    "command": "/usr/bin/clang -arch arm64 -c main_arm64.c -o main_arm64",
+    "directory": "src/test/resources/cxxCompilationDatabase",
+    "file": "src/test/resources/cxxCompilationDatabase/main_arm64.c"
+  }
+]

--- a/cpg-core/src/test/resources/cxxCompilationDatabase/main_arm64.c
+++ b/cpg-core/src/test/resources/cxxCompilationDatabase/main_arm64.c
@@ -1,0 +1,4 @@
+#if defined(__arm64__)
+int main() {}
+#else
+#endif


### PR DESCRIPTION
This PR adds support for the `-arch` clang command in the compilation database by automatically adding an appropriate symbol to the language frontend.
