### PR TITLE
Add EOG for key value pairs

### DIFF
--- a/cpg-core/specifications/eog.md
+++ b/cpg-core/specifications/eog.md
@@ -186,6 +186,26 @@ flowchart LR
   initializer --EOG--> parent
 ```
 
+## KeyValueExpression
+Represents a key / value pair that could be used in associative arrays, among others.
+
+Interesting fields:
+
+* `key: Expression`: The key used for later accessing this pair.
+* `value: Expression`: The value of the pair.
+
+Scheme:
+```mermaid
+flowchart LR
+  classDef outer fill:#fff,stroke:#ddd,stroke-dasharray:5 5;
+  prev:::outer --EOG--> child
+  child --EOG--> child2["value"]
+  parent(["KeyValueExpression"]) --EOG--> next:::outer
+  parent -.-> child["key"]
+  parent -.-> child2
+  child2 --EOG--> parent
+```
+
 ## DeclarationStatement
 
 Here, the EOG is only drawn to the child component if that component is a VariableDeclaration, not if it is a FunctionDeclaration.

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
@@ -133,6 +133,7 @@ open class EvaluationOrderGraphPass : Pass() {
             handleSynchronizedStatement(it as SynchronizedStatement)
         }
         map[NewExpression::class.java] = { handleNewExpression(it as NewExpression) }
+        map[KeyValueExpression::class.java] = { handleKeyValueExpression(it as KeyValueExpression) }
         map[CastExpression::class.java] = { handleCastExpression(it as CastExpression) }
         map[ExpressionList::class.java] = { handleExpressionList(it as ExpressionList) }
         map[ConditionalExpression::class.java] = {
@@ -645,6 +646,12 @@ open class EvaluationOrderGraphPass : Pass() {
 
     protected fun handleNewExpression(node: NewExpression) {
         createEOG(node.initializer)
+        pushToEOG(node)
+    }
+
+    protected fun handleKeyValueExpression(node: KeyValueExpression) {
+        createEOG(node.key)
+        createEOG(node.value)
         pushToEOG(node)
     }
 


### PR DESCRIPTION
Handles key value pairs in the EOG pass. Experimental evaluation in python showed that first the key and then the value seem to be evaluated.

Closes #469 