### PR TITLE
Inferring missing functions in namespace declarations

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/PleaseBeCareful.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/PleaseBeCareful.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg
+
+/**
+ * Annotation used to mark functions that could potentially be dangerous, in a way that could modify
+ * or alter the CPG tree structure that one does not intent to.
+ */
+annotation class PleaseBeCareful

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -684,16 +684,6 @@ class ScopeManager : ScopeProvider {
     }
 
     /**
-     * Directly jumps to the scope a given node defines (if it exists).
-     *
-     * Handle with care, here be dragons. Should not be exposed outside of the cpg-core module.
-     */
-    @PleaseBeCareful
-    internal fun jumpTo(node: Node): Scope? {
-        return jumpTo(lookupScope(node))
-    }
-
-    /**
      * This function can be used to wrap multiple statements contained in [init] into the scope of
      * [node]. It will execute [enterScope] before calling [init] and [leaveScope] afterwards.
      */

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CPPLanguage.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CPPLanguage.kt
@@ -48,6 +48,7 @@ class CPPLanguage :
     HasDefaultArguments,
     HasTemplates,
     HasComplexCallResolution,
+    HasStructs,
     HasClasses,
     HasUnknownType {
     override val fileExtensions = listOf("cpp", "cc", "cxx", "hpp", "hh")
@@ -300,7 +301,7 @@ class CPPLanguage :
             // If we want to use an inferred functionTemplateDeclaration, this needs to be provided.
             // Otherwise, we could not resolve to a template and no modifications are made
             val functionTemplateDeclaration =
-                holder.startInference().createInferredFunctionTemplate(templateCall)
+                holder.startInference(scopeManager).createInferredFunctionTemplate(templateCall)
             templateCall.templateInstantiation = functionTemplateDeclaration
             val edges = templateCall.templateParameterEdges
             // Set instantiation propertyEdges

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.kt
@@ -345,7 +345,8 @@ open class VariableUsageResolver : SymbolResolverPass() {
                 } else {
                     "class"
                 }
-            val record = base.startInference().inferRecordDeclaration(base, currentTU, kind)
+            val record =
+                base.startInference(scopeManager).inferRecordDeclaration(base, currentTU, kind)
             // update the record map
             if (record != null) recordMap[base.name] = record
         }
@@ -404,7 +405,7 @@ open class VariableUsageResolver : SymbolResolverPass() {
         // If we didn't find anything, we create a new function or method declaration
         return target
             ?: (declarationHolder ?: currentTU)
-                .startInference()
+                .startInference(scopeManager)
                 .createInferredFunctionDeclaration(
                     name,
                     null,

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/CallResolverTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/CallResolverTest.kt
@@ -117,6 +117,7 @@ class CallResolverTest : BaseTest() {
         val inferenceSignature = listOf(intType, intType, intType)
         for (inferredCall in
             calls.filter { c: CallExpression -> c.signature == inferenceSignature }) {
+
             val inferredTarget =
                 findByUniquePredicate(methods) { m: FunctionDeclaration ->
                     m.hasSignature(inferenceSignature)

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguage.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguage.kt
@@ -29,12 +29,14 @@ import de.fraunhofer.aisec.cpg.ScopeManager
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.frontends.HasGenerics
 import de.fraunhofer.aisec.cpg.frontends.HasShortCircuitOperators
+import de.fraunhofer.aisec.cpg.frontends.HasStructs
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.types.*
 import org.neo4j.ogm.annotation.Transient
 
 /** The Go language. */
-class GoLanguage : Language<GoLanguageFrontend>(), HasShortCircuitOperators, HasGenerics {
+class GoLanguage :
+    Language<GoLanguageFrontend>(), HasShortCircuitOperators, HasGenerics, HasStructs {
     override val fileExtensions = listOf("go")
     override val namespaceDelimiter = "."
     @Transient override val frontend = GoLanguageFrontend::class

--- a/cpg-language-go/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
+++ b/cpg-language-go/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
@@ -37,10 +37,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.FunctionType
 import de.fraunhofer.aisec.cpg.graph.types.TypeParser
 import java.nio.file.Path
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 class GoLanguageFrontendTest : BaseTest() {
 
@@ -679,6 +676,15 @@ class GoLanguageFrontendTest : BaseTest() {
         val call = (a.singleDeclaration as? VariableDeclaration)?.initializer as? CallExpression
         assertNotNull(call)
         assertTrue(call.invokes.contains(newAwesome))
+
+        val util = result.namespaces["util"]
+        assertNotNull(util)
+
+        // Check, if we correctly inferred this function in the namespace
+        val doSomethingElse = util.functions["DoSomethingElse"]
+        assertNotNull(doSomethingElse)
+        assertTrue(doSomethingElse.isInferred)
+        assertSame(util, doSomethingElse.scope?.astNode)
     }
 
     @Test

--- a/cpg-neo4j/src/test/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/ApplicationTest.kt
+++ b/cpg-neo4j/src/test/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/ApplicationTest.kt
@@ -29,6 +29,7 @@ import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.TranslationManager
 import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
+import de.fraunhofer.aisec.cpg.graph.functions
 import java.io.File
 import java.nio.file.Paths
 import kotlin.test.Test
@@ -60,6 +61,8 @@ class ApplicationTest {
             TranslationManager.builder().config(translationConfiguration).build()
         translationResult = translationManager.analyze().get()
 
+        assertEquals(31, translationResult.functions.size)
+
         val application = Application()
 
         application.pushToNeo4j(translationResult!!)
@@ -71,7 +74,7 @@ class ApplicationTest {
             val functions = session.loadAll(FunctionDeclaration::class.java)
             assertNotNull(functions)
 
-            assertEquals(38, functions.size)
+            assertEquals(31, functions.size)
 
             transaction.commit()
         }


### PR DESCRIPTION
Previously, we put all inferred function declarations in the global scope (the current TU). However, there are cases where the function is actually residing in a namespace declaration and we need to put it there.

This will not (yet) infer the namespace declaration if it is missing. This might even something that is specific to the frontend, e.g., generate namespace declarations out of import statements.

This will also now use the `ScopeManager` in the inference system, allowing for a better integration of inferred nodes. This for example reduces the amount of duplicate inferred nodes, since now just one is created and can be invoked by others.