### PR TITLE
Fix gradle publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'beta') && !contains(github.ref, 'alpha')
         run: |
           export ORG_GRADLE_PROJECT_signingKey=`echo ${{ secrets.GPG_PRIVATE_KEY }} | base64 -d`
-          ./gradlew --no-daemon -Dorg.gradle.internal.publish.checksums.insecure=true --parallel -Pversion=$VERSION -PenableGoFrontend=true -PenablePythonFrontend=true -PenableLLVMFrontend=true -PenableTypeScriptFrontend=true signMavenPublication build publish dokkaHtmlMultiModule
+          ./gradlew --no-daemon -Dorg.gradle.internal.publish.checksums.insecure=true --parallel -Pversion=$VERSION -PenableGoFrontend=true -PenablePythonFrontend=true -PenableLLVMFrontend=true -PenableTypeScriptFrontend=true publishAllModules dokkaHtmlMultiModule
         env:
           VERSION: ${{ steps.determine_version.outputs.version }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,19 @@ sonarqube {
     }
 }
 
+val publishAllModules by tasks.registering() {
+    subprojects.forEach {
+        dependsOn(it.tasks.named("publish"))
+    }
+}
+
+val publishAllModulesToMavenLocal by tasks.registering() {
+    subprojects.forEach {
+        dependsOn(it.tasks.named("publishToMavenLocal"))
+    }
+}
+
+
 //
 // Load the properties that define which frontends to include
 //


### PR DESCRIPTION
Registers two new compound tasks: 'publishAllModules' and 'publishAllModulesToMavenLocal'.
These tasks depend on the 'publish' respectively 'publishToMavenLocal' tasks in each sub module.

Fixes the github workflow to use the new publishAllModules task