### PR TITLE
Consider all children to find the `prevDFG` for `FunctionDeclaration`s

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
@@ -97,6 +97,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
                     as? de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
         }
         val returnStatement = this.newReturnStatement(returnStmt.toString())
+        returnStatement.isImplicit = !returnStmt.tokenRange.isPresent
 
         // expressionRefersToDeclaration to arguments, if there are any
         expression?.let { returnStatement.returnValue = it }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
@@ -97,7 +97,8 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
                     as? de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
         }
         val returnStatement = this.newReturnStatement(returnStmt.toString())
-        // JavaParser seems to add implicit return statements, that are not part of the original source code. We mark it as such
+        // JavaParser seems to add implicit return statements, that are not part of the original
+        // source code. We mark it as such
         returnStatement.isImplicit = !returnStmt.tokenRange.isPresent
 
         // expressionRefersToDeclaration to arguments, if there are any

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
@@ -97,6 +97,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
                     as? de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
         }
         val returnStatement = this.newReturnStatement(returnStmt.toString())
+        // JavaParser seems to add implicit return statements, that are not part of the original source code. We mark it as such
         returnStatement.isImplicit = !returnStmt.tokenRange.isPresent
 
         // expressionRefersToDeclaration to arguments, if there are any

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/BinaryOperator.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/BinaryOperator.kt
@@ -28,7 +28,6 @@ package de.fraunhofer.aisec.cpg.graph.statements.expressions
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.graph.types.TypeParser
-import java.util.List
 import java.util.Objects
 import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.Transient
