### PR TITLE
Improve order evaluation

### DIFF
--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFA.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFA.kt
@@ -81,7 +81,7 @@ class DFA(states: Set<State> = setOf()) : FSM(states) {
      *
      * Before calling this, initialize the orderEvaluation with [initializeOrderEvaluation]
      */
-    fun makeTransitionWithOp(op: String, cpgNode: Node): Boolean {
+    fun makeTransitionWithOp(op: Set<String>, cpgNode: Node): Boolean {
         checkNotNull(currentState) {
             "Cannot perform a transition because the FSM does not have a starting state!"
         }
@@ -89,7 +89,7 @@ class DFA(states: Set<State> = setOf()) : FSM(states) {
             "Before performing transitions, you must call [initializeOrderEvaluation] first."
         }
 
-        val possibleEdges = currentState!!.outgoingEdges.filter { e -> e.op == op }
+        val possibleEdges = currentState!!.outgoingEdges.filter { e -> e.op in op }
         val edgeToFollow = possibleEdges.singleOrNull()
         return if (edgeToFollow != null) {
             _executionTrace.add(

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFAOrderEvaluator.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFAOrderEvaluator.kt
@@ -49,6 +49,18 @@ import org.slf4j.LoggerFactory
  * - [nodeToRelevantMethod]: A mapping between CPG nodes and their operators used by the respective
  * edges in the [dfa]. Currently, we only consider [CallExpression]s. If a node is not contained in
  * this list, it is not considered by the evaluation as we assume that the method is not relevant.
+ * - [consideredResetNodes]: These nodes reset the order evaluation such that e.g., a reassignment of a variable with a
+ * new object is handled correctly. In this case, the constructor node must be part of the [consideredResetNodes].
+ * This allows the [DFAOrderEvaluator] to detect that in such a case,
+ * ```
+ *        (1) Botan p7 = new Botan(2);
+ *        (2) p7.start(iv);
+ *        (3) p7.finish(buf);
+ *
+ *        (4) p7 = new Botan(3);
+ *        (5) p7.start(iv);
+ * ```
+ * (4) should actually start a new order evaluation.
  * - [thisPositionOfNode]: If a non-object oriented language was used, this is a map from CPG nodes
  * (i.e., the [CallExpression]) to the argument position serving as base of the operation.
  *
@@ -60,6 +72,7 @@ open class DFAOrderEvaluator(
     val dfa: DFA,
     val consideredBases: Set<Node>,
     val nodeToRelevantMethod: Map<Node, Set<String>>,
+    val consideredResetNodes: Set<Node> = emptySet(),
     val thisPositionOfNode: Map<Node, Int> = mapOf(),
     val eliminateUnreachableCode: Boolean = true
 ) {
@@ -153,10 +166,39 @@ open class DFAOrderEvaluator(
             // try to make the transition in the DFA and retrieve the next nodes
             // to process for each of the paths.
             for (eogPath in eogPathSet) {
+                // Handle 'reset nodes'.
+                if (node in consideredResetNodes) {
+                    val baseAndOp =
+                        getBaseAndOpOfNode(node as CallExpression, eogPath, interproceduralFlows)
+                    if (baseAndOp != null) {
+                        val (base, _) = baseAndOp
+                        // get the DFA associated with this base
+                        val dfa = baseToFSM.computeIfAbsent(base) { dfa.deepCopy() }
+
+                        if (dfa.isAccepted) {
+                            actionAcceptingTermination(
+                                base,
+                                dfa,
+                                interproceduralFlows[base] == true
+                            )
+                        } else if (dfa.currentState?.isStart == true) {
+                            // nothing to do here, we just want to continue with the next nodes in
+                            // the EOG
+                        } else {
+                            actionNonAcceptingTermination(
+                                base,
+                                dfa,
+                                interproceduralFlows[base] == true
+                            )
+                            isValidOrder = false
+                        }
+                        dfa.initializeOrderEvaluation(node)
+                    }
+                }
                 // Currently, we only handle CallExpressions as "operation".
                 // Check if the current node is of interest for the DFA.
                 // This is the case if the map nodesToOp contains the node.
-                if (node is CallExpression && nodeToRelevantMethod.contains(node)) {
+                else if (node is CallExpression && nodeToRelevantMethod.contains(node)) {
                     val baseAndOp = getBaseAndOpOfNode(node, eogPath, interproceduralFlows)
 
                     if (
@@ -255,24 +297,21 @@ open class DFAOrderEvaluator(
      * Returns the "base" node belonging to [node], on which the DFA is based on. Ideally, this is a
      * variable declaration in the end.
      */
-    fun getBaseOfNode(node: CallExpression): Node? {
-        val base =
-            when {
-                node is MemberCallExpression -> node.base
-                node is ConstructExpression -> node.astParent?.getSuitableDFGTarget()
-                node.thisPosition != null ->
-                    node.getBaseOfCallExpressionUsingArgument(node.thisPosition!!)
-                else -> {
-                    val dfgTarget = node.getSuitableDFGTarget()
-                    if (dfgTarget != null && dfgTarget is ConstructExpression) {
-                        dfgTarget.getSuitableDFGTarget()
-                    } else {
-                        dfgTarget
-                    }
+    fun getBaseOfNode(node: CallExpression) =
+        when {
+            node is MemberCallExpression -> node.base
+            node is ConstructExpression -> node.astParent?.getSuitableDFGTarget()
+            node.thisPosition != null ->
+                node.getBaseOfCallExpressionUsingArgument(node.thisPosition!!)
+            else -> {
+                val dfgTarget = node.getSuitableDFGTarget()
+                if (dfgTarget != null && dfgTarget is ConstructExpression) {
+                    dfgTarget.getSuitableDFGTarget()
+                } else {
+                    dfgTarget
                 }
             }
-        return base
-    }
+        }
 
     /**
      * Returns a [Pair] holding the "base" and the "operator" of the function/method call happening
@@ -324,13 +363,10 @@ open class DFAOrderEvaluator(
         return null
     }
 
-    private fun Node.addEogPath(path: String) {
+    private fun Node.addEogPath(path: String) =
         nodeToEOGPathSet.computeIfAbsent(this) { mutableSetOf() }.add(path)
-    }
 
-    private fun Node.getEogPaths(): Set<String>? {
-        return nodeToEOGPathSet[this]
-    }
+    private fun Node.getEogPaths() = nodeToEOGPathSet[this]
 
     /**
      * If it's not an object-oriented language, we need to retrieve the base in a different way.

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFAOrderEvaluator.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFAOrderEvaluator.kt
@@ -176,6 +176,10 @@ open class DFAOrderEvaluator(
                         // get the DFA associated with this base
                         val dfa = baseToFSM.computeIfAbsent(base) { dfa.deepCopy() }
 
+                        // Encountering a reset node on [base] resets the order evaluation.
+                        // This means that the state of the [dfa] has to be evaluated and a finding
+                        // has to be generated
+                        // before continuing with another node.
                         if (dfa.isAccepted) {
                             actionAcceptingTermination(
                                 base,
@@ -193,7 +197,7 @@ open class DFAOrderEvaluator(
                             )
                             isValidOrder = false
                         }
-                        dfa.initializeOrderEvaluation(node)
+                        dfa.initializeOrderEvaluation(node) // reset the [dfa]
                     }
                 }
                 // Currently, we only handle CallExpressions as "operation".

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFAOrderEvaluator.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFAOrderEvaluator.kt
@@ -176,10 +176,10 @@ open class DFAOrderEvaluator(
                         // get the DFA associated with this base
                         val dfa = baseToFSM.computeIfAbsent(base) { dfa.deepCopy() }
 
-                        // Encountering a reset node on [base] resets the order evaluation.
+                        // Encountering a reset node on [base] should finalize and reset the current
+                        // order evaluation on [base].
                         // This means that the state of the [dfa] has to be evaluated and a finding
-                        // has to be generated
-                        // before continuing with another node.
+                        // has to be generated before continuing with another node.
                         if (dfa.isAccepted) {
                             actionAcceptingTermination(
                                 base,

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFAOrderEvaluator.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFAOrderEvaluator.kt
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory
  */
 open class DFAOrderEvaluator(
     var consideredBases: Set<Node>,
-    var nodeToRelevantMethod: Map<Node, String>,
+    var nodeToRelevantMethod: Map<Node, Set<String>>,
     var thisPositionOfNode: Map<Node, Int> = mapOf(),
     var eliminateUnreachableCode: Boolean = true
 ) {
@@ -292,7 +292,7 @@ open class DFAOrderEvaluator(
         node: CallExpression,
         eogPath: String,
         interproceduralFlows: MutableMap<String, Boolean>
-    ): Pair<String, String>? {
+    ): Pair<String, Set<String>>? {
         // The "base" node, on which the DFA is based on. Ideally, this is a variable declaration in
         // the end.
         var base = getBaseOfNode(node)

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFAOrderEvaluator.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFAOrderEvaluator.kt
@@ -49,9 +49,10 @@ import org.slf4j.LoggerFactory
  * - [nodeToRelevantMethod]: A mapping between CPG nodes and their operators used by the respective
  * edges in the [dfa]. Currently, we only consider [CallExpression]s. If a node is not contained in
  * this list, it is not considered by the evaluation as we assume that the method is not relevant.
- * - [consideredResetNodes]: These nodes reset the order evaluation such that e.g., a reassignment of a variable with a
- * new object is handled correctly. In this case, the constructor node must be part of the [consideredResetNodes].
- * This allows the [DFAOrderEvaluator] to detect that in such a case,
+ * - [consideredResetNodes]: These nodes reset the order evaluation such that e.g., a reassignment
+ * of a variable with a new object is handled correctly. In this case, the constructor node must be
+ * part of the [consideredResetNodes]. This allows the [DFAOrderEvaluator] to detect that in such a
+ * case,
  * ```
  *        (1) Botan p7 = new Botan(2);
  *        (2) p7.start(iv);

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFAOrderEvaluator.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFAOrderEvaluator.kt
@@ -43,10 +43,11 @@ import org.slf4j.LoggerFactory
 /**
  * This class uses a [DFA] to evaluate if the order of statements in the CPG is correct. It needs
  * the following inputs:
+ * - [dfa]: Describes the desired correct order of nodes
  * - [consideredBases]: A set of the IDs of nodes (typically the [VariableDeclaration]) which are
  * considered.
  * - [nodeToRelevantMethod]: A mapping between CPG nodes and their operators used by the respective
- * edges in the DFA. Currently, we only consider [CallExpression]s. If a node is not contained in
+ * edges in the [dfa]. Currently, we only consider [CallExpression]s. If a node is not contained in
  * this list, it is not considered by the evaluation as we assume that the method is not relevant.
  * - [thisPositionOfNode]: If a non-object oriented language was used, this is a map from CPG nodes
  * (i.e., the [CallExpression]) to the argument position serving as base of the operation.
@@ -56,10 +57,11 @@ import org.slf4j.LoggerFactory
  * results which may occur in unreachable code.
  */
 open class DFAOrderEvaluator(
-    var consideredBases: Set<Node>,
-    var nodeToRelevantMethod: Map<Node, Set<String>>,
-    var thisPositionOfNode: Map<Node, Int> = mapOf(),
-    var eliminateUnreachableCode: Boolean = true
+    val dfa: DFA,
+    val consideredBases: Set<Node>,
+    val nodeToRelevantMethod: Map<Node, Set<String>>,
+    val thisPositionOfNode: Map<Node, Int> = mapOf(),
+    val eliminateUnreachableCode: Boolean = true
 ) {
     private val nodeToEOGPathSet = mutableMapOf<Node, MutableSet<String>>()
     private val log: Logger = LoggerFactory.getLogger(DFAOrderEvaluator::class.java)
@@ -115,7 +117,7 @@ open class DFAOrderEvaluator(
      * `false`, if it is correct, the method returns `true`. The flag [stopOnWrongBase] makes the
      * FSM stop evaluation of a base if an unexpected operation was observed for that base.
      */
-    fun evaluateOrder(dfa: DFA, startNode: Node, stopOnWrongBase: Boolean = true): Boolean {
+    fun evaluateOrder(startNode: Node, stopOnWrongBase: Boolean = true): Boolean {
         // First dummy edge to simulate that we are in the start state.
         dfa.initializeOrderEvaluation(startNode)
 

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/ComplexDFAOrderEvaluationTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/ComplexDFAOrderEvaluationTest.kt
@@ -108,8 +108,8 @@ class ComplexDFAOrderEvaluationTest {
         nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = setOf("start()")
         nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("finish()")
 
-        val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p1Decl)
+        val orderEvaluator = DFAOrderEvaluator(dfa, consideredDecl, nodesToOp)
+        val everythingOk = orderEvaluator.evaluateOrder(p1Decl)
 
         assertTrue(everythingOk, "Expected correct order")
     }
@@ -132,8 +132,8 @@ class ComplexDFAOrderEvaluationTest {
         nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("process()")
         nodesToOp[(functionOk.body as CompoundStatement).statements[5]] = setOf("finish()")
 
-        val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p1Decl)
+        val orderEvaluator = DFAOrderEvaluator(dfa, consideredDecl, nodesToOp)
+        val everythingOk = orderEvaluator.evaluateOrder(p1Decl)
 
         assertTrue(everythingOk, "Expected correct order")
     }
@@ -157,8 +157,8 @@ class ComplexDFAOrderEvaluationTest {
         nodesToOp[(functionOk.body as CompoundStatement).statements[5]] = setOf("finish()")
         nodesToOp[(functionOk.body as CompoundStatement).statements[6]] = setOf("reset()")
 
-        val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p1Decl)
+        val orderEvaluator = DFAOrderEvaluator(dfa, consideredDecl, nodesToOp)
+        val everythingOk = orderEvaluator.evaluateOrder(p1Decl)
 
         assertTrue(everythingOk, "Expected correct order")
     }
@@ -184,8 +184,8 @@ class ComplexDFAOrderEvaluationTest {
         nodesToOp[(functionOk.body as CompoundStatement).statements[7]] = setOf("process()")
         nodesToOp[(functionOk.body as CompoundStatement).statements[8]] = setOf("finish()")
 
-        val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p2Decl)
+        val orderEvaluator = DFAOrderEvaluator(dfa, consideredDecl, nodesToOp)
+        val everythingOk = orderEvaluator.evaluateOrder(p2Decl)
 
         assertTrue(everythingOk, "Expected correct order")
     }
@@ -211,8 +211,8 @@ class ComplexDFAOrderEvaluationTest {
         nodesToOp[(functionOk.body as CompoundStatement).statements[7]] = setOf("process()")
         nodesToOp[(functionOk.body as CompoundStatement).statements[8]] = setOf("finish()")
 
-        val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p3Decl)
+        val orderEvaluator = DFAOrderEvaluator(dfa, consideredDecl, nodesToOp)
+        val everythingOk = orderEvaluator.evaluateOrder(p3Decl)
 
         assertTrue(everythingOk, "Expected correct order")
     }
@@ -239,8 +239,8 @@ class ComplexDFAOrderEvaluationTest {
         nodes[(functionOk.body as CompoundStatement).statements[8]] = setOf("finish()")
         nodes[(functionOk.body as CompoundStatement).statements[9]] = setOf("reset()")
 
-        val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodes)
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p3Decl)
+        val orderEvaluator = DFAOrderEvaluator(dfa, consideredDecl, nodes)
+        val everythingOk = orderEvaluator.evaluateOrder(p3Decl)
 
         assertTrue(everythingOk, "Expected correct order")
     }
@@ -262,8 +262,8 @@ class ComplexDFAOrderEvaluationTest {
         nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = setOf("process()")
         nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("finish()")
 
-        val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p5Decl)
+        val orderEvaluator = DFAOrderEvaluator(dfa, consideredDecl, nodesToOp)
+        val everythingOk = orderEvaluator.evaluateOrder(p5Decl)
 
         assertFalse(everythingOk, "Expected incorrect order")
     }
@@ -293,8 +293,8 @@ class ComplexDFAOrderEvaluationTest {
 
         nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("reset()")
 
-        val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p6Decl)
+        val orderEvaluator = DFAOrderEvaluator(dfa, consideredDecl, nodesToOp)
+        val everythingOk = orderEvaluator.evaluateOrder(p6Decl)
 
         assertFalse(everythingOk, "Expected incorrect order")
     }
@@ -324,8 +324,8 @@ class ComplexDFAOrderEvaluationTest {
 
         nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("reset()")
 
-        val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p6Decl)
+        val orderEvaluator = DFAOrderEvaluator(dfa, consideredDecl, nodesToOp)
+        val everythingOk = orderEvaluator.evaluateOrder(p6Decl)
 
         assertFalse(everythingOk, "Expected incorrect order")
     }
@@ -355,8 +355,8 @@ class ComplexDFAOrderEvaluationTest {
 
         nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("reset()")
 
-        val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p7Decl)
+        val orderEvaluator = DFAOrderEvaluator(dfa, consideredDecl, nodesToOp)
+        val everythingOk = orderEvaluator.evaluateOrder(p7Decl)
 
         assertFalse(everythingOk, "Expected incorrect order")
     }
@@ -385,8 +385,8 @@ class ComplexDFAOrderEvaluationTest {
 
         nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("reset()")
 
-        val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p7Decl)
+        val orderEvaluator = DFAOrderEvaluator(dfa, consideredDecl, nodesToOp)
+        val everythingOk = orderEvaluator.evaluateOrder(p7Decl)
 
         assertTrue(everythingOk, "Expected correct order")
     }
@@ -418,8 +418,8 @@ class ComplexDFAOrderEvaluationTest {
 
         nodesToOp[(functionOk.body as CompoundStatement).statements[7]] = setOf("reset()")
 
-        val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p8Decl)
+        val orderEvaluator = DFAOrderEvaluator(dfa, consideredDecl, nodesToOp)
+        val everythingOk = orderEvaluator.evaluateOrder(p8Decl)
 
         assertTrue(everythingOk, "Expected correct order")
     }
@@ -448,8 +448,8 @@ class ComplexDFAOrderEvaluationTest {
 
         nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("reset()")
 
-        val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p6Decl)
+        val orderEvaluator = DFAOrderEvaluator(dfa, consideredDecl, nodesToOp)
+        val everythingOk = orderEvaluator.evaluateOrder(p6Decl)
 
         assertTrue(everythingOk, "Expected correct order")
     }
@@ -474,13 +474,14 @@ class ComplexDFAOrderEvaluationTest {
         val withoutInterprocNodes = mutableListOf<Node>()
         val orderEvaluator =
             DummyDFAOrderEvaluator(
+                dfa,
                 consideredDecl,
                 nodesToOp,
                 mutableMapOf(),
                 afterInterprocNodes,
                 withoutInterprocNodes
             )
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p1Decl)
+        val everythingOk = orderEvaluator.evaluateOrder(p1Decl)
 
         assertFalse(everythingOk, "Expected incorrect order")
         assertContains(
@@ -511,6 +512,7 @@ class ComplexDFAOrderEvaluationTest {
         val withoutInterprocNodes = mutableListOf<Node>()
         val orderEvaluator =
             DummyDFAOrderEvaluator(
+                dfa,
                 consideredDecl,
                 nodesToOp,
                 mutableMapOf(),
@@ -520,7 +522,7 @@ class ComplexDFAOrderEvaluationTest {
         // We cannot use p1Decl as start of the analysis because it has no nextEOG edges. Instead,
         // we want to start with the first instruction of the function.
         val everythingOk =
-            orderEvaluator.evaluateOrder(dfa, (functionOk.body as CompoundStatement).statements[0])
+            orderEvaluator.evaluateOrder((functionOk.body as CompoundStatement).statements[0])
 
         assertFalse(everythingOk, "Expected incorrect order")
         assertContains(
@@ -551,13 +553,14 @@ class ComplexDFAOrderEvaluationTest {
         val withoutInterprocNodes = mutableListOf<Node>()
         val orderEvaluator =
             DummyDFAOrderEvaluator(
+                dfa,
                 consideredDecl,
                 nodesToOp,
                 mutableMapOf(),
                 possibleInterprocFailures,
                 withoutInterprocNodes
             )
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p1Decl)
+        val everythingOk = orderEvaluator.evaluateOrder(p1Decl)
 
         assertFalse(everythingOk, "Expected incorrect order")
         assertContains(
@@ -588,13 +591,14 @@ class ComplexDFAOrderEvaluationTest {
         val withoutInterprocNodes = mutableListOf<Node>()
         val orderEvaluator =
             DummyDFAOrderEvaluator(
+                dfa,
                 consideredDecl,
                 nodesToOp,
                 mutableMapOf(),
                 afterInterprocNodes,
                 withoutInterprocNodes
             )
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p1Decl)
+        val everythingOk = orderEvaluator.evaluateOrder(p1Decl)
 
         assertFalse(everythingOk, "Expected incorrect order")
         assertContains(
@@ -629,13 +633,14 @@ class ComplexDFAOrderEvaluationTest {
         val withoutInterprocNodes = mutableListOf<Node>()
         val orderEvaluator =
             DummyDFAOrderEvaluator(
+                dfa,
                 consideredDecl,
                 nodesToOp,
                 mutableMapOf(),
                 afterInterprocNodes,
                 withoutInterprocNodes
             )
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p1Decl)
+        val everythingOk = orderEvaluator.evaluateOrder(p1Decl)
 
         assertFalse(everythingOk, "Expected incorrect order")
         assertTrue(afterInterprocNodes.isEmpty(), "All nodes clearly violate the rule")
@@ -651,12 +656,13 @@ class ComplexDFAOrderEvaluationTest {
      * flows works. Collects the respective nodes and they can be used by the tests later.
      */
     class DummyDFAOrderEvaluator(
+        dfa: DFA,
         referencedVertices: Set<Node>,
         nodesToOp: Map<Node, Set<String>>,
         thisPositionOfNode: Map<Node, Int>,
         val possibleInterprocFailures: MutableList<Node>,
         val withoutInterprocNodes: MutableList<Node>
-    ) : DFAOrderEvaluator(referencedVertices, nodesToOp, thisPositionOfNode) {
+    ) : DFAOrderEvaluator(dfa, referencedVertices, nodesToOp, thisPositionOfNode) {
         private val log: Logger = LoggerFactory.getLogger(DummyDFAOrderEvaluator::class.java)
 
         override fun actionMissingTransitionForNode(

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/ComplexDFAOrderEvaluationTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/ComplexDFAOrderEvaluationTest.kt
@@ -662,7 +662,13 @@ class ComplexDFAOrderEvaluationTest {
         thisPositionOfNode: Map<Node, Int>,
         val possibleInterprocFailures: MutableList<Node>,
         val withoutInterprocNodes: MutableList<Node>
-    ) : DFAOrderEvaluator(dfa, referencedVertices, nodesToOp, thisPositionOfNode) {
+    ) :
+        DFAOrderEvaluator(
+            dfa = dfa,
+            consideredBases = referencedVertices,
+            nodeToRelevantMethod = nodesToOp,
+            thisPositionOfNode = thisPositionOfNode
+        ) {
         private val log: Logger = LoggerFactory.getLogger(DummyDFAOrderEvaluator::class.java)
 
         override fun actionMissingTransitionForNode(

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/ComplexDFAOrderEvaluationTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/ComplexDFAOrderEvaluationTest.kt
@@ -34,12 +34,12 @@ import de.fraunhofer.aisec.cpg.graph.byNameOrNull
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
+import de.fraunhofer.aisec.cpg.graph.followNextEOG
 import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.DeclaredReferenceExpression
 import de.fraunhofer.aisec.cpg.passes.EdgeCachePass
 import de.fraunhofer.aisec.cpg.passes.UnreachableEOGPass
-import de.fraunhofer.aisec.cpg.passes.followNextEOG
 import java.nio.file.Path
 import kotlin.test.*
 import org.junit.jupiter.api.BeforeAll
@@ -102,11 +102,11 @@ class ComplexDFAOrderEvaluationTest {
         assertNotNull(p1Decl)
         val consideredDecl = mutableSetOf(p1Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
-        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = "create()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = "init()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = "start()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = "finish()"
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
+        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("create()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("init()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = setOf("start()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("finish()")
 
         val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
         val everythingOk = orderEvaluator.evaluateOrder(dfa, p1Decl)
@@ -125,12 +125,12 @@ class ComplexDFAOrderEvaluationTest {
         assertNotNull(p1Decl)
         val consideredDecl = mutableSetOf(p1Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
-        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = "create()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = "init()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = "start()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = "process()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[5]] = "finish()"
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
+        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("create()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("init()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = setOf("start()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("process()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[5]] = setOf("finish()")
 
         val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
         val everythingOk = orderEvaluator.evaluateOrder(dfa, p1Decl)
@@ -149,13 +149,13 @@ class ComplexDFAOrderEvaluationTest {
         assertNotNull(p1Decl)
         val consideredDecl = mutableSetOf(p1Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
-        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = "create()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = "init()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = "start()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = "process()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[5]] = "finish()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[6]] = "reset()"
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
+        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("create()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("init()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = setOf("start()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("process()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[5]] = setOf("finish()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[6]] = setOf("reset()")
 
         val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
         val everythingOk = orderEvaluator.evaluateOrder(dfa, p1Decl)
@@ -174,15 +174,15 @@ class ComplexDFAOrderEvaluationTest {
         assertNotNull(p2Decl)
         val consideredDecl = mutableSetOf(p2Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
-        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = "create()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = "init()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = "start()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = "process()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[5]] = "process()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[6]] = "process()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[7]] = "process()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[8]] = "finish()"
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
+        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("create()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("init()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = setOf("start()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("process()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[5]] = setOf("process()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[6]] = setOf("process()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[7]] = setOf("process()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[8]] = setOf("finish()")
 
         val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
         val everythingOk = orderEvaluator.evaluateOrder(dfa, p2Decl)
@@ -201,15 +201,15 @@ class ComplexDFAOrderEvaluationTest {
         assertNotNull(p3Decl)
         val consideredDecl = mutableSetOf(p3Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
-        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = "create()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = "init()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = "start()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = "process()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[5]] = "finish()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[6]] = "start()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[7]] = "process()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[8]] = "finish()"
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
+        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("create()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("init()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = setOf("start()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("process()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[5]] = setOf("finish()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[6]] = setOf("start()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[7]] = setOf("process()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[8]] = setOf("finish()")
 
         val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
         val everythingOk = orderEvaluator.evaluateOrder(dfa, p3Decl)
@@ -228,16 +228,16 @@ class ComplexDFAOrderEvaluationTest {
         assertNotNull(p3Decl)
         val consideredDecl = mutableSetOf(p3Decl.declarations[0])
 
-        val nodes = mutableMapOf<Node, String>()
-        nodes[(functionOk.body as CompoundStatement).statements[1]] = "create()"
-        nodes[(functionOk.body as CompoundStatement).statements[2]] = "init()"
-        nodes[(functionOk.body as CompoundStatement).statements[3]] = "start()"
-        nodes[(functionOk.body as CompoundStatement).statements[4]] = "process()"
-        nodes[(functionOk.body as CompoundStatement).statements[5]] = "finish()"
-        nodes[(functionOk.body as CompoundStatement).statements[6]] = "start()"
-        nodes[(functionOk.body as CompoundStatement).statements[7]] = "process()"
-        nodes[(functionOk.body as CompoundStatement).statements[8]] = "finish()"
-        nodes[(functionOk.body as CompoundStatement).statements[9]] = "reset()"
+        val nodes = mutableMapOf<Node, Set<String>>()
+        nodes[(functionOk.body as CompoundStatement).statements[1]] = setOf("create()")
+        nodes[(functionOk.body as CompoundStatement).statements[2]] = setOf("init()")
+        nodes[(functionOk.body as CompoundStatement).statements[3]] = setOf("start()")
+        nodes[(functionOk.body as CompoundStatement).statements[4]] = setOf("process()")
+        nodes[(functionOk.body as CompoundStatement).statements[5]] = setOf("finish()")
+        nodes[(functionOk.body as CompoundStatement).statements[6]] = setOf("start()")
+        nodes[(functionOk.body as CompoundStatement).statements[7]] = setOf("process()")
+        nodes[(functionOk.body as CompoundStatement).statements[8]] = setOf("finish()")
+        nodes[(functionOk.body as CompoundStatement).statements[9]] = setOf("reset()")
 
         val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodes)
         val everythingOk = orderEvaluator.evaluateOrder(dfa, p3Decl)
@@ -256,11 +256,11 @@ class ComplexDFAOrderEvaluationTest {
         assertNotNull(p5Decl)
         val consideredDecl = mutableSetOf(p5Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
-        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = "init()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = "start()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = "process()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = "finish()"
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
+        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("init()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("start()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = setOf("process()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("finish()")
 
         val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
         val everythingOk = orderEvaluator.evaluateOrder(dfa, p5Decl)
@@ -279,19 +279,19 @@ class ComplexDFAOrderEvaluationTest {
         assertNotNull(p6Decl)
         val consideredDecl = mutableSetOf(p6Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
-        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = "create()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = "init()"
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
+        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("create()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("init()")
 
         val thenBranch =
             ((functionOk.body as CompoundStatement).statements[3] as? IfStatement)?.thenStatement
                 as? CompoundStatement
         assertNotNull(thenBranch)
-        nodesToOp[thenBranch.statements[0]] = "start()"
-        nodesToOp[thenBranch.statements[1]] = "process()"
-        nodesToOp[thenBranch.statements[2]] = "finish()"
+        nodesToOp[thenBranch.statements[0]] = setOf("start()")
+        nodesToOp[thenBranch.statements[1]] = setOf("process()")
+        nodesToOp[thenBranch.statements[2]] = setOf("finish()")
 
-        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = "reset()"
+        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("reset()")
 
         val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
         val everythingOk = orderEvaluator.evaluateOrder(dfa, p6Decl)
@@ -311,18 +311,18 @@ class ComplexDFAOrderEvaluationTest {
         assertNotNull(p6Decl)
         val consideredDecl = mutableSetOf(p6Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
         val loopBody =
             ((functionOk.body as CompoundStatement).statements[1] as? WhileStatement)?.statement
                 as? CompoundStatement
         assertNotNull(loopBody)
-        nodesToOp[loopBody.statements[0]] = "create()"
-        nodesToOp[loopBody.statements[1]] = "init()"
-        nodesToOp[loopBody.statements[2]] = "start()"
-        nodesToOp[loopBody.statements[3]] = "process()"
-        nodesToOp[loopBody.statements[4]] = "finish()"
+        nodesToOp[loopBody.statements[0]] = setOf("create()")
+        nodesToOp[loopBody.statements[1]] = setOf("init()")
+        nodesToOp[loopBody.statements[2]] = setOf("start()")
+        nodesToOp[loopBody.statements[3]] = setOf("process()")
+        nodesToOp[loopBody.statements[4]] = setOf("finish()")
 
-        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = "reset()"
+        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("reset()")
 
         val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
         val everythingOk = orderEvaluator.evaluateOrder(dfa, p6Decl)
@@ -342,18 +342,18 @@ class ComplexDFAOrderEvaluationTest {
         assertNotNull(p7Decl)
         val consideredDecl = mutableSetOf(p7Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
-        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = "create()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = "init()"
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
+        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("create()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("init()")
         val loopBody =
             ((functionOk.body as CompoundStatement).statements[3] as? WhileStatement)?.statement
                 as? CompoundStatement
         assertNotNull(loopBody)
-        nodesToOp[loopBody.statements[0]] = "start()"
-        nodesToOp[loopBody.statements[1]] = "process()"
-        nodesToOp[loopBody.statements[2]] = "finish()"
+        nodesToOp[loopBody.statements[0]] = setOf("start()")
+        nodesToOp[loopBody.statements[1]] = setOf("process()")
+        nodesToOp[loopBody.statements[2]] = setOf("finish()")
 
-        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = "reset()"
+        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("reset()")
 
         val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
         val everythingOk = orderEvaluator.evaluateOrder(dfa, p7Decl)
@@ -372,18 +372,18 @@ class ComplexDFAOrderEvaluationTest {
         assertNotNull(p7Decl)
         val consideredDecl = mutableSetOf(p7Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
-        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = "create()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = "init()"
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
+        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("create()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("init()")
         val loopBody =
             ((functionOk.body as CompoundStatement).statements[3] as? WhileStatement)?.statement
                 as? CompoundStatement
         assertNotNull(loopBody)
-        nodesToOp[loopBody.statements[0]] = "start()"
-        nodesToOp[loopBody.statements[1]] = "process()"
-        nodesToOp[loopBody.statements[2]] = "finish()"
+        nodesToOp[loopBody.statements[0]] = setOf("start()")
+        nodesToOp[loopBody.statements[1]] = setOf("process()")
+        nodesToOp[loopBody.statements[2]] = setOf("finish()")
 
-        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = "reset()"
+        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("reset()")
 
         val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
         val everythingOk = orderEvaluator.evaluateOrder(dfa, p7Decl)
@@ -402,21 +402,21 @@ class ComplexDFAOrderEvaluationTest {
         assertNotNull(p8Decl)
         val consideredDecl = mutableSetOf(p8Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
-        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = "create()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = "init()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = "start()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = "process()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[5]] = "finish()"
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
+        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("create()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("init()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = setOf("start()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("process()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[5]] = setOf("finish()")
         val loopBody =
             ((functionOk.body as CompoundStatement).statements[6] as? WhileStatement)?.statement
                 as? CompoundStatement
         assertNotNull(loopBody)
-        nodesToOp[loopBody.statements[0]] = "start()"
-        nodesToOp[loopBody.statements[1]] = "process()"
-        nodesToOp[loopBody.statements[2]] = "finish()"
+        nodesToOp[loopBody.statements[0]] = setOf("start()")
+        nodesToOp[loopBody.statements[1]] = setOf("process()")
+        nodesToOp[loopBody.statements[2]] = setOf("finish()")
 
-        nodesToOp[(functionOk.body as CompoundStatement).statements[7]] = "reset()"
+        nodesToOp[(functionOk.body as CompoundStatement).statements[7]] = setOf("reset()")
 
         val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
         val everythingOk = orderEvaluator.evaluateOrder(dfa, p8Decl)
@@ -435,18 +435,18 @@ class ComplexDFAOrderEvaluationTest {
         assertNotNull(p6Decl)
         val consideredDecl = mutableSetOf(p6Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
-        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = "create()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = "init()"
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
+        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("create()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("init()")
         val loopBody =
             ((functionOk.body as CompoundStatement).statements[3] as DoStatement).statement
                 as? CompoundStatement
         assertNotNull(loopBody)
-        nodesToOp[loopBody.statements[0]] = "start()"
-        nodesToOp[loopBody.statements[1]] = "process()"
-        nodesToOp[loopBody.statements[2]] = "finish()"
+        nodesToOp[loopBody.statements[0]] = setOf("start()")
+        nodesToOp[loopBody.statements[1]] = setOf("process()")
+        nodesToOp[loopBody.statements[2]] = setOf("finish()")
 
-        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = "reset()"
+        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("reset()")
 
         val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
         val everythingOk = orderEvaluator.evaluateOrder(dfa, p6Decl)
@@ -465,10 +465,10 @@ class ComplexDFAOrderEvaluationTest {
         assertNotNull(p1Decl)
         val consideredDecl = mutableSetOf(p1Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
-        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = "create()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = "start()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = "finish()"
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
+        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("create()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = setOf("start()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("finish()")
 
         val afterInterprocNodes = mutableListOf<Node>()
         val withoutInterprocNodes = mutableListOf<Node>()
@@ -502,10 +502,10 @@ class ComplexDFAOrderEvaluationTest {
         assertNotNull(p1Decl)
         val consideredDecl = mutableSetOf(p1Decl)
 
-        val nodesToOp = mutableMapOf<Node, String>()
-        nodesToOp[(functionOk.body as CompoundStatement).statements[0]] = "init()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = "start()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = "finish()"
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
+        nodesToOp[(functionOk.body as CompoundStatement).statements[0]] = setOf("init()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("start()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("finish()")
 
         val afterInterprocNodes = mutableListOf<Node>()
         val withoutInterprocNodes = mutableListOf<Node>()
@@ -542,10 +542,10 @@ class ComplexDFAOrderEvaluationTest {
         assertNotNull(p1Decl)
         val consideredDecl = mutableSetOf(p1Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
-        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = "create()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = "init()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = "start()"
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
+        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("create()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("init()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = setOf("start()")
 
         val possibleInterprocFailures = mutableListOf<Node>()
         val withoutInterprocNodes = mutableListOf<Node>()
@@ -579,10 +579,10 @@ class ComplexDFAOrderEvaluationTest {
         assertNotNull(p1Decl)
         val consideredDecl = mutableSetOf(p1Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
-        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = "create()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = "start()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = "finish()"
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
+        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("create()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = setOf("start()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("finish()")
 
         val afterInterprocNodes = mutableListOf<Node>()
         val withoutInterprocNodes = mutableListOf<Node>()
@@ -620,10 +620,10 @@ class ComplexDFAOrderEvaluationTest {
         assertNotNull(p1Decl)
         val consideredDecl = mutableSetOf(p1Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
-        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = "create()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[5]] = "start()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[6]] = "finish()"
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
+        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("create()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[5]] = setOf("start()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[6]] = setOf("finish()")
 
         val afterInterprocNodes = mutableListOf<Node>()
         val withoutInterprocNodes = mutableListOf<Node>()
@@ -652,7 +652,7 @@ class ComplexDFAOrderEvaluationTest {
      */
     class DummyDFAOrderEvaluator(
         referencedVertices: Set<Node>,
-        nodesToOp: Map<Node, String>,
+        nodesToOp: Map<Node, Set<String>>,
         thisPositionOfNode: Map<Node, Int>,
         val possibleInterprocFailures: MutableList<Node>,
         val withoutInterprocNodes: MutableList<Node>

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFAEqualityTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFAEqualityTest.kt
@@ -232,13 +232,13 @@ class DFAEqualityTest {
 
         val emptyNode = EmptyStatement()
         dfa.initializeOrderEvaluation(emptyNode)
-        dfa.makeTransitionWithOp("create()", emptyNode)
+        dfa.makeTransitionWithOp(setOf("create()"), emptyNode)
 
         assertTrue(dfa.isAccepted)
         assertNotEquals(oldDfa, dfa)
 
         oldDfa.initializeOrderEvaluation(emptyNode)
-        oldDfa.makeTransitionWithOp("create()", emptyNode)
+        oldDfa.makeTransitionWithOp(setOf("create()"), emptyNode)
         assertEquals(oldDfa, dfa)
 
         oldDfa.addEdge(

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/FSMTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/FSMTest.kt
@@ -104,7 +104,7 @@ class FSMTest {
 
         val emptyNode = EmptyStatement()
         dfa.initializeOrderEvaluation(emptyNode)
-        dfa.makeTransitionWithOp("create()", emptyNode)
+        dfa.makeTransitionWithOp(setOf("create()"), emptyNode)
 
         assertNotEquals(dfa, dfaCopy)
         assertEquals(dfa.executionTrace, dfa.deepCopy().executionTrace)

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/SimpleDFAOrderEvaluationTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/SimpleDFAOrderEvaluationTest.kt
@@ -93,8 +93,8 @@ class SimpleDFAOrderEvaluationTest {
         nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("start()")
         nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("finish()")
 
-        val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p4Decl)
+        val orderEvaluator = DFAOrderEvaluator(dfa, consideredDecl, nodesToOp)
+        val everythingOk = orderEvaluator.evaluateOrder(p4Decl)
 
         assertTrue(everythingOk, "Expected correct order")
     }
@@ -115,8 +115,8 @@ class SimpleDFAOrderEvaluationTest {
         // We do not model the call to foo() because it does not exist in our model.
         nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = setOf("finish()")
 
-        val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p4Decl)
+        val orderEvaluator = DFAOrderEvaluator(dfa, consideredDecl, nodesToOp)
+        val everythingOk = orderEvaluator.evaluateOrder(p4Decl)
 
         assertTrue(everythingOk, "Expected correct order")
     }
@@ -148,8 +148,8 @@ class SimpleDFAOrderEvaluationTest {
         // We do not model the call to foo() because it does not exist in our model.
         nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = setOf("finish()")
 
-        val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p4Decl)
+        val orderEvaluator = DFAOrderEvaluator(dfa, consideredDecl, nodesToOp)
+        val everythingOk = orderEvaluator.evaluateOrder(p4Decl)
 
         assertTrue(everythingOk, "Expected correct order")
     }
@@ -172,8 +172,8 @@ class SimpleDFAOrderEvaluationTest {
         // We do not model the call to foo() because it does not exist in our model.
         nodesToOp[(functionOk.body as CompoundStatement).statements[5]] = setOf("set_key()")
 
-        val orderEvaluator = DFAOrderEvaluator(consideredBases, nodesToOp)
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, pDecl)
+        val orderEvaluator = DFAOrderEvaluator(dfa, consideredBases, nodesToOp)
+        val everythingOk = orderEvaluator.evaluateOrder(pDecl)
 
         assertFalse(everythingOk, "Expected incorrect order")
     }
@@ -192,8 +192,8 @@ class SimpleDFAOrderEvaluationTest {
         val nodesToOp = mutableMapOf<Node, Set<String>>()
         nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("start()")
 
-        val orderEvaluator = DFAOrderEvaluator(consideredBases, nodesToOp)
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p2Decl)
+        val orderEvaluator = DFAOrderEvaluator(dfa, consideredBases, nodesToOp)
+        val everythingOk = orderEvaluator.evaluateOrder(p2Decl)
 
         assertFalse(everythingOk, "Expected incorrect order")
     }
@@ -217,8 +217,8 @@ class SimpleDFAOrderEvaluationTest {
         nodesToOp[thenBranch.statements[0]] = setOf("start()")
         nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("finish()")
 
-        val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p3Decl)
+        val orderEvaluator = DFAOrderEvaluator(dfa, consideredDecl, nodesToOp)
+        val everythingOk = orderEvaluator.evaluateOrder(p3Decl)
 
         assertFalse(everythingOk, "Expected incorrect order")
     }
@@ -244,8 +244,8 @@ class SimpleDFAOrderEvaluationTest {
         nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("start()")
         nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("finish()")
 
-        val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
-        val everythingOk = orderEvaluator.evaluateOrder(dfa, p4Decl)
+        val orderEvaluator = DFAOrderEvaluator(dfa, consideredDecl, nodesToOp)
+        val everythingOk = orderEvaluator.evaluateOrder(p4Decl)
 
         assertFalse(everythingOk, "Expected incorrect order")
     }

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/SimpleDFAOrderEvaluationTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/SimpleDFAOrderEvaluationTest.kt
@@ -89,9 +89,9 @@ class SimpleDFAOrderEvaluationTest {
         assertNotNull(p4Decl)
         val consideredDecl = mutableSetOf(p4Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
-        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = "start()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = "finish()"
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
+        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("start()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("finish()")
 
         val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
         val everythingOk = orderEvaluator.evaluateOrder(dfa, p4Decl)
@@ -110,10 +110,10 @@ class SimpleDFAOrderEvaluationTest {
         assertNotNull(p4Decl)
         val consideredDecl = mutableSetOf(p4Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
-        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = "start()"
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
+        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("start()")
         // We do not model the call to foo() because it does not exist in our model.
-        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = "finish()"
+        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = setOf("finish()")
 
         val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
         val everythingOk = orderEvaluator.evaluateOrder(dfa, p4Decl)
@@ -132,21 +132,21 @@ class SimpleDFAOrderEvaluationTest {
         assertNotNull(p4Decl)
         val consideredDecl = mutableSetOf(p4Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
         // We model the calls to start() for the then and the else branch
         val thenBranch =
             ((functionOk.body as CompoundStatement).statements[2] as? IfStatement)?.thenStatement
                 as? CompoundStatement
         assertNotNull(thenBranch)
-        nodesToOp[thenBranch.statements[0]] = "start()"
+        nodesToOp[thenBranch.statements[0]] = setOf("start()")
         val elseBranch =
             ((functionOk.body as CompoundStatement).statements[2] as? IfStatement)?.elseStatement
                 as? CompoundStatement
         assertNotNull(elseBranch)
-        nodesToOp[elseBranch.statements[0]] = "start()"
+        nodesToOp[elseBranch.statements[0]] = setOf("start()")
 
         // We do not model the call to foo() because it does not exist in our model.
-        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = "finish()"
+        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = setOf("finish()")
 
         val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
         val everythingOk = orderEvaluator.evaluateOrder(dfa, p4Decl)
@@ -165,12 +165,12 @@ class SimpleDFAOrderEvaluationTest {
         assertNotNull(pDecl)
         val consideredBases = mutableSetOf(pDecl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
-        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = "set_key()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = "start()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = "finish()"
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
+        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("set_key()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("start()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[3]] = setOf("finish()")
         // We do not model the call to foo() because it does not exist in our model.
-        nodesToOp[(functionOk.body as CompoundStatement).statements[5]] = "set_key()"
+        nodesToOp[(functionOk.body as CompoundStatement).statements[5]] = setOf("set_key()")
 
         val orderEvaluator = DFAOrderEvaluator(consideredBases, nodesToOp)
         val everythingOk = orderEvaluator.evaluateOrder(dfa, pDecl)
@@ -189,8 +189,8 @@ class SimpleDFAOrderEvaluationTest {
         assertNotNull(p2Decl)
         val consideredBases = mutableSetOf(p2Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
-        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = "start()"
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
+        nodesToOp[(functionOk.body as CompoundStatement).statements[1]] = setOf("start()")
 
         val orderEvaluator = DFAOrderEvaluator(consideredBases, nodesToOp)
         val everythingOk = orderEvaluator.evaluateOrder(dfa, p2Decl)
@@ -209,13 +209,13 @@ class SimpleDFAOrderEvaluationTest {
         assertNotNull(p3Decl)
         val consideredDecl = mutableSetOf(p3Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
         val thenBranch =
             ((functionOk.body as CompoundStatement).statements[1] as? IfStatement)?.thenStatement
                 as? CompoundStatement
         assertNotNull(thenBranch)
-        nodesToOp[thenBranch.statements[0]] = "start()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = "finish()"
+        nodesToOp[thenBranch.statements[0]] = setOf("start()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("finish()")
 
         val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
         val everythingOk = orderEvaluator.evaluateOrder(dfa, p3Decl)
@@ -234,15 +234,15 @@ class SimpleDFAOrderEvaluationTest {
         assertNotNull(p4Decl)
         val consideredDecl = mutableSetOf(p4Decl.declarations[0])
 
-        val nodesToOp = mutableMapOf<Node, String>()
+        val nodesToOp = mutableMapOf<Node, Set<String>>()
         val thenBranch =
             ((functionOk.body as CompoundStatement).statements[1] as? IfStatement)?.thenStatement
                 as? CompoundStatement
         assertNotNull(thenBranch)
-        nodesToOp[thenBranch.statements[0]] = "start()"
-        nodesToOp[thenBranch.statements[1]] = "finish()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = "start()"
-        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = "finish()"
+        nodesToOp[thenBranch.statements[0]] = setOf("start()")
+        nodesToOp[thenBranch.statements[1]] = setOf("finish()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[2]] = setOf("start()")
+        nodesToOp[(functionOk.body as CompoundStatement).statements[4]] = setOf("finish()")
 
         val orderEvaluator = DFAOrderEvaluator(consideredDecl, nodesToOp)
         val everythingOk = orderEvaluator.evaluateOrder(dfa, p4Decl)

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -396,7 +396,37 @@ fun Node.followPrevEOGEdgesUntilHit(predicate: (Node) -> Boolean): FulfilledAndF
 }
 
 /**
- * Returns a list of edges which are form the evaluation order between the starting node [this] and
+ * Returns a list of edges which are from the evaluation order between the starting node [this] and
+ * an edge fulfilling [predicate]. If the return value is not `null`, a path from [this] to such an
+ * edge is **possible but not mandatory**.
+ *
+ * It returns only a single possible path even if multiple paths are possible.
+ */
+fun Node.followNextEOG(predicate: (PropertyEdge<*>) -> Boolean): List<PropertyEdge<*>>? {
+    val path = mutableListOf<PropertyEdge<*>>()
+
+    for (edge in this.nextEOGEdges) {
+        val target = edge.end
+
+        path.add(edge)
+
+        if (predicate(edge)) {
+            return path
+        }
+
+        val subPath = target.followNextEOG(predicate)
+        if (subPath != null) {
+            path.addAll(subPath)
+
+            return path
+        }
+    }
+
+    return null
+}
+
+/**
+ * Returns a list of edges which are from the evaluation order between the starting node [this] and
  * an edge fulfilling [predicate]. If the return value is not `null`, a path from [this] to such an
  * edge is **possible but not mandatory**.
  *

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/EdgeCachePass.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/EdgeCachePass.kt
@@ -27,7 +27,6 @@ package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.processing.IVisitor
 import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
@@ -74,29 +73,6 @@ object Edges {
         toMap.clear()
         fromMap.clear()
     }
-}
-
-fun Node.followNextEOG(predicate: (PropertyEdge<*>) -> Boolean): List<PropertyEdge<*>>? {
-    val path = mutableListOf<PropertyEdge<*>>()
-
-    for (edge in this.nextEOGEdges) {
-        val target = edge.end
-
-        path.add(edge)
-
-        if (predicate(edge)) {
-            return path
-        }
-
-        val subPath = target.followNextEOG(predicate)
-        if (subPath != null) {
-            path.addAll(subPath)
-
-            return path
-        }
-    }
-
-    return null
 }
 
 /**


### PR DESCRIPTION
This pull request improves the DFA order evaluation in two aspects: 
- it allows a CPG node to correspond to multiple names allowing following syntax in Codyze/Coko:
```Kotlin
order(testObj::constructor) {
            +testObj::start.use { call(1) }
            +testObj::start
            +testObj::finish
        }
```
In this case, `testObj::start.use { call(1) }` corresponds to the set of `start` nodes that have `1` as an argument compared to `testObj::start`, which returns all nodes of `start`. The CPG nodes contained in both sets therefore need the ability to map to multiple names.
- Implement the `consideredResetNodes` feature, which allows the `DFAOrderEvaluator` to reset the order evaluation on a base when a reset node is encountered. This allows the correct evaluation of cases like the following:
```Java
Botan p7 = new Botan(2);
p7.start(iv);
p7.finish(buf);

p7 = new Botan(3); // Botan(3) would be in the consideredResetNodes and thus reset the order evaluation
p7.start(iv);
p7.finish(buf);
```
Before this change, the `DFAOrderEvaluator` would have triggered a false order evaluation error not realizing that `p7 = new Botan(3);` must finalize & reset the ongoing order evaluation.

Additionally, it moves `Node.followNextEOG` to the correct `Extensions.kt` file.