### PR TITLE
Correct parsing of functions in namespaces in C++

### DIFF
--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/types/TypeParser.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/types/TypeParser.java
@@ -29,7 +29,6 @@ import de.fraunhofer.aisec.cpg.ScopeManager;
 import de.fraunhofer.aisec.cpg.frontends.*;
 import de.fraunhofer.aisec.cpg.frontends.cpp.CLanguage;
 import de.fraunhofer.aisec.cpg.frontends.cpp.CPPLanguage;
-import de.fraunhofer.aisec.cpg.graph.Name;
 import de.fraunhofer.aisec.cpg.graph.TypeManager;
 import java.util.ArrayList;
 import java.util.List;
@@ -873,16 +872,19 @@ public class TypeParser {
     }
   }
 
-  /** Parses the type from a string and the supplied language. */
+  /** Parses the type from a char sequence and the supplied language. */
   @NotNull
   public static Type createFrom(
-      @NotNull String type, Language<? extends LanguageFrontend> language) {
-    return createFrom(type, language, false, null);
+      @NotNull CharSequence name,
+      Boolean resolveAlias,
+      Language<? extends LanguageFrontend> language) {
+    return createFrom(name.toString(), language, resolveAlias, null);
   }
 
-  /** Parses the type from a string and the supplied language. */
+  /** Parses the type from a char sequence and the supplied language. */
   @NotNull
-  public static Type createFrom(@NotNull Name name, Language<? extends LanguageFrontend> language) {
+  public static Type createFrom(
+      @NotNull CharSequence name, Language<? extends LanguageFrontend> language) {
     return createFrom(name.toString(), language, false, null);
   }
 }

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/ResolveInFrontend.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/passes/ResolveInFrontend.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.passes
+
+import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager
+
+/**
+ * Functions marked with this annotation are using features of the [ScopeManager] to resolve symbols
+ * (or scopes) during frontend parsing. This is something which we discourage. However, in
+ * non-context free languages such as C++ this is unavoidable to some degree.
+ */
+@Target(AnnotationTarget.FUNCTION) annotation class ResolveInFrontend(val method: String)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/PopulatedByPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/PopulatedByPass.kt
@@ -23,7 +23,7 @@
  *                    \______/ \__|       \______/
  *
  */
-package de.fraunhofer.aisec.cpg.graph
+package de.fraunhofer.aisec.cpg
 
 import de.fraunhofer.aisec.cpg.passes.Pass
 import kotlin.reflect.KClass

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ResolveInFrontend.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ResolveInFrontend.kt
@@ -23,9 +23,7 @@
  *                    \______/ \__|       \______/
  *
  */
