### PR TITLE
Add `ArrayRangeExpressions` to the EOGPass

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/ArrayRangeExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/ArrayRangeExpression.kt
@@ -26,18 +26,24 @@
 package de.fraunhofer.aisec.cpg.graph.statements.expressions
 
 import de.fraunhofer.aisec.cpg.graph.SubGraph
+import de.fraunhofer.aisec.cpg.graph.newLiteral
 import java.util.Objects
 
 /** Expressions of the form `floor ... ceiling` */
 class ArrayRangeExpression : Expression() {
     @field:SubGraph("AST") var floor: Expression? = null
 
+    @field:SubGraph("AST") var step: Expression? = newLiteral(1)
+
     @field:SubGraph("AST") var ceiling: Expression? = null
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is ArrayRangeExpression) return false
-        return super.equals(other) && floor == other.floor && ceiling == other.ceiling
+        return super.equals(other) &&
+            floor == other.floor &&
+            ceiling == other.ceiling &&
+            step == other.step
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), floor, ceiling)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
@@ -105,6 +105,9 @@ open class EvaluationOrderGraphPass : Pass() {
         map[ArrayCreationExpression::class.java] = {
             handleArrayCreationExpression(it as ArrayCreationExpression)
         }
+        map[ArrayRangeExpression::class.java] = {
+            handleArrayRangeExpression(it as ArrayRangeExpression)
+        }
         map[DeclarationStatement::class.java] = {
             handleDeclarationStatement(it as DeclarationStatement)
         }
@@ -393,6 +396,13 @@ open class EvaluationOrderGraphPass : Pass() {
             createEOG(dimension)
         }
         createEOG(node.initializer)
+        pushToEOG(node)
+    }
+
+    protected fun handleArrayRangeExpression(node: ArrayRangeExpression) {
+        createEOG(node.floor)
+        createEOG(node.ceiling)
+        createEOG(node.step)
         pushToEOG(node)
     }
 


### PR DESCRIPTION
Adds handling `ArrayRangeExpression`s to the EOG pass and also adds a `step` property to the class. However, I'm not sure if all languages (i.e., c++) use the expressions in a dynamic way. In that case, I'm not even sure how/if this would be modeled in the EOG.

I'd also suggest to rename the class from `ArrayRangeExpression` to `RangeExpression` since we do not really care about the array here (there's not even a way to specify the array).

Closes #377 (and is related to #372).