### PR TITLE
Increased performance timeout to 25s because of slow GitHub runners

### DIFF
--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/PerformanceRegressionTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/PerformanceRegressionTest.kt
@@ -63,9 +63,9 @@ class PerformanceRegressionTest {
         val tmp = kotlin.io.path.createTempFile("c_range", ".c")
         tmp.writeText(string)
 
-        // this should not exceed 20 seconds (it takes about 2800ms on a good machine, about
+        // this should not exceed 25 seconds (it takes about 2800ms on a good machine, about
         // 10-20s on GitHub, depending on the slowness of the runner)
-        assertTimeout(Duration.of(20, ChronoUnit.SECONDS)) {
+        assertTimeout(Duration.of(25, ChronoUnit.SECONDS)) {
             val tu =
                 analyzeAndGetFirstTU(listOf(tmp.toFile()), tmp.parent, true) {
                     // No need for parallel processing for a single file. this might make it fast


### PR DESCRIPTION
It seems that GitHub runners are getting slower and slower... This test still executes in 3-4s on my MacBook Pro M1.