-package de.fraunhofer.aisec.cpg.passes
-
-import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager
+package de.fraunhofer.aisec.cpg
 
 /**
  * Functions marked with this annotation are using features of the [ScopeManager] to resolve symbols

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CPPLanguage.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CPPLanguage.kt
@@ -140,11 +140,7 @@ class CPPLanguage :
         scopeManager: ScopeManager,
         currentTU: TranslationUnitDeclaration
     ): List<FunctionDeclaration> {
-        val invocationCandidates =
-            scopeManager
-                .resolveFunctionStopScopeTraversalOnDefinition(call)
-                .filter { it.hasSignature(call.signature) }
-                .toMutableList()
+        val invocationCandidates = scopeManager.resolveFunction(call).toMutableList()
         if (invocationCandidates.isEmpty()) {
             // Check for usage of default args
             invocationCandidates.addAll(resolveWithDefaultArgsFunc(call, scopeManager))
@@ -152,8 +148,7 @@ class CPPLanguage :
         if (invocationCandidates.isEmpty()) {
             // Check if the call can be resolved to a function template instantiation. If it can be
             // resolver, we resolve the call. Otherwise, there won't be an inferred template, we
-            // will do an
-            // inferred FunctionDeclaration instead.
+            // will do an inferred FunctionDeclaration instead.
             call.templateParameterEdges = mutableListOf()
             val (ok, candidates) =
                 handleTemplateFunctionCalls(null, call, false, scopeManager, currentTU)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontend.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontend.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.frontends.cpp
 
+import de.fraunhofer.aisec.cpg.ResolveInFrontend
 import de.fraunhofer.aisec.cpg.ScopeManager
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.frontends.Language
@@ -39,7 +40,6 @@ import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.helpers.Benchmark
-import de.fraunhofer.aisec.cpg.passes.ResolveInFrontend
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 import de.fraunhofer.aisec.cpg.sarif.Region
 import java.io.File

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.kt
@@ -33,10 +33,10 @@ import de.fraunhofer.aisec.cpg.graph.statements.CompoundStatement
 import de.fraunhofer.aisec.cpg.graph.statements.ReturnStatement
 import de.fraunhofer.aisec.cpg.graph.statements.Statement
 import de.fraunhofer.aisec.cpg.graph.types.*
+import java.util.function.Supplier
 import org.eclipse.cdt.core.dom.ast.*
 import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit.IDependencyTree.IASTInclusionNode
 import org.eclipse.cdt.internal.core.dom.parser.cpp.*
-import java.util.function.Supplier
 
 /**
  * This class is a [CXXHandler] which takes care of translating C/C++
@@ -215,11 +215,11 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
 
         frontend.processAttributes(declaration, ctx)
 
+        frontend.scopeManager.leaveScope(declaration)
+
         if (holder != null && outsideOfScope) {
             frontend.scopeManager.leaveScope(holder)
         }
-
-        frontend.scopeManager.leaveScope(declaration)
 
         // Check for declarations of the same function within the same translation unit to connect
         // definitions and declarations.

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.frontends.cpp
 
+import de.fraunhofer.aisec.cpg.ResolveInFrontend
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.scopes.NameScope
@@ -32,7 +33,6 @@ import de.fraunhofer.aisec.cpg.graph.scopes.RecordScope
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.helpers.Util
-import de.fraunhofer.aisec.cpg.passes.ResolveInFrontend
 import java.util.*
 import java.util.function.Supplier
 import java.util.regex.Pattern

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.kt
@@ -27,10 +27,13 @@ package de.fraunhofer.aisec.cpg.frontends.cpp
 
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.*
+import de.fraunhofer.aisec.cpg.graph.scopes.NameScope
 import de.fraunhofer.aisec.cpg.graph.scopes.RecordScope
+import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.graph.scopes.TemplateScope
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.helpers.Util
+import de.fraunhofer.aisec.cpg.passes.ResolveInFrontend
 import java.util.*
 import java.util.function.Supplier
 import java.util.regex.Pattern
@@ -156,31 +159,44 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
     }
 
     /**
-     * A small utility function that creates a [ConstructorDeclaration] if the local names of the
-     * function and its [RecordDeclaration] match. Otherwise, a [MethodDeclaration] with the
-     * appropriate [name] will be created.
+     * A small utility function that creates a [ConstructorDeclaration], [MethodDeclaration] or
+     * [FunctionDeclaration] depending on which scope the function should live in. This basically
+     * checks if the scope is a namespace or a record and if the name matches to the record (in case
+     * of a constructor).
      */
