### PR TITLE
JavaLanguageFrontend always requires JavaExternalTypeHierarchyResolver pass

### DIFF
--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/SizeEvaluatorTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/SizeEvaluatorTest.kt
@@ -36,7 +36,6 @@ import de.fraunhofer.aisec.cpg.graph.statements.DeclarationStatement
 import de.fraunhofer.aisec.cpg.graph.statements.ForStatement
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.BinaryOperator
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
-import de.fraunhofer.aisec.cpg.passes.JavaExternalTypeHierarchyResolver
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -53,7 +52,6 @@ class SizeEvaluatorTest {
                 true
             ) {
                 it.registerLanguage(JavaLanguage())
-                    .registerPass(JavaExternalTypeHierarchyResolver())
             }
 
         assertNotNull(tu)
@@ -87,7 +85,6 @@ class SizeEvaluatorTest {
                 true
             ) {
                 it.registerLanguage(JavaLanguage())
-                    .registerPass(JavaExternalTypeHierarchyResolver())
             }
 
         assertNotNull(tu)
@@ -124,7 +121,6 @@ class SizeEvaluatorTest {
                 true
             ) {
                 it.registerLanguage(JavaLanguage())
-                    .registerPass(JavaExternalTypeHierarchyResolver())
             }
 
         assertNotNull(tu)

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/ValueEvaluatorTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/ValueEvaluatorTest.kt
@@ -32,7 +32,6 @@ import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.DeclarationStatement
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
-import de.fraunhofer.aisec.cpg.passes.JavaExternalTypeHierarchyResolver
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -154,7 +153,6 @@ class ValueEvaluatorTest {
                 true
             ) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
 
         assertNotNull(tu)

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/query/QueryTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/query/QueryTest.kt
@@ -34,7 +34,6 @@ import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.passes.EdgeCachePass
-import de.fraunhofer.aisec.cpg.passes.JavaExternalTypeHierarchyResolver
 import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -734,7 +733,6 @@ class QueryTest {
                 .defaultPasses()
                 .defaultLanguages()
                 .registerLanguage(JavaLanguage())
-                .registerPass(JavaExternalTypeHierarchyResolver())
                 .build()
 
         val analyzer = TranslationManager.builder().config(config).build()
@@ -809,7 +807,6 @@ class QueryTest {
                 .defaultPasses()
                 .defaultLanguages()
                 .registerLanguage(JavaLanguage())
-                .registerPass(JavaExternalTypeHierarchyResolver())
                 .registerPass(EdgeCachePass())
                 .build()
 
@@ -864,7 +861,6 @@ class QueryTest {
                 .defaultPasses()
                 .defaultLanguages()
                 .registerLanguage(JavaLanguage())
-                .registerPass(JavaExternalTypeHierarchyResolver())
                 .registerPass(EdgeCachePass())
                 .build()
 
@@ -919,7 +915,6 @@ class QueryTest {
                 .defaultPasses()
                 .defaultLanguages()
                 .registerLanguage(JavaLanguage())
-                .registerPass(JavaExternalTypeHierarchyResolver())
                 .registerPass(EdgeCachePass())
                 .build()
 

--- a/cpg-console/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/AnalysisTest.kt
+++ b/cpg-console/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/AnalysisTest.kt
@@ -34,7 +34,6 @@ import de.fraunhofer.aisec.cpg.graph.byNameOrNull
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.DeclarationStatement
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
-import de.fraunhofer.aisec.cpg.passes.JavaExternalTypeHierarchyResolver
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertNotNull
@@ -78,7 +77,6 @@ class AnalysisTest {
                 .defaultPasses()
                 .defaultLanguages()
                 .registerLanguage(JavaLanguage())
-                .registerPass(JavaExternalTypeHierarchyResolver())
                 .build()
 
         val analyzer = TranslationManager.builder().config(config).build()

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
@@ -69,7 +69,9 @@ import java.io.IOException
 import java.util.function.Consumer
 
 /** Main parser for ONE Java file. */
-@RegisterExtraPass(JavaExternalTypeHierarchyResolver::class) // this pass is always required for Java
+@RegisterExtraPass(
+    JavaExternalTypeHierarchyResolver::class
+) // this pass is always required for Java
 open class JavaLanguageFrontend(
     language: Language<JavaLanguageFrontend>,
     config: TranslationConfiguration,

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
@@ -59,6 +59,8 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.types.UnknownType
 import de.fraunhofer.aisec.cpg.helpers.Benchmark
 import de.fraunhofer.aisec.cpg.helpers.CommonPath
+import de.fraunhofer.aisec.cpg.passes.JavaExternalTypeHierarchyResolver
+import de.fraunhofer.aisec.cpg.passes.order.RegisterExtraPass
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 import de.fraunhofer.aisec.cpg.sarif.Region
 import java.io.File
@@ -66,7 +68,8 @@ import java.io.FileNotFoundException
 import java.io.IOException
 import java.util.function.Consumer
 
-/** Main parser for ONE Java files. */
+/** Main parser for ONE Java file. */
+@RegisterExtraPass(JavaExternalTypeHierarchyResolver::class) // this pass is always required for Java
 open class JavaLanguageFrontend(
     language: Language<JavaLanguageFrontend>,
     config: TranslationConfiguration,

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/DFGTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/DFGTest.kt
@@ -34,7 +34,6 @@ import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
-import de.fraunhofer.aisec.cpg.passes.JavaExternalTypeHierarchyResolver
 import java.nio.file.Path
 import kotlin.test.*
 
@@ -52,7 +51,6 @@ internal class DFGTest {
                 true
             ) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
 
         // Test If-Block
@@ -115,7 +113,6 @@ internal class DFGTest {
                 true
             ) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
 
         val b = result.variables["b"]
@@ -140,7 +137,6 @@ internal class DFGTest {
                 true
             ) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
 
         val a = result.variables["a"]
@@ -211,7 +207,6 @@ internal class DFGTest {
                 true
             ) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
 
         val binaryOperatorAssignment = findByUniqueName(result.allChildren<BinaryOperator>(), "=")
@@ -275,7 +270,6 @@ internal class DFGTest {
         val result =
             analyze(listOf(topLevel.resolve("BasicSlice.java").toFile()), topLevel, true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
         val varA = findByUniqueName(result.variables, "a")
         assertNotNull(varA)
@@ -291,7 +285,6 @@ internal class DFGTest {
         val result =
             analyze(listOf(topLevel.resolve("LoopDFGs.java").toFile()), topLevel, true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
         val looping = result.methods["looping"]
         val methodNodes = SubgraphWalker.flattenAST(looping)
@@ -339,7 +332,6 @@ internal class DFGTest {
                 true
             ) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
         val looping = tu.methods["labeledBreakContinue"]
         val methodNodes = SubgraphWalker.flattenAST(looping)

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/EOGTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/EOGTest.kt
@@ -42,7 +42,6 @@ import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.helpers.Util
 import de.fraunhofer.aisec.cpg.helpers.Util.Connect
 import de.fraunhofer.aisec.cpg.passes.EvaluationOrderGraphPass
-import de.fraunhofer.aisec.cpg.passes.JavaExternalTypeHierarchyResolver
 import de.fraunhofer.aisec.cpg.processing.IVisitor
 import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
@@ -769,7 +768,6 @@ internal class EOGTest : BaseTest() {
         val result =
             analyze(listOf(topLevel.resolve("EOG.java").toFile()), topLevel, true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
 
         // Test If-Block
@@ -963,7 +961,6 @@ internal class EOGTest : BaseTest() {
         val tu =
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
         assertTrue(EvaluationOrderGraphPass.checkEOGInvariant(tu))
     }
@@ -981,7 +978,6 @@ internal class EOGTest : BaseTest() {
         val tu =
             analyzeAndGetFirstTU(listOf(toTranslate), topLevel, true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
         var nodes = SubgraphWalker.flattenAST(tu)
         // TODO: until explicitly added Return Statements are either removed again or code and

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/calls/ConstructorsTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/calls/ConstructorsTest.kt
@@ -34,7 +34,6 @@ import de.fraunhofer.aisec.cpg.graph.allChildren
 import de.fraunhofer.aisec.cpg.graph.declarations.ConstructorDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.variables
-import de.fraunhofer.aisec.cpg.passes.JavaExternalTypeHierarchyResolver
 import java.nio.file.Path
 import kotlin.test.*
 
@@ -45,10 +44,7 @@ internal class ConstructorsTest : BaseTest() {
     @Throws(Exception::class)
     fun testJava() {
         val result =
-            TestUtils.analyze("java", topLevel, true) {
-                it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
-            }
+            TestUtils.analyze("java", topLevel, true) { it.registerLanguage(JavaLanguage()) }
         val constructors = result.allChildren<ConstructorDeclaration>()
         val noArg = findByUniquePredicate(constructors) { it.parameters.size == 0 }
         val singleArg = findByUniquePredicate(constructors) { it.parameters.size == 1 }

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/calls/SuperCallTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/calls/SuperCallTest.kt
@@ -35,7 +35,6 @@ import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguage
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.DeclaredReferenceExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberExpression
-import de.fraunhofer.aisec.cpg.passes.JavaExternalTypeHierarchyResolver
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -48,11 +47,7 @@ internal class SuperCallTest : BaseTest() {
     @Test
     @Throws(Exception::class)
     fun testSimpleCall() {
-        val result =
-            analyze("java", topLevel, true) {
-                it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
-            }
+        val result = analyze("java", topLevel, true) { it.registerLanguage(JavaLanguage()) }
         val records = result.records
         val superClass = findByUniqueName(records, "SuperClass")
         val superMethods = superClass.methods
@@ -68,11 +63,7 @@ internal class SuperCallTest : BaseTest() {
     @Test
     @Throws(Exception::class)
     fun testInterfaceCall() {
-        val result =
-            analyze("java", topLevel, true) {
-                it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
-            }
+        val result = analyze("java", topLevel, true) { it.registerLanguage(JavaLanguage()) }
         val records = result.records
         val interface1 = findByUniqueName(records, "Interface1")
         val interface1Methods = interface1.methods
@@ -95,11 +86,7 @@ internal class SuperCallTest : BaseTest() {
     @Test
     @Throws(Exception::class)
     fun testSuperField() {
-        val result =
-            analyze("java", topLevel, true) {
-                it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
-            }
+        val result = analyze("java", topLevel, true) { it.registerLanguage(JavaLanguage()) }
         val records = result.records
         val superClass = findByUniqueName(records, "SuperClass")
         val superField = findByUniqueName(superClass.fields, "field")
@@ -123,11 +110,7 @@ internal class SuperCallTest : BaseTest() {
     @Test
     @Throws(Exception::class)
     fun testInnerCall() {
-        val result =
-            analyze("java", topLevel, true) {
-                it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
-            }
+        val result = analyze("java", topLevel, true) { it.registerLanguage(JavaLanguage()) }
         val records = result.records
         val superClass = findByUniqueName(records, "SuperClass")
         val superMethods = superClass.methods
@@ -143,11 +126,7 @@ internal class SuperCallTest : BaseTest() {
     @Test
     @Throws(Exception::class)
     fun testNoExcessFields() {
-        val result =
-            analyze("java", topLevel, true) {
-                it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
-            }
+        val result = analyze("java", topLevel, true) { it.registerLanguage(JavaLanguage()) }
         val records = result.records
 
         val superClass = records["SuperClass"]

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/variable_resolution/VariableResolverJavaTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/variable_resolution/VariableResolverJavaTest.kt
@@ -35,7 +35,6 @@ import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.statements.ForStatement
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Literal
-import de.fraunhofer.aisec.cpg.passes.JavaExternalTypeHierarchyResolver
 import java.nio.file.Path
 import java.util.concurrent.ExecutionException
 import kotlin.test.Test
@@ -189,11 +188,7 @@ internal class VariableResolverJavaTest : BaseTest() {
                         topLevel.resolve("ExternalClass.java")
                     )
                     .map(Path::toFile)
-            val result =
-                analyze(fileNames, topLevel, true) {
-                    it.registerLanguage(JavaLanguage())
-                    it.registerPass(JavaExternalTypeHierarchyResolver())
-                }
+            val result = analyze(fileNames, topLevel, true) { it.registerLanguage(JavaLanguage()) }
 
             val calls = result.calls { it.name.localName == "printLog" }
             val records = result.records

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/FrontendHelperTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/FrontendHelperTest.kt
@@ -33,7 +33,6 @@ import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.CompoundStatement
 import de.fraunhofer.aisec.cpg.graph.statements.ForStatement
-import de.fraunhofer.aisec.cpg.passes.JavaExternalTypeHierarchyResolver
 import de.fraunhofer.aisec.cpg.sarif.Region
 import java.io.File
 import kotlin.test.*
@@ -54,7 +53,6 @@ class FrontendHelperTest {
                 .defaultLanguages()
                 .failOnError(true)
                 .registerLanguage(JavaLanguage())
-                .registerPass(JavaExternalTypeHierarchyResolver())
                 .build()
 
         val analyzer = TranslationManager.builder().config(config).build()
@@ -139,7 +137,6 @@ class FrontendHelperTest {
                 .debugParser(true)
                 .defaultLanguages()
                 .registerLanguage(JavaLanguage())
-                .registerPass(JavaExternalTypeHierarchyResolver())
                 .failOnError(true)
                 .build()
 

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.kt
@@ -40,7 +40,6 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.FunctionType
 import de.fraunhofer.aisec.cpg.graph.types.TypeParser
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
-import de.fraunhofer.aisec.cpg.passes.JavaExternalTypeHierarchyResolver
 import de.fraunhofer.aisec.cpg.sarif.Region
 import java.io.File
 import java.math.BigInteger
@@ -57,7 +56,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val tu =
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
 
         val declaration = tu.byNameOrNull<RecordDeclaration>("LargeNegativeNumber")
@@ -95,7 +93,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val tu =
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
 
         val declaration = tu.declarations[0] as? RecordDeclaration
@@ -124,7 +121,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val tu =
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
         val declaration = tu.declarations[0] as? RecordDeclaration
         assertNotNull(declaration)
@@ -170,7 +166,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val tu =
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
 
         val declaration = tu.declarations[0] as? RecordDeclaration
@@ -216,7 +211,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val tu =
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
 
         val declaration = tu.declarations[0] as? RecordDeclaration
@@ -294,7 +288,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val declaration =
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
         // TODO: Use GraphExamples here as well.
         assertNotNull(declaration)
@@ -329,7 +322,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val declaration =
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
         assertNotNull(declaration)
     }
@@ -340,7 +332,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val declaration =
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
         val graphNodes = SubgraphWalker.flattenAST(declaration)
 
@@ -365,7 +356,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val declaration =
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
         assertNotNull(declaration)
 
@@ -419,7 +409,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val tu =
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
         assertNotNull(tu)
 
@@ -470,7 +459,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val tu =
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
         assertNotNull(tu)
 
@@ -501,7 +489,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val tu =
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
         assertNotNull(tu)
 
@@ -515,7 +502,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val tu =
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
         assertNotNull(tu)
 
@@ -547,7 +533,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
                     .defaultPasses()
                     .defaultLanguages()
                     .registerLanguage(JavaLanguage())
-                    .registerPass(JavaExternalTypeHierarchyResolver())
                     .processAnnotations(true)
             )
         assertFalse(declarations.isEmpty())
@@ -596,7 +581,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val tu =
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
         val record = tu.getDeclarationAs(0, RecordDeclaration::class.java)
         assertNotNull(record)
@@ -635,7 +619,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val result =
             TestUtils.analyze(listOf(file1, file2), file1.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
         val tu = findByUniqueName(result.translationUnits, "src/test/resources/fix-328/Cat.java")
         val namespace = tu.getDeclarationAs(0, NamespaceDeclaration::class.java)
@@ -732,7 +715,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
                 .defaultPasses()
                 .defaultLanguages()
                 .registerLanguage(JavaLanguage())
-                .registerPass(JavaExternalTypeHierarchyResolver())
                 .debugParser(true)
                 .failOnError(true)
                 .build()
@@ -758,7 +740,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
                 .defaultPasses()
                 .defaultLanguages()
                 .registerLanguage(JavaLanguage())
-                .registerPass(JavaExternalTypeHierarchyResolver())
                 .debugParser(true)
                 .failOnError(true)
                 .build()
@@ -775,7 +756,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val result =
             TestUtils.analyze(listOf(file), file.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
         val tu = result.translationUnits.firstOrNull()
         assertNotNull(tu)
@@ -814,7 +794,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val tu =
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
 
         val p = tu.namespaces["compiling"]

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StaticImportsTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StaticImportsTest.kt
@@ -31,7 +31,6 @@ import de.fraunhofer.aisec.cpg.TestUtils.findByUniqueName
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberExpression
-import de.fraunhofer.aisec.cpg.passes.JavaExternalTypeHierarchyResolver
 import java.nio.file.Path
 import kotlin.test.*
 
@@ -54,7 +53,6 @@ internal class StaticImportsTest : BaseTest() {
                 true
             ) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
         val methods = result.methods
         val test = findByUniqueName(methods, "test")
@@ -86,7 +84,6 @@ internal class StaticImportsTest : BaseTest() {
         val result =
             analyze("java", topLevel.resolve("asterisk"), true) {
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
         val methods = result.methods
         val main = methods["main", SearchModifier.UNIQUE]

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypeTests.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypeTests.kt
@@ -34,7 +34,6 @@ import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.assertLocalName
 import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguage
 import de.fraunhofer.aisec.cpg.graph.*
-import de.fraunhofer.aisec.cpg.passes.JavaExternalTypeHierarchyResolver
 import java.nio.file.Path
 import java.util.*
 import kotlin.test.*
@@ -125,11 +124,7 @@ internal class TypeTests : BaseTest() {
     @Throws(Exception::class)
     fun testParameterizedTypes() {
         val topLevel = Path.of("src", "test", "resources", "types")
-        val result =
-            analyze("java", topLevel, true) {
-                it.registerLanguage(JavaLanguage())
-                    .registerPass(JavaExternalTypeHierarchyResolver())
-            }
+        val result = analyze("java", topLevel, true) { it.registerLanguage(JavaLanguage()) }
 
         // Check Parameterized
         val recordDeclarations = result.records
@@ -163,11 +158,7 @@ internal class TypeTests : BaseTest() {
     @Throws(Exception::class)
     fun graphTest() {
         val topLevel = Path.of("src", "test", "resources", "types")
-        val result =
-            analyze("java", topLevel, true) {
-                it.registerLanguage(JavaLanguage())
-                    .registerPass(JavaExternalTypeHierarchyResolver())
-            }
+        val result = analyze("java", topLevel, true) { it.registerLanguage(JavaLanguage()) }
         val variables = result.allChildren<ObjectType>()
         val recordDeclarations = result.records
 
@@ -213,11 +204,7 @@ internal class TypeTests : BaseTest() {
     fun testCommonTypeTestJava() {
         disableTypeManagerCleanup()
         val topLevel = Path.of("src", "test", "resources", "compiling", "hierarchy")
-        val result =
-            analyze("java", topLevel, true) {
-                it.registerLanguage(JavaLanguage())
-                    .registerPass(JavaExternalTypeHierarchyResolver())
-            }
+        val result = analyze("java", topLevel, true) { it.registerLanguage(JavaLanguage()) }
         val root = TypeParser.createFrom("multistep.Root", JavaLanguage())
         val level0 = TypeParser.createFrom("multistep.Level0", JavaLanguage())
         val level1 = TypeParser.createFrom("multistep.Level1", JavaLanguage())

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/helpers/CommentMatcherTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/helpers/CommentMatcherTest.kt
@@ -33,7 +33,6 @@ import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.CompoundStatement
 import de.fraunhofer.aisec.cpg.graph.statements.ForStatement
-import de.fraunhofer.aisec.cpg.passes.JavaExternalTypeHierarchyResolver
 import de.fraunhofer.aisec.cpg.sarif.Region
 import java.io.File
 import kotlin.test.*
@@ -50,7 +49,6 @@ class CommentMatcherTest {
                 .debugParser(true)
                 .defaultLanguages()
                 .registerLanguage(JavaLanguage())
-                .registerPass(JavaExternalTypeHierarchyResolver())
                 .failOnError(true)
                 .build()
 

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/CallResolverTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/CallResolverTest.kt
@@ -120,10 +120,7 @@ class CallResolverTest : BaseTest() {
     @Throws(Exception::class)
     fun testJava() {
         val result =
-            TestUtils.analyze("java", topLevel, true) {
-                it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
-            }
+            TestUtils.analyze("java", topLevel, true) { it.registerLanguage(JavaLanguage()) }
         val records = result.records
         val intType = TypeParser.createFrom("int", JavaLanguage())
         val stringType = TypeParser.createFrom("java.lang.String", JavaLanguage())

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/DFGTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/DFGTest.kt
@@ -48,7 +48,6 @@ class DFGTest {
                 true
             ) {
                 it.registerLanguage(JavaLanguage())
-                    .registerPass(JavaExternalTypeHierarchyResolver())
             }
         val returnFunction = result.functions["testReturn"]
         assertNotNull(returnFunction)

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/UnresolvedDFGPassTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/UnresolvedDFGPassTest.kt
@@ -54,7 +54,6 @@ class UnresolvedDFGPassTest {
                     InferenceConfiguration.builder().inferDfgForUnresolvedCalls(true).build()
                 )
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
 
         // Flow from base to return value
@@ -98,7 +97,6 @@ class UnresolvedDFGPassTest {
                     InferenceConfiguration.builder().inferDfgForUnresolvedCalls(false).build()
                 )
                 it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
             }
 
         // No flow from base to return value

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/VariableResolverTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/VariableResolverTest.kt
@@ -48,11 +48,7 @@ internal class VariableResolverTest : BaseTest() {
     @Test
     @Throws(Exception::class)
     fun testFields() {
-        val result =
-            analyze("java", topLevel, true) {
-                it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
-            }
+        val result = analyze("java", topLevel, true) { it.registerLanguage(JavaLanguage()) }
         val methods = result.methods
         val fields = result.fields
         val field = findByUniqueName(fields, "field")
@@ -71,11 +67,7 @@ internal class VariableResolverTest : BaseTest() {
     @Test
     @Throws(Exception::class)
     fun testLocalVars() {
-        val result =
-            analyze("java", topLevel, true) {
-                it.registerLanguage(JavaLanguage())
-                it.registerPass(JavaExternalTypeHierarchyResolver())
-            }
+        val result = analyze("java", topLevel, true) { it.registerLanguage(JavaLanguage()) }
         val methods = result.methods
         val fields = result.fields
         val field = findByUniqueName(fields, "field")


### PR DESCRIPTION
This PR makes the `JavaExternalTypeHierarchyResolver` pass mandatory for Java by annotating the `JavaLanguageFrontend` accordingly.
All manual registrations of the pass are removed as they are now obsolete.