### PR TITLE
Merge all include paths from compilation database for unity build mode

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
@@ -216,6 +216,13 @@ private constructor(
                 }
 
                 sourceLocations = listOf(tmpFile)
+                if (config.compilationDatabase != null) {
+                    // merge include paths from all translation units
+                    config.compilationDatabase.addIncludePath(
+                        tmpFile,
+                        config.compilationDatabase.allIncludePaths
+                    )
+                }
             } else {
                 sourceLocations = list
             }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/CompilationDatabase.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/CompilationDatabase.kt
@@ -62,10 +62,21 @@ class CompilationDatabase : ArrayList<CompilationDatabase.CompilationDatabaseEnt
             return includePaths.keys.toList()
         }
 
+    fun addIncludePath(srcFile: File, paths: List<String>) {
+        includePaths[srcFile] = paths
+    }
+
     /** Returns the include paths for the specified file. */
     fun getIncludePaths(file: File): List<String>? {
         return includePaths[file]
     }
+
+    /** Returns the include paths for all files in compilation database. */
+    val allIncludePaths: List<String>
+        get() {
+            return includePaths.values.flatten()
+        }
+
     /** Returns defined symbols for the specified file. */
     fun getSymbols(file: File): Map<String, String>? {
         return symbols[file]
@@ -109,11 +120,13 @@ class CompilationDatabase : ArrayList<CompilationDatabase.CompilationDatabaseEnt
                         ParsedCompilationDatabaseEntry()
                     }
                 val basedir = entry.directory
-                var srcFile = File(resolveRelativePath(fileNameInTheObject, basedir))
+                val srcFile = File(resolveRelativePath(fileNameInTheObject, basedir))
 
                 if (srcFile.exists()) {
-                    db.includePaths[srcFile] =
+                    db.addIncludePath(
+                        srcFile,
                         parsedEntry.includes.map { resolveRelativePath(it, basedir) }
+                    )
                 }
 
                 db.symbols[srcFile] =


### PR DESCRIPTION
When using the unity build mode, all source files are included in a temporary main file.
When using this option together with a compilation database, we need to merge the include paths from all source files in the compilation database and assign them to the temporary main file.
This of course losses the possibility of setting include paths for individual translation units.