### PR TITLE
Introduce `Name` class and delegate `name` property of `Node` to a backing field

### DIFF
--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/Name.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/Name.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.graph
+
+import java.util.*
+import kotlin.reflect.KProperty
+
+/**
+ * This class represents anything that can have a "Name". In the simplest case it only represents a
+ * local name in a flat hierarchy, such as `myVariable`. However, it can also be used to represent
+ * fully qualified name with a complex name hierarchy, such as `my::namespace::function`.
+ */
+class Name(
+    /** The local name (sometimes also called simple name) without any namespace information. */
+    var localName: String,
+    /** The parent name, e.g,. the namespace this name lives in. */
+    var parent: Name? = null,
+    /** A potential namespace delimiter, usually either `.` or `::`. */
+    val delimiter: String = "."
+) {
+    /**
+     * Returns the string representation of this name using a fully qualified name notation with the
+     * specified [delimiter].
+     */
+    override fun toString() =
+        (if (parent != null) parent.toString() + delimiter else "") + localName
+
+    /** Implements kotlin propety delegation for a string getter. Returns the local name. */
+    operator fun getValue(node: Node, property: KProperty<*>) = localName
+
+    /**
+     * Implements kotlin property delegation for a string setter. Sets the local name to the
+     * supplied string.
+     */
+    operator fun setValue(node: Node, property: KProperty<*>, s: String) {
+        localName = s
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Name) return false
+
+        return localName == other.localName &&
+            parent == other.parent &&
+            delimiter == other.delimiter
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(localName, parent, delimiter)
+    }
+
+    companion object {
+        /**
+         * Tries to parse the given fully qualified name using the specified [delimiter] into a
+         * [Name].
+         */
+        fun parse(fqn: String, delimiter: String = "."): Name {
+            val parts = fqn.split(delimiter)
+
+            var name: Name? = null
+            for (part in parts) {
+                name = Name(part, name, delimiter)
+            }
+
+            // Actually this should not occur, but otherwise the compiler won't let us return a
+            // non-null Name
+            if (name == null) {
+                return Name(fqn, null, delimiter)
+            }
+
+            return name
+        }
+    }
+}

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -35,6 +35,7 @@ import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.processing.IVisitable
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 import java.util.*
+import kotlin.reflect.KProperty
 import org.apache.commons.lang3.builder.ToStringBuilder
 import org.apache.commons.lang3.builder.ToStringStyle
 import org.neo4j.ogm.annotation.GeneratedValue
@@ -44,10 +45,25 @@ import org.neo4j.ogm.annotation.typeconversion.Convert
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+class Name(var localName: String, var parent: Name? = null, private val delimiter: String = ".") {
+    override fun toString() =
+        localName + (if (parent != null) delimiter + parent.toString() else "")
+    override fun equals(other: Any?): Boolean = TODO("Add checks for both Name objects and Strings")
+    override fun hashCode() = toString().hashCode()
+    operator fun getValue(node: Node, property: KProperty<*>) = toString()
+    operator fun setValue(node: Node, property: KProperty<*>, s: String) {
+        parent = null
+        localName = s
+        // maybe analyze [s] to generate parents too
+    }
+}
+
 /** The base class for all graph objects that are going to be persisted in the database. */
 open class Node : IVisitable<Node>, Persistable {
+    val fullName: Name = Name(EMPTY_NAME)
+
     /** A human readable name. */
-    open var name = EMPTY_NAME // initialize it with an empty string
+    open var name by fullName
 
     /**
      * Original code snippet of this node. Most nodes will have a corresponding "code", but in cases

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -50,7 +50,9 @@ class Name(var localName: String, var parent: Name? = null, private val delimite
         localName + (if (parent != null) delimiter + parent.toString() else "")
     override fun equals(other: Any?): Boolean = TODO("Add checks for both Name objects and Strings")
     override fun hashCode() = toString().hashCode()
-    operator fun getValue(node: Node, property: KProperty<*>) = toString()
+
+    operator fun getValue(node: Node, property: KProperty<*>) = localName
+
     operator fun setValue(node: Node, property: KProperty<*>, s: String) {
         parent = null
         localName = s

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -34,6 +34,7 @@ import de.fraunhofer.aisec.cpg.helpers.LocationConverter
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.processing.IVisitable
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
+import java.util.*
 import org.apache.commons.lang3.builder.ToStringBuilder
 import org.apache.commons.lang3.builder.ToStringStyle
 import org.neo4j.ogm.annotation.GeneratedValue
@@ -43,7 +44,6 @@ import org.neo4j.ogm.annotation.Transient
 import org.neo4j.ogm.annotation.typeconversion.Convert
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.util.*
 
 /** The base class for all graph objects that are going to be persisted in the database. */
 open class Node : IVisitable<Node>, Persistable {

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/NameTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/NameTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.graph
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+internal class NameTest {
+
+    @Test
+    fun testToString() {
+        val simple = Name("myFunc")
+        assertEquals("myFunc", simple.toString())
+
+        val name = Name("string", Name("std"), "::")
+        assertEquals("std::string", name.toString())
+
+        val complex = Name("function", Name("namespace", Name("my")))
+        assertEquals("my.namespace.function", complex.toString())
+    }
+
+    @Test
+    fun testEquals() {
+        val a = Name("string", Name("std"), "::")
+        val b = Name("string", Name("std"), "::")
+        val c = Name("vector", Name("std"), "::")
+
+        assertEquals(a, b)
+        assertNotEquals(a, c)
+        assertNotEquals(b, c)
+    }
+
+    @Test
+    fun testParse() {
+        val fqn = "std::string"
+
+        val name = Name.parse(fqn, "::")
+        assertEquals(fqn, name.toString())
+    }
+}

--- a/cpg-language-go/src/main/golang/node.go
+++ b/cpg-language-go/src/main/golang/node.go
@@ -38,7 +38,7 @@ import (
 type Node jnigi.ObjectRef
 
 func (n *Node) SetName(s string) error {
-	return (*jnigi.ObjectRef)(n).SetField(env, "name", NewString(s))
+	return (*jnigi.ObjectRef)(n).CallMethod(env, "setName", nil, NewString(s))
 }
 
 func (n *Node) SetCode(s string) error {


### PR DESCRIPTION
This PR introduces a new `Name` class which represents all things that have a name. It will be the future decision point of symbol resolving based on local names and namespaces. In the meantime, we provide a bridge using Kotlin property delegation to not break anything (yet).