### PR TITLE
Fixed javadoc jar generation with dokka

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@
  *                    \______/ \__|       \______/
  *
  */
+import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -72,9 +73,17 @@ subprojects {
     apply(plugin = "maven-publish")
     apply(plugin = "signing")
 
+    val dokkaHtml by tasks.getting(DokkaTask::class)
+    val javadocJar by tasks.registering(Jar::class) {
+        dependsOn(dokkaHtml)
+        archiveClassifier.set("javadoc")
+        from(dokkaHtml.outputDirectory)
+    }
+
     publishing {
         publications {
             create<MavenPublication>(name) {
+                artifact(javadocJar)
                 from(components["java"])
 
                 pom {
@@ -143,7 +152,7 @@ subprojects {
     }
 
     java {
-        withJavadocJar()
+        //withJavadocJar()
         withSourcesJar()
     }
 

--- a/cpg-language-python/build.gradle.kts
+++ b/cpg-language-python/build.gradle.kts
@@ -86,12 +86,6 @@ tasks.named<Test>("test") {
     maxHeapSize = "4048m"
 }
 
-
-java {
-    withJavadocJar()
-    withSourcesJar()
-}
-
 signing {
     val signingKey: String? by project
     val signingPassword: String? by project


### PR DESCRIPTION
This PR fixes a problem that was introduced by dokka, where we ended up with an empty javadoc jar.
