### PR TITLE
Trying to make the regression test slightly faster

### DIFF
--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/PerformanceRegressionTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/PerformanceRegressionTest.kt
@@ -66,7 +66,15 @@ class PerformanceRegressionTest {
         // this should not exceed 20 seconds (it takes about 2800ms on a good machine, about
         // 10-20s on GitHub, depending on the slowness of the runner)
         assertTimeout(Duration.of(20, ChronoUnit.SECONDS)) {
-            val tu = analyzeAndGetFirstTU(listOf(tmp.toFile()), tmp.parent, true)
+            val tu =
+                analyzeAndGetFirstTU(listOf(tmp.toFile()), tmp.parent, true) {
+                    // No need for parallel processing for a single file. this might make it fast
+                    // enough for those special moments where for some reasons the GitHub runners
+                    // are
+                    // slowing down (maybe because of some hidden quota).
+                    it.useParallelFrontends(false)
+                    it.typeSystemActiveInFrontend(true)
+                }
             assertNotNull(tu)
         }
     }


### PR DESCRIPTION
We currently experience an issue on GitHub where sometimes (maybe because some hidden quota is hit), the GitHub runners slow down and we are not able to finish the regression test in time (20s), even though it still takes only about 2s on a good machine (aka my MacBook).

This disables parallel processing and might make it just fast enough for those special moments. Let's see.
