### PR TITLE
Add use-unity-build option to cpg-neo4j

### DIFF
--- a/cpg-neo4j/src/main/java/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
+++ b/cpg-neo4j/src/main/java/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
@@ -140,6 +140,12 @@ class Application : Callable<Int> {
     )
     private var loadIncludes: Boolean = false
 
+    @CommandLine.Option(
+        names = ["--use-unity-build"],
+        description = ["Enable unity build mode for C++ (requires --load-includes)"]
+    )
+    private var useUnityBuild: Boolean = false
+
     @CommandLine.Option(names = ["--includes-file"], description = ["Load includes from file"])
     private var includesFile: File? = null
 
@@ -307,6 +313,7 @@ class Application : Callable<Int> {
                 .optionalLanguage("de.fraunhofer.aisec.cpg.frontends.typescript.TypeScriptLanguage")
                 .loadIncludes(loadIncludes)
                 .debugParser(DEBUG_PARSER)
+                .useUnityBuild(useUnityBuild)
 
         if (mutuallyExclusiveParameters.softwareComponents.isNotEmpty()) {
             val components = mutableMapOf<String, List<File>>()


### PR DESCRIPTION
The unity build option is an optimization for C/C++ projects, where all source files are loaded as one translation unit, preventing header files from getting parsed twice.