### PR TITLE
Add frontend dependency plugin

### DIFF
--- a/buildSrc/src/main/kotlin/cpg.frontend-dependency-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cpg.frontend-dependency-conventions.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    kotlin("jvm")
+    `java-library`
+}
+
+val enableGoFrontend: Boolean by rootProject.extra
+val enablePythonFrontend: Boolean by rootProject.extra
+val enableLLVMFrontend: Boolean by rootProject.extra
+val enableTypeScriptFrontend: Boolean by rootProject.extra
+
+dependencies {
+    if (enableGoFrontend) api(project(":cpg-language-go"))
+    if (enablePythonFrontend) api(project(":cpg-language-python"))
+    if (enableLLVMFrontend) api(project(":cpg-language-llvm"))
+    if (enableTypeScriptFrontend) api(project(":cpg-language-typescript"))
+}

--- a/cpg-all/build.gradle.kts
+++ b/cpg-all/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("cpg.library-conventions")
+    id("cpg.frontend-dependency-conventions")
 }
 
 publishing {
@@ -15,18 +16,9 @@ publishing {
     }
 }
 
-val enableGoFrontend: Boolean by rootProject.extra
-val enablePythonFrontend: Boolean by rootProject.extra
-val enableLLVMFrontend: Boolean by rootProject.extra
-val enableTypeScriptFrontend: Boolean by rootProject.extra
 
 dependencies {
     // this exposes all of our (published) modules as dependency
     api(projects.cpgCore)
     api(projects.cpgAnalysis)
-
-    if (enableGoFrontend) api(project(":cpg-language-go"))
-    if (enablePythonFrontend) api(project(":cpg-language-python"))
-    if (enableLLVMFrontend) api(project(":cpg-language-llvm"))
-    if (enableTypeScriptFrontend) api(project(":cpg-language-typescript"))
 }

--- a/cpg-console/build.gradle.kts
+++ b/cpg-console/build.gradle.kts
@@ -25,6 +25,7 @@
  */
 plugins {
     id("cpg.application-conventions")
+    id("cpg.frontend-dependency-conventions")
 }
 
 publishing {

--- a/cpg-neo4j/build.gradle.kts
+++ b/cpg-neo4j/build.gradle.kts
@@ -25,6 +25,7 @@
  */
 plugins {
     id("cpg.application-conventions")
+    id("cpg.frontend-dependency-conventions")
 }
 
 application {


### PR DESCRIPTION
@maximiliankaul noticed that both the cpg-neo4j and the cpg-console are missing the optional language frontend dependencies. This pull request fixes that by introducing a new convention plugin.