@@ -198,7 +197,6 @@ class BinaryOperator : Expression(), HasType.TypeListener, Assignment, HasBase {
     companion object {
         /** Required for compound BinaryOperators. This should not be stored in the graph */
         @Transient
-        val compoundOperators =
-            List.of("*=", "/=", "%=", "+=", "-=", "<<=", ">>=", "&=", "^=", "|=")
+        val compoundOperators = listOf("*=", "/=", "%=", "+=", "-=", "<<=", ">>=", "&=", "^=", "|=")
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
@@ -245,8 +245,7 @@ open class ControlFlowSensitiveDFGPass : Pass() {
             ((node as? FunctionDeclaration)?.body as? CompoundStatement)?.statements?.lastOrNull()
         if (
             lastStatement is ReturnStatement &&
-                lastStatement.location ==
-                    null && // Location == null means that it's an "implicit" return statement
+                lastStatement.isImplicit &&
                 lastStatement !in reachableReturnStatements
         )
             lastStatement.removeNextDFG(node)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
@@ -235,7 +235,7 @@ open class ControlFlowSensitiveDFGPass : Pass() {
 
     /**
      * Removes the DFG edges for a potential implicit return statement if it is not
-     * in[reachableReturnStatements].
+     * in [reachableReturnStatements].
      */
     private fun removeUnreachableImplicitReturnStatement(
         node: Node,

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
@@ -234,8 +234,8 @@ open class ControlFlowSensitiveDFGPass : Pass() {
     }
 
     /**
-     * Removes the DFG edges for a potential implicit return statement if it is not
-     * in [reachableReturnStatements].
+     * Removes the DFG edges for a potential implicit return statement if it is not in
+     * [reachableReturnStatements].
      */
     private fun removeUnreachableImplicitReturnStatement(
         node: Node,

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
@@ -108,6 +108,8 @@ open class ControlFlowSensitiveDFGPass : Pass() {
         // GotoStatements
         val loopPoints = mutableMapOf<Node, MutableMap<Declaration, MutableSet<Node>>>()
 
+        val returnStatements = mutableSetOf<ReturnStatement>()
+
         // Iterate through the worklist
         while (worklist.isNotEmpty()) {
             // The node we will analyze now and the map of the last write statements to a variable.
@@ -206,6 +208,8 @@ open class ControlFlowSensitiveDFGPass : Pass() {
                 previousWrites[currentNode.refersTo]?.lastOrNull()?.let {
                     currentNode.addPrevDFG(it)
                 }
+            } else if (currentNode is ReturnStatement) {
+                returnStatements.add(currentNode)
             }
 
             // Check for loops: No loop statement with the same state as before and no write which
@@ -225,6 +229,27 @@ open class ControlFlowSensitiveDFGPass : Pass() {
                     }
             }
         }
+
+        removeUnreachableImplicitReturnStatement(node, returnStatements)
+    }
+
+    /**
+     * Removes the DFG edges for a potential implicit return statement if it is not
+     * in[reachableReturnStatements].
+     */
+    private fun removeUnreachableImplicitReturnStatement(
+        node: Node,
+        reachableReturnStatements: MutableSet<ReturnStatement>
+    ) {
+        val lastStatement =
+            ((node as? FunctionDeclaration)?.body as? CompoundStatement)?.statements?.lastOrNull()
+        if (
+            lastStatement is ReturnStatement &&
+                lastStatement.location ==
+                    null && // Location == null means that it's an "implicit" return statement
+                lastStatement !in reachableReturnStatements
+        )
+            lastStatement.removeNextDFG(node)
     }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
@@ -29,6 +29,7 @@ import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.graph.AccessValues
 import de.fraunhofer.aisec.cpg.graph.Assignment
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.allChildren
 import de.fraunhofer.aisec.cpg.graph.declarations.FieldDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
@@ -121,14 +122,7 @@ class DFGPass : Pass() {
      * the function.
      */
     private fun handleFunctionDeclaration(node: FunctionDeclaration) {
-        if (node.body is ReturnStatement) {
-            node.addPrevDFG(node.body as ReturnStatement)
-        } else if (node.body is CompoundStatement) {
-            (node.body as CompoundStatement)
-                .statements
-                .filterIsInstance<ReturnStatement>()
-                .forEach { node.addPrevDFG(it) }
-        }
+        node.allChildren<ReturnStatement>().forEach { node.addPrevDFG(it) }
     }
 
     /**

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/DFGTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/DFGTest.kt
@@ -49,17 +49,16 @@ class DFGTest {
         val returnFunction = result.functions["testReturn"]
         assertNotNull(returnFunction)
 
-        // TODO: For some reason, there's the "implicit" return statement even if the if and the
-        // else branch end with a return. It should be only 2 such statements...
-        assertEquals(3, returnFunction.prevDFG.size)
+        assertEquals(2, returnFunction.prevDFG.size)
 
-        val allReturns = returnFunction.allChildren<ReturnStatement>()
-        assertEquals(allReturns.toSet() as Set<Node>, returnFunction.prevDFG)
+        val allRealReturns = returnFunction.allChildren<ReturnStatement> { it.location != null }
+        assertEquals(allRealReturns.toSet() as Set<Node>, returnFunction.prevDFG)
 
-        assertEquals(1, allReturns[0].prevDFG.size)
-        assertTrue(returnFunction.literals.first { it.value == 2 } in allReturns[0].prevDFG)
-        assertEquals(1, allReturns[1].prevDFG.size)
-        assertTrue(returnFunction.refs.last { it.name.localName == "a" } in allReturns[1].prevDFG)
-        assertEquals(0, allReturns[2].prevDFG.size)
+        assertEquals(1, allRealReturns[0].prevDFG.size)
+        assertTrue(returnFunction.literals.first { it.value == 2 } in allRealReturns[0].prevDFG)
+        assertEquals(1, allRealReturns[1].prevDFG.size)
+        assertTrue(
+            returnFunction.refs.last { it.name.localName == "a" } in allRealReturns[1].prevDFG
+        )
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/DFGTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/DFGTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.passes
+
+import de.fraunhofer.aisec.cpg.TestUtils
+import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.statements.ReturnStatement
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class DFGTest {
+    companion object {
+        private val topLevel = Path.of("src", "test", "resources", "dfg")
+    }
+    @Test
+    fun testReturnStatement() {
+        val result =
+            TestUtils.analyze(
+                listOf(Path.of(topLevel.toString(), "ReturnTest.java").toFile()),
+                topLevel,
+                true
+            )
+        val returnFunction = result.functions["testReturn"]
+        assertNotNull(returnFunction)
+
+        // TODO: For some reason, there's the "implicit" return statement even if the if and the
+        // else branch end with a return. It should be only 2 such statements...
+        assertEquals(3, returnFunction.prevDFG.size)
+
+        val allReturns = returnFunction.allChildren<ReturnStatement>()
+        assertEquals(allReturns.toSet() as Set<Node>, returnFunction.prevDFG)
+
+        assertEquals(1, allReturns[0].prevDFG.size)
+        assertTrue(returnFunction.literals.first { it.value == 2 } in allReturns[0].prevDFG)
+        assertEquals(1, allReturns[1].prevDFG.size)
+        assertTrue(returnFunction.refs.last { it.name.localName == "a" } in allReturns[1].prevDFG)
+        assertEquals(0, allReturns[2].prevDFG.size)
+    }
+}

--- a/cpg-core/src/test/resources/dfg/ReturnTest.java
+++ b/cpg-core/src/test/resources/dfg/ReturnTest.java
@@ -1,0 +1,10 @@
+public class ReturnTest {
+    public int testReturn() {
+        int a = 1;
+        if(a == 5) {
+            return 2;
+        } else {
+            return a;
+        }
+    }
+}


### PR DESCRIPTION
I forgot to traverse the AST of function declarations to identify all possible return statements in the `DFGPass`. However, there is still an implicit return statement in the function even if it's not necessary. (@konradweiss Can we get rid of it?)

Fixes #1077 