### PR TITLE
Improvements to the `CXXLanguageFrontend`

### DIFF
--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/CastExpression.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/CastExpression.java
@@ -98,23 +98,12 @@ public class CastExpression extends Expression implements TypeListener {
   public void setCastOperator(int operatorCode) {
     String localName = null;
     switch (operatorCode) {
-      case 0:
-        localName = "cast";
-        break;
-      case 1:
-        localName = "dynamic_cast";
-        break;
-      case 2:
-        localName = "static_cast";
-        break;
-      case 3:
-        localName = "reinterpret_cast";
-        break;
-      case 4:
-        localName = "const_cast";
-        break;
-      default:
-        log.error("unknown operator {}", operatorCode);
+      case 0 -> localName = "cast";
+      case 1 -> localName = "dynamic_cast";
+      case 2 -> localName = "static_cast";
+      case 3 -> localName = "reinterpret_cast";
+      case 4 -> localName = "const_cast";
+      default -> log.error("unknown operator {}", operatorCode);
     }
 
     if (localName != null) {

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/DeclaredReferenceExpression.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/statements/expressions/DeclaredReferenceExpression.java
@@ -139,6 +139,11 @@ public class DeclaredReferenceExpression extends Expression
     if (!TypeManager.isTypeSystemActive()) {
       return;
     }
+
+    // since we want to update the sub types, we need to exclude ourselves from the root, otherwise
+    // it won't work. What a weird and broken system!
+    root.remove(this);
+
     List<Type> subTypes = new ArrayList<>(getPossibleSubTypes());
     subTypes.addAll(src.getPossibleSubTypes());
     setPossibleSubTypes(subTypes, root);

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/types/Type.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/types/Type.java
@@ -362,7 +362,7 @@ public abstract class Type extends Node {
       return true;
     }
 
-    return this.getTypeName().equals(t.getTypeName());
+    return this.getRoot().getName().equals(t.getRoot().getName());
   }
 
   @Override

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontend.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontend.kt
@@ -454,8 +454,13 @@ class CXXLanguageFrontend(
         }
     }
 
+    /** Returns the [Type] that is represented by an [IASTTypeId]. */
+    fun typeOf(id: IASTTypeId): Type {
+        return typeOf(id.abstractDeclarator, id.declSpecifier)
+    }
+
     /**
-     * Returns the [Type] that is represented by the [declarator] and [specifier]. This tries to
+     * Returns te [Type] that is represented by the [declarator] and [specifier]. This tries to
      * resolve as much information about the type on its own using by analyzing the AST of the
      * supplied declarator and specifier. Finally, [TypeParser.createFrom] is invoked on the
      * innermost type, but all other type adjustments, such as creating a [PointerType] is done

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.kt
@@ -144,8 +144,7 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
         val recordDeclaration = (declaration as? MethodDeclaration)?.recordDeclaration
 
         // We want to determine, whether we are currently outside a record. In this case, our
-        // function
-        // is either really a function or a method definition external to a class.
+        // function is either really a function or a method definition external to a class.
         val outsideOfRecord =
             !(frontend.scopeManager.currentScope is RecordScope ||
                 frontend.scopeManager.currentScope is TemplateScope)
@@ -246,7 +245,7 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
      * not. For some reason it seems that Eclipse CDT has no other means of differentiating a
      * typedef declaration from a regular one, except looking at the raw code
      */
-    val IASTSimpleDeclaration.isTypedef: Boolean
+    private val IASTSimpleDeclaration.isTypedef: Boolean
         get() {
             return if (this.rawSignature.contains("typedef")) {
                 if (this.declSpecifier is CPPASTCompositeTypeSpecifier) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.kt
@@ -282,8 +282,7 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
                         )
                     } else {
                         // specifying void as first parameter is ok and means that the function has
-                        // no
-                        // parameters
+                        // no parameters
                         if (i == 0) {
                             continue
                         } else {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilder.kt
@@ -155,7 +155,7 @@ fun MetadataProvider.newConditionalExpression(
     condition: Expression,
     thenExpr: Expression?,
     elseExpr: Expression?,
-    type: Type?,
+    type: Type? = UnknownType.getUnknownType(),
     code: String? = null,
     rawNode: Any? = null
 ): ConditionalExpression {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CallResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CallResolver.kt
@@ -283,7 +283,7 @@ open class CallResolver : SymbolResolverPass() {
         if (curClass == null) {
             // Handle function (not method) calls. C++ allows function overloading. Make sure we
             // have at least the same number of arguments
-            var candidates =
+            val candidates =
                 if (language is HasComplexCallResolution) {
                     // Handle CXX normal call resolution externally, otherwise it leads to increased
                     // complexity


### PR DESCRIPTION
This PR adds several improvements to the C/C++ language frontend. Primarily, we remove reliance to CDT types. This is one more step towards our strategy to use CDT solely as parser, but not do any kind of symbol resolving.

Fixes #28
Fixes #189
