### PR TITLE
Rename `cpg` submodule to `cpg-all`

### DIFF
--- a/cpg-all/build.gradle.kts
+++ b/cpg-all/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 publishing {
     publications {
-        named<MavenPublication>("cpg") {
+        named<MavenPublication>("cpg-all") {
             pom {
                 artifactId = "cpg" // for legacy reasons (this will be renamed to cpg-core at some point)
                 name.set("Code Property Graph")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("com.gradle.enterprise") version("3.6.4")
 }
 
-include(":cpg")
+include(":cpg-all")
 include(":cpg-core")
 include(":cpg-analysis")
 include(":cpg-neo4j")


### PR DESCRIPTION
Fixes issue when adding the cpg project as an 'includeBuild' in a project that uses project accessors (see: https://github.com/gradle/gradle/issues/16608)