### PR TITLE
Overhaul of the pass system

### DIFF
--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGPass.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGPass.kt
@@ -41,7 +41,7 @@ import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
  * by setting the [Properties.UNREACHABLE] property of an eog-edge to true.
  */
 @DependsOn(ControlFlowSensitiveDFGPass::class)
-class UnreachableEOGPass : Pass() {
+class UnreachableEOGPass : ComponentPass() {
     override fun accept(component: Component, result: TranslationResult) {
         for (tu in component.translationUnits) {
             tu.accept(

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGPass.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGPass.kt
@@ -25,7 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.ScopeManager
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.analysis.ValueEvaluator
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
@@ -41,8 +42,9 @@ import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
  * by setting the [Properties.UNREACHABLE] property of an eog-edge to true.
  */
 @DependsOn(ControlFlowSensitiveDFGPass::class)
-class UnreachableEOGPass : ComponentPass() {
-    override fun accept(component: Component, result: TranslationResult) {
+class UnreachableEOGPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
+    ComponentPass(config, scopeManager) {
+    override fun accept(component: Component) {
         for (tu in component.translationUnits) {
             tu.accept(
                 Strategy::AST_FORWARD,

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGPass.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGPass.kt
@@ -28,8 +28,8 @@ package de.fraunhofer.aisec.cpg.passes
 import de.fraunhofer.aisec.cpg.ScopeManager
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.analysis.ValueEvaluator
-import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.graph.edge.Properties
 import de.fraunhofer.aisec.cpg.graph.statements.IfStatement
 import de.fraunhofer.aisec.cpg.graph.statements.WhileStatement
@@ -42,24 +42,24 @@ import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
  * by setting the [Properties.UNREACHABLE] property of an eog-edge to true.
  */
 @DependsOn(ControlFlowSensitiveDFGPass::class)
-class UnreachableEOGPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
-    ComponentPass(config, scopeManager) {
-    override fun accept(component: Component) {
-        for (tu in component.translationUnits) {
-            tu.accept(
-                Strategy::AST_FORWARD,
-                object : IVisitor<Node>() {
-                    override fun visit(t: Node) {
-                        when (t) {
-                            is IfStatement -> handleIfStatement(t)
-                            is WhileStatement -> handleWhileStatement(t)
-                        }
-
-                        super.visit(t)
+class UnreachableEOGPass(
+    config: TranslationConfiguration,
+    scopeManager: ScopeManager,
+) : TranslationUnitPass(config, scopeManager) {
+    override fun accept(tu: TranslationUnitDeclaration) {
+        tu.accept(
+            Strategy::AST_FORWARD,
+            object : IVisitor<Node>() {
+                override fun visit(t: Node) {
+                    when (t) {
+                        is IfStatement -> handleIfStatement(t)
+                        is WhileStatement -> handleWhileStatement(t)
                     }
+
+                    super.visit(t)
                 }
-            )
-        }
+            }
+        )
     }
 
     private fun handleIfStatement(n: IfStatement) {

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGPass.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGPass.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.analysis.ValueEvaluator
+import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.edge.Properties
 import de.fraunhofer.aisec.cpg.graph.statements.IfStatement
@@ -41,8 +42,8 @@ import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
  */
 @DependsOn(ControlFlowSensitiveDFGPass::class)
 class UnreachableEOGPass : Pass() {
-    override fun accept(t: TranslationResult) {
-        for (tu in t.translationUnits) {
+    override fun accept(component: Component, result: TranslationResult) {
+        for (tu in component.translationUnits) {
             tu.accept(
                 Strategy::AST_FORWARD,
                 object : IVisitor<Node>() {

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/MultiValueEvaluatorTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/MultiValueEvaluatorTest.kt
@@ -195,7 +195,7 @@ class MultiValueEvaluatorTest {
                 topLevel,
                 true
             ) {
-                it.registerPass(EdgeCachePass())
+                it.registerPass<EdgeCachePass>()
             }
 
         assertNotNull(tu)

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/ComplexDFAOrderEvaluationTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/ComplexDFAOrderEvaluationTest.kt
@@ -86,8 +86,8 @@ class ComplexDFAOrderEvaluationTest {
                 true
             ) {
                 it.registerLanguage<JavaLanguage>()
-                    .registerPass(UnreachableEOGPass())
-                    .registerPass(EdgeCachePass())
+                    .registerPass<UnreachableEOGPass>()
+                    .registerPass<EdgeCachePass>()
             }
     }
 

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/SimpleDFAOrderEvaluationTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/SimpleDFAOrderEvaluationTest.kt
@@ -73,8 +73,8 @@ class SimpleDFAOrderEvaluationTest {
                 true
             ) {
                 it.registerLanguage<JavaLanguage>()
-                    .registerPass(UnreachableEOGPass())
-                    .registerPass(EdgeCachePass())
+                    .registerPass<UnreachableEOGPass>()
+                    .registerPass<EdgeCachePass>()
             }
     }
 

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGPassTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGPassTest.kt
@@ -55,7 +55,7 @@ class UnreachableEOGPassTest {
                 topLevel,
                 true
             ) {
-                it.registerLanguage<JavaLanguage>().registerPass(UnreachableEOGPass())
+                it.registerLanguage<JavaLanguage>().registerPass<UnreachableEOGPass>()
             }
     }
 

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGandDFGTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGandDFGTest.kt
@@ -54,7 +54,7 @@ class UnreachableEOGandDFGTest {
                 topLevel,
                 true
             ) {
-                it.registerLanguage<JavaLanguage>().registerPass(UnreachableEOGPass())
+                it.registerLanguage<JavaLanguage>().registerPass<UnreachableEOGPass>()
             }
     }
 

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/query/QueryTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/query/QueryTest.kt
@@ -552,7 +552,7 @@ class QueryTest {
                 .sourceLocations(File("src/test/resources/query/array2.cpp"))
                 .defaultPasses()
                 .defaultLanguages()
-                .registerPass(EdgeCachePass())
+                .registerPass<EdgeCachePass>()
                 .build()
 
         val analyzer = TranslationManager.builder().config(config).build()
@@ -585,7 +585,7 @@ class QueryTest {
                 .sourceLocations(File("src/test/resources/query/array3.cpp"))
                 .defaultPasses()
                 .defaultLanguages()
-                .registerPass(EdgeCachePass())
+                .registerPass<EdgeCachePass>()
                 .build()
 
         val analyzer = TranslationManager.builder().config(config).build()
@@ -636,7 +636,7 @@ class QueryTest {
                 .sourceLocations(File("src/test/resources/query/array_correct.cpp"))
                 .defaultPasses()
                 .defaultLanguages()
-                .registerPass(EdgeCachePass())
+                .registerPass<EdgeCachePass>()
                 .build()
 
         val analyzer = TranslationManager.builder().config(config).build()
@@ -817,7 +817,7 @@ class QueryTest {
                 .defaultPasses()
                 .defaultLanguages()
                 .registerLanguage(JavaLanguage())
-                .registerPass(EdgeCachePass())
+                .registerPass<EdgeCachePass>()
                 .build()
 
         val analyzer = TranslationManager.builder().config(config).build()
@@ -871,7 +871,7 @@ class QueryTest {
                 .defaultPasses()
                 .defaultLanguages()
                 .registerLanguage(JavaLanguage())
-                .registerPass(EdgeCachePass())
+                .registerPass<EdgeCachePass>()
                 .build()
 
         val analyzer = TranslationManager.builder().config(config).build()
@@ -925,7 +925,7 @@ class QueryTest {
                 .defaultPasses()
                 .defaultLanguages()
                 .registerLanguage(JavaLanguage())
-                .registerPass(EdgeCachePass())
+                .registerPass<EdgeCachePass>()
                 .build()
 
         val analyzer = TranslationManager.builder().config(config).build()

--- a/cpg-analysis/src/test/resources/log4j2.xml
+++ b/cpg-analysis/src/test/resources/log4j2.xml
@@ -1,0 +1,14 @@
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss,SSS} %-5p %C{1} %m%n"/>
+            <ThresholdFilter level="DEBUG"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger level="DEBUG" name="de.fraunhofer.aisec.cpg"/>
+        <Root level="DEBUG">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/TypeManager.java
+++ b/cpg-core/src/main/java/de/fraunhofer/aisec/cpg/graph/TypeManager.java
@@ -121,6 +121,7 @@ public class TypeManager {
    * @param typeParameters List containing all ParameterizedTypes used by the recordDeclaration and
    *     will be stored as value in the map
    */
+  @Deprecated
   public void addTypeParameter(
       RecordDeclaration recordDeclaration, List<ParameterizedType> typeParameters) {
     this.recordToTypeParameters.put(recordDeclaration, typeParameters);
@@ -135,6 +136,7 @@ public class TypeManager {
    * @return
    */
   @Nullable
+  @Deprecated
   public ParameterizedType getTypeParameter(TemplateDeclaration templateDeclaration, String name) {
     if (this.templateToTypeParameters.containsKey(templateDeclaration)) {
       for (ParameterizedType parameterizedType :

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
@@ -100,7 +100,7 @@ private constructor(
      * annotation on a [LanguageFrontend].
      */
     val replacedPasses:
-        Map<KClass<out Pass<*>>, Pair<KClass<out Language<*>>, KClass<out Pass<*>>>>,
+        Map<Pair<KClass<out Pass<*>>, KClass<out Language<*>>>, KClass<out Pass<*>>>,
     languages: List<Language<out LanguageFrontend>>,
     codeInNodes: Boolean,
     processAnnotations: Boolean,
@@ -228,7 +228,7 @@ private constructor(
         private val includeBlocklist = mutableListOf<Path>()
         private val passes = mutableListOf<KClass<out Pass<*>>>()
         private val replacedPasses =
-            mutableMapOf<KClass<out Pass<*>>, Pair<KClass<out Language<*>>, KClass<out Pass<*>>>>()
+            mutableMapOf<Pair<KClass<out Pass<*>>, KClass<out Language<*>>>, KClass<out Pass<*>>>()
         private var codeInNodes = true
         private var processAnnotations = false
         private var disableCleanup = false
@@ -401,7 +401,7 @@ private constructor(
             forLanguage: KClass<out Language<*>>,
             with: KClass<out Pass<*>>
         ): Builder {
-            replacedPasses[passType] = Pair(forLanguage, with)
+            replacedPasses[Pair(passType, forLanguage)] = with
             return this
         }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
@@ -377,6 +377,12 @@ private constructor(
             return this
         }
 
+        inline fun <reified P : Pass<*>, reified L : Language<*>> replacePass(
+            with: Pass<*>
+        ): Builder {
+            return replacePass(P::class, L::class, with)
+        }
+
         fun replacePass(
             passType: KClass<out Pass<*>>,
             forLanguage: KClass<out Language<*>>,

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
@@ -95,9 +95,14 @@ private constructor(
                 for (pass in config.registeredPasses) {
                     bench = Benchmark(pass.javaClass, "Executing Pass", false, result)
                     if (pass.runsWithCurrentFrontend(executedFrontends)) {
-                        executedPasses.add(pass)
-                        pass.accept(result)
+                        // Apply pass for each component.
+                        // TODO(oxisto): select pass based on language of component
+                        for (component in result.components) {
+                            pass.accept(component, result)
+                        }
                     }
+
+                    executedPasses.add(pass)
                     bench.addMeasurement()
                     if (result.isCancelled) {
                         log.warn("Analysis interrupted, stopping Pass evaluation")

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
@@ -35,7 +35,7 @@ import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.TypeManager
 import de.fraunhofer.aisec.cpg.helpers.Benchmark
 import de.fraunhofer.aisec.cpg.helpers.Util
-import de.fraunhofer.aisec.cpg.passes.Pass
+import de.fraunhofer.aisec.cpg.passes.*
 import java.io.File
 import java.io.PrintWriter
 import java.lang.reflect.InvocationTargetException
@@ -82,7 +82,7 @@ private constructor(
                     false,
                     result
                 )
-            val executedPasses = mutableSetOf<Pass>()
+            val executedPasses = mutableSetOf<Pass<*>>()
             var executedFrontends = setOf<LanguageFrontend>()
 
             try {
@@ -95,11 +95,7 @@ private constructor(
                 for (pass in config.registeredPasses) {
                     bench = Benchmark(pass.javaClass, "Executing Pass", false, result)
                     if (pass.runsWithCurrentFrontend(executedFrontends)) {
-                        // Apply pass for each component.
-                        // TODO(oxisto): select pass based on language of component
-                        for (component in result.components) {
-                            pass.accept(component, result)
-                        }
+                        executePassSequential(pass, result)
                     }
 
                     executedPasses.add(pass)
@@ -127,7 +123,7 @@ private constructor(
         }
     }
 
-    val passes: List<Pass>
+    val passes: List<Pass<*>>
         get() = config.registeredPasses
 
     fun isCancelled(): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
@@ -29,6 +29,7 @@ import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.helpers.MeasurementHolder
 import de.fraunhofer.aisec.cpg.helpers.StatisticsHolder
+import de.fraunhofer.aisec.cpg.passes.PassTarget
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Consumer
@@ -47,7 +48,7 @@ class TranslationResult(
      * and then finally merged into this one.
      */
     val scopeManager: ScopeManager
-) : Node(), StatisticsHolder {
+) : Node(), StatisticsHolder, PassTarget {
 
     /**
      * Entry points to the CPG: "SoftwareComponent" refer to programs, application, other "bundles"

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
@@ -80,6 +80,7 @@ class TranslationResult(
      *
      * @return the list of all translation units.
      */
+    @Deprecated(message = "translation units of individual components should be accessed instead")
     val translationUnits: List<TranslationUnitDeclaration>
         get() {
             if (components.size == 1) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.graph
 
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
+import de.fraunhofer.aisec.cpg.passes.PassTarget
 
 /**
  * A node which presents some kind of complete piece of software, e.g., an application, a library,
@@ -34,7 +35,7 @@ import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
  * This node holds all translation units belonging to this software component as well as (potential)
  * entry points or interactions with other software.
  */
-open class Component() : Node() {
+open class Component() : Node(), PassTarget {
     /** All translation units belonging to this application. */
     @AST val translationUnits: MutableList<TranslationUnitDeclaration> = mutableListOf()
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
@@ -36,6 +36,7 @@ import de.fraunhofer.aisec.cpg.graph.scopes.RecordScope
 import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.Type
+import de.fraunhofer.aisec.cpg.passes.executePassSequential
 
 fun LanguageFrontend.translationResult(
     config: TranslationConfiguration,
@@ -46,7 +47,7 @@ fun LanguageFrontend.translationResult(
     node.addComponent(component)
     init(node)
 
-    config.registeredPasses.forEach { it.accept(component, node) }
+    config.registeredPasses.forEach { executePassSequential(it, node) }
 
     return node
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
@@ -47,7 +47,7 @@ fun LanguageFrontend.translationResult(
     node.addComponent(component)
     init(node)
 
-    config.registeredPasses.forEach { executePassSequential(it, node) }
+    config.registeredPasses.forEach { executePassSequential(it, node, listOf()) }
 
     return node
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
@@ -46,7 +46,7 @@ fun LanguageFrontend.translationResult(
     node.addComponent(component)
     init(node)
 
-    config.registeredPasses.forEach { it.accept(node) }
+    config.registeredPasses.forEach { it.accept(component, node) }
 
     return node
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TranslationUnitDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TranslationUnitDeclaration.kt
@@ -33,12 +33,13 @@ import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.unwrap
 import de.fraunhofer.aisec.cpg.graph.statements.Statement
+import de.fraunhofer.aisec.cpg.passes.PassTarget
 import java.util.Objects
 import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.Relationship
 
 /** The top most declaration, representing a translation unit, for example a file. */
-class TranslationUnitDeclaration : Declaration(), DeclarationHolder, StatementHolder {
+class TranslationUnitDeclaration : Declaration(), DeclarationHolder, StatementHolder, PassTarget {
     /** A list of declarations within this unit. */
     @Relationship(value = "DECLARATIONS", direction = Relationship.Direction.OUTGOING)
     @AST

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CallResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CallResolver.kt
@@ -76,9 +76,9 @@ open class CallResolver : SymbolResolverPass() {
         containingType.clear()
     }
 
-    override fun accept(translationResult: TranslationResult) {
-        scopeManager = translationResult.scopeManager
-        config = translationResult.config
+    override fun accept(component: Component, result: TranslationResult) {
+        scopeManager = result.scopeManager
+        config = result.config
 
         walker = ScopedWalker(scopeManager)
         walker.registerHandler { _, _, currNode -> walker.collectDeclarations(currNode) }
@@ -88,17 +88,17 @@ open class CallResolver : SymbolResolverPass() {
             registerMethods(currentClass, currentNode)
         }
 
-        for (tu in translationResult.translationUnits) {
+        for (tu in component.translationUnits) {
             walker.iterate(tu)
         }
         walker.clearCallbacks()
         walker.registerHandler { node, _ -> fixInitializers(node) }
-        for (tu in translationResult.translationUnits) {
+        for (tu in component.translationUnits) {
             walker.iterate(tu)
         }
         walker.clearCallbacks()
         walker.registerHandler { node, _ -> handleNode(node) }
-        for (tu in translationResult.translationUnits) {
+        for (tu in component.translationUnits) {
             walker.iterate(tu)
         }
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CallResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CallResolver.kt
@@ -25,7 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.ScopeManager
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.frontends.HasComplexCallResolution
 import de.fraunhofer.aisec.cpg.frontends.HasDefaultArguments
 import de.fraunhofer.aisec.cpg.frontends.HasSuperClasses
@@ -64,7 +65,8 @@ import org.slf4j.LoggerFactory
  * This pass should NOT use any DFG edges because they are computed / adjusted in a later stage.
  */
 @DependsOn(VariableUsageResolver::class)
-open class CallResolver : SymbolResolverPass() {
+open class CallResolver(config: TranslationConfiguration, scopeManager: ScopeManager) :
+    SymbolResolverPass(config, scopeManager) {
     /**
      * This seems to be a map between function declarations (more likely method declarations) and
      * their parent record (more accurately their type). Seems to be only used by
@@ -76,10 +78,7 @@ open class CallResolver : SymbolResolverPass() {
         containingType.clear()
     }
 
-    override fun accept(component: Component, result: TranslationResult) {
-        scopeManager = result.scopeManager
-        config = result.config
-
+    override fun accept(component: Component) {
         walker = ScopedWalker(scopeManager)
         walker.registerHandler { _, _, currNode -> walker.collectDeclarations(currNode) }
         walker.registerHandler { node, _ -> findRecords(node) }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
@@ -25,7 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.ScopeManager
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.FieldDeclaration
@@ -48,12 +49,15 @@ import de.fraunhofer.aisec.cpg.passes.order.DependsOn
  */
 @DependsOn(EvaluationOrderGraphPass::class)
 @DependsOn(DFGPass::class)
-open class ControlFlowSensitiveDFGPass : ComponentPass() {
+open class ControlFlowSensitiveDFGPass(
+    config: TranslationConfiguration,
+    scopeManager: ScopeManager
+) : ComponentPass(config, scopeManager) {
     override fun cleanup() {
         // Nothing to do
     }
 
-    override fun accept(component: Component, result: TranslationResult) {
+    override fun accept(component: Component) {
         val walker = IterativeGraphWalker()
         walker.registerOnNodeVisit(::handle)
         for (tu in component.translationUnits) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
@@ -48,7 +48,7 @@ import de.fraunhofer.aisec.cpg.passes.order.DependsOn
  */
 @DependsOn(EvaluationOrderGraphPass::class)
 @DependsOn(DFGPass::class)
-open class ControlFlowSensitiveDFGPass : Pass() {
+open class ControlFlowSensitiveDFGPass : ComponentPass() {
     override fun cleanup() {
         // Nothing to do
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
@@ -28,10 +28,7 @@ package de.fraunhofer.aisec.cpg.passes
 import de.fraunhofer.aisec.cpg.ScopeManager
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.graph.*
-import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
-import de.fraunhofer.aisec.cpg.graph.declarations.FieldDeclaration
-import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
-import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.edge.Properties
 import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.BinaryOperator
@@ -51,18 +48,16 @@ import de.fraunhofer.aisec.cpg.passes.order.DependsOn
 @DependsOn(DFGPass::class)
 open class ControlFlowSensitiveDFGPass(
     config: TranslationConfiguration,
-    scopeManager: ScopeManager
-) : ComponentPass(config, scopeManager) {
+    scopeManager: ScopeManager,
+) : TranslationUnitPass(config, scopeManager) {
     override fun cleanup() {
         // Nothing to do
     }
 
-    override fun accept(component: Component) {
+    override fun accept(tu: TranslationUnitDeclaration) {
         val walker = IterativeGraphWalker()
         walker.registerOnNodeVisit(::handle)
-        for (tu in component.translationUnits) {
-            walker.iterate(tu)
-        }
+        walker.iterate(tu)
     }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
@@ -53,10 +53,10 @@ open class ControlFlowSensitiveDFGPass : Pass() {
         // Nothing to do
     }
 
-    override fun accept(translationResult: TranslationResult) {
+    override fun accept(component: Component, result: TranslationResult) {
         val walker = IterativeGraphWalker()
         walker.registerOnNodeVisit(::handle)
-        for (tu in translationResult.translationUnits) {
+        for (tu in component.translationUnits) {
             walker.iterate(tu)
         }
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
@@ -39,7 +39,7 @@ import de.fraunhofer.aisec.cpg.passes.order.DependsOn
 /** Adds the DFG edges for various types of nodes. */
 @DependsOn(VariableUsageResolver::class)
 @DependsOn(CallResolver::class)
-class DFGPass : Pass() {
+class DFGPass : ComponentPass() {
     override fun accept(component: Component, result: TranslationResult) {
         val inferDfgForUnresolvedCalls =
             result.translationManager.config.inferenceConfiguration.inferDfgForUnresolvedSymbols

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
@@ -25,7 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.ScopeManager
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.FieldDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
@@ -39,10 +40,10 @@ import de.fraunhofer.aisec.cpg.passes.order.DependsOn
 /** Adds the DFG edges for various types of nodes. */
 @DependsOn(VariableUsageResolver::class)
 @DependsOn(CallResolver::class)
-class DFGPass : ComponentPass() {
-    override fun accept(component: Component, result: TranslationResult) {
-        val inferDfgForUnresolvedCalls =
-            result.translationManager.config.inferenceConfiguration.inferDfgForUnresolvedSymbols
+class DFGPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
+    ComponentPass(config, scopeManager) {
+    override fun accept(component: Component) {
+        val inferDfgForUnresolvedCalls = config.inferenceConfiguration.inferDfgForUnresolvedSymbols
         val walker = IterativeGraphWalker()
         walker.registerOnNodeVisit2 { node, parent ->
             handle(node, parent, inferDfgForUnresolvedCalls)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
@@ -26,15 +26,12 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationResult
-import de.fraunhofer.aisec.cpg.graph.AccessValues
-import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.allChildren
+import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.FieldDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
-import de.fraunhofer.aisec.cpg.graph.variables
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker.IterativeGraphWalker
 import de.fraunhofer.aisec.cpg.helpers.Util
 import de.fraunhofer.aisec.cpg.passes.order.DependsOn
@@ -43,14 +40,14 @@ import de.fraunhofer.aisec.cpg.passes.order.DependsOn
 @DependsOn(VariableUsageResolver::class)
 @DependsOn(CallResolver::class)
 class DFGPass : Pass() {
-    override fun accept(tr: TranslationResult) {
+    override fun accept(component: Component, result: TranslationResult) {
         val inferDfgForUnresolvedCalls =
-            tr.translationManager.config.inferenceConfiguration.inferDfgForUnresolvedSymbols
+            result.translationManager.config.inferenceConfiguration.inferDfgForUnresolvedSymbols
         val walker = IterativeGraphWalker()
         walker.registerOnNodeVisit2 { node, parent ->
             handle(node, parent, inferDfgForUnresolvedCalls)
         }
-        for (tu in tr.translationUnits) {
+        for (tu in component.translationUnits) {
             walker.iterate(tu)
         }
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EdgeCachePass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EdgeCachePass.kt
@@ -25,7 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.ScopeManager
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
@@ -82,8 +83,9 @@ object Edges {
  *
  * The cache itself is stored in the [Edges] object.
  */
-class EdgeCachePass : ComponentPass() {
-    override fun accept(component: Component, result: TranslationResult) {
+class EdgeCachePass(config: TranslationConfiguration, scopeManager: ScopeManager) :
+    ComponentPass(config, scopeManager) {
+    override fun accept(component: Component) {
         Edges.clear()
 
         for (tu in component.translationUnits) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EdgeCachePass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EdgeCachePass.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.processing.IVisitor
@@ -82,19 +83,19 @@ object Edges {
  * The cache itself is stored in the [Edges] object.
  */
 class EdgeCachePass : Pass() {
-    override fun accept(result: TranslationResult) {
+    override fun accept(component: Component, result: TranslationResult) {
         Edges.clear()
 
-        for (tu in result.translationUnits) {
+        for (tu in component.translationUnits) {
             tu.accept(
                 Strategy::AST_FORWARD,
                 object : IVisitor<Node>() {
-                    override fun visit(n: Node) {
-                        visitAST(n)
-                        visitDFG(n)
-                        visitEOG(n)
+                    override fun visit(t: Node) {
+                        visitAST(t)
+                        visitDFG(t)
+                        visitEOG(t)
 
-                        super.visit(n)
+                        super.visit(t)
                     }
                 }
             )

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EdgeCachePass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EdgeCachePass.kt
@@ -82,7 +82,7 @@ object Edges {
  *
  * The cache itself is stored in the [Edges] object.
  */
-class EdgeCachePass : Pass() {
+class EdgeCachePass : ComponentPass() {
     override fun accept(component: Component, result: TranslationResult) {
         Edges.clear()
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
@@ -28,7 +28,6 @@ package de.fraunhofer.aisec.cpg.passes
 import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.frontends.HasShortCircuitOperators
 import de.fraunhofer.aisec.cpg.frontends.ProcessedListener
-import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.StatementHolder
 import de.fraunhofer.aisec.cpg.graph.TypeManager
@@ -71,7 +70,7 @@ import org.slf4j.LoggerFactory
  */
 @Suppress("MemberVisibilityCanBePrivate")
 @DependsOn(CallResolver::class)
-open class EvaluationOrderGraphPass : Pass() {
+open class EvaluationOrderGraphPass : TranslationUnitPass() {
     protected val map = mutableMapOf<Class<out Node>, (Node) -> Unit>()
     private var currentPredecessors = mutableListOf<Node>()
     private val nextEdgeProperties = EnumMap<Properties, Any?>(Properties::class.java)
@@ -171,13 +170,11 @@ open class EvaluationOrderGraphPass : Pass() {
         currentPredecessors.clear()
     }
 
-    override fun accept(component: Component, result: TranslationResult) {
+    override fun accept(tu: TranslationUnitDeclaration, result: TranslationResult) {
         scopeManager = result.scopeManager
-        for (tu in component.translationUnits) {
-            createEOG(tu)
-            removeUnreachableEOGEdges(tu)
-            // checkEOGInvariant(tu); To insert when trying to check if the invariant holds
-        }
+        createEOG(tu)
+        removeUnreachableEOGEdges(tu)
+        // checkEOGInvariant(tu); To insert when trying to check if the invariant holds
     }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
@@ -25,7 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.ScopeManager
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.frontends.HasShortCircuitOperators
 import de.fraunhofer.aisec.cpg.frontends.ProcessedListener
 import de.fraunhofer.aisec.cpg.graph.Node
@@ -70,7 +71,8 @@ import org.slf4j.LoggerFactory
  */
 @Suppress("MemberVisibilityCanBePrivate")
 @DependsOn(CallResolver::class)
-open class EvaluationOrderGraphPass : TranslationUnitPass() {
+open class EvaluationOrderGraphPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
+    TranslationUnitPass(config, scopeManager) {
     protected val map = mutableMapOf<Class<out Node>, (Node) -> Unit>()
     private var currentPredecessors = mutableListOf<Node>()
     private val nextEdgeProperties = EnumMap<Properties, Any?>(Properties::class.java)
@@ -170,8 +172,7 @@ open class EvaluationOrderGraphPass : TranslationUnitPass() {
         currentPredecessors.clear()
     }
 
-    override fun accept(tu: TranslationUnitDeclaration, result: TranslationResult) {
-        scopeManager = result.scopeManager
+    override fun accept(tu: TranslationUnitDeclaration) {
         createEOG(tu)
         removeUnreachableEOGEdges(tu)
         // checkEOGInvariant(tu); To insert when trying to check if the invariant holds

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
@@ -175,7 +175,6 @@ open class EvaluationOrderGraphPass(config: TranslationConfiguration, scopeManag
     override fun accept(tu: TranslationUnitDeclaration) {
         createEOG(tu)
         removeUnreachableEOGEdges(tu)
-        // checkEOGInvariant(tu); To insert when trying to check if the invariant holds
     }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.passes
 import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.frontends.HasShortCircuitOperators
 import de.fraunhofer.aisec.cpg.frontends.ProcessedListener
+import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.StatementHolder
 import de.fraunhofer.aisec.cpg.graph.TypeManager
@@ -170,9 +171,9 @@ open class EvaluationOrderGraphPass : Pass() {
         currentPredecessors.clear()
     }
 
-    override fun accept(result: TranslationResult) {
+    override fun accept(component: Component, result: TranslationResult) {
         scopeManager = result.scopeManager
-        for (tu in result.translationUnits) {
+        for (tu in component.translationUnits) {
             createEOG(tu)
             removeUnreachableEOGEdges(tu)
             // checkEOGInvariant(tu); To insert when trying to check if the invariant holds

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/FilenameMapper.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/FilenameMapper.kt
@@ -25,7 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.ScopeManager
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.passes.order.ExecuteLast
@@ -33,8 +34,9 @@ import de.fraunhofer.aisec.cpg.processing.IVisitor
 import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 
 @ExecuteLast
-class FilenameMapper : TranslationUnitPass() {
-    override fun accept(tu: TranslationUnitDeclaration, result: TranslationResult) {
+class FilenameMapper(config: TranslationConfiguration, scopeManager: ScopeManager) :
+    TranslationUnitPass(config, scopeManager) {
+    override fun accept(tu: TranslationUnitDeclaration) {
         val file = tu.name.toString()
         tu.file = file
         handle(tu, file)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/FilenameMapper.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/FilenameMapper.kt
@@ -26,20 +26,18 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationResult
-import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.passes.order.ExecuteLast
 import de.fraunhofer.aisec.cpg.processing.IVisitor
 import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 
 @ExecuteLast
-class FilenameMapper : Pass() {
-    override fun accept(component: Component, result: TranslationResult) {
-        for (tu in component.translationUnits) {
-            val file = tu.name.toString()
-            tu.file = file
-            handle(tu, file)
-        }
+class FilenameMapper : TranslationUnitPass() {
+    override fun accept(tu: TranslationUnitDeclaration, result: TranslationResult) {
+        val file = tu.name.toString()
+        tu.file = file
+        handle(tu, file)
     }
 
     private fun handle(node: Node, file: String) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/FilenameMapper.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/FilenameMapper.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.passes.order.ExecuteLast
 import de.fraunhofer.aisec.cpg.processing.IVisitor
@@ -33,8 +34,8 @@ import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 
 @ExecuteLast
 class FilenameMapper : Pass() {
-    override fun accept(translationResult: TranslationResult) {
-        for (tu in translationResult.translationUnits) {
+    override fun accept(component: Component, result: TranslationResult) {
+        for (tu in component.translationUnits) {
             val file = tu.name.toString()
             tu.file = file
             handle(tu, file)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/FunctionPointerCallResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/FunctionPointerCallResolver.kt
@@ -56,7 +56,7 @@ import java.util.function.Consumer
 @DependsOn(CallResolver::class)
 @DependsOn(DFGPass::class)
 @RequiredFrontend(CXXLanguageFrontend::class)
-class FunctionPointerCallResolver : Pass() {
+class FunctionPointerCallResolver : ComponentPass() {
     private lateinit var walker: ScopedWalker
     private var inferDfgForUnresolvedCalls = false
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/FunctionPointerCallResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/FunctionPointerCallResolver.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.frontends.cpp.CXXLanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
@@ -59,16 +60,17 @@ class FunctionPointerCallResolver : Pass() {
     private lateinit var walker: ScopedWalker
     private var inferDfgForUnresolvedCalls = false
 
-    override fun accept(t: TranslationResult) {
-        scopeManager = t.scopeManager
-        inferDfgForUnresolvedCalls = t.config.inferenceConfiguration.inferDfgForUnresolvedSymbols
-        walker = ScopedWalker(t.scopeManager)
+    override fun accept(component: Component, result: TranslationResult) {
+        scopeManager = result.scopeManager
+        inferDfgForUnresolvedCalls =
+            result.config.inferenceConfiguration.inferDfgForUnresolvedSymbols
+        walker = ScopedWalker(result.scopeManager)
         walker.registerHandler { _: RecordDeclaration?, _: Node?, currNode: Node? ->
             walker.collectDeclarations(currNode)
         }
         walker.registerHandler { node, _ -> resolve(node) }
 
-        for (tu in t.translationUnits) {
+        for (tu in component.translationUnits) {
             walker.iterate(tu)
         }
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
@@ -25,7 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.ScopeManager
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.*
@@ -39,7 +40,8 @@ import java.util.*
 import java.util.regex.Pattern
 
 @DependsOn(TypeHierarchyResolver::class)
-open class ImportResolver : ComponentPass() {
+open class ImportResolver(config: TranslationConfiguration, scopeManager: ScopeManager) :
+    ComponentPass(config, scopeManager) {
     protected val records: MutableList<RecordDeclaration> = ArrayList()
     protected val importables: MutableMap<String, Declaration> = HashMap()
 
@@ -48,7 +50,7 @@ open class ImportResolver : ComponentPass() {
         importables.clear()
     }
 
-    override fun accept(component: Component, result: TranslationResult) {
+    override fun accept(component: Component) {
         for (tu in component.translationUnits) {
             findImportables(tu)
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.newFieldDeclaration
@@ -47,8 +48,8 @@ open class ImportResolver : Pass() {
         importables.clear()
     }
 
-    override fun accept(result: TranslationResult) {
-        for (tu in result.translationUnits) {
+    override fun accept(component: Component, result: TranslationResult) {
+        for (tu in component.translationUnits) {
             findImportables(tu)
         }
         for (recordDecl in records) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
@@ -39,7 +39,7 @@ import java.util.*
 import java.util.regex.Pattern
 
 @DependsOn(TypeHierarchyResolver::class)
-open class ImportResolver : Pass() {
+open class ImportResolver : ComponentPass() {
     protected val records: MutableList<RecordDeclaration> = ArrayList()
     protected val importables: MutableMap<String, Declaration> = HashMap()
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
@@ -91,6 +91,7 @@ sealed class Pass<T : PassTarget>(
         }
         return false
     }
+
     companion object {
 
         val log: Logger = LoggerFactory.getLogger(Pass::class.java)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
@@ -31,9 +31,9 @@ import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.frontends.TranslationException
-import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.LanguageProvider
+import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.passes.order.*
 import java.util.function.Consumer

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
@@ -30,18 +30,25 @@ import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
+import de.fraunhofer.aisec.cpg.frontends.TranslationException
 import de.fraunhofer.aisec.cpg.graph.Component
+import de.fraunhofer.aisec.cpg.graph.LanguageProvider
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.passes.order.*
-import java.util.function.BiConsumer
+import java.util.function.Consumer
+import kotlin.reflect.KClass
+import kotlin.reflect.full.primaryConstructor
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-abstract class ComponentPass : Pass<Component>()
+abstract class ComponentPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
+    Pass<Component>(config, scopeManager)
 
-abstract class TranslationResultPass : Pass<TranslationResult>()
+abstract class TranslationResultPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
+    Pass<TranslationResult>(config, scopeManager)
 
-abstract class TranslationUnitPass : Pass<TranslationUnitDeclaration>()
+abstract class TranslationUnitPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
+    Pass<TranslationUnitDeclaration>(config, scopeManager)
 
 interface PassTarget
 
@@ -56,74 +63,18 @@ interface PassTarget
  * passes. Instead of directly subclassing this type, one of the types [TranslationResultPass],
  * [ComponentPass] or [TranslationUnitPass] must be used.
  */
-sealed class Pass<T : PassTarget> : BiConsumer<T, TranslationResult> {
+sealed class Pass<T : PassTarget>(
+    val config: TranslationConfiguration,
+    val scopeManager: ScopeManager
+) : Consumer<T> {
     var name: String
         protected set
 
-    /**
-     * Dependencies which, if present, have to be executed before this pass. Note: Dependencies
-     * registered here will not be added automatically to the list of active passes. Use
-     * [hardDependencies] to add them automatically.
-     */
-    internal val softDependencies: MutableSet<Class<out Pass<*>>>
-
-    /**
-     * Dependencies which have to be executed before this pass. Note: Dependencies registered here
-     * will be added to the list of active passes automatically. Use [softDependencies] if this is
-     * not desired.
-     */
-    internal val hardDependencies: MutableSet<Class<out Pass<*>>>
-    internal val executeBefore: MutableSet<Class<out Pass<*>>>
-
-    fun addSoftDependency(toAdd: Class<out Pass<*>>) {
-        softDependencies.add(toAdd)
-    }
-
-    lateinit var scopeManager: ScopeManager
-    protected var config: TranslationConfiguration? = null
-
     init {
         name = this.javaClass.name
-        hardDependencies = HashSet()
-        softDependencies = HashSet()
-        executeBefore = HashSet()
-
-        // collect all dependencies added by [DependsOn] annotations.
-        if (this.javaClass.getAnnotationsByType(DependsOn::class.java).isNotEmpty()) {
-            val dependencies = this.javaClass.getAnnotationsByType(DependsOn::class.java)
-            for (d in dependencies) {
-                if (d.softDependency) {
-                    softDependencies.add(d.value.java)
-                } else {
-                    hardDependencies.add(d.value.java)
-                }
-            }
-        }
-        if (this.javaClass.getAnnotationsByType(ExecuteBefore::class.java).isNotEmpty()) {
-            val dependencies = this.javaClass.getAnnotationsByType(ExecuteBefore::class.java)
-            for (d in dependencies) {
-                executeBefore.add(d.other.java)
-            }
-        }
     }
 
     abstract fun cleanup()
-
-    val isLastPass: Boolean
-        get() =
-            try {
-                this.javaClass.isAnnotationPresent(ExecuteLast::class.java)
-            } catch (e: Exception) {
-                false
-            }
-
-    val isFirstPass: Boolean
-        get() =
-            try {
-                this.javaClass.isAnnotationPresent(ExecuteFirst::class.java)
-            } catch (e: Exception) {
-                false
-            }
 
     /**
      * Check if the pass requires a specific language frontend and if that frontend has been
@@ -147,29 +98,83 @@ sealed class Pass<T : PassTarget> : BiConsumer<T, TranslationResult> {
 }
 
 /**
- * Executes the given [pass] sequentially on the nodes of [result]. Depending on the type of pass,
- * this will either execute the pass directly on the overall result, loop through each component or
- * through each translation unit.
+ * Creates a new [Pass] (based on [cls]) and executes it sequentially on the nodes of [result].
+ * Depending on the type of pass, this will either execute the pass directly on the overall result,
+ * loop through each component or through each translation unit.
  */
-fun executePassSequential(pass: Pass<*>, result: TranslationResult) {
-    when (pass) {
+fun executePassSequential(
+    cls: KClass<out Pass<*>>,
+    result: TranslationResult,
+    executedFrontends: Collection<LanguageFrontend>
+) {
+    // This is a bit tricky but actually better than other reflection magic. We are creating a
+    // "prototype" instance of our pass class, so we can deduce certain type information more
+    // easily.
+    val prototype =
+        cls.primaryConstructor?.call(result.config, result.scopeManager)
+            ?: throw TranslationException("Could not create prototype pass")
+
+    when (prototype) {
+        is TranslationResultPass -> {
+            executePass(
+                (prototype as TranslationResultPass)::class,
+                result,
+                result.config,
+                result.scopeManager,
+                executedFrontends
+            )
+        }
         is ComponentPass -> {
             for (component in result.components) {
-                pass.accept(component, result)
+                executePass(
+                    (prototype as ComponentPass)::class,
+                    component,
+                    result.config,
+                    result.scopeManager,
+                    executedFrontends
+                )
             }
-        }
-        is TranslationResultPass -> {
-            pass.accept(result, result)
         }
         is TranslationUnitPass -> {
             for (component in result.components) {
                 for (tu in component.translationUnits) {
-                    val realPass = checkForReplacement(pass, tu.language, result.config)
-                    realPass.accept(tu, result)
+                    executePass(
+                        (prototype as TranslationUnitPass)::class,
+                        tu,
+                        result.config,
+                        result.scopeManager,
+                        executedFrontends
+                    )
                 }
             }
         }
     }
+}
+
+inline fun <reified T : PassTarget> executePass(
+    cls: KClass<out Pass<T>>,
+    target: T,
+    config: TranslationConfiguration,
+    scopeManager: ScopeManager,
+    executedFrontends: Collection<LanguageFrontend>
+): Pass<T>? {
+    val language =
+        if (target is LanguageProvider) {
+            target.language
+        } else {
+            null
+        }
+
+    val realClass = checkForReplacement(cls, language, config)
+
+    val pass = realClass.primaryConstructor?.call(config, scopeManager)
+    if (pass?.runsWithCurrentFrontend(executedFrontends) == true) {
+        pass.accept(target)
+        pass.cleanup()
+        return pass
+    }
+
+    return null
 }
 
 /**
@@ -177,18 +182,18 @@ fun executePassSequential(pass: Pass<*>, result: TranslationResult) {
  * [language]. Currently, we only allow replacement on translation unit level, as this is the only
  * level which has a single language set.
  */
-fun checkForReplacement(
-    pass: TranslationUnitPass,
+fun <T : PassTarget> checkForReplacement(
+    cls: KClass<out Pass<T>>,
     language: Language<*>?,
     config: TranslationConfiguration
-): TranslationUnitPass {
-    val replacements = config.replacedPasses[pass::class]
+): KClass<out Pass<T>> {
+    val replacements = config.replacedPasses[cls]
     if (replacements != null) {
         val langClass = replacements.first
-        if (langClass.isInstance(language) && replacements.second is TranslationUnitPass) {
-            return replacements.second as TranslationUnitPass
+        if (langClass.isInstance(language)) {
+            return replacements.second as KClass<out Pass<T>>
         }
     }
 
-    return pass
+    return cls
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
@@ -31,6 +31,7 @@ import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.frontends.TranslationException
+import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.LanguageProvider
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
@@ -41,15 +42,32 @@ import kotlin.reflect.full.primaryConstructor
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-abstract class ComponentPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
-    Pass<Component>(config, scopeManager)
-
+/**
+ * A [TranslationResultPass] is a pass that operates on a [TranslationResult]. If used with
+ * [executePassSequential], one [Pass] object is instantiated for the whole [TranslationResult].
+ */
 abstract class TranslationResultPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
     Pass<TranslationResult>(config, scopeManager)
 
+/**
+ * A [ComponentPass] is a pass that operates on a [Component]. If used with [executePassSequential],
+ * one [Pass] object is instantiated for each [Component] in a [TranslationResult].
+ */
+abstract class ComponentPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
+    Pass<Component>(config, scopeManager)
+
+/**
+ * A [TranslationUnitPass] is a pass that operates on a [TranslationUnitDeclaration]. If used with
+ * [executePassSequential], one [Pass] object is instantiated for each [TranslationUnitDeclaration]
+ * in a [Component].
+ */
 abstract class TranslationUnitPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
     Pass<TranslationUnitDeclaration>(config, scopeManager)
 
+/**
+ * A pass target is an interface for a [Node] on which a [Pass] can operate, it should only be
+ * implemented by [TranslationResult], [Component] and [TranslationUnitDeclaration].
+ */
 interface PassTarget
 
 /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
@@ -206,13 +206,9 @@ fun <T : PassTarget> checkForReplacement(
     language: Language<*>?,
     config: TranslationConfiguration
 ): KClass<out Pass<T>> {
-    val replacements = config.replacedPasses[cls]
-    if (replacements != null) {
-        val langClass = replacements.first
-        if (langClass.isInstance(language)) {
-            return replacements.second as KClass<out Pass<T>>
-        }
+    if (language == null) {
+        return cls
     }
 
-    return cls
+    return config.replacedPasses[Pair(cls, language::class)] as? KClass<out Pass<T>> ?: cls
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
@@ -29,17 +29,18 @@ import de.fraunhofer.aisec.cpg.ScopeManager
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.passes.order.*
-import java.util.function.Consumer
+import java.util.function.BiConsumer
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 /**
  * Represents an abstract class that enhances the graph before it is persisted.
  *
- * Passes are expected to mutate the [TranslationResult].
+ * Passes are expected to mutate the [Component].
  */
-abstract class Pass protected constructor() : Consumer<TranslationResult> {
+abstract class Pass protected constructor() : BiConsumer<Component, TranslationResult> {
     var name: String
         protected set
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
@@ -28,19 +28,35 @@ package de.fraunhofer.aisec.cpg.passes
 import de.fraunhofer.aisec.cpg.ScopeManager
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.Component
+import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.passes.order.*
 import java.util.function.BiConsumer
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+abstract class ComponentPass : Pass<Component>()
+
+abstract class TranslationResultPass : Pass<TranslationResult>()
+
+abstract class TranslationUnitPass : Pass<TranslationUnitDeclaration>()
+
+interface PassTarget
+
 /**
- * Represents an abstract class that enhances the graph before it is persisted.
+ * Represents an abstract class that enhances the graph before it is persisted. Passes can exist at
+ * three different levels:
+ * - the overall [TranslationResult]
+ * - a [Component], and
+ * - a [TranslationUnitDeclaration].
  *
- * Passes are expected to mutate the [Component].
+ * A level should be chosen as granular as possible, to allow for the (future) parallel execution of
+ * passes. Instead of directly subclassing this type, one of the types [TranslationResultPass],
+ * [ComponentPass] or [TranslationUnitPass] must be used.
  */
-abstract class Pass protected constructor() : BiConsumer<Component, TranslationResult> {
+sealed class Pass<T : PassTarget> : BiConsumer<T, TranslationResult> {
     var name: String
         protected set
 
@@ -49,17 +65,17 @@ abstract class Pass protected constructor() : BiConsumer<Component, TranslationR
      * registered here will not be added automatically to the list of active passes. Use
      * [hardDependencies] to add them automatically.
      */
-    internal val softDependencies: MutableSet<Class<out Pass>>
+    internal val softDependencies: MutableSet<Class<out Pass<*>>>
 
     /**
      * Dependencies which have to be executed before this pass. Note: Dependencies registered here
      * will be added to the list of active passes automatically. Use [softDependencies] if this is
      * not desired.
      */
-    internal val hardDependencies: MutableSet<Class<out Pass>>
-    internal val executeBefore: MutableSet<Class<out Pass>>
+    internal val hardDependencies: MutableSet<Class<out Pass<*>>>
+    internal val executeBefore: MutableSet<Class<out Pass<*>>>
 
-    fun addSoftDependency(toAdd: Class<out Pass?>) {
+    fun addSoftDependency(toAdd: Class<out Pass<*>>) {
         softDependencies.add(toAdd)
     }
 
@@ -77,16 +93,16 @@ abstract class Pass protected constructor() : BiConsumer<Component, TranslationR
             val dependencies = this.javaClass.getAnnotationsByType(DependsOn::class.java)
             for (d in dependencies) {
                 if (d.softDependency) {
-                    softDependencies.add(d.value.java)
+                    softDependencies.add(d.value.java as Class<out Pass<*>>)
                 } else {
-                    hardDependencies.add(d.value.java)
+                    hardDependencies.add(d.value.java as Class<out Pass<*>>)
                 }
             }
         }
         if (this.javaClass.getAnnotationsByType(ExecuteBefore::class.java).isNotEmpty()) {
             val dependencies = this.javaClass.getAnnotationsByType(ExecuteBefore::class.java)
             for (d in dependencies) {
-                executeBefore.add(d.other.java)
+                executeBefore.add(d.other.java as Class<out Pass<*>>)
             }
         }
     }
@@ -124,8 +140,52 @@ abstract class Pass protected constructor() : BiConsumer<Component, TranslationR
         }
         return false
     }
-
     companion object {
+
         val log: Logger = LoggerFactory.getLogger(Pass::class.java)
+    }
+}
+
+fun executePassSequential(pass: Pass<*>, result: TranslationResult) {
+    when (pass) {
+        is ComponentPass -> {
+            for (component in result.components) {
+                pass.accept(component, result)
+            }
+        }
+        is TranslationResultPass -> {
+            pass.accept(result, result)
+        }
+        is TranslationUnitPass -> {
+            for (component in result.components) {
+                for (tu in component.translationUnits) {
+                    val realPass = checkForReplacement(pass, tu.language, result.config)
+                    realPass.accept(tu, result)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Checks, whether the specified pass has a replacement configured in [config] for the given
+ * [language]. Currently, we only allow replacement on translation unit level, as this is the only
+ * level which has a single language set.
+ */
+fun checkForReplacement(
+    pass: TranslationUnitPass,
+    language: Language<*>?,
+    config: TranslationConfiguration
+): TranslationUnitPass {
+    val replacements = config.replacedPasses[pass::class]
+    return if (replacements != null) {
+        val langClass = replacements.first
+        if (langClass.isInstance(language) && replacements.second is TranslationUnitPass) {
+            replacements.second as TranslationUnitPass
+        } else {
+            pass
+        }
+    } else {
+        pass
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/StatisticsCollectionPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/StatisticsCollectionPass.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.ProblemNode
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
@@ -38,11 +39,11 @@ import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker.ScopedWalker
  */
 class StatisticsCollectionPass : Pass() {
 
-    /** Iterates the nodes of the [translationResult] to collect statistics. */
-    override fun accept(translationResult: TranslationResult) {
+    /** Iterates the nodes of the [result] to collect statistics. */
+    override fun accept(component: Component, result: TranslationResult) {
         var problemNodes = 0
         var nodes = 0
-        val walker = ScopedWalker(translationResult.scopeManager)
+        val walker = ScopedWalker(result.scopeManager)
         walker.registerHandler { _: RecordDeclaration?, _: Node?, currNode: Node? ->
             nodes++
             if (currNode is ProblemNode) {
@@ -50,12 +51,11 @@ class StatisticsCollectionPass : Pass() {
             }
         }
 
-        for (tu in translationResult.translationUnits) {
+        for (tu in component.translationUnits) {
             walker.iterate(tu)
         }
 
-        val nodeMeasurement =
-            MeasurementHolder(this.javaClass, "Measuring Nodes", false, translationResult)
+        val nodeMeasurement = MeasurementHolder(this.javaClass, "Measuring Nodes", false, result)
         nodeMeasurement.addMeasurement("Total graph nodes", nodes.toString())
         nodeMeasurement.addMeasurement("Problem nodes", problemNodes.toString())
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/StatisticsCollectionPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/StatisticsCollectionPass.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationResult
-import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.ProblemNode
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
@@ -37,10 +36,10 @@ import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker.ScopedWalker
  * A [Pass] collecting statistics for the graph. Currently, it collects the number of nodes and the
  * number of problem nodes (i.e., nodes where the translation failed for some reason).
  */
-class StatisticsCollectionPass : Pass() {
+class StatisticsCollectionPass : TranslationResultPass() {
 
     /** Iterates the nodes of the [result] to collect statistics. */
-    override fun accept(component: Component, result: TranslationResult) {
+    override fun accept(r: TranslationResult, result: TranslationResult) {
         var problemNodes = 0
         var nodes = 0
         val walker = ScopedWalker(result.scopeManager)
@@ -51,7 +50,7 @@ class StatisticsCollectionPass : Pass() {
             }
         }
 
-        for (tu in component.translationUnits) {
+        for (tu in result.translationUnits) {
             walker.iterate(tu)
         }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/StatisticsCollectionPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/StatisticsCollectionPass.kt
@@ -25,6 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
+import de.fraunhofer.aisec.cpg.ScopeManager
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.ProblemNode
@@ -36,10 +38,11 @@ import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker.ScopedWalker
  * A [Pass] collecting statistics for the graph. Currently, it collects the number of nodes and the
  * number of problem nodes (i.e., nodes where the translation failed for some reason).
  */
-class StatisticsCollectionPass : TranslationResultPass() {
+class StatisticsCollectionPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
+    TranslationResultPass(config, scopeManager) {
 
     /** Iterates the nodes of the [result] to collect statistics. */
-    override fun accept(r: TranslationResult, result: TranslationResult) {
+    override fun accept(result: TranslationResult) {
         var problemNodes = 0
         var nodes = 0
         val walker = ScopedWalker(result.scopeManager)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolverPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolverPass.kt
@@ -32,7 +32,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.DeclaredReferenceExp
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 
-abstract class SymbolResolverPass : Pass() {
+abstract class SymbolResolverPass : ComponentPass() {
     protected lateinit var walker: SubgraphWalker.ScopedWalker
     lateinit var currentTU: TranslationUnitDeclaration
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolverPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolverPass.kt
@@ -25,6 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
+import de.fraunhofer.aisec.cpg.ScopeManager
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.frontends.HasSuperClasses
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.*
@@ -32,7 +34,8 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.DeclaredReferenceExp
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 
-abstract class SymbolResolverPass : ComponentPass() {
+abstract class SymbolResolverPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
+    ComponentPass(config, scopeManager) {
     protected lateinit var walker: SubgraphWalker.ScopedWalker
     lateinit var currentTU: TranslationUnitDeclaration
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeHierarchyResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeHierarchyResolver.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.EnumDeclaration
@@ -58,8 +59,8 @@ open class TypeHierarchyResolver : Pass() {
     protected val recordMap = mutableMapOf<Name, RecordDeclaration>()
     protected val enums = mutableListOf<EnumDeclaration>()
 
-    override fun accept(translationResult: TranslationResult) {
-        for (tu in translationResult.translationUnits) {
+    override fun accept(component: Component, result: TranslationResult) {
+        for (tu in component.translationUnits) {
             findRecordsAndEnums(tu)
         }
         for (recordDecl in recordMap.values) {
@@ -75,7 +76,7 @@ open class TypeHierarchyResolver : Pass() {
             enumDecl.superTypeDeclarations = allSupertypes
         }
 
-        translationResult.translationUnits.forEach { SubgraphWalker.refreshType(it) }
+        result.translationUnits.forEach { SubgraphWalker.refreshType(it) }
     }
 
     protected fun findRecordsAndEnums(node: Node) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeHierarchyResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeHierarchyResolver.kt
@@ -55,7 +55,7 @@ import java.util.*
  * at places where it is crucial to have parsed all [RecordDeclaration]s. Otherwise, type
  * information in the graph might not be fully correct
  */
-open class TypeHierarchyResolver : Pass() {
+open class TypeHierarchyResolver : ComponentPass() {
     protected val recordMap = mutableMapOf<Name, RecordDeclaration>()
     protected val enums = mutableListOf<EnumDeclaration>()
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeHierarchyResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeHierarchyResolver.kt
@@ -25,7 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.ScopeManager
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.Node
@@ -55,11 +56,12 @@ import java.util.*
  * at places where it is crucial to have parsed all [RecordDeclaration]s. Otherwise, type
  * information in the graph might not be fully correct
  */
-open class TypeHierarchyResolver : ComponentPass() {
+open class TypeHierarchyResolver(config: TranslationConfiguration, scopeManager: ScopeManager) :
+    ComponentPass(config, scopeManager) {
     protected val recordMap = mutableMapOf<Name, RecordDeclaration>()
     protected val enums = mutableListOf<EnumDeclaration>()
 
-    override fun accept(component: Component, result: TranslationResult) {
+    override fun accept(component: Component) {
         for (tu in component.translationUnits) {
             findRecordsAndEnums(tu)
         }
@@ -76,7 +78,7 @@ open class TypeHierarchyResolver : ComponentPass() {
             enumDecl.superTypeDeclarations = allSupertypes
         }
 
-        result.translationUnits.forEach { SubgraphWalker.refreshType(it) }
+        component.translationUnits.forEach { SubgraphWalker.refreshType(it) }
     }
 
     protected fun findRecordsAndEnums(node: Node) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
@@ -25,7 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.ScopeManager
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.HasType
 import de.fraunhofer.aisec.cpg.graph.HasType.SecondaryTypeEdge
@@ -37,7 +38,8 @@ import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker.IterativeGraphWalker
 import de.fraunhofer.aisec.cpg.passes.order.DependsOn
 
 @DependsOn(CallResolver::class)
-open class TypeResolver : ComponentPass() {
+open class TypeResolver(config: TranslationConfiguration, scopeManager: ScopeManager) :
+    ComponentPass(config, scopeManager) {
     protected val firstOrderTypes = mutableSetOf<Type>()
     protected val typeState = mutableMapOf<Type, MutableList<Type>>()
 
@@ -150,7 +152,7 @@ open class TypeResolver : ComponentPass() {
      *
      * @param result
      */
-    override fun accept(component: Component, result: TranslationResult) {
+    override fun accept(component: Component) {
         removeDuplicateTypes()
         val walker = IterativeGraphWalker()
         walker.registerOnNodeVisit(::ensureUniqueType)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
@@ -150,7 +150,7 @@ open class TypeResolver(config: TranslationConfiguration, scopeManager: ScopeMan
      * Pass on the TypeSystem: Sets RecordDeclaration Relationship from ObjectType to
      * RecordDeclaration
      *
-     * @param result
+     * @param component
      */
     override fun accept(component: Component) {
         removeDuplicateTypes()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.HasType
 import de.fraunhofer.aisec.cpg.graph.HasType.SecondaryTypeEdge
 import de.fraunhofer.aisec.cpg.graph.Node
@@ -147,16 +148,16 @@ open class TypeResolver : Pass() {
      * Pass on the TypeSystem: Sets RecordDeclaration Relationship from ObjectType to
      * RecordDeclaration
      *
-     * @param translationResult
+     * @param result
      */
-    override fun accept(translationResult: TranslationResult) {
+    override fun accept(component: Component, result: TranslationResult) {
         removeDuplicateTypes()
         val walker = IterativeGraphWalker()
         walker.registerOnNodeVisit(::ensureUniqueType)
         walker.registerOnNodeVisit(::handle)
         walker.registerOnNodeVisit(::ensureUniqueSecondaryTypeEdge)
 
-        for (tu in translationResult.translationUnits) {
+        for (tu in component.translationUnits) {
             walker.iterate(tu)
         }
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
@@ -37,7 +37,7 @@ import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker.IterativeGraphWalker
 import de.fraunhofer.aisec.cpg.passes.order.DependsOn
 
 @DependsOn(CallResolver::class)
-open class TypeResolver : Pass() {
+open class TypeResolver : ComponentPass() {
     protected val firstOrderTypes = mutableSetOf<Type>()
     protected val typeState = mutableMapOf<Type, MutableList<Type>>()
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.kt
@@ -25,7 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.ScopeManager
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.frontends.HasStructs
 import de.fraunhofer.aisec.cpg.frontends.HasSuperClasses
 import de.fraunhofer.aisec.cpg.graph.*
@@ -58,12 +59,10 @@ import org.slf4j.LoggerFactory
  * rather makes their "refersTo" point to the appropriate [ValueDeclaration].
  */
 @DependsOn(TypeHierarchyResolver::class)
-open class VariableUsageResolver : SymbolResolverPass() {
+open class VariableUsageResolver(config: TranslationConfiguration, scopeManager: ScopeManager) :
+    SymbolResolverPass(config, scopeManager) {
 
-    override fun accept(component: Component, result: TranslationResult) {
-        scopeManager = result.scopeManager
-        config = result.config
-
+    override fun accept(component: Component) {
         walker = ScopedWalker(scopeManager)
         for (tu in component.translationUnits) {
             currentTU = tu

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.kt
@@ -76,14 +76,14 @@ open class VariableUsageResolver : SymbolResolverPass() {
 
         collectSupertypes()
 
-        for (tu in result.translationUnits) {
+        for (tu in component.translationUnits) {
             walker.clearCallbacks()
             walker.registerHandler { curClass, parent, node ->
                 resolveFieldUsages(curClass, parent, node)
             }
             walker.iterate(tu)
         }
-        for (tu in result.translationUnits) {
+        for (tu in component.translationUnits) {
             walker.clearCallbacks()
             walker.registerHandler(::resolveLocalVarUsage)
             walker.iterate(tu)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/VariableUsageResolver.kt
@@ -60,12 +60,12 @@ import org.slf4j.LoggerFactory
 @DependsOn(TypeHierarchyResolver::class)
 open class VariableUsageResolver : SymbolResolverPass() {
 
-    override fun accept(result: TranslationResult) {
+    override fun accept(component: Component, result: TranslationResult) {
         scopeManager = result.scopeManager
         config = result.config
 
         walker = ScopedWalker(scopeManager)
-        for (tu in result.translationUnits) {
+        for (tu in component.translationUnits) {
             currentTU = tu
             walker.clearCallbacks()
             walker.registerHandler { _, _, currNode -> walker.collectDeclarations(currNode) }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/DependsOn.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/DependsOn.kt
@@ -39,4 +39,4 @@ import kotlin.reflect.KClass
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
 @Repeatable
-annotation class DependsOn(val value: KClass<out Pass>, val softDependency: Boolean = false)
+annotation class DependsOn(val value: KClass<out Pass<*>>, val softDependency: Boolean = false)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/ExecuteBefore.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/ExecuteBefore.kt
@@ -35,4 +35,4 @@ import kotlin.reflect.KClass
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
 @Repeatable
-annotation class ExecuteBefore(val other: KClass<out Pass>)
+annotation class ExecuteBefore(val other: KClass<out Pass<*>>)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/PassWithDependencies.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/PassWithDependencies.kt
@@ -26,9 +26,27 @@
 package de.fraunhofer.aisec.cpg.passes.order
 
 import de.fraunhofer.aisec.cpg.passes.Pass
+import kotlin.reflect.KClass
+import kotlin.reflect.full.hasAnnotation
 
 /** A simple helper class to match a pass with dependencies. */
 data class PassWithDependencies(
-    val pass: Pass<*>,
-    val dependencies: MutableSet<Class<out Pass<*>>>
-)
+    val pass: KClass<out Pass<*>>,
+    val softDependencies: MutableSet<KClass<out Pass<*>>>,
+    val hardDependencies: MutableSet<KClass<out Pass<*>>>
+) {
+    val dependencies: Set<KClass<out Pass<*>>>
+        get() {
+            return softDependencies + hardDependencies
+        }
+
+    val isFirstPass: Boolean
+        get() {
+            return pass.hasAnnotation<ExecuteFirst>()
+        }
+
+    val isLastPass: Boolean
+        get() {
+            return pass.hasAnnotation<ExecuteLast>()
+        }
+}

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/PassWithDependencies.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/PassWithDependencies.kt
@@ -28,4 +28,7 @@ package de.fraunhofer.aisec.cpg.passes.order
 import de.fraunhofer.aisec.cpg.passes.Pass
 
 /** A simple helper class to match a pass with dependencies. */
-data class PassWithDependencies(val pass: Pass, val dependencies: MutableSet<Class<out Pass>>)
+data class PassWithDependencies(
+    val pass: Pass<*>,
+    val dependencies: MutableSet<Class<out Pass<*>>>
+)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/PassWithDependencies.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/PassWithDependencies.kt
@@ -25,9 +25,11 @@
  */
 package de.fraunhofer.aisec.cpg.passes.order
 
+import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.passes.Pass
 import kotlin.reflect.KClass
 import kotlin.reflect.full.hasAnnotation
+import org.apache.commons.lang3.builder.ToStringBuilder
 
 /** A simple helper class to match a pass with dependencies. */
 data class PassWithDependencies(
@@ -49,4 +51,12 @@ data class PassWithDependencies(
         get() {
             return pass.hasAnnotation<ExecuteLast>()
         }
+
+    override fun toString(): String {
+        return ToStringBuilder(this, Node.TO_STRING_STYLE)
+            .append("pass", pass.simpleName)
+            .append("softDependencies", softDependencies.map { it.simpleName })
+            .append("hardDependencies", hardDependencies.map { it.simpleName })
+            .toString()
+    }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/PassWithDepsContainer.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/PassWithDepsContainer.kt
@@ -30,6 +30,7 @@ import de.fraunhofer.aisec.cpg.passes.Pass
 import de.fraunhofer.aisec.cpg.passes.Pass.Companion.log
 import java.util.*
 import kotlin.reflect.KClass
+import kotlin.reflect.full.findAnnotations
 
 /**
  * A simple helper class for keeping track of passes and their (currently not satisfied)
@@ -62,8 +63,9 @@ class PassWithDepsContainer {
      * working list.
      */
     private fun removeDependencyByClass(cls: KClass<out Pass<*>>) {
-        for ((_, value) in workingList) {
-            value.remove(cls)
+        for (pass in workingList) {
+            pass.softDependencies.remove(cls)
+            pass.hardDependencies.remove(cls)
         }
     }
 
@@ -95,14 +97,12 @@ class PassWithDepsContainer {
         val softDependencies = mutableSetOf<KClass<out Pass<*>>>()
         val hardDependencies = mutableSetOf<KClass<out Pass<*>>>()
 
-        if (this.javaClass.getAnnotationsByType(DependsOn::class.java).isNotEmpty()) {
-            val dependencies = this.javaClass.getAnnotationsByType(DependsOn::class.java)
-            for (d in dependencies) {
-                if (d.softDependency) {
-                    softDependencies += d.value
-                } else {
-                    hardDependencies += d.value
-                }
+        val dependencies = cls.findAnnotations<DependsOn>()
+        for (d in dependencies) {
+            if (d.softDependency) {
+                softDependencies += d.value
+            } else {
+                hardDependencies += d.value
             }
         }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/PassWithDepsContainer.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/PassWithDepsContainer.kt
@@ -28,8 +28,8 @@ package de.fraunhofer.aisec.cpg.passes.order
 import de.fraunhofer.aisec.cpg.ConfigurationException
 import de.fraunhofer.aisec.cpg.passes.Pass
 import de.fraunhofer.aisec.cpg.passes.Pass.Companion.log
-import java.lang.reflect.InvocationTargetException
 import java.util.*
+import kotlin.reflect.KClass
 
 /**
  * A simple helper class for keeping track of passes and their (currently not satisfied)
@@ -61,7 +61,7 @@ class PassWithDepsContainer {
      * Iterate through all elements and remove the provided dependency [cls] from all passes in the
      * working list.
      */
-    private fun removeDependencyByClass(cls: Class<out Pass<*>>) {
+    private fun removeDependencyByClass(cls: KClass<out Pass<*>>) {
         for ((_, value) in workingList) {
             value.remove(cls)
         }
@@ -72,17 +72,17 @@ class PassWithDepsContainer {
     }
 
     fun getFirstPasses(): List<PassWithDependencies> {
-        return workingList.filter { it.pass.isFirstPass }
+        return workingList.filter { it.isFirstPass }
     }
 
     fun getLastPasses(): List<PassWithDependencies> {
-        return workingList.filter { it.pass.isLastPass }
+        return workingList.filter { it.isLastPass }
     }
 
-    private fun dependencyPresent(dep: Class<out Pass<*>>): Boolean {
+    private fun dependencyPresent(dep: KClass<out Pass<*>>): Boolean {
         var result = false
         for (currentElement in workingList) {
-            if (dep == currentElement.pass.javaClass) {
+            if (dep == currentElement.pass) {
                 result = true
                 break
             }
@@ -91,24 +91,22 @@ class PassWithDepsContainer {
         return result
     }
 
-    private fun createNewPassWithDependency(cls: Class<out Pass<*>>): PassWithDependencies {
-        val newPass =
-            try {
-                cls.getConstructor().newInstance()
-            } catch (e: InstantiationException) {
-                throw ConfigurationException(e)
-            } catch (e: InvocationTargetException) {
-                throw ConfigurationException(e)
-            } catch (e: IllegalAccessException) {
-                throw ConfigurationException(e)
-            } catch (e: NoSuchMethodException) {
-                throw ConfigurationException(e)
-            }
+    private fun createNewPassWithDependency(cls: KClass<out Pass<*>>): PassWithDependencies {
+        val softDependencies = mutableSetOf<KClass<out Pass<*>>>()
+        val hardDependencies = mutableSetOf<KClass<out Pass<*>>>()
 
-        val deps: MutableSet<Class<out Pass<*>>> = HashSet()
-        deps.addAll(newPass.hardDependencies)
-        deps.addAll(newPass.softDependencies)
-        return PassWithDependencies(newPass, deps)
+        if (this.javaClass.getAnnotationsByType(DependsOn::class.java).isNotEmpty()) {
+            val dependencies = this.javaClass.getAnnotationsByType(DependsOn::class.java)
+            for (d in dependencies) {
+                if (d.softDependency) {
+                    softDependencies += d.value
+                } else {
+                    hardDependencies += d.value
+                }
+            }
+        }
+
+        return PassWithDependencies(cls, softDependencies, hardDependencies)
     }
 
     /**
@@ -119,7 +117,7 @@ class PassWithDepsContainer {
         val it = workingList.listIterator()
         while (it.hasNext()) {
             val current = it.next()
-            for (dependency in current.pass.hardDependencies) {
+            for (dependency in current.hardDependencies) {
                 if (!dependencyPresent(dependency)) {
                     log.info(
                         "Registering a required hard dependency which was not registered explicitly: {}",
@@ -131,11 +129,11 @@ class PassWithDepsContainer {
         }
 
         // add required dependencies to the working list
-        val missingPasses: MutableList<Class<out Pass<*>>> = ArrayList()
+        val missingPasses: MutableList<KClass<out Pass<*>>> = ArrayList()
 
         // initially populate the missing dependencies list given the current passes
         for (currentElement in workingList) {
-            for (dependency in currentElement.pass.hardDependencies) {
+            for (dependency in currentElement.hardDependencies) {
                 if (!dependencyPresent(dependency)) {
                     missingPasses.add(dependency)
                 }
@@ -149,11 +147,11 @@ class PassWithDepsContainer {
      *
      * @return The first pass that has no active dependencies on success. null otherwise.
      */
-    fun getAndRemoveFirstPassWithoutDependencies(): Pass<*>? {
-        var result: Pass<*>? = null
+    fun getAndRemoveFirstPassWithoutDependencies(): KClass<out Pass<*>>? {
+        var result: KClass<out Pass<*>>? = null
 
         for (currentElement in workingList) {
-            if (workingList.size > 1 && currentElement.pass.isLastPass) {
+            if (workingList.size > 1 && currentElement.isLastPass) {
                 // last pass can only be added at the end
                 continue
             }
@@ -162,7 +160,7 @@ class PassWithDepsContainer {
                 result = currentElement.pass
 
                 // remove the pass from the other pass's dependencies
-                removeDependencyByClass(result.javaClass)
+                removeDependencyByClass(result)
                 workingList.remove(currentElement)
                 break
             }
@@ -177,7 +175,7 @@ class PassWithDepsContainer {
      *
      * @return The first pass if present. Otherwise, null.
      */
-    fun getAndRemoveFirstPass(): Pass<*>? {
+    fun getAndRemoveFirstPass(): KClass<out Pass<*>>? {
         val firstPasses = getFirstPasses()
         if (firstPasses.size > 1) {
             throw ConfigurationException(
@@ -186,10 +184,10 @@ class PassWithDepsContainer {
         }
         return if (firstPasses.isNotEmpty()) {
             val firstPass = firstPasses.first()
-            if (firstPass.pass.hardDependencies.isNotEmpty()) {
+            if (firstPass.hardDependencies.isNotEmpty()) {
                 throw ConfigurationException("The first pass has a hard dependency.")
             } else {
-                removeDependencyByClass(firstPass.pass.javaClass)
+                removeDependencyByClass(firstPass.pass)
                 workingList.remove(firstPass)
                 firstPass.pass
             }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/PassWithDepsContainer.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/PassWithDepsContainer.kt
@@ -61,7 +61,7 @@ class PassWithDepsContainer {
      * Iterate through all elements and remove the provided dependency [cls] from all passes in the
      * working list.
      */
-    private fun removeDependencyByClass(cls: Class<out Pass>) {
+    private fun removeDependencyByClass(cls: Class<out Pass<*>>) {
         for ((_, value) in workingList) {
             value.remove(cls)
         }
@@ -79,7 +79,7 @@ class PassWithDepsContainer {
         return workingList.filter { it.pass.isLastPass }
     }
 
-    private fun dependencyPresent(dep: Class<out Pass>): Boolean {
+    private fun dependencyPresent(dep: Class<out Pass<*>>): Boolean {
         var result = false
         for (currentElement in workingList) {
             if (dep == currentElement.pass.javaClass) {
@@ -91,7 +91,7 @@ class PassWithDepsContainer {
         return result
     }
 
-    private fun createNewPassWithDependency(cls: Class<out Pass>): PassWithDependencies {
+    private fun createNewPassWithDependency(cls: Class<out Pass<*>>): PassWithDependencies {
         val newPass =
             try {
                 cls.getConstructor().newInstance()
@@ -105,7 +105,7 @@ class PassWithDepsContainer {
                 throw ConfigurationException(e)
             }
 
-        val deps: MutableSet<Class<out Pass>> = HashSet()
+        val deps: MutableSet<Class<out Pass<*>>> = HashSet()
         deps.addAll(newPass.hardDependencies)
         deps.addAll(newPass.softDependencies)
         return PassWithDependencies(newPass, deps)
@@ -131,7 +131,7 @@ class PassWithDepsContainer {
         }
 
         // add required dependencies to the working list
-        val missingPasses: MutableList<Class<out Pass>> = ArrayList()
+        val missingPasses: MutableList<Class<out Pass<*>>> = ArrayList()
 
         // initially populate the missing dependencies list given the current passes
         for (currentElement in workingList) {
@@ -149,8 +149,8 @@ class PassWithDepsContainer {
      *
      * @return The first pass that has no active dependencies on success. null otherwise.
      */
-    fun getAndRemoveFirstPassWithoutDependencies(): Pass? {
-        var result: Pass? = null
+    fun getAndRemoveFirstPassWithoutDependencies(): Pass<*>? {
+        var result: Pass<*>? = null
 
         for (currentElement in workingList) {
             if (workingList.size > 1 && currentElement.pass.isLastPass) {
@@ -177,7 +177,7 @@ class PassWithDepsContainer {
      *
      * @return The first pass if present. Otherwise, null.
      */
-    fun getAndRemoveFirstPass(): Pass? {
+    fun getAndRemoveFirstPass(): Pass<*>? {
         val firstPasses = getFirstPasses()
         if (firstPasses.size > 1) {
             throw ConfigurationException(

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/RegisterExtraPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/RegisterExtraPass.kt
@@ -32,4 +32,4 @@ import kotlin.reflect.KClass
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
 @Repeatable
-annotation class RegisterExtraPass(val value: KClass<out Pass>)
+annotation class RegisterExtraPass(val value: KClass<out Pass<*>>)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/ReplacePass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/ReplacePass.kt
@@ -26,14 +26,22 @@
 package de.fraunhofer.aisec.cpg.passes.order
 
 import de.fraunhofer.aisec.cpg.frontends.Language
+import de.fraunhofer.aisec.cpg.passes.EvaluationOrderGraphPass
 import de.fraunhofer.aisec.cpg.passes.Pass
 import kotlin.reflect.KClass
 
+/**
+ * This annotation can be used to replace a certain [Pass] (identified by [old]) for a specific
+ * [Language] (identified by [lang]) with another [Pass] (identified by [with]).
+ *
+ * The primary use-case for this annotation is to allow language frontends to override specific
+ * passes, such as the [EvaluationOrderGraphPass] in order to optimize language specific graphs.
+ */
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
 @Repeatable
 annotation class ReplacePass(
-    val value: KClass<out Pass<*>>,
+    val old: KClass<out Pass<*>>,
     val lang: KClass<out Language<*>>,
     val with: KClass<out Pass<*>>
 )

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/ReplacePass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/ReplacePass.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Fraunhofer AISEC. All rights reserved.
+ * Copyright (c) 2023, Fraunhofer AISEC. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,13 +23,17 @@
  *                    \______/ \__|       \______/
  *
  */
-package de.fraunhofer.aisec.cpg
+package de.fraunhofer.aisec.cpg.passes.order
 
+import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.passes.Pass
 import kotlin.reflect.KClass
 
-/**
- * This annotation denotes that, this property is populates by a pass. Optionally, also specifying
- * which Pass class is responsible.
- */
-annotation class PopulatedByPass(vararg val value: KClass<out Pass<*>>)
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+@Repeatable
+annotation class ReplacePass(
+    val value: KClass<out Pass<*>>,
+    val lang: KClass<out Language<*>>,
+    val with: KClass<out Pass<*>>
+)

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontendTest.kt
@@ -1420,16 +1420,16 @@ internal class CXXLanguageFrontendTest : BaseTest() {
         val file = File("src/test/resources/c/func_ptr_call.c")
         val tu =
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), false) {
-                it.registerPass(TypeHierarchyResolver())
-                it.registerPass(ImportResolver())
-                it.registerPass(VariableUsageResolver())
-                it.registerPass(CallResolver()) // creates CG
-                it.registerPass(DFGPass())
-                it.registerPass(EvaluationOrderGraphPass()) // creates EOG
-                it.registerPass(TypeResolver())
-                it.registerPass(ControlFlowSensitiveDFGPass())
-                it.registerPass(FunctionPointerCallResolver())
-                it.registerPass(FilenameMapper())
+                it.registerPass<TypeHierarchyResolver>()
+                it.registerPass<ImportResolver>()
+                it.registerPass<VariableUsageResolver>()
+                it.registerPass<CallResolver>() // creates CG
+                it.registerPass<DFGPass>()
+                it.registerPass<EvaluationOrderGraphPass>() // creates EOG
+                it.registerPass<TypeResolver>()
+                it.registerPass<ControlFlowSensitiveDFGPass>()
+                it.registerPass<FunctionPointerCallResolver>()
+                it.registerPass<FilenameMapper>()
             }
 
         val target = tu.functions["target"]
@@ -1468,16 +1468,16 @@ internal class CXXLanguageFrontendTest : BaseTest() {
         val file = File("src/test/resources/c/func_ptr_call.c")
         val tu =
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), false) {
-                it.registerPass(TypeHierarchyResolver())
-                it.registerPass(ImportResolver())
-                it.registerPass(VariableUsageResolver())
-                it.registerPass(CallResolver()) // creates CG
-                it.registerPass(DFGPass())
-                it.registerPass(EvaluationOrderGraphPass()) // creates EOG
-                it.registerPass(TypeResolver())
-                it.registerPass(FunctionPointerCallResolver())
-                it.registerPass(ControlFlowSensitiveDFGPass())
-                it.registerPass(FilenameMapper())
+                it.registerPass<TypeHierarchyResolver>()
+                it.registerPass<ImportResolver>()
+                it.registerPass<VariableUsageResolver>()
+                it.registerPass<CallResolver>() // creates CG
+                it.registerPass<DFGPass>()
+                it.registerPass<EvaluationOrderGraphPass>() // creates EOG
+                it.registerPass<TypeResolver>()
+                it.registerPass<FunctionPointerCallResolver>()
+                it.registerPass<ControlFlowSensitiveDFGPass>()
+                it.registerPass<FilenameMapper>()
             }
 
         val target = tu.functions["target"]

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/FluentTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/FluentTest.kt
@@ -170,7 +170,8 @@ class FluentTest {
         assertNotNull(lit2.scope)
         assertEquals(2, lit2.value)
 
-        VariableUsageResolver().accept(result.components.first(), result)
+        VariableUsageResolver(TranslationConfiguration.builder().build(), scopeManager)
+            .accept(result.components.first())
 
         // Now the reference should be resolved
         assertRefersTo(ref, variable)

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/FluentTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/FluentTest.kt
@@ -170,7 +170,7 @@ class FluentTest {
         assertNotNull(lit2.scope)
         assertEquals(2, lit2.value)
 
-        VariableUsageResolver().accept(result)
+        VariableUsageResolver().accept(result.components.first(), result)
 
         // Now the reference should be resolved
         assertRefersTo(ref, variable)

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/ShortcutsTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/ShortcutsTest.kt
@@ -227,7 +227,7 @@ class ShortcutsTest {
             GraphExamples.getShortcutClass(
                 TranslationConfiguration.builder()
                     .defaultPasses()
-                    .registerPass(EdgeCachePass())
+                    .registerPass<EdgeCachePass>()
                     .registerLanguage(TestLanguage("."))
                     .build()
             )

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/AssignExpressionTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/AssignExpressionTest.kt
@@ -109,7 +109,7 @@ class AssignExpressionTest {
             assertLocalName("error", refErr.type)
 
             // Invoke the DFG pass
-            DFGPass().accept(result.components.first(), result)
+            DFGPass(result.config, result.scopeManager).accept(result.components.first())
 
             assertTrue(refA.prevDFG.contains(call))
             assertTrue(refErr.prevDFG.contains(call))

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/AssignExpressionTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/AssignExpressionTest.kt
@@ -109,7 +109,7 @@ class AssignExpressionTest {
             assertLocalName("error", refErr.type)
 
             // Invoke the DFG pass
-            DFGPass().accept(result)
+            DFGPass().accept(result.components.first(), result)
 
             assertTrue(refA.prevDFG.contains(call))
             assertTrue(refErr.prevDFG.contains(call))

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypePropagationTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypePropagationTest.kt
@@ -92,7 +92,7 @@ class TypePropagationTest {
                     }
                 }
             }
-        VariableUsageResolver().accept(result)
+        VariableUsageResolver().accept(result.components.first(), result)
 
         val binaryOp =
             (result.functions["main"]?.body as? CompoundStatement)?.statements?.get(2)

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypePropagationTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypePropagationTest.kt
@@ -92,7 +92,7 @@ class TypePropagationTest {
                     }
                 }
             }
-        VariableUsageResolver().accept(result.components.first(), result)
+        VariableUsageResolver(result.config, result.scopeManager).accept(result.components.first())
 
         val binaryOp =
             (result.functions["main"]?.body as? CompoundStatement)?.statements?.get(2)

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ReplaceTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ReplaceTest.kt
@@ -59,10 +59,11 @@ class ReplaceTest {
         val config =
             TranslationConfiguration.builder().registerLanguage<ReplaceTestLanguage>().build()
 
-        assertContains(config.replacedPasses.keys, EvaluationOrderGraphPass::class)
-
-        val pair = config.replacedPasses[EvaluationOrderGraphPass::class]
-        assertNotNull(pair)
+        assertContains(config.replacedPasses.values, ReplacedPass::class)
+        assertContains(
+            config.replacedPasses.keys,
+            Pair(EvaluationOrderGraphPass::class, ReplaceTestLanguage::class)
+        )
 
         val cls =
             checkForReplacement(EvaluationOrderGraphPass::class, ReplaceTestLanguage(), config)
@@ -74,17 +75,22 @@ class ReplaceTest {
         val config =
             TranslationConfiguration.builder()
                 .replacePass<EvaluationOrderGraphPass, StructTestLanguage, ReplacedPass>()
+                .replacePass<EvaluationOrderGraphPass, ReplaceTestLanguage, ReplacedPass>()
                 .build()
 
-        assertContains(config.replacedPasses.keys, EvaluationOrderGraphPass::class)
-
-        val pair = config.replacedPasses[EvaluationOrderGraphPass::class]
-        assertNotNull(pair)
+        assertContains(config.replacedPasses.values, ReplacedPass::class)
+        assertContains(
+            config.replacedPasses.keys,
+            Pair(EvaluationOrderGraphPass::class, StructTestLanguage::class)
+        )
 
         var cls = checkForReplacement(EvaluationOrderGraphPass::class, TestLanguage(), config)
         assertEquals(EvaluationOrderGraphPass::class, cls)
 
         cls = checkForReplacement(EvaluationOrderGraphPass::class, StructTestLanguage(), config)
+        assertEquals(ReplacedPass::class, cls)
+
+        cls = checkForReplacement(EvaluationOrderGraphPass::class, ReplaceTestLanguage(), config)
         assertEquals(ReplacedPass::class, cls)
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ReplaceTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ReplaceTest.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.ScopeManager
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.frontends.StructTestLanguage
 import de.fraunhofer.aisec.cpg.frontends.TestLanguage
 import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
 import de.fraunhofer.aisec.cpg.passes.order.ReplacePass
@@ -66,6 +67,25 @@ class ReplaceTest {
         assertNotNull(pair)
 
         val pass = checkForReplacement(EvaluationOrderGraphPass(), ReplaceTestLanguage(), config)
+        assertIs<ReplacedPass>(pass)
+    }
+
+    @Test
+    fun testReplaceFunction() {
+        val config =
+            TranslationConfiguration.builder()
+                .replacePass<EvaluationOrderGraphPass, StructTestLanguage>(ReplacedPass())
+                .build()
+
+        assertContains(config.replacedPasses.keys, EvaluationOrderGraphPass::class)
+
+        val pair = config.replacedPasses[EvaluationOrderGraphPass::class]
+        assertNotNull(pair)
+
+        var pass = checkForReplacement(EvaluationOrderGraphPass(), TestLanguage(), config)
+        assertIs<EvaluationOrderGraphPass>(pass)
+
+        pass = checkForReplacement(EvaluationOrderGraphPass(), StructTestLanguage(), config)
         assertIs<ReplacedPass>(pass)
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ReplaceTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ReplaceTest.kt
@@ -32,10 +32,7 @@ import de.fraunhofer.aisec.cpg.frontends.TestLanguage
 import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
 import de.fraunhofer.aisec.cpg.passes.order.ReplacePass
 import kotlin.reflect.KClass
-import kotlin.test.Test
-import kotlin.test.assertContains
-import kotlin.test.assertIs
-import kotlin.test.assertNotNull
+import kotlin.test.*
 
 class ReplaceTest {
 
@@ -54,7 +51,8 @@ class ReplaceTest {
         }
     }
 
-    class ReplacedPass : EvaluationOrderGraphPass()
+    class ReplacedPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
+        EvaluationOrderGraphPass(config, scopeManager)
 
     @Test
     fun testReplaceAnnotation() {
@@ -66,15 +64,16 @@ class ReplaceTest {
         val pair = config.replacedPasses[EvaluationOrderGraphPass::class]
         assertNotNull(pair)
 
-        val pass = checkForReplacement(EvaluationOrderGraphPass(), ReplaceTestLanguage(), config)
-        assertIs<ReplacedPass>(pass)
+        val cls =
+            checkForReplacement(EvaluationOrderGraphPass::class, ReplaceTestLanguage(), config)
+        assertEquals(ReplacedPass::class, cls)
     }
 
     @Test
     fun testReplaceFunction() {
         val config =
             TranslationConfiguration.builder()
-                .replacePass<EvaluationOrderGraphPass, StructTestLanguage>(ReplacedPass())
+                .replacePass<EvaluationOrderGraphPass, StructTestLanguage, ReplacedPass>()
                 .build()
 
         assertContains(config.replacedPasses.keys, EvaluationOrderGraphPass::class)
@@ -82,10 +81,10 @@ class ReplaceTest {
         val pair = config.replacedPasses[EvaluationOrderGraphPass::class]
         assertNotNull(pair)
 
-        var pass = checkForReplacement(EvaluationOrderGraphPass(), TestLanguage(), config)
-        assertIs<EvaluationOrderGraphPass>(pass)
+        var cls = checkForReplacement(EvaluationOrderGraphPass::class, TestLanguage(), config)
+        assertEquals(EvaluationOrderGraphPass::class, cls)
 
-        pass = checkForReplacement(EvaluationOrderGraphPass(), StructTestLanguage(), config)
-        assertIs<ReplacedPass>(pass)
+        cls = checkForReplacement(EvaluationOrderGraphPass::class, StructTestLanguage(), config)
+        assertEquals(ReplacedPass::class, cls)
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ReplaceTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ReplaceTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.passes
+
+import de.fraunhofer.aisec.cpg.ScopeManager
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.frontends.TestLanguage
+import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
+import de.fraunhofer.aisec.cpg.passes.order.ReplacePass
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+
+class ReplaceTest {
+
+    @ReplacePass(EvaluationOrderGraphPass::class, ReplaceTestLanguage::class, ReplacedPass::class)
+    class ReplaceTestLanguageFrontend : TestLanguageFrontend()
+
+    class ReplaceTestLanguage : TestLanguage() {
+        override val frontend: KClass<out TestLanguageFrontend>
+            get() = ReplaceTestLanguageFrontend::class
+
+        override fun newFrontend(
+            config: TranslationConfiguration,
+            scopeManager: ScopeManager
+        ): TestLanguageFrontend {
+            return ReplaceTestLanguageFrontend()
+        }
+    }
+
+    class ReplacedPass : EvaluationOrderGraphPass()
+
+    @Test
+    fun testReplaceAnnotation() {
+        val config =
+            TranslationConfiguration.builder().registerLanguage<ReplaceTestLanguage>().build()
+
+        assertContains(config.replacedPasses.keys, EvaluationOrderGraphPass::class)
+
+        val pair = config.replacedPasses[EvaluationOrderGraphPass::class]
+        assertNotNull(pair)
+
+        val pass = checkForReplacement(EvaluationOrderGraphPass(), ReplaceTestLanguage(), config)
+        assertIs<ReplacedPass>(pass)
+    }
+}

--- a/cpg-core/src/testFixtures/kotlin/de/fraunhofer/aisec/cpg/frontends/TestLanguage.kt
+++ b/cpg-core/src/testFixtures/kotlin/de/fraunhofer/aisec/cpg/frontends/TestLanguage.kt
@@ -77,7 +77,7 @@ open class TestLanguage(namespaceDelimiter: String = "::") : Language<TestLangua
 class StructTestLanguage(namespaceDelimiter: String = "::") :
     TestLanguage(namespaceDelimiter), HasStructs, HasClasses, HasDefaultArguments
 
-class TestLanguageFrontend(
+open class TestLanguageFrontend(
     scopeManager: ScopeManager = ScopeManager(),
     namespaceDelimiter: String = "::",
     language: Language<out LanguageFrontend> = TestLanguage(namespaceDelimiter)

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
@@ -112,8 +112,8 @@ class GoExtraPass : Pass(), ScopeProvider {
     override val scope: Scope?
         get() = scopeManager.currentScope
 
-    override fun accept(t: TranslationResult) {
-        scopeManager = t.scopeManager
+    override fun accept(component: Component, result: TranslationResult) {
+        scopeManager = result.scopeManager
 
         val walker = SubgraphWalker.ScopedWalker(scopeManager)
         walker.registerHandler { _, parent, node ->
@@ -125,7 +125,7 @@ class GoExtraPass : Pass(), ScopeProvider {
             }
         }
 
-        for (tu in t.translationUnits) {
+        for (tu in component.translationUnits) {
             walker.iterate(tu)
         }
     }

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
@@ -25,7 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.ScopeManager
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.frontends.golang.GoLanguage
@@ -107,14 +108,13 @@ import de.fraunhofer.aisec.cpg.passes.order.ExecuteBefore
 @ExecuteBefore(VariableUsageResolver::class)
 @ExecuteBefore(CallResolver::class)
 @ExecuteBefore(DFGPass::class)
-class GoExtraPass : ComponentPass(), ScopeProvider {
+class GoExtraPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
+    ComponentPass(config, scopeManager), ScopeProvider {
 
     override val scope: Scope?
         get() = scopeManager.currentScope
 
-    override fun accept(component: Component, result: TranslationResult) {
-        scopeManager = result.scopeManager
-
+    override fun accept(component: Component) {
         val walker = SubgraphWalker.ScopedWalker(scopeManager)
         walker.registerHandler { _, parent, node ->
             when (node) {

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
@@ -107,7 +107,7 @@ import de.fraunhofer.aisec.cpg.passes.order.ExecuteBefore
 @ExecuteBefore(VariableUsageResolver::class)
 @ExecuteBefore(CallResolver::class)
 @ExecuteBefore(DFGPass::class)
-class GoExtraPass : Pass(), ScopeProvider {
+class GoExtraPass : ComponentPass(), ScopeProvider {
 
     override val scope: Scope?
         get() = scopeManager.currentScope

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaExternalTypeHierarchyResolver.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaExternalTypeHierarchyResolver.kt
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory
 @DependsOn(TypeHierarchyResolver::class)
 @ExecuteBefore(ImportResolver::class)
 @RequiredFrontend(JavaLanguageFrontend::class)
-class JavaExternalTypeHierarchyResolver : Pass() {
+class JavaExternalTypeHierarchyResolver : ComponentPass() {
     override fun accept(component: Component, result: TranslationResult) {
         val resolver = CombinedTypeSolver()
 

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaExternalTypeHierarchyResolver.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaExternalTypeHierarchyResolver.kt
@@ -31,6 +31,7 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeS
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver
 import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.TypeManager
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.graph.types.TypeParser
@@ -44,22 +45,18 @@ import org.slf4j.LoggerFactory
 @ExecuteBefore(ImportResolver::class)
 @RequiredFrontend(JavaLanguageFrontend::class)
 class JavaExternalTypeHierarchyResolver : Pass() {
-    override fun accept(translationResult: TranslationResult) {
+    override fun accept(component: Component, result: TranslationResult) {
         val resolver = CombinedTypeSolver()
 
         resolver.add(ReflectionTypeSolver())
-        var root = translationResult.config.topLevel
-        if (root == null && translationResult.config.softwareComponents.size == 1) {
+        var root = result.config.topLevel
+        if (root == null && result.config.softwareComponents.size == 1) {
             root =
-                translationResult.config.softwareComponents[
-                        translationResult.config.softwareComponents.keys.first()]
+                result.config.softwareComponents[result.config.softwareComponents.keys.first()]
                     ?.let { CommonPath.commonPath(it) }
         }
         if (root == null) {
-            log.warn(
-                "Could not determine source root for {}",
-                translationResult.config.softwareComponents
-            )
+            log.warn("Could not determine source root for {}", result.config.softwareComponents)
         } else {
             log.info("Source file root used for type solver: {}", root)
             resolver.add(JavaParserTypeSolver(root))

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypeTests.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypeTests.kt
@@ -127,16 +127,12 @@ internal class TypeTests : BaseTest() {
         val result = analyze("java", topLevel, true) { it.registerLanguage(JavaLanguage()) }
 
         // Check Parameterized
-        val recordDeclarations = result.records
-        val recordDeclarationBox = findByUniqueName(recordDeclarations, "Box")
-        val typeT = TypeManager.getInstance().getTypeParameter(recordDeclarationBox, "T")
-        assertNotNull(typeT)
-        assertEquals(typeT, TypeManager.getInstance().getTypeParameter(recordDeclarationBox, "T"))
-
         // Type of field t
         val fieldDeclarations = result.fields
         val fieldDeclarationT = findByUniqueName(fieldDeclarations, "t")
-        assertEquals(typeT, fieldDeclarationT.type)
+        val typeT = fieldDeclarationT.type
+        assertIs<ParameterizedType>(typeT)
+        assertLocalName("T", typeT)
         assertTrue(fieldDeclarationT.possibleSubTypes.contains(typeT))
 
         // Parameter of set Method

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CompressLLVMPass.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CompressLLVMPass.kt
@@ -25,7 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.ScopeManager
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.frontends.llvm.LLVMIRLanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
@@ -42,8 +43,9 @@ import java.util.*
 
 @ExecuteFirst
 @RequiredFrontend(LLVMIRLanguageFrontend::class)
-class CompressLLVMPass : ComponentPass() {
-    override fun accept(component: Component, result: TranslationResult) {
+class CompressLLVMPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
+    ComponentPass(config, scopeManager) {
+    override fun accept(component: Component) {
         val flatAST = SubgraphWalker.flattenAST(component)
         // Get all goto statements
         val allGotos = flatAST.filterIsInstance<GotoStatement>()

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CompressLLVMPass.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CompressLLVMPass.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.frontends.llvm.LLVMIRLanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.newDeclaredReferenceExpression
 import de.fraunhofer.aisec.cpg.graph.newVariableDeclaration
@@ -42,8 +43,8 @@ import java.util.*
 @ExecuteFirst
 @RequiredFrontend(LLVMIRLanguageFrontend::class)
 class CompressLLVMPass : Pass() {
-    override fun accept(t: TranslationResult) {
-        val flatAST = SubgraphWalker.flattenAST(t)
+    override fun accept(component: Component, result: TranslationResult) {
+        val flatAST = SubgraphWalker.flattenAST(component)
         // Get all goto statements
         val allGotos = flatAST.filterIsInstance<GotoStatement>()
         // Get all LabelStatements which are only referenced from a single GotoStatement

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CompressLLVMPass.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CompressLLVMPass.kt
@@ -42,7 +42,7 @@ import java.util.*
 
 @ExecuteFirst
 @RequiredFrontend(LLVMIRLanguageFrontend::class)
-class CompressLLVMPass : Pass() {
+class CompressLLVMPass : ComponentPass() {
     override fun accept(component: Component, result: TranslationResult) {
         val flatAST = SubgraphWalker.flattenAST(component)
         // Get all goto statements
@@ -85,8 +85,7 @@ class CompressLLVMPass : Pass() {
                         (node.thenStatement as GotoStatement).targetLabel?.subStatement
                 }
                 // Replace the else-statement with the basic block it jumps to iff we found that
-                // its
-                // goto statement is the only one jumping to the target
+                // its goto statement is the only one jumping to the target
                 if (
                     node.elseStatement in gotosToReplace &&
                         node !in

--- a/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
+++ b/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
@@ -37,7 +37,7 @@ import java.lang.Class
 import java.net.ConnectException
 import java.nio.file.Paths
 import java.util.concurrent.Callable
-import kotlin.reflect.full.createInstance
+import kotlin.reflect.KClass
 import kotlin.system.exitProcess
 import org.neo4j.driver.exceptions.AuthenticationException
 import org.neo4j.ogm.config.Configuration
@@ -382,15 +382,13 @@ class Application : Callable<Int> {
             for (pass in pieces) {
                 if (pass.contains(".")) {
                     translationConfiguration.registerPass(
-                        Class.forName(pass).kotlin.createInstance() as Pass
+                        Class.forName(pass).kotlin as KClass<out Pass<*>>
                     )
                 } else {
                     if (pass !in passClassMap) {
                         throw ConfigurationException("Asked to produce unknown pass")
                     }
-                    passClassMap[pass]?.let {
-                        translationConfiguration.registerPass(it.createInstance())
-                    }
+                    passClassMap[pass]?.let { translationConfiguration.registerPass(it) }
                 }
             }
         }


### PR DESCRIPTION
This PR contains a slight overhaul of the pass system. Specifically, instead of just applying a pass to the whole translation result, it is now either applied to individual components, a translation unit or the whole result. Instead of directly subclassing from `Pass`, it is now needed to subclass `ComponentPass`, `TranslationResultPass` or `TranslationUnitPass`.

That will allow us in the future, to have language-specific execution of passes in individual software components (e.g., server code and client code) or translation units. 

Furthermore, this PR changes the way when passes are actually instantiated. Previously, they were implicitly (or explicitly) created at the time one called `defaultPasses()` or `registerPass` on the `TranslationConfiguration`. This meant, that later important state information, such as the config or the scope manager was injected weirdly in the `accept` method and the single `Pass` object was re-used for different executions. This led to errors if passes were incorrectly cleaned between executions.

In the new system, a `TranslationConfiguration` is only holding a reference to the `KClass` of a pass. The pass is then instantiated out of the class dynamically, once it is actually needed and only "lives" for its scope of execution (e.g. translation result, component, tu).