### PR TITLE
Fix issue #709 

### DIFF
--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.kt
@@ -241,6 +241,9 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
                 frontend.expressionHandler.handle(argument as IASTInitializerClause)?.let {
                     templateArguments.add(it)
                 }
+            }  else if (argument is IASTIdExpression) {
+                // add to templateArguments
+                frontend.expressionHandler.handle(argument)?.let { templateArguments.add(it) }
             }
         }
         return templateArguments

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.kt
@@ -241,7 +241,7 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
                 frontend.expressionHandler.handle(argument as IASTInitializerClause)?.let {
                     templateArguments.add(it)
                 }
-            }  else if (argument is IASTIdExpression) {
+            } else if (argument is IASTIdExpression) {
                 // add to templateArguments
                 frontend.expressionHandler.handle(argument)?.let { templateArguments.add(it) }
             }


### PR DESCRIPTION
This is a fix to the issue #709. 
For the following code, 

```
template <int a>
void foo() {
    std::cout << "a: " << a << std::endl;
}

template <int a>
void bar() {
    foo<a>();
}


```

while calling the ` foo<a>(); `  the template argument `a` was not getting added to the [templateArguments](https://github.com/Fraunhofer-AISEC/cpg/blob/6113010845c7fe43ca87b59dd9fc1e08ad1a5e50/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.kt#L235). To fix this issue, the corresponding argument is checked if it is of type `IASTIdExpression` and then added to the templateArguments. 