### PR TITLE
Use `UNREACHABLE` property in `followNextEOG` methods

### DIFF
--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -376,13 +376,20 @@ fun Node.followPrevEOGEdgesUntilHit(predicate: (Node) -> Boolean): FulfilledAndF
         val currentPath = worklist.removeFirst()
         // The last node of the path is where we continue. We get all of its outgoing DFG edges and
         // follow them
-        if (currentPath.last().prevEOG.isEmpty()) {
+        if (
+            currentPath.last().prevEOGEdges.none { it.getProperty(Properties.UNREACHABLE) != true }
+        ) {
             // No further nodes in the path and the path criteria are not satisfied.
             failedPaths.add(currentPath)
             continue // Don't add this path anymore. The requirement is satisfied.
         }
 
-        for (next in currentPath.last().prevEOG) {
+        for (next in
+            currentPath
+                .last()
+                .prevEOGEdges
+                .filter { it.getProperty(Properties.UNREACHABLE) != true }
+                .map { it.start }) {
             // Copy the path for each outgoing DFG edge and add the next node
             val nextPath = mutableListOf<Node>()
             nextPath.addAll(currentPath)
@@ -443,7 +450,7 @@ fun Node.followNextEOG(predicate: (PropertyEdge<*>) -> Boolean): List<PropertyEd
 fun Node.followPrevEOG(predicate: (PropertyEdge<*>) -> Boolean): List<PropertyEdge<*>>? {
     val path = mutableListOf<PropertyEdge<*>>()
 
-    for (edge in this.prevEOGEdges) {
+    for (edge in this.prevEOGEdges.filter { it.getProperty(Properties.UNREACHABLE) != true }) {
         val source = edge.start
 
         path.add(edge)

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/DeclarationStatement.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/DeclarationStatement.java
@@ -42,7 +42,7 @@ import org.neo4j.ogm.annotation.Relationship;
 /**
  * A {@link Statement}, which contains a single or multiple {@link Declaration}s. Usually these
  * statements occur if one defines a variable within a function body. A function body is a {@link
- * CompoundStatement}, which can only contain other statements, but not declarations. Therefore
+ * CompoundStatement}, which can only contain other statements, but not declarations. Therefore,
  * declarations are wrapped in a {@link DeclarationStatement}.
  */
 public class DeclarationStatement extends Statement {


### PR DESCRIPTION
We may want to filter unreachable paths from the results of the `followNextEOG` and `followNextEOGUntilHit` methods. Closes #1049 

I realized that we do not set this property for the `prevEOGEdges` even if it should be a bi-directional property. Unreachable basically means that there's a condition which makes this specific transition `n1 - nextEOG -> n2` impossible. This means that also `n1 <- prevEOG - n2` should be not be relevant for the backwards traversal, right? Should we add this feature as well (@oxisto @konradweiss)?