### PR TITLE
Fix problem with PropertyEdges in EnumDeclaration

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CLanguage.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CLanguage.kt
@@ -31,6 +31,7 @@ import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.frontends.*
 import de.fraunhofer.aisec.cpg.graph.types.*
 import kotlin.reflect.KClass
+import org.neo4j.ogm.annotation.Transient
 
 /** The C language. */
 open class CLanguage :
@@ -42,7 +43,7 @@ open class CLanguage :
     HasShortCircuitOperators {
     override val fileExtensions = listOf("c", "h")
     override val namespaceDelimiter = "::"
-    override val frontend: KClass<out CXXLanguageFrontend> = CXXLanguageFrontend::class
+    @Transient override val frontend: KClass<out CXXLanguageFrontend> = CXXLanguageFrontend::class
     override val qualifiers = listOf("const", "volatile", "restrict", "atomic")
     override val elaboratedTypeSpecifier = listOf("struct", "union", "enum")
     override val conjunctiveOperators = listOf("&&")

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CPPLanguage.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CPPLanguage.kt
@@ -40,6 +40,7 @@ import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.passes.*
 import de.fraunhofer.aisec.cpg.passes.inference.startInference
 import java.util.regex.Pattern
+import org.neo4j.ogm.annotation.Transient
 
 /** The C++ language. */
 class CPPLanguage :

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguage.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguage.kt
@@ -31,6 +31,7 @@ import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.frontends.*
 import de.fraunhofer.aisec.cpg.graph.types.*
 import kotlin.reflect.KClass
+import org.neo4j.ogm.annotation.Transient
 
 /** The Java language. */
 open class JavaLanguage :
@@ -44,7 +45,7 @@ open class JavaLanguage :
     HasShortCircuitOperators {
     override val fileExtensions = listOf("java")
     override val namespaceDelimiter = "."
-    override val frontend: KClass<out JavaLanguageFrontend> = JavaLanguageFrontend::class
+    @Transient override val frontend: KClass<out JavaLanguageFrontend> = JavaLanguageFrontend::class
     override val superClassKeyword = "super"
     override val qualifiers = listOf("final", "volatile")
     override val unknownTypeString = listOf("var")

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -86,6 +86,7 @@ open class Node : IVisitable<Node>, Persistable, LanguageProvider, ScopeProvider
      * class would be a [RecordScope] pointing to the [RecordDeclaration].
      */
     @Relationship(value = "SCOPE", direction = Relationship.Direction.OUTGOING)
+    @JsonBackReference
     override var scope: Scope? = null
 
     /** Optional comment of this node. */

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/SubGraph.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/SubGraph.kt
@@ -33,6 +33,7 @@ import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
  * [SubgraphWalker.getAstChildren]. Could be replaced with @Relationship{sub-graph:'ast'} if
  * switching to an OGM that supports relationship properties.
  */
+@Target(AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.RUNTIME)
 @EdgeProperty(key = "sub-graph")
 annotation class SubGraph(vararg val value: String)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/EnumDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/EnumDeclaration.kt
@@ -34,17 +34,17 @@ import org.neo4j.ogm.annotation.Relationship
 
 class EnumDeclaration : Declaration() {
     @Relationship(value = "ENTRIES", direction = Relationship.Direction.OUTGOING)
-    var entryEdges: List<PropertyEdge<EnumConstantDeclaration>> = ArrayList()
+    @field:SubGraph("AST")
+    var entryEdges: MutableList<PropertyEdge<EnumConstantDeclaration>> = ArrayList()
 
     @Relationship(value = "SUPER_TYPES", direction = Relationship.Direction.OUTGOING)
-    var superTypeEdges: List<PropertyEdge<Type>> = ArrayList()
+    var superTypeEdges: MutableList<PropertyEdge<Type>> = ArrayList()
 
     @Relationship var superTypeDeclarations: Set<RecordDeclaration> = HashSet()
 
-    @property:SubGraph("AST")
-    var entries: List<EnumConstantDeclaration> by PropertyEdgeDelegate(EnumDeclaration::entryEdges)
+    var entries by PropertyEdgeDelegate(EnumDeclaration::entryEdges)
 
-    var superTypes: List<Type> by PropertyEdgeDelegate(EnumDeclaration::superTypeEdges)
+    var superTypes by PropertyEdgeDelegate(EnumDeclaration::superTypeEdges)
 
     override fun toString(): String {
         return ToStringBuilder(this, TO_STRING_STYLE)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/IncludeDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/IncludeDeclaration.kt
@@ -36,17 +36,17 @@ import org.neo4j.ogm.annotation.Relationship
 
 class IncludeDeclaration : Declaration() {
     @Relationship(value = "INCLUDES", direction = Relationship.Direction.OUTGOING)
+    @field:SubGraph("AST")
     private val includeEdges: MutableList<PropertyEdge<IncludeDeclaration>> = ArrayList()
 
     @Relationship(value = "PROBLEMS", direction = Relationship.Direction.OUTGOING)
+    @field:SubGraph("AST")
     private val problemEdges: MutableList<PropertyEdge<ProblemDeclaration>> = ArrayList()
 
     var filename: String? = null
 
-    @property:SubGraph("AST")
     val includes: List<IncludeDeclaration> by PropertyEdgeDelegate(IncludeDeclaration::includeEdges)
 
-    @property:SubGraph("AST")
     val problems: List<ProblemDeclaration> by PropertyEdgeDelegate(IncludeDeclaration::problemEdges)
 
     fun addInclude(includeDeclaration: IncludeDeclaration?) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/DesignatedInitializerExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/DesignatedInitializerExpression.kt
@@ -37,9 +37,9 @@ class DesignatedInitializerExpression : Expression() {
     @field:SubGraph("AST") var rhs: Expression? = null
 
     @Relationship(value = "LHS", direction = Relationship.Direction.OUTGOING)
+    @field:SubGraph("AST")
     var lhsEdges: MutableList<PropertyEdge<Expression>> = mutableListOf()
 
-    @property:SubGraph("AST")
     var lhs: List<Expression> by PropertyEdgeDelegate(DesignatedInitializerExpression::lhsEdges)
 
     override fun toString(): String {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/DesignatedInitializerExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/DesignatedInitializerExpression.kt
@@ -37,7 +37,7 @@ class DesignatedInitializerExpression : Expression() {
     @field:SubGraph("AST") var rhs: Expression? = null
 
     @Relationship(value = "LHS", direction = Relationship.Direction.OUTGOING)
-    var lhsEdges: List<PropertyEdge<Expression>> = listOf()
+    var lhsEdges: MutableList<PropertyEdge<Expression>> = mutableListOf()
 
     @property:SubGraph("AST")
     var lhs: List<Expression> by PropertyEdgeDelegate(DesignatedInitializerExpression::lhsEdges)

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguage.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguage.kt
@@ -34,12 +34,13 @@ import de.fraunhofer.aisec.cpg.graph.types.FloatingPointType
 import de.fraunhofer.aisec.cpg.graph.types.IntegerType
 import de.fraunhofer.aisec.cpg.graph.types.NumericType
 import de.fraunhofer.aisec.cpg.graph.types.StringType
+import org.neo4j.ogm.annotation.Transient
 
 /** The Go language. */
 open class GoLanguage : Language<GoLanguageFrontend>(), HasShortCircuitOperators, HasGenerics {
     override val fileExtensions = listOf("go")
     override val namespaceDelimiter = "."
-    override val frontend = GoLanguageFrontend::class
+    @Transient override val frontend = GoLanguageFrontend::class
     override val conjunctiveOperators = listOf("&&")
     override val disjunctiveOperators = listOf("||")
     override val startCharacter = '['

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguage.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguage.kt
@@ -32,12 +32,13 @@ import de.fraunhofer.aisec.cpg.graph.types.FloatingPointType
 import de.fraunhofer.aisec.cpg.graph.types.IntegerType
 import de.fraunhofer.aisec.cpg.graph.types.NumericType
 import kotlin.reflect.KClass
+import org.neo4j.ogm.annotation.Transient
 
 /** The LLVM IR language. */
 class LLVMIRLanguage : Language<LLVMIRLanguageFrontend>() {
     override val fileExtensions = listOf("ll")
     override val namespaceDelimiter = "::"
-    override val frontend: KClass<out LLVMIRLanguageFrontend> = LLVMIRLanguageFrontend::class
+    @Transient override val frontend: KClass<out LLVMIRLanguageFrontend> = LLVMIRLanguageFrontend::class
 
     // TODO: In theory, the integers can have any bitwidth from 1 to 1^32 bits. It's not known if
     // they are interpreted as signed or unsigned.

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguage.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguage.kt
@@ -38,7 +38,8 @@ import org.neo4j.ogm.annotation.Transient
 class LLVMIRLanguage : Language<LLVMIRLanguageFrontend>() {
     override val fileExtensions = listOf("ll")
     override val namespaceDelimiter = "::"
-    @Transient override val frontend: KClass<out LLVMIRLanguageFrontend> = LLVMIRLanguageFrontend::class
+    @Transient
+    override val frontend: KClass<out LLVMIRLanguageFrontend> = LLVMIRLanguageFrontend::class
 
     // TODO: In theory, the integers can have any bitwidth from 1 to 1^32 bits. It's not known if
     // they are interpreted as signed or unsigned.

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
@@ -37,7 +37,8 @@ import org.neo4j.ogm.annotation.Transient
 class PythonLanguage : Language<PythonLanguageFrontend>(), HasShortCircuitOperators {
     override val fileExtensions = listOf("py")
     override val namespaceDelimiter = "."
-    @Transient override val frontend: KClass<out PythonLanguageFrontend> = PythonLanguageFrontend::class
+    @Transient
+    override val frontend: KClass<out PythonLanguageFrontend> = PythonLanguageFrontend::class
     override val conjunctiveOperators = listOf("and")
     override val disjunctiveOperators = listOf("or")
 

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
@@ -31,12 +31,13 @@ import de.fraunhofer.aisec.cpg.frontends.HasShortCircuitOperators
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.types.*
 import kotlin.reflect.KClass
+import org.neo4j.ogm.annotation.Transient
 
 /** The Python language. */
 class PythonLanguage : Language<PythonLanguageFrontend>(), HasShortCircuitOperators {
     override val fileExtensions = listOf("py")
     override val namespaceDelimiter = "."
-    override val frontend: KClass<out PythonLanguageFrontend> = PythonLanguageFrontend::class
+    @Transient override val frontend: KClass<out PythonLanguageFrontend> = PythonLanguageFrontend::class
     override val conjunctiveOperators = listOf("and")
     override val disjunctiveOperators = listOf("or")
 

--- a/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/JavaScriptLanguage.kt
+++ b/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/JavaScriptLanguage.kt
@@ -36,7 +36,8 @@ import org.neo4j.ogm.annotation.Transient
 open class JavaScriptLanguage : Language<TypeScriptLanguageFrontend>(), HasShortCircuitOperators {
     override val fileExtensions = listOf("js", "jsx")
     override val namespaceDelimiter = "."
-    @Transient override val frontend: KClass<out TypeScriptLanguageFrontend> =
+    @Transient
+    override val frontend: KClass<out TypeScriptLanguageFrontend> =
         TypeScriptLanguageFrontend::class
     override val conjunctiveOperators = listOf("&&", "&&=", "??", "??=")
     override val disjunctiveOperators = listOf("||", "||=")

--- a/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/JavaScriptLanguage.kt
+++ b/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/JavaScriptLanguage.kt
@@ -30,12 +30,13 @@ import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.frontends.HasShortCircuitOperators
 import de.fraunhofer.aisec.cpg.frontends.Language
 import kotlin.reflect.KClass
+import org.neo4j.ogm.annotation.Transient
 
 /** The JavaScript language. */
 open class JavaScriptLanguage : Language<TypeScriptLanguageFrontend>(), HasShortCircuitOperators {
     override val fileExtensions = listOf("js", "jsx")
     override val namespaceDelimiter = "."
-    override val frontend: KClass<out TypeScriptLanguageFrontend> =
+    @Transient override val frontend: KClass<out TypeScriptLanguageFrontend> =
         TypeScriptLanguageFrontend::class
     override val conjunctiveOperators = listOf("&&", "&&=", "??", "??=")
     override val disjunctiveOperators = listOf("||", "||=")


### PR DESCRIPTION
OGM seems to require `MutableLists` or it will throw a stackoverflow exception (which is very misleading).  I also reviewed the other occurrences of relationships to ensure that we fix this problem everywhere.

In addition, I fixed the inconsistent usage of the `SubGraph` annotation. Annotating properties (or even methods) works but isn't supported by the `SubgraphWalker` (yet).

Closes #1106 