### PR TITLE
fix DFA.initializeOrderEvaluation to allow multiple evaluations

### DIFF
--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFA.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFA.kt
@@ -67,6 +67,7 @@ class DFA(states: Set<State> = setOf()) : FSM(states) {
         checkNotNull(startState) {
             "To perform an order evaluation on a DFA, the DFA must have a start state. This DFA does not have a start state."
         }
+        _executionTrace.clear() // necessary when re-using the same [DFA] object for multiple order evaluations
         _executionTrace.add(
             Trace(state = startState, cpgNode = cpgNode, edge = Edge("", nextState = startState))
         )
@@ -95,7 +96,9 @@ class DFA(states: Set<State> = setOf()) : FSM(states) {
                 Trace(state = currentState!!, cpgNode = cpgNode, edge = edgeToFollow)
             )
             true
-        } else false
+        } else {
+            false
+        }
     }
 
     /** Create a shallow copy */

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFA.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFA.kt
@@ -67,7 +67,7 @@ class DFA(states: Set<State> = setOf()) : FSM(states) {
         checkNotNull(startState) {
             "To perform an order evaluation on a DFA, the DFA must have a start state. This DFA does not have a start state."
         }
-        _executionTrace.clear() // necessary when re-using the same [DFA] object for multiple order evaluations
+        _executionTrace.clear() // for using the same [DFA] object for multiple order evaluations
         _executionTrace.add(
             Trace(state = startState, cpgNode = cpgNode, edge = Edge("", nextState = startState))
         )


### PR DESCRIPTION
While working on Codyze I noticed that the current DFA implementation does not support multiple order evaluations with the same DFA object. This is because the internally used worklist of visited nodes cannot be reset.
This issue did not arise until now because Codyze-v2 created a new DFA object for each order evaluation (see for loop [here](https://github.com/Fraunhofer-AISEC/codyze/blob/v2.3.0/codyze-v2/src/main/java/de/fraunhofer/aisec/codyze/analysis/markevaluation/ExpressionEvaluator.java#L123), which always creates a new [OrderEvaluation](https://github.com/Fraunhofer-AISEC/codyze/blob/6487ef495bc257d1b1a0a3428c78bbda94a49dff/codyze-v2/src/main/java/de/fraunhofer/aisec/codyze/analysis/markevaluation/OrderEvaluator.java#L50) object)