### PR TITLE
Upgrade Eclipse CDT to 11 and Java to 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
-          java-version: "15"
+          java-version: "17"
       - name: Build
         run: |
           cd cpg-language-go/src/main/golang
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "zulu"
-          java-version: "15"
+          java-version: "17"
           cache: "gradle"
       - uses: actions/setup-python@v4
         with:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The most recent version is being published to Maven central and can be used as a
 ```
 repositories {
     ivy {
-        setUrl("https://download.eclipse.org/tools/cdt/releases/10.3/cdt-10.3.2/plugins")
+        setUrl("https://download.eclipse.org/tools/cdt/releases/11.0/cdt-11.0.0/plugins")
         metadataSources {
             artifact()
         }

--- a/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts
@@ -25,7 +25,7 @@ repositories {
     mavenCentral()
 
     ivy {
-        setUrl("https://download.eclipse.org/tools/cdt/releases/10.3/cdt-10.3.2/plugins")
+        setUrl("https://download.eclipse.org/tools/cdt/releases/11.0/cdt-11.0.0/plugins")
         metadataSources {
             artifact()
         }
@@ -38,7 +38,7 @@ repositories {
 //
 // common documentation, signing and publishing configuration
 //
-// this disables gradles alternative to POM files, which cause problems when publishing on Maven
+// this disables gradle's alternative to POM files, which cause problems when publishing on Maven
 tasks.withType<GenerateModuleMetadata> {
     enabled = false
 }
@@ -114,7 +114,7 @@ signing {
 // specify Java & Kotlin JVM version
 kotlin {
     jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ jackson = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", versi
 eclipse-runtime = { module = "org.eclipse.platform:org.eclipse.core.runtime", version = "3.26.0"}
 osgi-service = { module = "org.osgi:org.osgi.service.prefs", version = "1.1.2"}
 icu4j = { module = "com.ibm.icu:icu4j", version = "72.1"}
-eclipse-cdt-core = { module = "org.eclipse.cdt:core", version = "7.2.100.202105180159"}
+eclipse-cdt-core = { module = "org.eclipse.cdt:core", version = "8.0.0.202211292120"}
 commons-io = { module = "commons-io:commons-io", version = "2.11.0"}
 jetbrains-annotations = { module = "org.jetbrains:annotations", version = "24.0.0"}
 picocli = { module = "info.picocli:picocli", version = "4.7.0"}


### PR DESCRIPTION
We should take the chance with the next major CPG version to upgrade CDT. The recent version of CDT however needs Java 17, making this a great time to upgrade to this LTS version.
