### PR TITLE
Update slf4j and log4j

### DIFF
--- a/cpg-console/build.gradle.kts
+++ b/cpg-console/build.gradle.kts
@@ -66,7 +66,8 @@ dependencies {
     api(project(":cpg-analysis"))
     api(project(":cpg-neo4j"))
 
-    implementation("org.apache.logging.log4j:log4j-slf4j18-impl:2.18.0")
+    implementation("org.apache.logging.log4j:log4j-slf4j2-impl:2.19.0")
+    implementation("org.apache.logging.log4j:log4j-core:2.19.0")
 
     testImplementation(testFixtures(project(":cpg-core")))
 

--- a/cpg-core/build.gradle.kts
+++ b/cpg-core/build.gradle.kts
@@ -58,9 +58,8 @@ dependencies {
 
     api("org.neo4j:neo4j-ogm-core:3.2.37")
 
-    api("org.slf4j:jul-to-slf4j:2.0.3")
-    api("org.slf4j:slf4j-api:2.0.3")
-    implementation("org.apache.logging.log4j:log4j-slf4j18-impl:2.18.0")
+    implementation("org.apache.logging.log4j:log4j-slf4j2-impl:2.19.0")
+    implementation("org.apache.logging.log4j:log4j-core:2.19.0")
 
     api("com.github.javaparser:javaparser-symbol-solver-core:3.24.4")
     api("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.4")

--- a/cpg-neo4j/build.gradle.kts
+++ b/cpg-neo4j/build.gradle.kts
@@ -74,7 +74,8 @@ dependencies {
     api(project(":cpg-language-go"))
     api(project(":cpg-language-typescript"))
 
-    implementation("org.apache.logging.log4j:log4j-slf4j18-impl:2.18.0")
+    implementation("org.apache.logging.log4j:log4j-slf4j2-impl:2.19.0")
+    implementation("org.apache.logging.log4j:log4j-core:2.19.0")
 
     // neo4j
     api("org.neo4j", "neo4j-ogm-core", versions["neo4j-ogm"])


### PR DESCRIPTION
Currently, we are using an old version of the logging API, which results in a warning when starting the cpg:
```
Unexpected problem occured during version sanity check
Reported exception:
java.lang.AbstractMethodError: Receiver class org.apache.logging.slf4j.SLF4JServiceProvider does not define or inherit an implementation of the resolved method 'abstract java.lang.String getRequestedApiVersion()' of interface org.slf4j.spi.SLF4JServiceProvider.
    at org.slf4j.LoggerFactory.versionSanityCheck(LoggerFactory.java:298)
    at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:141)
    at org.slf4j.LoggerFactory.getProvider(LoggerFactory.java:422)
    at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:408)
    at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:357)
    at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:383)
    at de.fraunhofer.aisec.cpg.TranslationConfiguration.<clinit>(TranslationConfiguration.java:57)
    at de.fraunhofer.aisec.cpg_vis_neo4j.Application.setupTranslationConfiguration(Application.kt:326)
    at de.fraunhofer.aisec.cpg_vis_neo4j.Application.call(Application.kt:414)
    at de.fraunhofer.aisec.cpg_vis_neo4j.Application.call(Application.kt:70)
    at picocli.CommandLine.executeUserObject(CommandLine.java:1953)
    at picocli.CommandLine.access$1300(CommandLine.java:145)
    at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2358)
    at picocli.CommandLine$RunLast.handle(CommandLine.java:2352)
    at picocli.CommandLine$RunLast.handle(CommandLine.java:2314)
    at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
    at picocli.CommandLine$RunLast.execute(CommandLine.java:2316)
    at picocli.CommandLine.execute(CommandLine.java:2078)
    at de.fraunhofer.aisec.cpg_vis_neo4j.ApplicationKt.main(Application.kt:459)
[...]
```

This PR updates the slf4j and log4j dependencies to the new version.