### PR TITLE
Resolve relative include path when loading compilation database

### DIFF
--- a/cpg-core/src/test/resources/cxxCompilationDatabase/compile_commands_arch.json
+++ b/cpg-core/src/test/resources/cxxCompilationDatabase/compile_commands_arch.json
@@ -2,6 +2,6 @@
   {
     "command": "/usr/bin/clang -arch arm64 -c main_arm64.c -o main_arm64",
     "directory": "src/test/resources/cxxCompilationDatabase",
-    "file": "src/test/resources/cxxCompilationDatabase/main_arm64.c"
+    "file": "main_arm64.c"
   }
 ]

--- a/cpg-core/src/test/resources/cxxCompilationDatabase/compile_commands_arguments.json
+++ b/cpg-core/src/test/resources/cxxCompilationDatabase/compile_commands_arguments.json
@@ -15,6 +15,6 @@
       "main.c"
     ],
     "directory": "src/test/resources/cxxCompilationDatabase",
-    "file": "src/test/resources/cxxCompilationDatabase/main.c"
+    "file": "main.c"
   }
 ]

--- a/cpg-core/src/test/resources/cxxCompilationDatabase/compile_commands_commands.json
+++ b/cpg-core/src/test/resources/cxxCompilationDatabase/compile_commands_commands.json
@@ -2,7 +2,7 @@
   {
     "command": "/usr/bin/gcc -c -I includes_1 -Iincludes_2 -Isys_includes/ -DFOO=1 -D BAR=2 -DINFO=\"hi\" -DDEBUG=1 main.c -o main",
     "directory": "src/test/resources/cxxCompilationDatabase",
-    "file": "src/test/resources/cxxCompilationDatabase/main.c",
-    "output": "src/test/resources/cxxCompilationDatabase/main"
+    "file": "main.c",
+    "output": "main"
   }
 ]

--- a/cpg-core/src/test/resources/cxxCompilationDatabase/compile_commands_multi_tus.json
+++ b/cpg-core/src/test/resources/cxxCompilationDatabase/compile_commands_multi_tus.json
@@ -9,7 +9,7 @@
       "main_tu_1.c"
     ],
     "directory": "src/test/resources/cxxCompilationDatabase",
-    "file": "src/test/resources/cxxCompilationDatabase/main_tu_1.c"
+    "file": "main_tu_1.c"
   },
   {
     "arguments": [
@@ -21,7 +21,7 @@
       "main_tu_2.c"
     ],
     "directory": "src/test/resources/cxxCompilationDatabase",
-    "file": "src/test/resources/cxxCompilationDatabase/main_tu_2.c"
+    "file": "main_tu_2.c"
   },
   {
     "arguments": [
@@ -30,7 +30,7 @@
       "missing_file.c"
     ],
     "directory": "src/test/resources/cxxCompilationDatabase",
-    "file": "src/test/resources/cxxCompilationDatabase/missing_file.c"
+    "file": "missing_file.c"
   }
 
 ]

--- a/cpg-core/src/test/resources/cxxCompilationDatabase/compile_commands_simple.json
+++ b/cpg-core/src/test/resources/cxxCompilationDatabase/compile_commands_simple.json
@@ -2,6 +2,6 @@
   {
     "command": "/usr/bin/gcc -c main_simple.c -o main_simple",
     "directory": "src/test/resources/cxxCompilationDatabase",
-    "file": "src/test/resources/cxxCompilationDatabase/main_simple.c"
+    "file": "main_simple.c"
   }
 ]


### PR DESCRIPTION
Interpret the include paths in the compilation database as relative to the specified directory (as it is for the source file already).

Ref: https://clang.llvm.org/docs/JSONCompilationDatabase.html

> directory: The working directory of the compilation. All paths specified in the command or file fields must be either absolute or relative to this directory.

main.c
```c
#include "header.h"

int main() {
    foo();
    return 0;
}
```

compile_commands.json:
```json
[
  {
    "arguments": [
      "/usr/bin/gcc",
      "-c",
      "-Iinc",
      "src/main.c"
    ],
    "directory": "/code/",
    "file": "src/main.c"
  }
]
```

Folder structure:
```
/code/
├── compile_commands.json
├── inc
│   └── header.h
└── src
    └── main.c
```