### PR TITLE
Fixed C++ FQN for methods with unknown classes

### DIFF
--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.kt
@@ -442,7 +442,7 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
                         // typedef'd name is called S. However, to make things a little bit easier
                         // we also transfer the name to the record declaration.
                         ctx.declarators.firstOrNull()?.name?.toString()?.let {
-                            primaryDeclaration?.name = language.parseName(it)
+                            primaryDeclaration?.name = parseName(it)
                             // We need to inform the later steps that we want to take the name
                             // of this declaration as the basis for the result type of the typedef
                             useNameOfDeclarator = true

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.kt
@@ -215,12 +215,12 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
         if (parent != null) {
             // In this case, the name contains a qualifier, and we can try to check, if we have a
             // matching record declaration for the parent name
-            val scope = frontend.scopeManager.currentScope
-            if (scope != null) {
-                recordDeclaration = frontend.scopeManager.getRecordForName(scope, parent)
-            }
+            recordDeclaration =
+                frontend.scopeManager.currentScope?.let {
+                    frontend.scopeManager.getRecordForName(it, parent)
+                }
 
-            declaration = createMethodOrConstructor(name, null, ctx.parent)
+            declaration = createMethodOrConstructor(name, recordDeclaration, ctx.parent)
         } else if (frontend.scopeManager.isInRecord) {
             // if it is inside a record scope, it is a method
             recordDeclaration = frontend.scopeManager.currentRecord

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/Name.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/Name.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.graph
 
+import de.fraunhofer.aisec.cpg.frontends.Handler
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import java.util.*
@@ -106,14 +107,15 @@ class Name(
 }
 
 /**
- * A small utility extension function that uses the namespace information in a [Language] to parse a
- * fully qualified name.
+ * A small utility extension function that uses the language information in a [LanguageProvider]
+ * (such as a [Node], a [Language], a [LanguageFrontend] or a [Handler]) to parse a fully qualified
+ * name.
  */
-fun Language<out LanguageFrontend>?.parseName(fqn: CharSequence) =
-    parseName(fqn, this?.namespaceDelimiter ?: ".")
+fun LanguageProvider?.parseName(fqn: CharSequence) =
+    parseName(fqn, this?.language?.namespaceDelimiter ?: ".")
 
 /** Tries to parse the given fully qualified name using the specified [delimiter] into a [Name]. */
-fun parseName(fqn: CharSequence, delimiter: String = ".", vararg splitDelimiters: String): Name {
+internal fun parseName(fqn: CharSequence, delimiter: String, vararg splitDelimiters: String): Name {
     val parts = fqn.split(delimiter, *splitDelimiters)
 
     var name: Name? = null

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/Name.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/Name.kt
@@ -102,8 +102,23 @@ class Name(
     /** This function appends a string to the local name and returns a new [Name]. */
     fun append(s: String) = Name(localName + s, parent, delimiter)
 
+    /**
+     * This functions replaces all occurrences of [oldValue] with [newValue] in the local name and
+     * returns a new [Name].
+     */
+    fun replace(oldValue: String, newValue: String) =
+        Name(localName.replace(oldValue, newValue), parent, delimiter)
+
     /** Compare names according to the string representation of the [fullName]. */
     override fun compareTo(other: Name) = fullName.compareTo(other.toString())
+
+    /**
+     * A name can be considered as "qualified", if it has any specified [parent]. Otherwise, only
+     * the [localName] is specified and the name is "unqualified".
+     */
+    fun isQualified(): Boolean {
+        return parent != null
+    }
 }
 
 /**

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -126,16 +126,17 @@ fun Node.applyMetadata(
     if (name != null) {
         val language = this.language
 
-        // Let's check, if this is an FQN by any chance. Then we need to parse the name. In the
-        // future, we might do that differently.
-        if (language != null && name.contains(language.namespaceDelimiter)) {
-            this.name = language.parseName(name)
-        } else if (name is Name) {
-            // The name could already be a real "name" (of our Name class). In this case we can just
-            // set the name. This is preferred over parsing an FQN.
+        // The name could already be a real "name" (of our Name class). In this case we can just set
+        // the name (if it is qualified). This is preferred over passing an FQN as
+        // CharSequence/String.
+        if (name is Name && name.isQualified()) {
             this.name = name
+        } else if (language != null && name.contains(language.namespaceDelimiter)) {
+            // Let's check, if this is an FQN as string / char sequence by any chance. Then we need
+            // to parse the name. In the future, we might drop compatibility for this
+            this.name = language.parseName(name)
         } else {
-            // Otherwise, a local name is supplied. Some nodes only have a local name. In this case,
+            // Otherwise, a local name is supplied. Some nodes only want a local name. In this case,
             // we create a new name with the supplied (local) name and set the parent to null.
             val parent =
                 if (localNameOnly) {

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/CallResolver.kt
@@ -387,7 +387,7 @@ open class CallResolver : SymbolResolverPass() {
 
     private fun resolveExplicitConstructorInvocation(eci: ExplicitConstructorInvocation) {
         if (eci.containingClass != null) {
-            val recordDeclaration = recordMap[eci.language.parseName(eci.containingClass)]
+            val recordDeclaration = recordMap[eci.parseName(eci.containingClass)]
             val signature = eci.arguments.map { it.type }
             if (recordDeclaration != null) {
                 val constructor =
@@ -439,7 +439,7 @@ open class CallResolver : SymbolResolverPass() {
             curClass.staticImportStatements
                 .filter { it.endsWith(".$name") }
                 .map { it.substring(0, it.lastIndexOf('.')) }
-                .mapNotNull { recordMap[call.language.parseName(it)] }
+                .mapNotNull { recordMap[call.parseName(it)] }
 
         for (recordDeclaration in containingRecords) {
             val inferred =

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.kt
@@ -118,7 +118,7 @@ open class VariableUsageResolver : SymbolResolverPass() {
             } else {
                 null
             },
-            reference.language.parseName(functionName),
+            reference.parseName(functionName),
             fptrType
         )
     }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXIncludeTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXIncludeTest.kt
@@ -31,6 +31,7 @@ import de.fraunhofer.aisec.cpg.TestUtils.analyzeWithBuilder
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.get
+import de.fraunhofer.aisec.cpg.graph.records
 import de.fraunhofer.aisec.cpg.graph.statements.ReturnStatement
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.DeclaredReferenceExpression
 import de.fraunhofer.aisec.cpg.sarif.Region
@@ -241,7 +242,7 @@ internal class CXXIncludeTest : BaseTest() {
     @Throws(Exception::class)
     fun testLoadIncludes() {
         val file = File("src/test/resources/include.cpp")
-        val translationUnitDeclarations =
+        val tus =
             analyzeWithBuilder(
                 TranslationConfiguration.builder()
                     .sourceLocations(listOf(file))
@@ -251,11 +252,10 @@ internal class CXXIncludeTest : BaseTest() {
                     .defaultLanguages()
                     .failOnError(true)
             )
-        assertNotNull(translationUnitDeclarations)
+        assertNotNull(tus)
 
-        // first one should NOT be a class (since it is defined in the header)
-        val recordDeclaration =
-            translationUnitDeclarations[0].getDeclarationAs(0, RecordDeclaration::class.java)
-        assertNull(recordDeclaration)
+        // the tu should not contain any classes, since they are defined in the header (which are
+        // not loaded)
+        assertTrue(tus.firstOrNull().records.isEmpty())
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/NameTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/NameTest.kt
@@ -66,7 +66,7 @@ internal class NameTest {
 
     @Test
     fun testEndsWith() {
-        val name = parseName("A.B")
+        val name = parseName("A.B", ".")
         assertTrue(name.lastPartsMatch("B"))
         assertTrue(name.lastPartsMatch("A.B"))
     }

--- a/cpg-core/src/test/resources/cxx/recordstmt.cpp
+++ b/cpg-core/src/test/resources/cxx/recordstmt.cpp
@@ -36,3 +36,7 @@ int main() {
   s.method();
   s.method(SomeClass::CONSTANT);
 }
+
+int OtherClass::anotherMethod() {
+    return 1;
+}

--- a/cpg-language-go/src/main/golang/language.go
+++ b/cpg-language-go/src/main/golang/language.go
@@ -26,8 +26,6 @@
 package cpg
 
 import (
-	"log"
-
 	"tekao.net/jnigi"
 )
 
@@ -54,14 +52,4 @@ func (l *Language) GetClassName() string {
 
 func (l *Language) IsArray() bool {
 	return false
-}
-
-func (l *Language) ParseName(fqn string) *Name {
-	var n *Name = (*Name)(jnigi.NewObjectRef(NameClass))
-	err := env.CallStaticMethod(NameKtClass, "parseName", n, l, NewCharSequence(fqn))
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	return n
 }


### PR DESCRIPTION
The FQN of method decorations for unknown classes were wrong. Additionally, there was too much boilerplate code in the C++ method name handling (there still probably is). This PR relieves some of this pain.