### PR TITLE
don't use broken isAnnotationPresent() check

### DIFF
--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/TranslationConfiguration.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/TranslationConfiguration.java
@@ -502,7 +502,7 @@ public class TranslationConfiguration {
     private void registerExtraFrontendPasses() throws ConfigurationException {
 
       for (Class<? extends LanguageFrontend> frontend : frontends.keySet()) {
-        if (frontend.isAnnotationPresent(RegisterExtraPass.class)) {
+        if (frontend.getAnnotationsByType(RegisterExtraPass.class).length != 0) {
           RegisterExtraPass[] extraPasses = frontend.getAnnotationsByType(RegisterExtraPass.class);
           for (RegisterExtraPass p : extraPasses) {
             try {

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/Pass.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/Pass.java
@@ -67,7 +67,7 @@ public abstract class Pass implements Consumer<@NotNull TranslationResult> {
     softDependencies = new HashSet<>();
 
     // collect all dependencies added by [DependsOn] annotations.
-    if (this.getClass().isAnnotationPresent(DependsOn.class)) {
+    if (this.getClass().getAnnotationsByType(DependsOn.class).length != 0) {
       DependsOn[] dependencies = this.getClass().getAnnotationsByType(DependsOn.class);
       for (DependsOn d : dependencies) {
         if (d.softDependency()) {


### PR DESCRIPTION
The previously used `isAnnotationPresent` check does not properly work with `repeatable` annotations as they are internally collected in a "container" annotation (which is not checked by `isAnnotationPresent`). However, `getAnnotationsByType` also checks containers and seems to work as the name suggests unlike the previously used function