-    private fun createMethodOrConstructor(
+    private fun createFunctionOrMethodOrConstructor(
         name: Name,
-        recordDeclaration: RecordDeclaration?,
+        scope: Scope?,
         ctx: IASTNode,
-    ): MethodDeclaration {
+    ): FunctionDeclaration {
+        // Retrieve the AST node for the scope we need to put the function in
+        val holder = scope?.astNode
+
         // Check, if it's a constructor. This is the case if the local names of the function and the
         // record declaration match
-        val method =
-            if (name.localName == recordDeclaration?.name?.localName) {
-                newConstructorDeclaration(name, null, recordDeclaration, ctx)
+        val func =
+            if (holder is RecordDeclaration && name.localName == holder.name.localName) {
+                newConstructorDeclaration(name, null, holder, ctx)
+            } else if (scope?.astNode is NamespaceDeclaration) {
+                // It could also be a scoped function declaration.
+                newFunctionDeclaration(name, null, ctx)
             } else {
-                newMethodDeclaration(name, null, false, recordDeclaration, ctx)
+                // Otherwise, it's a method to a known or unknown record
+                newMethodDeclaration(name, null, false, holder as? RecordDeclaration, ctx)
             }
 
-        return method
+        // Also make sure to correctly set the scope of the function, regardless where we are in the
+        // AST currently
+        func.scope = scope
+
+        return func
     }
 
+    @ResolveInFrontend("lookupScope")
     private fun handleFunctionDeclarator(ctx: IASTStandardFunctionDeclarator): ValueDeclaration {
         // Programmers can wrap the function name in as many levels of parentheses as they like. CDT
         // treats these levels as separate declarators, so we need to get to the bottom for the
-        // actual name...
+        // actual name using the realName extension function.
         val (nameDecl: IASTDeclarator, hasPointer) = ctx.realName()
         var name = parseName(nameDecl.name.toString())
 
@@ -199,43 +215,40 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
         }
         val declaration: FunctionDeclaration
 
-        // If this is a method, this is its record declaration
-        var recordDeclaration: RecordDeclaration? = null
+        // We need to check if this function is actually part of a named declaration, such as a
+        // record or a namespace, but defined externally.
+        var parentScope: NameScope? = null
 
-        // remember, if this is a method declaration outside the record
-        val outsideOfRecord =
-            !(frontend.scopeManager.currentRecord != null ||
-                frontend.scopeManager.currentScope is TemplateScope)
-
-        // Check for function definitions that are really methods and constructors, i.e. if they
-        // contain a scope operator
+        // Check for function definitions that really belong to a named scoped, i.e. if they
+        // contain a scope operator. This could either be a namespace or a record.
         val parent = name.parent
         if (parent != null) {
             // In this case, the name contains a qualifier, and we can try to check, if we have a
-            // matching record declaration for the parent name
-            recordDeclaration =
-                frontend.scopeManager.currentScope?.let {
-                    frontend.scopeManager.getRecordForName(it, parent)
-                }
+            // matching name scope for the parent name
+            parentScope = frontend.scopeManager.lookupScope(parent.toString())
 
-            declaration = createMethodOrConstructor(name, recordDeclaration, ctx.parent)
+            declaration = createFunctionOrMethodOrConstructor(name, parentScope, ctx.parent)
         } else if (frontend.scopeManager.isInRecord) {
-            // if it is inside a record scope, it is a method
-            recordDeclaration = frontend.scopeManager.currentRecord
-            declaration = createMethodOrConstructor(name, recordDeclaration, ctx.parent)
+            // If the current scope is already a record, it's a method
+            declaration =
+                createFunctionOrMethodOrConstructor(
+                    name,
+                    frontend.scopeManager.currentScope,
+                    ctx.parent
+                )
         } else {
-            // a plain old function, outside any record scope
+            // a plain old function, outside any named scope
             declaration = newFunctionDeclaration(name, ctx.rawSignature, ctx.parent)
         }
 
-        // If we know our record declaration, but are outside the actual record, we
-        // need to temporarily enter the record scope. This way, we can do a little trick
+        // We want to determine, whether we are currently outside a named scope on the AST
+        val outsideOfScope = frontend.scopeManager.currentScope != declaration.scope
+
+        // If we know our parent scope, but are outside the actual scope on the AST, we
+        // need to temporarily enter the scope. This way, we can do a little trick
         // and (manually) add the declaration to the AST element of the current scope
-        // (probably the global scope), but associate it to the record scope. Otherwise, we
-        // will get a lot of false-positives such as A::foo, when we look for the function foo.
-        // This is not the best solution and should be optimized once we finally have a good FQN
-        // system.
-        if (recordDeclaration != null && outsideOfRecord) {
+        // (probably the global scope), but associate it to the named scope.
+        if (parentScope != null && outsideOfScope) {
             // Bypass the scope manager and manually add it to the AST parent
             val parent = frontend.scopeManager.currentScope?.astNode
             if (parent != null && parent is DeclarationHolder) {
@@ -243,17 +256,16 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
             }
 
             // Enter the record scope
-            frontend.scopeManager.enterScope(recordDeclaration)
+            parentScope.astNode?.let { frontend.scopeManager.enterScope(it) }
 
             // We also need to by-pass the scope manager for this, because it will
-            // otherwise add the declaration to the AST element of the record scope (the record
-            // declaration); in this case to the `methods` fields. However, since `methods` is an
-            // AST field, (for now) we only want those methods in  there, that were actual AST
+            // otherwise add the declaration to the AST element of the named scope (the record
+            // or namespace declaration); in the case of a record declaration to the `methods`
+            // fields. However, since `methods` is an
+            // AST field, (for now) we only want those methods in there, that were actual AST
             // parents. This is also something that we need to figure out how we want to handle
             // this.
-            (frontend.scopeManager.currentScope as? RecordScope)
-                ?.valueDeclarations
-                ?.add(declaration)
+            parentScope.valueDeclarations.add(declaration)
         } else {
             // Add the declaration via the scope manager
             frontend.scopeManager.addDeclaration(declaration)
@@ -325,8 +337,8 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
 
         // if we know our record declaration, but are outside the actual record, we
         // need to leave the record scope again afterwards
-        if (recordDeclaration != null && outsideOfRecord) {
-            frontend.scopeManager.leaveScope(recordDeclaration)
+        if (parentScope != null && outsideOfScope) {
+            parentScope.astNode?.let { frontend.scopeManager.leaveScope(it) }
         }
 
         // We recognize an ambiguity here, but cannot solve it at the moment

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/DeclaratorHandler.kt
@@ -30,7 +30,6 @@ import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.scopes.NameScope
 import de.fraunhofer.aisec.cpg.graph.scopes.RecordScope
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
-import de.fraunhofer.aisec.cpg.graph.scopes.TemplateScope
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.helpers.Util
 import de.fraunhofer.aisec.cpg.passes.ResolveInFrontend

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -199,13 +199,9 @@ fun MetadataProvider.newAnnotationMember(
  * Provides a nice alias to [TypeParser.createFrom]. In the future, this should not be used anymore
  * since we are moving away from the [TypeParser] altogether.
  */
-fun LanguageProvider.parseType(name: String) = TypeParser.createFrom(name, language)
-
-/**
- * Provides a nice alias to [TypeParser.createFrom]. In the future, this should not be used anymore
- * since we are moving away from the [TypeParser] altogether.
- */
-fun LanguageProvider.parseType(name: Name) = TypeParser.createFrom(name, language)
+@JvmOverloads
+fun LanguageProvider.parseType(name: CharSequence, resolveAlias: Boolean = false) =
+    TypeParser.createFrom(name, resolveAlias, language)
 
 /** Returns a new [Name] based on the [localName] and the current namespace as parent. */
 fun NamespaceProvider.fqn(localName: String): Name {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.graph.statements.expressions
 
+import de.fraunhofer.aisec.cpg.PopulatedByPass
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.HasType.SecondaryTypeEdge
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/ConstructExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/ConstructExpression.kt
@@ -25,8 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.graph.statements.expressions
 
+import de.fraunhofer.aisec.cpg.PopulatedByPass
 import de.fraunhofer.aisec.cpg.graph.HasType
-import de.fraunhofer.aisec.cpg.graph.PopulatedByPass
 import de.fraunhofer.aisec.cpg.graph.TypeManager
 import de.fraunhofer.aisec.cpg.graph.declarations.ConstructorDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration

--- a/cpg-core/src/test/resources/cxx/namespaced_function.cpp
+++ b/cpg-core/src/test/resources/cxx/namespaced_function.cpp
@@ -1,0 +1,22 @@
+namespace ABC {
+  // The FQN of this struct should be ABC:A
+  struct A {};
+
+  void foo();
+  void bar(ABC::A a);
+};
+
+// This is a function (not a method!) within the namespace ABC
+void ABC::foo() {
+  // This "A" type is actually ABC:A because the default scope of this function is the namespace ABC
+  A a;
+  bar(a);
+}
+
+void ABC::bar(ABC::A a) {
+}
+
+int main() {
+  ABC::foo();
+  return 0;
+}

--- a/cpg-language-go/src/main/golang/types.go
+++ b/cpg-language-go/src/main/golang/types.go
@@ -88,7 +88,7 @@ func InitEnv(e *jnigi.Env) {
 
 func TypeParser_createFrom(s string, l *Language) *Type {
 	var t Type
-	err := env.CallStaticMethod(TypeParserClass, "createFrom", &t, NewString(s), l)
+	err := env.CallStaticMethod(TypeParserClass, "createFrom", &t, NewCharSequence(s), l)
 	if err != nil {
 		log.Fatal(err)
 


### PR DESCRIPTION
Furthermore, this tries to mitigate the problem that types used within such a function could refer to a namespaced entity but are referred with its local name. Since this requires resolving of symbols in a frontend, we introduce a new annotaiton `@ResolveInFrontend` to warn developers.

Fixes #1070
