### PR TITLE
Introduction of `callee` in `CallExpression`

### DIFF
--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.kt
@@ -468,8 +468,7 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
                 )
         } else if (reference is UnaryOperator && reference.operatorCode == "*") {
             // Classic C-style function pointer call -> let's extract the target
-            callExpression =
-                NodeBuilder.newCallExpression(reference.input.name, "", reference.code, false)
+            callExpression = NodeBuilder.newCallExpression(reference, "", reference.code, false)
         } else if (
             ctx.functionNameExpression is IASTIdExpression &&
                 (ctx.functionNameExpression as IASTIdExpression).name is CPPASTTemplateId
@@ -478,7 +477,8 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
                 ((ctx.functionNameExpression as IASTIdExpression).name as CPPASTTemplateId)
                     .templateName
                     .toString()
-            callExpression = NodeBuilder.newCallExpression(name, name, ctx.rawSignature, true)
+            val ref = NodeBuilder.newDeclaredReferenceExpression(name)
+            callExpression = NodeBuilder.newCallExpression(ref, name, ctx.rawSignature, true)
             getTemplateArguments(
                     (ctx.functionNameExpression as IASTIdExpression).name as CPPASTTemplateId
                 )
@@ -506,7 +506,7 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
             // if (!fullNamePrefix.isEmpty()) {
             //  fqn = fullNamePrefix + "." + fqn;
             // }
-            callExpression = NodeBuilder.newCallExpression(name, fqn, ctx.rawSignature, false)
+            callExpression = NodeBuilder.newCallExpression(reference, fqn, ctx.rawSignature, false)
         }
 
         for ((i, argument) in ctx.arguments.withIndex()) {

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java
@@ -730,8 +730,9 @@ public class ExpressionHandler extends Handler<Statement, Expression, JavaLangua
                 name, qualifiedName, methodCallExpr.toString(), targetClass);
       }
     } else {
+      var ref = NodeBuilder.newDeclaredReferenceExpression(name);
       callExpression =
-          NodeBuilder.newCallExpression(name, qualifiedName, methodCallExpr.toString(), false);
+          NodeBuilder.newCallExpression(ref, qualifiedName, methodCallExpr.toString(), false);
     }
 
     callExpression.setType(TypeParser.createFrom(typeString, true));

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -57,7 +57,7 @@ object NodeBuilder {
     @JvmStatic
     @JvmOverloads
     fun newCallExpression(
-        name: String?,
+        callee: Expression?,
         fqn: String?,
         code: String? = null,
         template: Boolean,
@@ -65,7 +65,7 @@ object NodeBuilder {
         rawNode: Any? = null
     ): CallExpression {
         val node = CallExpression()
-        node.name = name!!
+        node.callee = callee
         node.setCodeAndRegion(lang, rawNode, code)
         node.fqn = fqn
         node.template = template

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
@@ -36,6 +36,7 @@ import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsL
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.transformIntoOutgoingPropertyEdgeList
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.unwrap
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
+import de.fraunhofer.aisec.cpg.graph.types.FunctionPointerType
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.passes.CallResolver
 import java.util.*
@@ -106,10 +107,16 @@ open class CallExpression : Expression(), HasType.TypeListener, HasBase, Seconda
         set(value) {
             field?.unregisterTypeListener(this)
 
-            // We also want to update this node's name, based on the callee. This is purely for
-            // readability reasons
             field = value
-            this.name = value?.name ?: ""
+            // We also want to update this node's name, based on the callee. This is purely for
+            // readability reasons. We have a special handling for function pointers, where we want
+            // to have the name of the variable. This might change in the future.
+            this.name =
+                if (value is UnaryOperator && value.input.type is FunctionPointerType) {
+                    value.input.name
+                } else {
+                    value?.name ?: ""
+                }
 
             // Register the callee as a type listener for this call expressions. Once we re-design
             // call resolution, we need to probably do this in the opposite way so that the call

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
@@ -39,6 +39,7 @@ import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
 import de.fraunhofer.aisec.cpg.graph.types.FunctionPointerType
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.passes.CallResolver
+import de.fraunhofer.aisec.cpg.passes.VariableUsageResolver
 import java.util.*
 import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.Relationship
@@ -100,7 +101,9 @@ open class CallExpression : Expression(), HasType.TypeListener, HasBase, Seconda
 
     /**
      * The expression that is being "called". This is currently not yet used in the [CallResolver]
-     * but will be in the future.
+     * but will be in the future. In most cases, this is a [DeclaredReferenceExpression] and its
+     * [DeclaredReferenceExpression.refersTo] is intentionally left empty. It is not filled by the
+     * [VariableUsageResolver].
      */
     @field:SubGraph("AST")
     var callee: Expression? = null

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
@@ -97,6 +97,26 @@ open class CallExpression : Expression(), HasType.TypeListener, HasBase, Seconda
             value?.registerTypeListener(this)
         }
 
+    /**
+     * The expression that is being "called". This is currently not yet used in the [CallResolver]
+     * but will be in the future.
+     */
+    @field:SubGraph("AST")
+    var callee: Expression? = null
+        set(value) {
+            field?.unregisterTypeListener(this)
+
+            // We also want to update this node's name, based on the callee. This is purely for
+            // readability reasons
+            field = value
+            this.name = value?.name ?: ""
+
+            // Register the callee as a type listener for this call expressions. Once we re-design
+            // call resolution, we need to probably do this in the opposite way so that the call
+            // expressions listens for the type of the callee.
+            field?.registerTypeListener(this)
+        }
+
     var fqn: String? = null
 
     fun setArgument(index: Int, argument: Expression) {

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.java
@@ -32,6 +32,7 @@ import de.fraunhofer.aisec.cpg.TranslationResult;
 import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguageFrontend;
 import de.fraunhofer.aisec.cpg.graph.*;
 import de.fraunhofer.aisec.cpg.graph.declarations.*;
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression;
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.DeclaredReferenceExpression;
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberCallExpression;
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberExpression;
@@ -209,6 +210,13 @@ public class VariableUsageResolver extends Pass {
         return;
       }
 
+      // For now, we need to ignore reference expressions that are directly embedded into call
+      // expressions, because they are the "callee" property. In the future, we will use this
+      // property to actually resolve the function call.
+      if (parent instanceof CallExpression && ((CallExpression) parent).getCallee() == current) {
+        return;
+      }
+
       // only consider resolving, if the language frontend did not specify a resolution
       Optional<? extends Declaration> refersTo =
           ref.getRefersTo() == null
@@ -267,7 +275,7 @@ public class VariableUsageResolver extends Pass {
     }
   }
 
-  protected void resolveFieldUsages(Node current, RecordDeclaration curClass) {
+  protected void resolveFieldUsages(RecordDeclaration curClass, Node parent, Node current) {
     if (current instanceof MemberExpression) {
       MemberExpression memberExpression = (MemberExpression) current;
       Declaration baseTarget = null;

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManagerTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManagerTest.kt
@@ -130,7 +130,13 @@ internal class ScopeManagerTest : BaseTest() {
         assertEquals(scopeA, final.lookupScope(namespaceA2))
 
         // resolve symbol
-        val call = NodeBuilder.newCallExpression("func1", "A::func1", null, false)
+        val call =
+            NodeBuilder.newCallExpression(
+                NodeBuilder.newDeclaredReferenceExpression("func1"),
+                "A::func1",
+                null,
+                false
+            )
         val func = final.resolveFunction(call).firstOrNull()
 
         assertEquals(func1, func)

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/StatementHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/StatementHandler.kt
@@ -299,7 +299,7 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
 
         val dummyCall =
             newCallExpression(
-                "llvm.catchswitch",
+                llvmInternalRef("llvm.catchswitch"),
                 "llvm.catchswitch",
                 lang.getCodeFromRawNode(instr),
                 false
@@ -331,7 +331,7 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
 
             val matchesCatchpad =
                 newCallExpression(
-                    "llvm.matchesCatchpad",
+                    llvmInternalRef("llvm.matchesCatchpad"),
                     "llvm.matchesCatchpad",
                     lang.getCodeFromRawNode(instr),
                     false
@@ -387,7 +387,7 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
 
         val dummyCall =
             newCallExpression(
-                "llvm.cleanuppad",
+                llvmInternalRef("llvm.cleanuppad"),
                 "llvm.cleanuppad",
                 lang.getCodeFromRawNode(instr),
                 false
@@ -414,7 +414,7 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
 
         val dummyCall =
             newCallExpression(
-                "llvm.catchpad",
+                llvmInternalRef("llvm.catchpad"),
                 "llvm.catchpad",
                 lang.getCodeFromRawNode(instr),
                 false
@@ -436,7 +436,12 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
     @FunctionReplacement(["llvm.va_arg"], "va_arg")
     private fun handleVaArg(instr: LLVMValueRef): Statement {
         val callExpr =
-            newCallExpression("llvm.va_arg", "llvm.va_arg", lang.getCodeFromRawNode(instr), false)
+            newCallExpression(
+                llvmInternalRef("llvm.va_arg"),
+                "llvm.va_arg",
+                lang.getCodeFromRawNode(instr),
+                false
+            )
         val operandName = lang.getOperandValueAtIndex(instr, 0)
         callExpr.addArgument(operandName)
         val expectedType = lang.typeOf(instr)
@@ -770,7 +775,8 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
         // randomly.
         // The implementation of this function would depend on the data type (e.g. for integers, it
         // could be rand())
-        val callExpression = newCallExpression("llvm.freeze", "llvm.freeze", instrCode, false)
+        val callExpression =
+            newCallExpression(llvmInternalRef("llvm.freeze"), "llvm.freeze", instrCode, false)
         callExpression.addArgument(operand)
 
         // res = (arg != undef && arg != poison) ? arg : llvm.freeze(in)
@@ -789,7 +795,8 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
     @FunctionReplacement(["llvm.fence"], "fence")
     private fun handleFence(instr: LLVMValueRef): Statement {
         val instrString = lang.getCodeFromRawNode(instr)
-        val callExpression = newCallExpression("llvm.fence", "llvm.fence", instrString, false)
+        val callExpression =
+            newCallExpression(llvmInternalRef("llvm.fence"), "llvm.fence", instrString, false)
         val ordering =
             newLiteral(
                 LLVMGetOrdering(instr),
@@ -1119,7 +1126,14 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
             )
         }
 
-        val callExpr = newCallExpression(calledFuncName, calledFuncName, instrStr, false)
+        val callee =
+            newDeclaredReferenceExpression(
+                calledFuncName,
+                lang.typeOf(calledFunc),
+                lang.getCodeFromRawNode(calledFunc)
+            )
+
+        val callExpr = newCallExpression(callee, calledFuncName, instrStr, false)
 
         while (idx < max) {
             val operandName = lang.getOperandValueAtIndex(instr, idx)
@@ -1520,7 +1534,7 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
             // Resulting statement: i1 lhs = isordered(op1, op2)
             binaryOperator =
                 newCallExpression(
-                    "isunordered",
+                    llvmInternalRef("isunordered"),
                     "isunordered",
                     LLVMPrintValueToString(instr).string,
                     false
@@ -1532,7 +1546,7 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
             // Resulting statement: i1 lhs = !isordered(op1, op2)
             val unorderedCall =
                 newCallExpression(
-                    "isunordered",
+                    llvmInternalRef("isunordered"),
                     "isunordered",
                     LLVMPrintValueToString(instr).string,
                     false
@@ -1571,7 +1585,7 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
                 binOpUnordered.rhs = binaryOperator
                 val unorderedCall =
                     newCallExpression(
-                        "isunordered",
+                        llvmInternalRef("isunordered"),
                         "isunordered",
                         LLVMPrintValueToString(instr).string,
                         false
@@ -1642,5 +1656,13 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
             }
         }
         return labelName
+    }
+
+    /**
+     * This functions creates a new [DeclaredReferenceExpression] to an internal LLVM function. This
+     * would allow us to handle them all in the same way.
+     */
+    private fun llvmInternalRef(name: String): DeclaredReferenceExpression {
+        return newDeclaredReferenceExpression(name, lang = lang)
     }
 }

--- a/cpg-language-python/src/main/python/CPGPython/_expressions.py
+++ b/cpg-language-python/src/main/python/CPGPython/_expressions.py
@@ -219,7 +219,7 @@ def handle_expression_impl(self, expr):
                     return cast
                 else:
                     call = NodeBuilder.newCallExpression(
-                        name, name, self.get_src_code(expr), False)
+                        ref, name, self.get_src_code(expr), False)
         for a in expr.args:
             call.addArgument(self.handle_expression(a))
         for keyword in expr.keywords:

--- a/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/ExpressionHandler.kt
+++ b/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/ExpressionHandler.kt
@@ -247,8 +247,11 @@ class ExpressionHandler(lang: TypeScriptLanguageFrontend) :
             // TODO: fqn - how?
             val fqn = name
             // regular function call
+
+            val ref = NodeBuilder.newDeclaredReferenceExpression(name)
+
             call =
-                NodeBuilder.newCallExpression(name, fqn, this.lang.getCodeFromRawNode(node), false)
+                NodeBuilder.newCallExpression(ref, fqn, this.lang.getCodeFromRawNode(node), false)
         }
 
         // parse the arguments. the first node is the identifier, so we skip that


### PR DESCRIPTION
This PR introduces an additional field `callee` in a call expression. The idea behind this field is to have an `Expression` that is being "called" by the call expression. For most cases, this will be a `DeclaredReferenceExpression` pointing to the function declaration. However, in some languages, other things might be "callable".

Note, that this is currently not yet used in the `CallResolver`, but only introduces the field in preparation of #773 
