### PR TITLE
Improved literal parsing in C++

### DIFF
--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/types/BooleanType.kt
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/types/BooleanType.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.graph.types
+
+import de.fraunhofer.aisec.cpg.frontends.Language
+import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
+
+/** Instances of this class represent boolean types. */
+class BooleanType(
+    typeName: CharSequence = "bool",
+    bitWidth: Int? = 1,
+    language: Language<out LanguageFrontend>? = null,
+    modifier: Modifier = Modifier.UNSIGNED
+) : NumericType(typeName, bitWidth, language, modifier) {
+
+    override fun duplicate(): Type {
+        return BooleanType(this.name, bitWidth, language, modifier)
+    }
+}

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CPPLanguage.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CPPLanguage.kt
@@ -56,7 +56,7 @@ class CPPLanguage :
     @Transient
     override val simpleTypes =
         mapOf(
-            "boolean" to IntegerType("boolean", 1, this, NumericType.Modifier.SIGNED),
+            "bool" to BooleanType("bool", 1, this, NumericType.Modifier.SIGNED),
             "char" to IntegerType("char", 8, this, NumericType.Modifier.NOT_APPLICABLE),
             "byte" to IntegerType("byte", 8, this, NumericType.Modifier.SIGNED),
             "short" to IntegerType("short", 16, this, NumericType.Modifier.SIGNED),
@@ -79,6 +79,8 @@ class CPPLanguage :
             "unsigned int" to IntegerType("unsigned int", 32, this, NumericType.Modifier.UNSIGNED),
             "unsigned long" to
                 IntegerType("unsigned long", 64, this, NumericType.Modifier.UNSIGNED),
+            "unsigned long long" to
+                IntegerType("unsigned long long", 64, this, NumericType.Modifier.UNSIGNED),
             "unsigned long long int" to
                 IntegerType("unsigned long long int", 64, this, NumericType.Modifier.UNSIGNED),
             "std::string" to StringType("std::string", this),

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.kt
@@ -720,11 +720,20 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
     private fun handleFloatLiteral(ctx: IASTLiteralExpression): Expression {
         val (strippedValue, suffix) = ctx.valueWithSuffix
 
-        return when (suffix) {
-            "f" -> newLiteral(strippedValue.toFloat(), parseType("float"), ctx.rawSignature)
-            "l" ->
-                newLiteral(strippedValue.toBigDecimal(), parseType("long double"), ctx.rawSignature)
-            else -> newLiteral(strippedValue.toDouble(), parseType("double"), ctx.rawSignature)
+        return try {
+            when (suffix) {
+                "f" -> newLiteral(strippedValue.toFloat(), parseType("float"), ctx.rawSignature)
+                "l" ->
+                    newLiteral(
+                        strippedValue.toBigDecimal(),
+                        parseType("long double"),
+                        ctx.rawSignature
+                    )
+                else -> newLiteral(strippedValue.toDouble(), parseType("double"), ctx.rawSignature)
+            }
+        } catch (ex: NumberFormatException) {
+            // It could be that we cannot parse the literal, in this case we return an error
+            ProblemExpression("could not parse literal: ${ex.message}")
         }
     }
 

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.kt
@@ -843,9 +843,13 @@ internal class CXXLanguageFrontendTest : BaseTest() {
         assertIs<IntegerType>(hex.type)
         assertLocalName("unsigned long long", hex.type)
 
-        val duration = tu.variables["duration"]
-        assertNotNull(duration)
-        assertIs<ProblemExpression>(duration.initializer)
+        val duration_ms = tu.variables["duration_ms"]
+        assertNotNull(duration_ms)
+        assertIs<ProblemExpression>(duration_ms.initializer)
+
+        val duration_s = tu.variables["duration_s"]
+        assertNotNull(duration_s)
+        assertIs<ProblemExpression>(duration_s.initializer)
     }
 
     @Test

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.kt
@@ -781,55 +781,71 @@ internal class CXXLanguageFrontendTest : BaseTest() {
     @Test
     @Throws(Exception::class)
     fun testLiterals() {
-        val file = File("src/test/resources/literals.cpp")
-        val declaration = analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true)
-        val s = declaration.getDeclarationAs(0, VariableDeclaration::class.java)
-        assertEquals(createTypeFrom("char[]", true), s!!.type)
-        assertLocalName("s", s)
+        val file = File("src/test/resources/cxx/literals.cpp")
+        val tu = analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true)
+
+        val s = tu.variables["s"]
+        assertNotNull(s)
+        assertIs<PointerType>(s.type)
+        assertLocalName("char[]", s.type)
 
         var initializer = s.initializer as? Literal<*>
         assertNotNull(initializer)
         assertEquals("string", initializer.value)
 
-        val i = declaration.getDeclarationAs(1, VariableDeclaration::class.java)
-        assertEquals(createTypeFrom("int", true), i!!.type)
-        assertLocalName("i", i)
+        val i = tu.variables["i"]
+        assertNotNull(i)
+        assertIs<IntegerType>(i.type)
+        assertLocalName("int", i.type)
 
         initializer = i.initializer as? Literal<*>
         assertNotNull(initializer)
         assertEquals(1, initializer.value)
 
-        val f = declaration.getDeclarationAs(2, VariableDeclaration::class.java)
-        assertEquals(createTypeFrom("float", true), f!!.type)
-        assertLocalName("f", f)
+        val f = tu.variables["f"]
+        assertNotNull(f)
+        assertIs<FloatingPointType>(f.type)
+        assertLocalName("float", f.type)
 
         initializer = f.initializer as? Literal<*>
         assertNotNull(initializer)
         assertEquals(0.2f, initializer.value)
 
-        val d = declaration.getDeclarationAs(3, VariableDeclaration::class.java)
-        assertEquals(createTypeFrom("double", true), d!!.type)
-        assertLocalName("d", d)
+        val d = tu.variables["d"]
+        assertNotNull(d)
+        assertIs<FloatingPointType>(d.type)
+        assertLocalName("double", d.type)
 
         initializer = d.initializer as? Literal<*>
         assertNotNull(initializer)
         assertEquals(0.2, initializer.value)
 
-        val b = declaration.getDeclarationAs(4, VariableDeclaration::class.java)
-        assertEquals(createTypeFrom("bool", true), b!!.type)
-        assertLocalName("b", b)
+        val b = tu.variables["b"]
+        assertNotNull(b)
+        assertIs<BooleanType>(b.type)
+        assertLocalName("bool", b.type)
 
         initializer = b.initializer as? Literal<*>
         assertNotNull(initializer)
         assertEquals(false, initializer.value)
 
-        val c = declaration.getDeclarationAs(5, VariableDeclaration::class.java)
-        assertEquals(createTypeFrom("char", true), c!!.type)
-        assertLocalName("c", c)
+        val c = tu.variables["c"]
+        assertNotNull(c)
+        assertIs<IntegerType>(c.type)
+        assertLocalName("char", c.type)
 
         initializer = c.initializer as? Literal<*>
         assertNotNull(initializer)
         assertEquals('c', initializer.value)
+
+        val hex = tu.variables["hex"]
+        assertNotNull(hex)
+        assertIs<IntegerType>(hex.type)
+        assertLocalName("unsigned long long", hex.type)
+
+        val duration = tu.variables["duration"]
+        assertNotNull(duration)
+        assertIs<ProblemExpression>(duration.initializer)
     }
 
     @Test

--- a/cpg-core/src/test/resources/cxx/literals.cpp
+++ b/cpg-core/src/test/resources/cxx/literals.cpp
@@ -8,4 +8,5 @@ auto hex = 0xfull;
 
 // ms is a custom literal suffix (provided by <chrono>. however, we are not handling this at the moment, so this
 // will result in an error
-auto duration = 250ms;
+auto duration_ms = 250ms;
+auto duration_s = 2.5s;

--- a/cpg-core/src/test/resources/cxx/literals.cpp
+++ b/cpg-core/src/test/resources/cxx/literals.cpp
@@ -1,0 +1,11 @@
+char s[] = "string";
+int i = 1;
+float f = 0.2f;
+double d = 0.2;
+bool b = false;
+char c = 'c';
+auto hex = 0xfull;
+
+// ms is a custom literal suffix (provided by <chrono>. however, we are not handling this at the moment, so this
+// will result in an error
+auto duration = 250ms;

--- a/cpg-core/src/test/resources/literals.cpp
+++ b/cpg-core/src/test/resources/literals.cpp
@@ -1,6 +1,0 @@
-char s[] = "string";
-int i = 1;
-float f = 0.2f;
-double d = 0.2;
-bool b = false;
-char c = 'c';


### PR DESCRIPTION
This PR improves the parsing of literals in C++. For one, unknown custom suffixes should not result in an error, since we cannot parse them (yet), and not crash the translation. Second, a problem with suffix confusion between float and double has been fixed as well.

This also adds a `BooleanType` as primitive type and correctly sets the C++ boolean type to `bool`.

Fixes #1084
Fixes #1099
