### PR TITLE
Fixed unwrap of `usage` in `ValueDeclaration`

### DIFF
--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/declarations/ValueDeclaration.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/declarations/ValueDeclaration.java
@@ -83,8 +83,9 @@ public abstract class ValueDeclaration extends Declaration implements HasType {
 
   /** All usages of the variable/field. */
   public List<DeclaredReferenceExpression> getUsages() {
-    return unwrap(usageEdges, false);
+    return unwrap(usageEdges, true);
   }
+
   /** All usages of the variable/field with the access value. */
   public List<PropertyEdge<DeclaredReferenceExpression>> getUsageEdges() {
     return usageEdges;


### PR DESCRIPTION
Fixes #1059