### PR TITLE
Made the `FunctionPointerCallResolver` compatible with the `ControlFlowSensitiveDFGPass`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
@@ -439,10 +439,10 @@ private constructor(
             registerPass(VariableUsageResolver())
             registerPass(CallResolver()) // creates CG
             registerPass(DFGPass())
-            registerPass(FunctionPointerCallResolver())
             registerPass(EvaluationOrderGraphPass()) // creates EOG
             registerPass(TypeResolver())
             registerPass(ControlFlowSensitiveDFGPass())
+            registerPass(FunctionPointerCallResolver())
             registerPass(FilenameMapper())
             return this
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/FunctionPointerCallResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/FunctionPointerCallResolver.kt
@@ -27,16 +27,12 @@ package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.frontends.cpp.CXXLanguageFrontend
-import de.fraunhofer.aisec.cpg.graph.HasType
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.TypeManager
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.BinaryOperator
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.LambdaExpression
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberCallExpression
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.FunctionPointerType
 import de.fraunhofer.aisec.cpg.graph.types.IncompleteType
 import de.fraunhofer.aisec.cpg.graph.types.Type
@@ -109,12 +105,12 @@ class FunctionPointerCallResolver : Pass() {
         }
     }
 
-    private fun handleFunctionPointerCall(call: CallExpression, pointer: HasType) {
+    private fun handleFunctionPointerCall(call: CallExpression, pointer: Expression) {
         val pointerType = pointer.type as FunctionPointerType
         val invocationCandidates: MutableList<FunctionDeclaration> = ArrayList()
         val work: Deque<Node> = ArrayDeque()
         val seen = IdentitySet<Node>()
-        work.push(pointer as Node)
+        work.push(pointer)
         while (!work.isEmpty()) {
             val curr = work.pop()
             if (!seen.add(curr)) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.kt
@@ -125,18 +125,23 @@ open class VariableUsageResolver : SymbolResolverPass() {
         // of this call expression back to its original variable declaration. In the future, we want
         // to extend this particular code to resolve all callee references to their declarations,
         // i.e., their function definitions and get rid of the separate CallResolver.
+        var wouldResolveTo: Declaration? = null
         if (parent is CallExpression && parent.callee === current) {
             // Peek into the declaration, and if it is a variable, we can proceed normally, as we
             // are running into the special case explained above. Otherwise, we abort here (for
             // now).
-            val wouldResolveTo = scopeManager.resolveReference(current, current.scope)
+            wouldResolveTo = scopeManager.resolveReference(current, current.scope)
             if (wouldResolveTo !is VariableDeclaration) {
                 return
             }
         }
 
-        // only consider resolving, if the language frontend did not specify a resolution
-        var refersTo = current.refersTo ?: scopeManager.resolveReference(current, current.scope)
+        // Only consider resolving, if the language frontend did not specify a resolution. If we
+        // already have populated the wouldResolveTo variable, we can re-use this instead of
+        // resolving again
+        var refersTo =
+            current.refersTo
+                ?: wouldResolveTo ?: scopeManager.resolveReference(current, current.scope)
 
         var recordDeclType: Type? = null
         if (currentClass != null) {

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.kt
@@ -1415,6 +1415,42 @@ internal class CXXLanguageFrontendTest : BaseTest() {
 
     @Test
     @Throws(Exception::class)
+    fun testFunctionPointerCall() {
+        val file = File("src/test/resources/c/func_ptr_call.c")
+        val tu = analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true)
+
+        val target = tu.functions["target"]
+        assertNotNull(target)
+
+        val main = tu.functions["main"]
+        assertNotNull(main)
+
+        // We do not want any inferred functions
+        assertTrue(tu.functions.none { it.isInferred })
+
+        val noParamPointerCall = tu.calls("no_param").firstOrNull { it.callee is UnaryOperator }
+        assertInvokes(assertNotNull(noParamPointerCall), target)
+
+        val noParamNoInitPointerCall =
+            tu.calls("no_param_uninitialized").firstOrNull { it.callee is UnaryOperator }
+        assertInvokes(assertNotNull(noParamNoInitPointerCall), target)
+
+        val noParamCall =
+            tu.calls("no_param").firstOrNull { it.callee is DeclaredReferenceExpression }
+        assertInvokes(assertNotNull(noParamCall), target)
+
+        val noParamNoInitCall =
+            tu.calls("no_param_uninitialized").firstOrNull {
+                it.callee is DeclaredReferenceExpression
+            }
+        assertInvokes(assertNotNull(noParamNoInitCall), target)
+
+        val targetCall = tu.calls["target"]
+        assertInvokes(assertNotNull(targetCall), target)
+    }
+
+    @Test
+    @Throws(Exception::class)
     fun testNamespacedFunction() {
         val file = File("src/test/resources/cxx/namespaced_function.cpp")
         val tu = analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true)

--- a/cpg-core/src/test/resources/c/func_ptr_call.c
+++ b/cpg-core/src/test/resources/c/func_ptr_call.c
@@ -1,0 +1,24 @@
+void target() {}
+
+int main() {
+  // Declares a function pointer with an initializer set to a function
+  void (*no_param)() = &target;
+  // Declares a function pointer without an initial value
+  void (*no_param_uninitialized) ();
+
+  // Sets the second function pointer to the function
+  no_param_uninitialized = &target;
+
+  // The following syntax is the "normal" syntax that is usually
+  // used by de-referencing the pointer and calling it
+  (*no_param)();
+  (*no_param_uninitialized)();
+
+  // However, C/C++ also allows us to directly call the function pointer
+  // with a syntax that is indistinguishable from a regular function call
+  no_param();
+  no_param_uninitialized();
+
+  // We can of course also just directly call our target function
+  target();
+}


### PR DESCRIPTION
The function pointer call resolver pass had a hidden blocking dependency on the `ControlFlowSensitiveDFGPass`, in a way that it needed to be executed BEFORE the control flow sensitive DFG was built. This was/is because of inconsistencies between both the "regular" DFG pass and the control-flow sensitive one (which we need to tackle in a seperate PR).

This PR makes resolving function pointers a little bit cleaner, since basically it tries to resolve every `callee` of a `CallExpression` that is of `FunctionPointerType`, regardless of any AST structure or other weird resolving. This also moves the `VariableUsageResovler` a little bit closer to resolving not just variables, but also functions (since in the long term we want to merge it with the `CallResolver`)
