### PR TITLE
Using the correct `MetadataProvider` in Java

### DIFF
--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.java
@@ -121,8 +121,7 @@ public class ExpressionHandler extends Handler<Statement, Expression, JavaLangua
    */
   private Statement handleArrayCreationExpr(Expression expr) {
     ArrayCreationExpr arrayCreationExpr = (ArrayCreationExpr) expr;
-    ArrayCreationExpression creationExpression =
-        newArrayCreationExpression(frontend.getLanguage(), expr.toString());
+    ArrayCreationExpression creationExpression = newArrayCreationExpression(this, expr.toString());
 
     // in Java, an array creation expression either specifies an initializer or dimensions
 
@@ -771,7 +770,7 @@ public class ExpressionHandler extends Handler<Statement, Expression, JavaLangua
       code = code.substring(4); // remove "new "
     }
 
-    ConstructExpression ctor = newConstructExpression(frontend.getLanguage(), code);
+    ConstructExpression ctor = newConstructExpression(this, code);
     ctor.setType(t);
     frontend.setCodeAndLocation(ctor, expr);
 

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.kt
@@ -160,14 +160,21 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val tryStatement = main.bodyOrNull<TryStatement>(0)
         assertNotNull(tryStatement)
 
+        var scope = tryStatement.scope
+        assertNotNull(scope)
+
         // should have 3 catch clauses
         val catchClauses = tryStatement.catchClauses
         assertEquals(3, catchClauses.size)
+
+        val firstCatch = catchClauses.firstOrNull()
+        assertNotNull(firstCatch)
+
+        scope = firstCatch.scope
+        assertNotNull(scope)
+
         // first exception type was? resolved, so we can expect a FQN
-        assertEquals(
-            createTypeFrom("java.lang.NumberFormatException"),
-            catchClauses[0].parameter?.type
-        )
+        assertEquals(createTypeFrom("java.lang.NumberFormatException"), firstCatch.parameter?.type)
         // second one could not be resolved so we do not have an FQN
         assertEquals(createTypeFrom("NotResolvableTypeException"), catchClauses[1].parameter?.type)
         // third type should have been resolved through the import
@@ -176,6 +183,9 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         // and 1 finally
         val finallyBlock = tryStatement.finallyBlock
         assertNotNull(finallyBlock)
+
+        scope = finallyBlock.scope
+        assertNotNull(scope)
     }
 
     @Test


### PR DESCRIPTION
The expression and statement handler in Java were only using the language as a metadata provider. Additionally, some nodes are directly constructing using `new`, which should be avoided anyway.

Fixes #1021
