### PR TITLE
Use `ConcurrentHashMap` to keep language-specific `UnknownType`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This library uses [Eclipse CDT](https://www.eclipse.org/cdt/) for parsing C/C++ 
 
 In order to improve some formal aspects of our library, we created several specifications of our core concepts. Currently, the following specifications exist:
 * [Dataflow Graph](./cpg-core/specifications/dfg.md)
+* [Evaluation Order Graph](./cpg-core/specifications/eog.md)
 * [Language and Language Frontend](./cpg-core/specifications/language.md)
 
 We aim to provide more specifications over time and also include them in a new generated documentation site.

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/UnknownType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/UnknownType.kt
@@ -30,6 +30,7 @@ import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.types.PointerType.PointerOrigin
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * UnknownType describe the case in which it is not possible for the CPG to determine which Type is
@@ -82,11 +83,14 @@ class UnknownType : Type {
 
     companion object {
         /** A map of [UnknownType] and their respective [Language]. */
-        private val unknownTypes = mutableMapOf<Language<*>?, UnknownType>()
+        private val unknownTypes = ConcurrentHashMap<Language<*>?, UnknownType>()
+        private val unknownTypeNull = UnknownType()
 
         /** Use this function to obtain an [UnknownType] for the particular [language]. */
         @JvmStatic
         fun getUnknownType(language: Language<out LanguageFrontend>?): UnknownType {
+            if (language == null) return unknownTypeNull
+
             return unknownTypes.computeIfAbsent(language) {
                 val unknownType = UnknownType()
                 unknownType.language = language


### PR DESCRIPTION
We had to observe some random crashes when using the unknown type map recently with concurrent modification exceptions. This PR should fix this issue.