### PR TITLE
Optionally enable `JavaLanguage` for neo4j

### DIFF
--- a/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
+++ b/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
@@ -313,6 +313,7 @@ class Application : Callable<Int> {
             TranslationConfiguration.builder()
                 .topLevel(topLevel)
                 .defaultLanguages()
+                .optionalLanguage("de.fraunhofer.aisec.cpg.frontends.java.JavaLanguage")
                 .optionalLanguage("de.fraunhofer.aisec.cpg.frontends.golang.GoLanguage")
                 .optionalLanguage("de.fraunhofer.aisec.cpg.frontends.llvm.LLVMIRLanguage")
                 .optionalLanguage("de.fraunhofer.aisec.cpg.frontends.python.PythonLanguage")


### PR DESCRIPTION
Since the `JavaLanguageFrontend` is not part of the `defaultLanguages()` anymore, the `JavaLanguageFrontend` is not loaded for neo4j anymore.