### PR TITLE
Make `TypeManager` not a singleton anymore

### DIFF
--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGPass.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGPass.kt
@@ -25,8 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.analysis.ValueEvaluator
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
@@ -42,10 +41,7 @@ import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
  * by setting the [Properties.UNREACHABLE] property of an eog-edge to true.
  */
 @DependsOn(ControlFlowSensitiveDFGPass::class)
-class UnreachableEOGPass(
-    config: TranslationConfiguration,
-    scopeManager: ScopeManager,
-) : TranslationUnitPass(config, scopeManager) {
+class UnreachableEOGPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {
     override fun accept(tu: TranslationUnitDeclaration) {
         tu.accept(
             Strategy::AST_FORWARD,

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/ValueEvaluatorTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/ValueEvaluatorTest.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.analysis
 
 import de.fraunhofer.aisec.cpg.TestUtils
 import de.fraunhofer.aisec.cpg.frontends.TestHandler
+import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
 import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguage
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
@@ -181,7 +182,7 @@ class ValueEvaluatorTest {
 
     @Test
     fun testHandlePlus() {
-        with(TestHandler()) {
+        with(TestHandler(TestLanguageFrontend())) {
             val binOp = newBinaryOperator("+")
             binOp.lhs = newLiteral(3, parseType("int"))
             binOp.rhs = newLiteral(2, parseType("int"))
@@ -242,7 +243,7 @@ class ValueEvaluatorTest {
 
     @Test
     fun testHandleMinus() {
-        with(TestHandler()) {
+        with(TestHandler(TestLanguageFrontend())) {
             val binOp = newBinaryOperator("-")
             binOp.lhs = newLiteral(3, parseType("int"))
             binOp.rhs = newLiteral(2, parseType("int"))
@@ -300,7 +301,7 @@ class ValueEvaluatorTest {
 
     @Test
     fun testHandleTimes() {
-        with(TestHandler()) {
+        with(TestHandler(TestLanguageFrontend())) {
             val binOp = newBinaryOperator("*")
             binOp.lhs = newLiteral(3, parseType("int"))
             binOp.rhs = newLiteral(2, parseType("int"))
@@ -358,7 +359,7 @@ class ValueEvaluatorTest {
 
     @Test
     fun testHandleDiv() {
-        with(TestHandler()) {
+        with(TestHandler(TestLanguageFrontend())) {
             // For two integer values, we keep the result as a long.
             val binOp = newBinaryOperator("/")
             binOp.lhs = newLiteral(3, parseType("int"))
@@ -421,7 +422,7 @@ class ValueEvaluatorTest {
 
     @Test
     fun testHandleUnary() {
-        with(TestHandler()) {
+        with(TestHandler(TestLanguageFrontend())) {
             val neg = newUnaryOperator("-", false, true)
             neg.input = newLiteral(3, parseType("int"))
             assertEquals(-3, ValueEvaluator().evaluate(neg))

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -791,9 +791,9 @@ class ScopeManager : ScopeProvider {
     override val scope: Scope?
         get() = currentScope
 
-    fun activateTypes(node: Node) {
+    fun activateTypes(node: Node, typeManager: TypeManager) {
         val num = AtomicInteger()
-        val typeCache = TypeManager.getInstance().typeCache
+        val typeCache = typeManager.typeCache
         node.accept(
             Strategy::AST_FORWARD,
             object : IVisitor<Node>() {
@@ -802,8 +802,7 @@ class ScopeManager : ScopeProvider {
                         val typeNode = t as HasType
                         typeCache.getOrDefault(typeNode, emptyList()).forEach {
                             (t as HasType).type =
-                                TypeManager.getInstance()
-                                    .resolvePossibleTypedef(it, this@ScopeManager)
+                                typeManager.resolvePossibleTypedef(it, this@ScopeManager)
                         }
                         typeCache.remove(t as HasType)
                         num.getAndIncrement()
@@ -816,9 +815,7 @@ class ScopeManager : ScopeProvider {
         // For some nodes it may happen that they are not reachable via AST, but we still need to
         // set their type to the requested value
         typeCache.forEach { (n, types) ->
-            types.forEach { t ->
-                n.type = TypeManager.getInstance().resolvePossibleTypedef(t, this)
-            }
+            types.forEach { t -> n.type = typeManager.resolvePossibleTypedef(t, this) }
         }
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationContext.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationContext.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Fraunhofer AISEC. All rights reserved.
+ * Copyright (c) 2023, Fraunhofer AISEC. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,27 @@
  */
 package de.fraunhofer.aisec.cpg
 
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import de.fraunhofer.aisec.cpg.graph.TypeManager
 
-abstract class BaseTest {
-    protected var log: Logger = LoggerFactory.getLogger(this.javaClass)
-}
+/**
+ * The translation context holds all necessary managers and configurations needed during the
+ * translation process.
+ */
+class TranslationContext(
+    /** The configuration for this translation. */
+    val config: TranslationConfiguration,
+
+    /**
+     * The scope manager which comprises the complete translation result. In case of sequential
+     * parsing, this scope manager is passed to the individual frontends one after another. In case
+     * of sequential parsing, individual scope managers will be passed to each language frontend
+     * (through individual contexts) and then finally merged into a final one.
+     */
+    val scopeManager: ScopeManager,
+
+    /**
+     * The type manager is responsible for managing type information. Currently, we have one
+     * instance of a [TypeManager] for the overall [TranslationResult].
+     */
+    val typeManager: TypeManager
+)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Handler.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Handler.kt
@@ -25,8 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.frontends
 
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.graph.*
-import de.fraunhofer.aisec.cpg.graph.newCallExpression
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.helpers.Util.errorWithFileLocation
 import java.lang.reflect.ParameterizedType
@@ -51,7 +51,7 @@ abstract class Handler<S : Node, T, L : LanguageFrontend>(
     protected val configConstructor: Supplier<S>,
     /** Returns the frontend which used this handler. */
     var frontend: L
-) : LanguageProvider, CodeAndLocationProvider, ScopeProvider, NamespaceProvider {
+) : LanguageProvider, CodeAndLocationProvider, ScopeProvider, NamespaceProvider, ContextProvider {
     protected val map = HashMap<Class<out T>, HandlerInterface<S, T>>()
     private val typeOfT: Class<*>?
 
@@ -180,6 +180,9 @@ abstract class Handler<S : Node, T, L : LanguageFrontend>(
 
     override val namespace: Name?
         get() = frontend.namespace
+
+    override val ctx: TranslationContext
+        get() = frontend.ctx
 
     companion object {
         @JvmStatic protected val log: Logger = LoggerFactory.getLogger(Handler::class.java)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.frontends
 
 import de.fraunhofer.aisec.cpg.ScopeManager
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
@@ -47,23 +48,27 @@ import org.slf4j.LoggerFactory
  * [github wiki page](https://github.com/Fraunhofer-AISEC/cpg/wiki/Language-Frontends).
  */
 abstract class LanguageFrontend(
+    /** The language this frontend works for. */
     override val language: Language<out LanguageFrontend>,
-    val config: TranslationConfiguration,
-    scopeManager: ScopeManager,
+
+    /**
+     * The translation context, which contains all necessary managers used in this frontend parsing
+     * process. Note, that different contexts could passed to frontends, e.g., in parallel parsing
+     * to supply different managers to different frontends.
+     */
+    final override var ctx: TranslationContext,
 ) :
     ProcessedListener(),
     CodeAndLocationProvider,
     LanguageProvider,
     ScopeProvider,
-    NamespaceProvider {
-    var scopeManager: ScopeManager = scopeManager
-        set(scopeManager) {
-            field = scopeManager
-            field.lang = this
-        }
+    NamespaceProvider,
+    ContextProvider {
+    val scopeManager: ScopeManager = ctx.scopeManager
+    val typeManager: TypeManager = ctx.typeManager
+    val config: TranslationConfiguration = ctx.config
 
     init {
-        // this.scopeManager = scopeManager
         this.scopeManager.lang = this
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageTraits.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageTraits.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.frontends
 
 import de.fraunhofer.aisec.cpg.ScopeManager
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
@@ -71,7 +72,7 @@ interface HasTemplates : HasGenerics {
         curClass: RecordDeclaration?,
         templateCall: CallExpression,
         applyInference: Boolean,
-        scopeManager: ScopeManager,
+        ctx: TranslationContext,
         currentTU: TranslationUnitDeclaration
     ): Pair<Boolean, List<FunctionDeclaration>>
 }
@@ -97,7 +98,7 @@ interface HasComplexCallResolution : LanguageTrait {
      */
     fun refineNormalCallResolution(
         call: CallExpression,
-        scopeManager: ScopeManager,
+        ctx: TranslationContext,
         currentTU: TranslationUnitDeclaration
     ): List<FunctionDeclaration>
 
@@ -113,7 +114,7 @@ interface HasComplexCallResolution : LanguageTrait {
         curClass: RecordDeclaration?,
         possibleContainingTypes: Set<Type>,
         call: CallExpression,
-        scopeManager: ScopeManager,
+        ctx: TranslationContext,
         currentTU: TranslationUnitDeclaration,
         callResolver: CallResolver
     ): List<FunctionDeclaration>
@@ -130,7 +131,8 @@ interface HasComplexCallResolution : LanguageTrait {
     fun refineInvocationCandidatesFromRecord(
         recordDeclaration: RecordDeclaration,
         call: CallExpression,
-        namePattern: Pattern
+        namePattern: Pattern,
+        ctx: TranslationContext
     ): List<FunctionDeclaration>
 }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontend.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLanguageFrontend.kt
@@ -26,8 +26,7 @@
 package de.fraunhofer.aisec.cpg.frontends.cpp
 
 import de.fraunhofer.aisec.cpg.ResolveInFrontend
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.frontends.TranslationException
@@ -76,11 +75,8 @@ import org.slf4j.LoggerFactory
  * ad [GPPLanguage]). This enables us (to some degree) to deal with the finer difference between C
  * and C++ code.
  */
-class CXXLanguageFrontend(
-    language: Language<CXXLanguageFrontend>,
-    config: TranslationConfiguration,
-    scopeManager: ScopeManager,
-) : LanguageFrontend(language, config, scopeManager) {
+class CXXLanguageFrontend(language: Language<CXXLanguageFrontend>, ctx: TranslationContext) :
+    LanguageFrontend(language, ctx) {
 
     /**
      * The dialect used by this language frontend, either [GCCLanguage] for C or [GPPLanguage] for
@@ -556,7 +552,7 @@ class CXXLanguageFrontend(
                 }
             }
 
-        type = TypeManager.getInstance().registerType(type)
+        type = typeManager.registerType(type)
         type = this.adjustType(declarator, type)
 
         return type
@@ -637,7 +633,7 @@ class CXXLanguageFrontend(
         }
 
         // Make sure, the type manager knows about this type
-        return TypeManager.getInstance().registerType(type)
+        return typeManager.registerType(type)
     }
 
     companion object {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/DeclarationHandler.kt
@@ -312,12 +312,11 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
                 val typeParamDeclaration =
                     frontend.declaratorHandler.handle(templateParameter) as TypeParamDeclaration
                 val parameterizedType =
-                    TypeManager.getInstance()
-                        .createOrGetTypeParameter(
-                            templateDeclaration,
-                            templateParameter.name.toString(),
-                            language
-                        )
+                    frontend.typeManager.createOrGetTypeParameter(
+                        templateDeclaration,
+                        templateParameter.name.toString(),
+                        language
+                    )
                 typeParamDeclaration.type = parameterizedType
                 if (templateParameter.defaultType != null) {
                     val defaultType =
@@ -377,8 +376,7 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
         templateDeclaration: TemplateDeclaration,
         innerDeclaration: RecordDeclaration
     ) {
-        val parameterizedTypes =
-            TypeManager.getInstance().getAllParameterizedType(templateDeclaration)
+        val parameterizedTypes = frontend.typeManager.getAllParameterizedType(templateDeclaration)
 
         // Loop through all the methods and adjust their receiver types
         for (method in (innerDeclaration as? RecordDeclaration)?.methods ?: listOf()) {
@@ -543,13 +541,12 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
         val (nameDecl: IASTDeclarator, _) = declarator.realName()
 
         val declaration =
-            TypeManager.getInstance()
-                .createTypeAlias(
-                    frontend,
-                    frontend.getCodeFromRawNode(ctx),
-                    type,
-                    nameDecl.name.toString()
-                )
+            frontend.typeManager.createTypeAlias(
+                frontend,
+                frontend.getCodeFromRawNode(ctx),
+                type,
+                nameDecl.name.toString()
+            )
 
         // Add the declaration to the current scope
         frontend.scopeManager.addDeclaration(declaration)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/ExpressionHandler.kt
@@ -356,7 +356,7 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
                 ) {
                     // this can either be just a meaningless bracket or it can be a cast expression
                     val typeName = (ctx.operand as IASTIdExpression).name.toString()
-                    if (TypeManager.getInstance().typeExists(typeName)) {
+                    if (frontend.typeManager.typeExists(typeName)) {
                         val cast = newCastExpression(frontend.getCodeFromRawNode<Any>(ctx))
                         cast.castType = parseType(typeName)
                         cast.expression = input ?: newProblemExpression("could not parse input")

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilder.kt
@@ -588,6 +588,7 @@ fun MetadataProvider.newProblemExpression(
 
 fun <T> Literal<T>.duplicate(implicit: Boolean): Literal<T> {
     val duplicate = Literal<T>()
+    duplicate.ctx = this.ctx
     duplicate.language = this.language
     duplicate.value = this.value
     duplicate.type = this.type
@@ -610,6 +611,7 @@ fun <T> Literal<T>.duplicate(implicit: Boolean): Literal<T> {
 
 fun TypeExpression.duplicate(implicit: Boolean): TypeExpression {
     val duplicate = TypeExpression()
+    duplicate.ctx = this.ctx
     duplicate.name = this.name.clone()
     duplicate.language = this.language
     duplicate.type = this.type

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
@@ -25,10 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.graph.builder
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
-import de.fraunhofer.aisec.cpg.TranslationManager
-import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.*
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.*
@@ -38,16 +35,17 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.passes.executePassSequential
 
-fun LanguageFrontend.translationResult(
-    config: TranslationConfiguration,
-    init: TranslationResult.() -> Unit
-): TranslationResult {
-    val node = TranslationResult(TranslationManager.builder().config(config).build(), scopeManager)
+fun LanguageFrontend.translationResult(init: TranslationResult.() -> Unit): TranslationResult {
+    val node =
+        TranslationResult(
+            TranslationManager.builder().config(ctx.config).build(),
+            ctx,
+        )
     val component = Component()
     node.addComponent(component)
     init(node)
 
-    config.registeredPasses.forEach { executePassSequential(it, node, listOf()) }
+    ctx.config.registeredPasses.forEach { executePassSequential(it, ctx, node, listOf()) }
 
     return node
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ConstructorDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ConstructorDeclaration.kt
@@ -25,7 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.graph.declarations
 
-import de.fraunhofer.aisec.cpg.graph.types.TypeParser
+import de.fraunhofer.aisec.cpg.graph.parseType
 
 /**
  * The declaration of a constructor within a [RecordDeclaration]. Is it essentially a special case
@@ -39,7 +39,7 @@ class ConstructorDeclaration : MethodDeclaration() {
             super.recordDeclaration = recordDeclaration
             if (recordDeclaration != null) {
                 // constructors always have implicitly the return type of their class
-                returnTypes = listOf(TypeParser.createFrom(recordDeclaration.name, language))
+                returnTypes = listOf(parseType(recordDeclaration.name))
             }
         }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/FieldDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/FieldDeclaration.kt
@@ -25,13 +25,11 @@
  */
 package de.fraunhofer.aisec.cpg.graph.declarations
 
-import de.fraunhofer.aisec.cpg.graph.AST
-import de.fraunhofer.aisec.cpg.graph.HasInitializer
-import de.fraunhofer.aisec.cpg.graph.HasType
-import de.fraunhofer.aisec.cpg.graph.TypeManager
+import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.InitializerListExpression
 import de.fraunhofer.aisec.cpg.graph.types.Type
+import de.fraunhofer.aisec.cpg.graph.types.UnknownType
 import java.util.*
 import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.Relationship
@@ -81,10 +79,10 @@ class FieldDeclaration : ValueDeclaration(), HasType.TypeListener, HasInitialize
     var modifiers: List<String> = mutableListOf()
 
     override fun typeChanged(src: HasType, root: MutableList<HasType>, oldType: Type) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
-        if (!TypeManager.getInstance().isUnknown(type) && src.propagationType == oldType) {
+        if (type !is UnknownType && src.propagationType == oldType) {
             return
         }
         val previous = type
@@ -98,7 +96,7 @@ class FieldDeclaration : ValueDeclaration(), HasType.TypeListener, HasInitialize
                 // can be ignored once we have a type
                 if (isArray) {
                     src.type
-                } else if (!TypeManager.getInstance().isUnknown(type)) {
+                } else if (type !is UnknownType) {
                     return
                 } else {
                     src.type.dereference()
@@ -113,7 +111,7 @@ class FieldDeclaration : ValueDeclaration(), HasType.TypeListener, HasInitialize
     }
 
     override fun possibleSubTypesChanged(src: HasType, root: MutableList<HasType>) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
         val subTypes: MutableList<Type> = ArrayList(possibleSubTypes)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/FunctionDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/FunctionDeclaration.kt
@@ -25,14 +25,11 @@
  */
 package de.fraunhofer.aisec.cpg.graph.declarations
 
-import de.fraunhofer.aisec.cpg.graph.AST
-import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
-import de.fraunhofer.aisec.cpg.graph.TypeManager
+import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.edge.Properties
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
-import de.fraunhofer.aisec.cpg.graph.newUnknownType
 import de.fraunhofer.aisec.cpg.graph.statements.CompoundStatement
 import de.fraunhofer.aisec.cpg.graph.statements.Statement
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
@@ -133,7 +130,7 @@ open class FunctionDeclaration : ValueDeclaration(), DeclarationHolder {
                     return true
                 }
                 val provided = targetSignature[i]
-                if (!TypeManager.getInstance().isSupertypeOf(declared.type, provided, this)) {
+                if (!isSupertypeOf(declared.type, provided)) {
                     return false
                 }
             }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/RecordDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/RecordDeclaration.kt
@@ -31,10 +31,10 @@ import de.fraunhofer.aisec.cpg.graph.StatementHolder
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
+import de.fraunhofer.aisec.cpg.graph.parseType
 import de.fraunhofer.aisec.cpg.graph.statements.Statement
 import de.fraunhofer.aisec.cpg.graph.types.ObjectType
 import de.fraunhofer.aisec.cpg.graph.types.Type
-import de.fraunhofer.aisec.cpg.graph.types.TypeParser
 import java.util.stream.Collectors
 import java.util.stream.Stream
 import org.apache.commons.lang3.builder.ToStringBuilder
@@ -216,7 +216,7 @@ class RecordDeclaration : Declaration(), DeclarationHolder, StatementHolder {
      * @return the type
      */
     fun toType(): Type {
-        val type = TypeParser.createFrom(name, language)
+        val type = parseType(name)
         if (type is ObjectType) {
             // as a shortcut, directly set the record declaration. This will be otherwise done
             // later by a pass, but for some frontends we need this immediately, so we set

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/VariableDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/VariableDeclaration.kt
@@ -29,6 +29,7 @@ import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.InitializerListExpression
 import de.fraunhofer.aisec.cpg.graph.types.Type
+import de.fraunhofer.aisec.cpg.graph.types.UnknownType
 import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.Relationship
 
@@ -81,10 +82,10 @@ class VariableDeclaration : ValueDeclaration(), HasType.TypeListener, HasInitial
     }
 
     override fun typeChanged(src: HasType, root: MutableList<HasType>, oldType: Type) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
-        if (!TypeManager.getInstance().isUnknown(type) && src.propagationType == oldType) {
+        if (type !is UnknownType && src.propagationType == oldType) {
             return
         }
         val previous = type
@@ -97,7 +98,7 @@ class VariableDeclaration : ValueDeclaration(), HasType.TypeListener, HasInitial
                 // otherwise it can be ignored once we have a type
                 if (isArray) {
                     src.type
-                } else if (!TypeManager.getInstance().isUnknown(type)) {
+                } else if (type !is UnknownType) {
                     return
                 } else {
                     src.type.dereference()
@@ -112,7 +113,7 @@ class VariableDeclaration : ValueDeclaration(), HasType.TypeListener, HasInitial
     }
 
     override fun possibleSubTypesChanged(src: HasType, root: MutableList<HasType>) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
         val subTypes: MutableList<Type> = ArrayList(possibleSubTypes)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/ArrayCreationExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/ArrayCreationExpression.kt
@@ -27,11 +27,11 @@ package de.fraunhofer.aisec.cpg.graph.statements.expressions
 
 import de.fraunhofer.aisec.cpg.graph.AST
 import de.fraunhofer.aisec.cpg.graph.HasType
-import de.fraunhofer.aisec.cpg.graph.TypeManager
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
+import de.fraunhofer.aisec.cpg.graph.isTypeSystemActive
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import java.util.*
 import org.neo4j.ogm.annotation.Relationship
@@ -82,7 +82,7 @@ class ArrayCreationExpression : Expression(), HasType.TypeListener {
     override fun hashCode() = Objects.hash(super.hashCode(), initializer, dimensions)
 
     override fun typeChanged(src: HasType, root: MutableList<HasType>, oldType: Type) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
         val previous = type
@@ -93,7 +93,7 @@ class ArrayCreationExpression : Expression(), HasType.TypeListener {
     }
 
     override fun possibleSubTypesChanged(src: HasType, root: MutableList<HasType>) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
         val subTypes: MutableList<Type> = ArrayList(possibleSubTypes)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/ArraySubscriptionExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/ArraySubscriptionExpression.kt
@@ -76,7 +76,7 @@ class ArraySubscriptionExpression : Expression(), HasType.TypeListener, HasBase 
     }
 
     override fun typeChanged(src: HasType, root: MutableList<HasType>, oldType: Type) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
         val previous = type
@@ -87,7 +87,7 @@ class ArraySubscriptionExpression : Expression(), HasType.TypeListener, HasBase 
     }
 
     override fun possibleSubTypesChanged(src: HasType, root: MutableList<HasType>) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
         val subTypes: MutableList<Type> = ArrayList(possibleSubTypes)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/AssignExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/AssignExpression.kt
@@ -113,7 +113,7 @@ class AssignExpression : Expression(), AssignmentHolder, HasType.TypeListener {
     override var declarations = mutableListOf<VariableDeclaration>()
 
     override fun typeChanged(src: HasType, root: MutableList<HasType>, oldType: Type) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
 
@@ -138,7 +138,7 @@ class AssignExpression : Expression(), AssignmentHolder, HasType.TypeListener {
     }
 
     override fun possibleSubTypesChanged(src: HasType, root: MutableList<HasType>) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/BinaryOperator.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/BinaryOperator.kt
@@ -125,7 +125,7 @@ class BinaryOperator :
     }
 
     override fun typeChanged(src: HasType, root: MutableList<HasType>, oldType: Type) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
         val previous = type
@@ -164,7 +164,7 @@ class BinaryOperator :
     }
 
     override fun possibleSubTypesChanged(src: HasType, root: MutableList<HasType>) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
         val subTypes: MutableList<Type> = ArrayList(possibleSubTypes)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
@@ -267,7 +267,7 @@ open class CallExpression : Expression(), HasType.TypeListener, SecondaryTypeEdg
     }
 
     override fun typeChanged(src: HasType, root: MutableList<HasType>, oldType: Type) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
 
@@ -288,7 +288,7 @@ open class CallExpression : Expression(), HasType.TypeListener, SecondaryTypeEdg
                 null
             }
         val alternative = if (types.isNotEmpty()) types[0] else newUnknownType()
-        val commonType = TypeManager.getInstance().getCommonType(types, this).orElse(alternative)
+        val commonType = getCommonType(types).orElse(alternative)
         val subTypes: MutableList<Type> = ArrayList(possibleSubTypes)
 
         subTypes.remove(oldType)
@@ -301,7 +301,7 @@ open class CallExpression : Expression(), HasType.TypeListener, SecondaryTypeEdg
     }
 
     override fun possibleSubTypesChanged(src: HasType, root: MutableList<HasType>) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CastExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CastExpression.kt
@@ -46,11 +46,11 @@ class CastExpression : Expression(), HasType.TypeListener {
     }
 
     override fun typeChanged(src: HasType, root: MutableList<HasType>, oldType: Type) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
         val previous = type
-        if (TypeManager.getInstance().isSupertypeOf(castType, src.propagationType, this)) {
+        if (isSupertypeOf(castType, src.propagationType)) {
             setType(src.propagationType, root)
         } else {
             resetTypes(castType)
@@ -61,7 +61,7 @@ class CastExpression : Expression(), HasType.TypeListener {
     }
 
     override fun possibleSubTypesChanged(src: HasType, root: MutableList<HasType>) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
         setPossibleSubTypes(ArrayList(src.possibleSubTypes), root)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/ConditionalExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/ConditionalExpression.kt
@@ -55,7 +55,7 @@ class ConditionalExpression : Expression(), HasType.TypeListener, ArgumentHolder
         }
 
     override fun typeChanged(src: HasType, root: MutableList<HasType>, oldType: Type) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
         val previous = type
@@ -68,7 +68,7 @@ class ConditionalExpression : Expression(), HasType.TypeListener, ArgumentHolder
         subTypes.remove(oldType)
         subTypes.addAll(types)
         val alternative = if (types.isNotEmpty()) types[0] else newUnknownType()
-        setType(TypeManager.getInstance().getCommonType(types, this).orElse(alternative), root)
+        setType(getCommonType(types).orElse(alternative), root)
         setPossibleSubTypes(subTypes, root)
         if (previous != type) {
             type.typeOrigin = Type.Origin.DATAFLOW
@@ -76,7 +76,7 @@ class ConditionalExpression : Expression(), HasType.TypeListener, ArgumentHolder
     }
 
     override fun possibleSubTypesChanged(src: HasType, root: MutableList<HasType>) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
         val subTypes: MutableList<Type> = ArrayList(possibleSubTypes)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/ConstructExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/ConstructExpression.kt
@@ -28,11 +28,11 @@ package de.fraunhofer.aisec.cpg.graph.statements.expressions
 import de.fraunhofer.aisec.cpg.PopulatedByPass
 import de.fraunhofer.aisec.cpg.graph.AST
 import de.fraunhofer.aisec.cpg.graph.HasType
-import de.fraunhofer.aisec.cpg.graph.TypeManager
 import de.fraunhofer.aisec.cpg.graph.declarations.*
+import de.fraunhofer.aisec.cpg.graph.isTypeSystemActive
+import de.fraunhofer.aisec.cpg.graph.parseType
 import de.fraunhofer.aisec.cpg.graph.types.FunctionType
 import de.fraunhofer.aisec.cpg.graph.types.Type
-import de.fraunhofer.aisec.cpg.graph.types.TypeParser
 import de.fraunhofer.aisec.cpg.graph.types.UnknownType
 import de.fraunhofer.aisec.cpg.passes.CallResolver
 import java.util.*
@@ -80,7 +80,7 @@ class ConstructExpression : CallExpression(), HasType.TypeListener {
         set(value) {
             field = value
             if (value != null && this.type is UnknownType) {
-                type = TypeParser.createFrom(value.name, language)
+                type = parseType(value.name)
             }
         }
 
@@ -107,7 +107,7 @@ class ConstructExpression : CallExpression(), HasType.TypeListener {
      * work around the first case in a different way.
      */
     override fun typeChanged(src: HasType, root: MutableList<HasType>, oldType: Type) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/DeclaredReferenceExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/DeclaredReferenceExpression.kt
@@ -28,10 +28,10 @@ package de.fraunhofer.aisec.cpg.graph.statements.expressions
 import de.fraunhofer.aisec.cpg.PopulatedByPass
 import de.fraunhofer.aisec.cpg.graph.AccessValues
 import de.fraunhofer.aisec.cpg.graph.HasType
-import de.fraunhofer.aisec.cpg.graph.TypeManager
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
+import de.fraunhofer.aisec.cpg.graph.isTypeSystemActive
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.passes.VariableUsageResolver
 import java.util.*
@@ -100,7 +100,7 @@ open class DeclaredReferenceExpression : Expression(), HasType.TypeListener {
     }
 
     override fun typeChanged(src: HasType, root: MutableList<HasType>, oldType: Type) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
         val previous = type
@@ -111,7 +111,7 @@ open class DeclaredReferenceExpression : Expression(), HasType.TypeListener {
     }
 
     override fun possibleSubTypesChanged(src: HasType, root: MutableList<HasType>) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/ExpressionList.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/ExpressionList.kt
@@ -27,12 +27,12 @@ package de.fraunhofer.aisec.cpg.graph.statements.expressions
 
 import de.fraunhofer.aisec.cpg.graph.AST
 import de.fraunhofer.aisec.cpg.graph.HasType
-import de.fraunhofer.aisec.cpg.graph.TypeManager
 import de.fraunhofer.aisec.cpg.graph.edge.Properties
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.transformIntoOutgoingPropertyEdgeList
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.unwrap
+import de.fraunhofer.aisec.cpg.graph.isTypeSystemActive
 import de.fraunhofer.aisec.cpg.graph.statements.Statement
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import java.util.*
@@ -76,7 +76,7 @@ class ExpressionList : Expression(), HasType.TypeListener {
     }
 
     override fun typeChanged(src: HasType, root: MutableList<HasType>, oldType: Type) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
         val previous = type
@@ -88,7 +88,7 @@ class ExpressionList : Expression(), HasType.TypeListener {
     }
 
     override fun possibleSubTypesChanged(src: HasType, root: MutableList<HasType>) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
         setPossibleSubTypes(ArrayList(src.possibleSubTypes), root)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/LambdaExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/LambdaExpression.kt
@@ -27,11 +27,12 @@ package de.fraunhofer.aisec.cpg.graph.statements.expressions
 
 import de.fraunhofer.aisec.cpg.graph.AST
 import de.fraunhofer.aisec.cpg.graph.HasType
-import de.fraunhofer.aisec.cpg.graph.TypeManager
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
+import de.fraunhofer.aisec.cpg.graph.isTypeSystemActive
 import de.fraunhofer.aisec.cpg.graph.types.FunctionPointerType
 import de.fraunhofer.aisec.cpg.graph.types.Type
+import de.fraunhofer.aisec.cpg.graph.types.UnknownType
 
 /**
  * This expression denotes the usage of an anonymous / lambda function. It connects the inner
@@ -62,11 +63,11 @@ class LambdaExpression : Expression(), HasType.TypeListener {
         }
 
     override fun typeChanged(src: HasType, root: MutableList<HasType>, oldType: Type) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
 
-        if (!TypeManager.getInstance().isUnknown(type) && src.propagationType == oldType) {
+        if (type !is UnknownType && src.propagationType == oldType) {
             return
         }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/UnaryOperator.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/UnaryOperator.kt
@@ -28,7 +28,7 @@ package de.fraunhofer.aisec.cpg.graph.statements.expressions
 import de.fraunhofer.aisec.cpg.graph.AST
 import de.fraunhofer.aisec.cpg.graph.AccessValues
 import de.fraunhofer.aisec.cpg.graph.HasType
-import de.fraunhofer.aisec.cpg.graph.TypeManager
+import de.fraunhofer.aisec.cpg.graph.isTypeSystemActive
 import de.fraunhofer.aisec.cpg.graph.types.PointerType
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.helpers.Util.distinctBy
@@ -103,7 +103,7 @@ class UnaryOperator : Expression(), HasType.TypeListener {
     }
 
     override fun typeChanged(src: HasType, root: MutableList<HasType>, oldType: Type) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
         val previous = type
@@ -135,7 +135,7 @@ class UnaryOperator : Expression(), HasType.TypeListener {
     }
 
     override fun possibleSubTypesChanged(src: HasType, root: MutableList<HasType>) {
-        if (!TypeManager.isTypeSystemActive()) {
+        if (!isTypeSystemActive) {
             return
         }
         if (src is HasType.TypeListener && getsDataFromInput(src as HasType.TypeListener)) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionType.kt
@@ -27,9 +27,9 @@ package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
-import de.fraunhofer.aisec.cpg.graph.TypeManager
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.newUnknownType
+import de.fraunhofer.aisec.cpg.graph.registerType
 
 /**
  * A type representing a function. It contains a list of parameters and one or more return types.
@@ -80,7 +80,7 @@ constructor(
                     func.language
                 )
 
-            return TypeManager.getInstance().registerType(type)
+            return func.registerType(type)
         }
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/HasType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/HasType.kt
@@ -25,9 +25,11 @@
  */
 package de.fraunhofer.aisec.cpg.graph
 
+import de.fraunhofer.aisec.cpg.frontends.TranslationException
 import de.fraunhofer.aisec.cpg.graph.types.Type
+import java.util.Optional
 
-interface HasType {
+interface HasType : ContextProvider {
     var type: Type
 
     /**
@@ -99,4 +101,34 @@ interface HasType {
     interface SecondaryTypeEdge {
         fun updateType(typeState: Collection<Type>)
     }
+}
+
+val Node.isTypeSystemActive: Boolean
+    get() {
+        return TypeManager.isTypeSystemActive()
+    }
+
+fun Node.isSupertypeOf(superType: Type, subType: Type?): Boolean {
+    val c = ctx ?: throw TranslationException("context not available")
+    return c.typeManager.isSupertypeOf(superType, subType, this)
+}
+
+fun HasType.cacheType(type: Type) {
+    val c = ctx ?: throw TranslationException("context not available")
+    c.typeManager.cacheType(this, type)
+}
+
+fun <T : Type> Node.registerType(type: T): T {
+    val c = ctx ?: throw TranslationException("context not available")
+    return c.typeManager.registerType(type)
+}
+
+fun Node.getCommonType(types: Collection<Type>): Optional<Type> {
+    val c = ctx ?: throw TranslationException("context not available")
+    return c.typeManager.getCommonType(types, this.ctx)
+}
+
+fun Node.stopPropagation(type: Type, newType: Type): Boolean {
+    val c = ctx ?: throw TranslationException("context not available")
+    return c.typeManager.stopPropagation(type, newType)
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
@@ -25,8 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.edge.Properties
@@ -46,10 +45,8 @@ import de.fraunhofer.aisec.cpg.passes.order.DependsOn
  */
 @DependsOn(EvaluationOrderGraphPass::class)
 @DependsOn(DFGPass::class)
-open class ControlFlowSensitiveDFGPass(
-    config: TranslationConfiguration,
-    scopeManager: ScopeManager,
-) : TranslationUnitPass(config, scopeManager) {
+open class ControlFlowSensitiveDFGPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {
+
     override fun cleanup() {
         // Nothing to do
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
@@ -25,8 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.FieldDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
@@ -40,8 +39,7 @@ import de.fraunhofer.aisec.cpg.passes.order.DependsOn
 /** Adds the DFG edges for various types of nodes. */
 @DependsOn(VariableUsageResolver::class)
 @DependsOn(CallResolver::class)
-class DFGPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
-    ComponentPass(config, scopeManager) {
+class DFGPass(ctx: TranslationContext) : ComponentPass(ctx) {
     override fun accept(component: Component) {
         val inferDfgForUnresolvedCalls = config.inferenceConfiguration.inferDfgForUnresolvedSymbols
         val walker = IterativeGraphWalker()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EdgeCachePass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EdgeCachePass.kt
@@ -25,8 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
@@ -83,8 +82,7 @@ object Edges {
  *
  * The cache itself is stored in the [Edges] object.
  */
-class EdgeCachePass(config: TranslationConfiguration, scopeManager: ScopeManager) :
-    ComponentPass(config, scopeManager) {
+class EdgeCachePass(ctx: TranslationContext) : ComponentPass(ctx) {
     override fun accept(component: Component) {
         Edges.clear()
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
@@ -25,13 +25,11 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.HasShortCircuitOperators
 import de.fraunhofer.aisec.cpg.frontends.ProcessedListener
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.StatementHolder
-import de.fraunhofer.aisec.cpg.graph.TypeManager
 import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.edge.Properties
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
@@ -71,8 +69,7 @@ import org.slf4j.LoggerFactory
  */
 @Suppress("MemberVisibilityCanBePrivate")
 @DependsOn(CallResolver::class)
-open class EvaluationOrderGraphPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
-    TranslationUnitPass(config, scopeManager) {
+open class EvaluationOrderGraphPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {
     protected val map = mutableMapOf<Class<out Node>, (Node) -> Unit>()
     private var currentPredecessors = mutableListOf<Node>()
     private val nextEdgeProperties = EnumMap<Properties, Any?>(Properties::class.java)
@@ -580,9 +577,7 @@ open class EvaluationOrderGraphPass(config: TranslationConfiguration, scopeManag
                 val catchParam = catchClause.parameter
                 if (catchParam == null) { // e.g. catch (...)
                     currentPredecessors.addAll(eogEdges)
-                } else if (
-                    TypeManager.getInstance().isSupertypeOf(catchParam.type, throwType, node)
-                ) {
+                } else if (typeManager.isSupertypeOf(catchParam.type, throwType, node)) {
                     currentPredecessors.addAll(eogEdges)
                     toRemove.add(throwType)
                 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/FilenameMapper.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/FilenameMapper.kt
@@ -25,8 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.passes.order.ExecuteLast
@@ -34,8 +33,7 @@ import de.fraunhofer.aisec.cpg.processing.IVisitor
 import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 
 @ExecuteLast
-class FilenameMapper(config: TranslationConfiguration, scopeManager: ScopeManager) :
-    TranslationUnitPass(config, scopeManager) {
+class FilenameMapper(ctx: TranslationContext) : TranslationUnitPass(ctx) {
     override fun accept(tu: TranslationUnitDeclaration) {
         val file = tu.name.toString()
         tu.file = file

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/FunctionPointerCallResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/FunctionPointerCallResolver.kt
@@ -25,8 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.cpp.CXXLanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
@@ -57,8 +56,7 @@ import java.util.function.Consumer
 @DependsOn(CallResolver::class)
 @DependsOn(DFGPass::class)
 @RequiredFrontend(CXXLanguageFrontend::class)
-class FunctionPointerCallResolver(config: TranslationConfiguration, scopeManager: ScopeManager) :
-    ComponentPass(config, scopeManager) {
+class FunctionPointerCallResolver(ctx: TranslationContext) : ComponentPass(ctx) {
     private lateinit var walker: ScopedWalker
     private var inferDfgForUnresolvedCalls = false
 
@@ -152,7 +150,7 @@ class FunctionPointerCallResolver(config: TranslationConfiguration, scopeManager
         call.invokes = invocationCandidates
         // We have to update the dfg edges because this call could now be resolved (which was not
         // the case before).
-        DFGPass(config, scopeManager).handleCallExpression(call, inferDfgForUnresolvedCalls)
+        DFGPass(ctx).handleCallExpression(call, inferDfgForUnresolvedCalls)
     }
 
     override fun cleanup() {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
@@ -25,13 +25,9 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
-import de.fraunhofer.aisec.cpg.graph.Component
-import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.TranslationContext
+import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.*
-import de.fraunhofer.aisec.cpg.graph.newFieldDeclaration
-import de.fraunhofer.aisec.cpg.graph.newMethodDeclaration
 import de.fraunhofer.aisec.cpg.graph.types.UnknownType
 import de.fraunhofer.aisec.cpg.passes.order.DependsOn
 import de.fraunhofer.aisec.cpg.processing.IVisitor
@@ -40,8 +36,7 @@ import java.util.*
 import java.util.regex.Pattern
 
 @DependsOn(TypeHierarchyResolver::class)
-open class ImportResolver(config: TranslationConfiguration, scopeManager: ScopeManager) :
-    ComponentPass(config, scopeManager) {
+open class ImportResolver(ctx: TranslationContext) : ComponentPass(ctx) {
     protected val records: MutableList<RecordDeclaration> = ArrayList()
     protected val importables: MutableMap<String, Declaration> = HashMap()
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/StatisticsCollectionPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/StatisticsCollectionPass.kt
@@ -25,8 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.ProblemNode
@@ -38,14 +37,13 @@ import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker.ScopedWalker
  * A [Pass] collecting statistics for the graph. Currently, it collects the number of nodes and the
  * number of problem nodes (i.e., nodes where the translation failed for some reason).
  */
-class StatisticsCollectionPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
-    TranslationResultPass(config, scopeManager) {
+class StatisticsCollectionPass(ctx: TranslationContext) : TranslationResultPass(ctx) {
 
     /** Iterates the nodes of the [result] to collect statistics. */
     override fun accept(result: TranslationResult) {
         var problemNodes = 0
         var nodes = 0
-        val walker = ScopedWalker(result.scopeManager)
+        val walker = ScopedWalker(ctx.scopeManager)
         walker.registerHandler { _: RecordDeclaration?, _: Node?, currNode: Node? ->
             nodes++
             if (currNode is ProblemNode) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolverPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolverPass.kt
@@ -25,8 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.HasSuperClasses
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.*
@@ -34,8 +33,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.DeclaredReferenceExp
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 
-abstract class SymbolResolverPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
-    ComponentPass(config, scopeManager) {
+abstract class SymbolResolverPass(ctx: TranslationContext) : ComponentPass(ctx) {
     protected lateinit var walker: SubgraphWalker.ScopedWalker
     lateinit var currentTU: TranslationUnitDeclaration
 
@@ -55,7 +53,7 @@ abstract class SymbolResolverPass(config: TranslationConfiguration, scopeManager
     protected fun findEnums(node: Node?) {
         if (node is EnumDeclaration) {
             // TODO: Use the name instead of the type.
-            val type = TypeParser.createFrom(node.name, node.language)
+            val type = node.parseType(node.name)
             enumMap.putIfAbsent(type, node)
         }
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeHierarchyResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeHierarchyResolver.kt
@@ -25,8 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.Node
@@ -56,8 +55,7 @@ import java.util.*
  * at places where it is crucial to have parsed all [RecordDeclaration]s. Otherwise, type
  * information in the graph might not be fully correct
  */
-open class TypeHierarchyResolver(config: TranslationConfiguration, scopeManager: ScopeManager) :
-    ComponentPass(config, scopeManager) {
+open class TypeHierarchyResolver(ctx: TranslationContext) : ComponentPass(ctx) {
     protected val recordMap = mutableMapOf<Name, RecordDeclaration>()
     protected val enums = mutableListOf<EnumDeclaration>()
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
@@ -25,21 +25,18 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.HasType
 import de.fraunhofer.aisec.cpg.graph.HasType.SecondaryTypeEdge
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.TypeManager
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker.IterativeGraphWalker
 import de.fraunhofer.aisec.cpg.passes.order.DependsOn
 
 @DependsOn(CallResolver::class)
-open class TypeResolver(config: TranslationConfiguration, scopeManager: ScopeManager) :
-    ComponentPass(config, scopeManager) {
+open class TypeResolver(ctx: TranslationContext) : ComponentPass(ctx) {
     protected val firstOrderTypes = mutableSetOf<Type>()
     protected val typeState = mutableMapOf<Type, MutableList<Type>>()
 
@@ -108,7 +105,6 @@ open class TypeResolver(config: TranslationConfiguration, scopeManager: ScopeMan
     }
 
     protected fun removeDuplicateTypes() {
-        val typeManager = TypeManager.getInstance()
         // Remove duplicate firstOrderTypes
         firstOrderTypes.addAll(typeManager.firstOrderTypes)
 
@@ -241,6 +237,5 @@ open class TypeResolver(config: TranslationConfiguration, scopeManager: ScopeMan
     override fun cleanup() {
         firstOrderTypes.clear()
         typeState.clear()
-        TypeManager.reset()
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/GraphExamples.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/GraphExamples.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg
 import de.fraunhofer.aisec.cpg.frontends.StructTestLanguage
 import de.fraunhofer.aisec.cpg.frontends.TestLanguage
 import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.TypeManager
 import de.fraunhofer.aisec.cpg.graph.builder.*
 import de.fraunhofer.aisec.cpg.graph.newVariableDeclaration
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
@@ -36,6 +37,12 @@ import java.net.URI
 
 class GraphExamples {
     companion object {
+
+        fun testFrontend(config: TranslationConfiguration): TestLanguageFrontend {
+            val ctx = TranslationContext(config, ScopeManager(), TypeManager())
+            val language = config.languages.filterIsInstance<TestLanguage>().first()
+            return TestLanguageFrontend(language.namespaceDelimiter, language, ctx)
+        }
 
         fun getInferenceRecordPtr(
             config: TranslationConfiguration =
@@ -47,30 +54,25 @@ class GraphExamples {
                     )
                     .build()
         ) =
-            TestLanguageFrontend(
-                    ScopeManager(),
-                    config.languages.first().namespaceDelimiter,
-                    config.languages.first()
-                )
-                .build {
-                    translationResult(config) {
-                        translationUnit("record.cpp") {
-                            // The main method
-                            function("main", t("int")) {
-                                body {
-                                    declare { variable("node", t("T*")) }
-                                    member("value", ref("node"), "->") assign literal(42, t("int"))
-                                    member("next", ref("node"), "->") assign ref("node")
-                                    memberCall(
-                                        "dump",
-                                        ref("node")
-                                    ) // TODO: Do we have to encode the "->" here?
-                                    returnStmt { isImplicit = true }
-                                }
+            testFrontend(config).build {
+                translationResult {
+                    translationUnit("record.cpp") {
+                        // The main method
+                        function("main", t("int")) {
+                            body {
+                                declare { variable("node", t("T*")) }
+                                member("value", ref("node"), "->") assign literal(42, t("int"))
+                                member("next", ref("node"), "->") assign ref("node")
+                                memberCall(
+                                    "dump",
+                                    ref("node")
+                                ) // TODO: Do we have to encode the "->" here?
+                                returnStmt { isImplicit = true }
                             }
                         }
                     }
                 }
+            }
 
         fun getInferenceRecord(
             config: TranslationConfiguration =
@@ -82,26 +84,21 @@ class GraphExamples {
                     )
                     .build()
         ) =
-            TestLanguageFrontend(
-                    ScopeManager(),
-                    config.languages.first().namespaceDelimiter,
-                    config.languages.first()
-                )
-                .build {
-                    translationResult(config) {
-                        translationUnit("record.cpp") {
-                            // The main method
-                            function("main", t("int")) {
-                                body {
-                                    declare { variable("node", t("T")) }
-                                    member("value", ref("node")) assign literal(42, t("int"))
-                                    member("next", ref("node")) assign { reference(ref("node")) }
-                                    returnStmt { isImplicit = true }
-                                }
+            testFrontend(config).build {
+                translationResult {
+                    translationUnit("record.cpp") {
+                        // The main method
+                        function("main", t("int")) {
+                            body {
+                                declare { variable("node", t("T")) }
+                                member("value", ref("node")) assign literal(42, t("int"))
+                                member("next", ref("node")) assign { reference(ref("node")) }
+                                returnStmt { isImplicit = true }
                             }
                         }
                     }
                 }
+            }
 
         fun getVariables(
             config: TranslationConfiguration =
@@ -110,8 +107,8 @@ class GraphExamples {
                     .registerLanguage(TestLanguage("."))
                     .build()
         ) =
-            TestLanguageFrontend(ScopeManager(), ".").build {
-                translationResult(config) {
+            testFrontend(config).build {
+                translationResult {
                     translationUnit("Variables.java") {
                         record("Variables") {
                             field("field", t("int")) {
@@ -161,8 +158,8 @@ class GraphExamples {
                     .registerLanguage(TestLanguage("."))
                     .build()
         ) =
-            TestLanguageFrontend(ScopeManager(), ".").build {
-                translationResult(config) {
+            testFrontend(config).build {
+                translationResult {
                     translationUnit("unaryoperator.cpp") {
                         // The main method
                         function("somefunc") {
@@ -183,8 +180,8 @@ class GraphExamples {
                     .registerLanguage(TestLanguage("."))
                     .build()
         ) =
-            TestLanguageFrontend(ScopeManager(), ".").build {
-                translationResult(config) {
+            testFrontend(config).build {
+                translationResult {
                     translationUnit("compoundoperator.cpp") {
                         // The main method
                         function("somefunc") {
@@ -205,8 +202,8 @@ class GraphExamples {
                     .registerLanguage(TestLanguage("."))
                     .build()
         ) =
-            TestLanguageFrontend(ScopeManager(), ".").build {
-                translationResult(config) {
+            testFrontend(config).build {
+                translationResult {
                     translationUnit("conditional_expression.cpp") {
                         // The main method
                         function("main", t("int")) {
@@ -281,8 +278,8 @@ class GraphExamples {
                     .registerLanguage(TestLanguage("."))
                     .build()
         ) =
-            TestLanguageFrontend(ScopeManager(), ".").build {
-                translationResult(config) {
+            testFrontend(config).build {
+                translationResult {
                     translationUnit("BasicSlice.java") {
                         record("BasicSlice") {
                             // The main method
@@ -367,8 +364,8 @@ class GraphExamples {
                     .registerLanguage(TestLanguage("."))
                     .build()
         ) =
-            TestLanguageFrontend(ScopeManager(), ".").build {
-                translationResult(config) {
+            testFrontend(config).build {
+                translationResult {
                     translationUnit("ControlFlowSensitiveDFGIfMerge.java") {
                         record("ControlFlowSensitiveDFGIfMerge") {
                             field("bla", t("int")) {}
@@ -439,8 +436,8 @@ class GraphExamples {
                     .registerLanguage(TestLanguage("."))
                     .build()
         ) =
-            TestLanguageFrontend(ScopeManager(), ".").build {
-                translationResult(config) {
+            testFrontend(config).build {
+                translationResult {
                     translationUnit("ControlFlowSesitiveDFGSwitch.java") {
                         record("ControlFlowSesitiveDFGSwitch") {
                             // The main method
@@ -513,8 +510,8 @@ class GraphExamples {
                     .registerLanguage(TestLanguage("."))
                     .build()
         ) =
-            TestLanguageFrontend(ScopeManager(), ".").build {
-                translationResult(config) {
+            testFrontend(config).build {
+                translationResult {
                     translationUnit("ControlFlowSensitiveDFGIfNoMerge.java") {
                         record("ControlFlowSensitiveDFGIfNoMerge") {
                             // The main method
@@ -551,8 +548,8 @@ class GraphExamples {
                     .registerLanguage(TestLanguage("."))
                     .build()
         ) =
-            TestLanguageFrontend(ScopeManager(), ".").build {
-                translationResult(config) {
+            testFrontend(config).build {
+                translationResult {
                     translationUnit("LoopDFGs.java") {
                         record("LoopDFGs") {
                             // The main method
@@ -632,8 +629,8 @@ class GraphExamples {
                     .registerLanguage(TestLanguage("."))
                     .build()
         ) =
-            TestLanguageFrontend(ScopeManager(), ".").build {
-                translationResult(config) {
+            testFrontend(config).build {
+                translationResult {
                     translationUnit("LoopDFGs.java") {
                         record("LoopDFGs") {
                             // The main method
@@ -683,8 +680,8 @@ class GraphExamples {
                     .registerLanguage(TestLanguage("."))
                     .build()
         ) =
-            TestLanguageFrontend(ScopeManager(), ".").build {
-                translationResult(config) {
+            testFrontend(config).build {
+                translationResult {
                     translationUnit("DelayedAssignmentAfterRHS.java") {
                         record("DelayedAssignmentAfterRHS") {
                             // The main method
@@ -709,8 +706,8 @@ class GraphExamples {
                     .registerLanguage(TestLanguage("."))
                     .build()
         ) =
-            TestLanguageFrontend(ScopeManager(), ".").build {
-                translationResult(config) {
+            testFrontend(config).build {
+                translationResult {
                     translationUnit("ReturnTest.java") {
                         record("ReturnTest", "class") {
                             method("testReturn", t("int")) {
@@ -755,8 +752,8 @@ class GraphExamples {
                     .registerLanguage(TestLanguage("."))
                     .build()
         ) =
-            TestLanguageFrontend(ScopeManager(), ".").build {
-                translationResult(config) {
+            testFrontend(config).build {
+                translationResult {
                     translationUnit("RecordDeclaration.java") {
                         namespace("compiling") {
                             record("SimpleClass", "class") {
@@ -801,8 +798,8 @@ class GraphExamples {
                     .registerLanguage(TestLanguage("."))
                     .build()
         ) =
-            TestLanguageFrontend(ScopeManager(), ".").build {
-                translationResult(config) {
+            testFrontend(config).build {
+                translationResult {
                     translationUnit("Dataflow.java") {
                         record("Dataflow") {
                             field("attr", t("String")) { literal("", t("String")) }
@@ -864,8 +861,8 @@ class GraphExamples {
                     .registerLanguage(TestLanguage("."))
                     .build()
         ) =
-            TestLanguageFrontend(ScopeManager(), ".").build {
-                translationResult(config) {
+            testFrontend(config).build {
+                translationResult {
                     translationUnit("ShortcutClass.java") {
                         record("ShortcutClass") {
                             field("attr", t("int")) { literal(0, t("int")) }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLiteralTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXLiteralTest.kt
@@ -33,7 +33,6 @@ import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Literal
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.UnaryOperator
 import de.fraunhofer.aisec.cpg.graph.types.Type
-import de.fraunhofer.aisec.cpg.graph.types.TypeParser
 import java.io.File
 import java.math.BigInteger
 import kotlin.test.Test
@@ -54,12 +53,12 @@ internal class CXXLiteralTest : BaseTest() {
 
         val funcDecl = zero.iterator().next()
         assertLocalName("zero", funcDecl)
-        assertLiteral(0, createTypeFrom("int"), funcDecl, "i")
-        assertLiteral(0L, createTypeFrom("long"), funcDecl, "l_with_suffix")
-        assertLiteral(0L, createTypeFrom("long long"), funcDecl, "l_long_long_with_suffix")
+        assertLiteral(0, tu.parseType("int"), funcDecl, "i")
+        assertLiteral(0L, tu.parseType("long"), funcDecl, "l_with_suffix")
+        assertLiteral(0L, tu.parseType("long long"), funcDecl, "l_long_long_with_suffix")
         assertLiteral(
             BigInteger.valueOf(0),
-            createTypeFrom("unsigned long long"),
+            tu.parseType("unsigned long long"),
             funcDecl,
             "l_unsigned_long_long_with_suffix"
         )
@@ -74,31 +73,31 @@ internal class CXXLiteralTest : BaseTest() {
         assertFalse(decimal.isEmpty())
         val funcDecl = decimal.iterator().next()
         assertLocalName("decimal", funcDecl)
-        assertLiteral(42, createTypeFrom("int"), funcDecl, "i")
-        assertLiteral(1000, createTypeFrom("int"), funcDecl, "i_with_literal")
-        assertLiteral(9223372036854775807L, createTypeFrom("long"), funcDecl, "l")
-        assertLiteral(9223372036854775807L, createTypeFrom("long"), funcDecl, "l_with_suffix")
+        assertLiteral(42, tu.parseType("int"), funcDecl, "i")
+        assertLiteral(1000, tu.parseType("int"), funcDecl, "i_with_literal")
+        assertLiteral(9223372036854775807L, tu.parseType("long"), funcDecl, "l")
+        assertLiteral(9223372036854775807L, tu.parseType("long"), funcDecl, "l_with_suffix")
         assertLiteral(
             9223372036854775807L,
-            createTypeFrom("long long"),
+            tu.parseType("long long"),
             funcDecl,
             "l_long_long_with_suffix"
         )
         assertLiteral(
             BigInteger("9223372036854775809"),
-            createTypeFrom("unsigned long"),
+            tu.parseType("unsigned long"),
             funcDecl,
             "l_unsigned_long_with_suffix"
         )
         assertLiteral(
             BigInteger("9223372036854775808"),
-            createTypeFrom("unsigned long long"),
+            tu.parseType("unsigned long long"),
             funcDecl,
             "l_long_long_implicit"
         )
         assertLiteral(
             BigInteger("9223372036854775809"),
-            createTypeFrom("unsigned long long"),
+            tu.parseType("unsigned long long"),
             funcDecl,
             "l_unsigned_long_long_with_suffix"
         )
@@ -113,11 +112,11 @@ internal class CXXLiteralTest : BaseTest() {
         assertFalse(octal.isEmpty())
         val funcDecl = octal.iterator().next()
         assertLocalName("octal", funcDecl)
-        assertLiteral(42, createTypeFrom("int"), funcDecl, "i")
-        assertLiteral(42L, createTypeFrom("long"), funcDecl, "l_with_suffix")
+        assertLiteral(42, tu.parseType("int"), funcDecl, "i")
+        assertLiteral(42L, tu.parseType("long"), funcDecl, "l_with_suffix")
         assertLiteral(
             BigInteger.valueOf(42),
-            createTypeFrom("unsigned long long"),
+            tu.parseType("unsigned long long"),
             funcDecl,
             "l_unsigned_long_long_with_suffix"
         )
@@ -133,11 +132,11 @@ internal class CXXLiteralTest : BaseTest() {
         assertFalse(hex.isEmpty())
         val funcDecl = hex.iterator().next()
         assertLocalName("hex", funcDecl)
-        assertLiteral(42, createTypeFrom("int"), funcDecl, "i")
-        assertLiteral(42L, createTypeFrom("long"), funcDecl, "l_with_suffix")
+        assertLiteral(42, tu.parseType("int"), funcDecl, "i")
+        assertLiteral(42L, tu.parseType("long"), funcDecl, "l_with_suffix")
         assertLiteral(
             BigInteger.valueOf(42),
-            createTypeFrom("unsigned long long"),
+            tu.parseType("unsigned long long"),
             funcDecl,
             "l_unsigned_long_long_with_suffix"
         )
@@ -197,6 +196,4 @@ internal class CXXLiteralTest : BaseTest() {
         assertEquals(expectedType, literal.type)
         assertEquals(expectedValue, literal.value)
     }
-
-    private fun createTypeFrom(typename: String) = TypeParser.createFrom(typename, CPPLanguage())
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXSymbolConfigurationTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cpp/CXXSymbolConfigurationTest.kt
@@ -25,11 +25,9 @@
  */
 package de.fraunhofer.aisec.cpg.frontends.cpp
 
-import de.fraunhofer.aisec.cpg.BaseTest
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
-import de.fraunhofer.aisec.cpg.assertLocalName
+import de.fraunhofer.aisec.cpg.*
 import de.fraunhofer.aisec.cpg.frontends.TranslationException
+import de.fraunhofer.aisec.cpg.graph.TypeManager
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.BinaryOperator
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
@@ -49,8 +47,11 @@ internal class CXXSymbolConfigurationTest : BaseTest() {
         val tu =
             CXXLanguageFrontend(
                     CPPLanguage(),
-                    TranslationConfiguration.builder().defaultPasses().build(),
-                    ScopeManager(),
+                    TranslationContext(
+                        TranslationConfiguration.builder().build(),
+                        ScopeManager(),
+                        TypeManager()
+                    )
                 )
                 .parse(File("src/test/resources/symbols.cpp"))
         val main = tu.getDeclarationsByName("main", FunctionDeclaration::class.java)
@@ -79,20 +80,17 @@ internal class CXXSymbolConfigurationTest : BaseTest() {
     @Test
     @Throws(TranslationException::class)
     fun testWithSymbols() {
+        val config =
+            TranslationConfiguration.builder()
+                .symbols(mapOf(Pair("HELLO_WORLD", "\"Hello World\""), Pair("INCREASE(X)", "X+1")))
+                .defaultPasses()
+                .build()
+
         // let's try with symbol definitions
         val tu =
             CXXLanguageFrontend(
                     CPPLanguage(),
-                    TranslationConfiguration.builder()
-                        .symbols(
-                            mapOf(
-                                Pair("HELLO_WORLD", "\"Hello World\""),
-                                Pair("INCREASE(X)", "X+1")
-                            )
-                        )
-                        .defaultPasses()
-                        .build(),
-                    ScopeManager(),
+                    TranslationContext(config, ScopeManager(), TypeManager())
                 )
                 .parse(File("src/test/resources/symbols.cpp"))
         val main = tu.getDeclarationsByName("main", FunctionDeclaration::class.java)

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/FluentTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/FluentTest.kt
@@ -44,10 +44,9 @@ import kotlin.test.*
 class FluentTest {
     @Test
     fun test() {
-        val scopeManager = ScopeManager()
         val result =
-            TestLanguageFrontend(scopeManager).build {
-                translationResult(TranslationConfiguration.builder().build()) {
+            TestLanguageFrontend().build {
+                translationResult {
                     translationUnit("file.cpp") {
                         function("main", t("int")) {
                             param("argc", t("int"))
@@ -170,8 +169,7 @@ class FluentTest {
         assertNotNull(lit2.scope)
         assertEquals(2, lit2.value)
 
-        VariableUsageResolver(TranslationConfiguration.builder().build(), scopeManager)
-            .accept(result.components.first())
+        VariableUsageResolver(result.finalCtx).accept(result.components.first())
 
         // Now the reference should be resolved
         assertRefersTo(ref, variable)

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/AssignExpressionTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/AssignExpressionTest.kt
@@ -25,9 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.graph.statements.expressions
 
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.assertLocalName
-import de.fraunhofer.aisec.cpg.frontends.TestLanguage
 import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.builder.function
@@ -41,7 +39,7 @@ import kotlin.test.*
 class AssignExpressionTest {
     @Test
     fun propagateSimple() {
-        with(TestLanguage()) {
+        with(TestLanguageFrontend()) {
             val refA = newDeclaredReferenceExpression("a")
             val refB = newDeclaredReferenceExpression("b")
 
@@ -65,7 +63,7 @@ class AssignExpressionTest {
     fun propagateTuple() {
         with(TestLanguageFrontend()) {
             val result = build {
-                translationResult(TranslationConfiguration.builder().build()) {
+                translationResult {
                     translationUnit {
                         val func =
                             function(
@@ -109,7 +107,7 @@ class AssignExpressionTest {
             assertLocalName("error", refErr.type)
 
             // Invoke the DFG pass
-            DFGPass(result.config, result.scopeManager).accept(result.components.first())
+            DFGPass(ctx).accept(result.components.first())
 
             assertTrue(refA.prevDFG.contains(call))
             assertTrue(refErr.prevDFG.contains(call))

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypePropagationTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypePropagationTest.kt
@@ -25,8 +25,6 @@
  */
 package de.fraunhofer.aisec.cpg.graph.types
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.builder.*
@@ -43,7 +41,7 @@ class TypePropagationTest {
     fun testBinopTypePropagation() {
         val result =
             TestLanguageFrontend().build {
-                translationResult(TranslationConfiguration.builder().build()) {
+                translationResult {
                     translationUnit("test") {
                         function("main", t("int")) {
                             body {
@@ -76,10 +74,9 @@ class TypePropagationTest {
     @Test
     fun testAssignTypePropagation() {
         // TODO: This test is related to issue 1071 (it models case 2).
-        val scopeManager = ScopeManager()
         val result =
-            TestLanguageFrontend(scopeManager).build {
-                translationResult(TranslationConfiguration.builder().build()) {
+            TestLanguageFrontend().build {
+                translationResult {
                     translationUnit("test") {
                         function("main", t("int")) {
                             body {
@@ -92,7 +89,7 @@ class TypePropagationTest {
                     }
                 }
             }
-        VariableUsageResolver(result.config, result.scopeManager).accept(result.components.first())
+        VariableUsageResolver(result.finalCtx).accept(result.components.first())
 
         val binaryOp =
             (result.functions["main"]?.body as? CompoundStatement)?.statements?.get(2)

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypedefTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypedefTest.kt
@@ -29,7 +29,6 @@ import de.fraunhofer.aisec.cpg.BaseTest
 import de.fraunhofer.aisec.cpg.TestUtils.analyze
 import de.fraunhofer.aisec.cpg.TestUtils.findByUniqueName
 import de.fraunhofer.aisec.cpg.TestUtils.findByUniquePredicate
-import de.fraunhofer.aisec.cpg.graph.TypeManager
 import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
 import de.fraunhofer.aisec.cpg.graph.records
 import de.fraunhofer.aisec.cpg.graph.variables
@@ -72,7 +71,7 @@ internal class TypedefTest : BaseTest() {
         assertEquals(NumericType.Modifier.UNSIGNED, returnType.modifier)
         assertEquals(uintfp1.type, uintfp2.type)
 
-        val typedefs = result.scopeManager.currentTypedefs
+        val typedefs = result.finalCtx.scopeManager.currentTypedefs
         val def =
             typedefs.stream().filter { it.alias.name.localName == "test" }.findAny().orElse(null)
         assertNotNull(def)
@@ -83,6 +82,7 @@ internal class TypedefTest : BaseTest() {
     fun testWithModifier() {
         val result = analyze("cpp", topLevel, true)
         val variables = result.variables
+        val typeManager = result.finalCtx.typeManager
 
         // pointer
         val l1ptr = findByUniqueName(variables, "l1ptr")
@@ -98,9 +98,9 @@ internal class TypedefTest : BaseTest() {
         val l2arr = findByUniqueName(variables, "l2arr")
         val l3arr = findByUniqueName(variables, "l3arr")
         val l4arr = findByUniqueName(variables, "l4arr")
-        assertTrue(TypeManager.getInstance().checkArrayAndPointer(l1arr.type, l2arr.type))
-        assertTrue(TypeManager.getInstance().checkArrayAndPointer(l1arr.type, l3arr.type))
-        assertTrue(TypeManager.getInstance().checkArrayAndPointer(l1arr.type, l4arr.type))
+        assertTrue(typeManager.checkArrayAndPointer(l1arr.type, l2arr.type))
+        assertTrue(typeManager.checkArrayAndPointer(l1arr.type, l3arr.type))
+        assertTrue(typeManager.checkArrayAndPointer(l1arr.type, l4arr.type))
     }
 
     @Test

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/CallResolverTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/CallResolverTest.kt
@@ -43,7 +43,6 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CastExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Literal
 import de.fraunhofer.aisec.cpg.graph.types.Type
-import de.fraunhofer.aisec.cpg.graph.types.TypeParser
 import de.fraunhofer.aisec.cpg.graph.types.UnknownType
 import java.io.File
 import java.nio.file.Path
@@ -154,9 +153,13 @@ class CallResolverTest : BaseTest() {
                 topLevel,
                 true
             )
+        val tu = result.translationUnits.firstOrNull()
+        assertNotNull(tu)
+
         val records = result.records
-        val intType = TypeParser.createFrom("int", CPPLanguage())
-        val stringType = TypeParser.createFrom("char*", CPPLanguage())
+
+        val intType = tu.parseType("int")
+        val stringType = tu.parseType("char*")
         testMethods(records, intType, stringType)
         testOverriding(records)
 

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ReplaceTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ReplaceTest.kt
@@ -25,8 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.ScopeManager
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.StructTestLanguage
 import de.fraunhofer.aisec.cpg.frontends.TestLanguage
 import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
@@ -43,16 +43,12 @@ class ReplaceTest {
         override val frontend: KClass<out TestLanguageFrontend>
             get() = ReplaceTestLanguageFrontend::class
 
-        override fun newFrontend(
-            config: TranslationConfiguration,
-            scopeManager: ScopeManager
-        ): TestLanguageFrontend {
+        override fun newFrontend(ctx: TranslationContext): TestLanguageFrontend {
             return ReplaceTestLanguageFrontend()
         }
     }
 
-    class ReplacedPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
-        EvaluationOrderGraphPass(config, scopeManager)
+    class ReplacedPass(ctx: TranslationContext) : EvaluationOrderGraphPass(ctx)
 
     @Test
     fun testReplaceAnnotation() {

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/UnresolvedDFGPassTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/UnresolvedDFGPassTest.kt
@@ -25,11 +25,11 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
+import de.fraunhofer.aisec.cpg.GraphExamples.Companion.testFrontend
 import de.fraunhofer.aisec.cpg.InferenceConfiguration
-import de.fraunhofer.aisec.cpg.ScopeManager
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.frontends.TestLanguage
-import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.builder.*
 import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration
@@ -97,19 +97,19 @@ class UnresolvedDFGPassTest {
 
     companion object {
 
-        fun getDfgUnresolvedCalls(inferUnresolved: Boolean) =
-            TestLanguageFrontend(ScopeManager(), ".").build {
-                translationResult(
-                    TranslationConfiguration.builder()
-                        .defaultPasses()
-                        .registerLanguage(TestLanguage("."))
-                        .inferenceConfiguration(
-                            InferenceConfiguration.builder()
-                                .inferDfgForUnresolvedCalls(inferUnresolved)
-                                .build()
-                        )
-                        .build()
-                ) {
+        fun getDfgUnresolvedCalls(inferUnresolved: Boolean): TranslationResult {
+            val config =
+                TranslationConfiguration.builder()
+                    .defaultPasses()
+                    .registerLanguage(TestLanguage("."))
+                    .inferenceConfiguration(
+                        InferenceConfiguration.builder()
+                            .inferDfgForUnresolvedCalls(inferUnresolved)
+                            .build()
+                    )
+                    .build()
+            return testFrontend(config).build {
+                translationResult {
                     translationUnit("DfgUnresolvedCalls.java") {
                         record("DfgUnresolvedCalls") {
                             field("i", t("int")) { modifiers = listOf("private") }
@@ -176,5 +176,6 @@ class UnresolvedDFGPassTest {
                     }
                 }
             }
+        }
     }
 }

--- a/cpg-core/src/testFixtures/kotlin/de/fraunhofer/aisec/cpg/TestUtils.kt
+++ b/cpg-core/src/testFixtures/kotlin/de/fraunhofer/aisec/cpg/TestUtils.kt
@@ -27,7 +27,6 @@ package de.fraunhofer.aisec.cpg
 
 import de.fraunhofer.aisec.cpg.frontends.CompilationDatabase
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.TypeManager
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
@@ -39,8 +38,6 @@ import java.util.function.Consumer
 import java.util.function.Predicate
 import java.util.stream.Collectors
 import kotlin.test.*
-import org.apache.commons.lang3.reflect.FieldUtils
-import org.mockito.Mockito
 
 object TestUtils {
 
@@ -189,13 +186,6 @@ object TestUtils {
             }
             configModifier?.accept(it)
         }
-    }
-
-    @Throws(IllegalAccessException::class)
-    fun disableTypeManagerCleanup() {
-        val spy = Mockito.spy(TypeManager.getInstance())
-        Mockito.doNothing().`when`(spy).cleanup()
-        FieldUtils.writeStaticField(TypeManager::class.java, "instance", spy, true)
     }
 
     /**

--- a/cpg-core/src/testFixtures/kotlin/de/fraunhofer/aisec/cpg/frontends/TestLanguage.kt
+++ b/cpg-core/src/testFixtures/kotlin/de/fraunhofer/aisec/cpg/frontends/TestLanguage.kt
@@ -25,9 +25,9 @@
  */
 package de.fraunhofer.aisec.cpg.frontends
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.*
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.TypeManager
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.ProblemExpression
 import de.fraunhofer.aisec.cpg.graph.types.FloatingPointType
@@ -45,7 +45,7 @@ import kotlin.reflect.KClass
  */
 open class TestLanguage(namespaceDelimiter: String = "::") : Language<TestLanguageFrontend>() {
     override val fileExtensions: List<String> = listOf()
-    override val namespaceDelimiter: String
+    final override val namespaceDelimiter: String
     override val frontend: KClass<out TestLanguageFrontend> = TestLanguageFrontend::class
     override val compoundAssignmentOperators =
         setOf("+=", "-=", "*=", "/=", "%=", "<<=", ">>=", "&=", "|=", "^=")
@@ -66,11 +66,8 @@ open class TestLanguage(namespaceDelimiter: String = "::") : Language<TestLangua
         this.namespaceDelimiter = namespaceDelimiter
     }
 
-    override fun newFrontend(
-        config: TranslationConfiguration,
-        scopeManager: ScopeManager,
-    ): TestLanguageFrontend {
-        return TestLanguageFrontend()
+    override fun newFrontend(ctx: TranslationContext): TestLanguageFrontend {
+        return TestLanguageFrontend(language = this, ctx = ctx)
     }
 }
 
@@ -78,15 +75,15 @@ class StructTestLanguage(namespaceDelimiter: String = "::") :
     TestLanguage(namespaceDelimiter), HasStructs, HasClasses, HasDefaultArguments
 
 open class TestLanguageFrontend(
-    scopeManager: ScopeManager = ScopeManager(),
     namespaceDelimiter: String = "::",
-    language: Language<out LanguageFrontend> = TestLanguage(namespaceDelimiter)
-) :
-    LanguageFrontend(
-        language,
-        TranslationConfiguration.builder().build(),
-        scopeManager,
-    ) {
+    language: Language<out LanguageFrontend> = TestLanguage(namespaceDelimiter),
+    ctx: TranslationContext =
+        TranslationContext(
+            TranslationConfiguration.builder().build(),
+            ScopeManager(),
+            TypeManager()
+        ),
+) : LanguageFrontend(language, ctx) {
     override fun parse(file: File): TranslationUnitDeclaration {
         TODO("Not yet implemented")
     }
@@ -104,8 +101,5 @@ open class TestLanguageFrontend(
     }
 }
 
-class TestHandler :
-    Handler<Node, Any, TestLanguageFrontend>(
-        Supplier { ProblemExpression() },
-        TestLanguageFrontend()
-    )
+class TestHandler(frontend: TestLanguageFrontend) :
+    Handler<Node, Any, TestLanguageFrontend>(Supplier { ProblemExpression() }, frontend)

--- a/cpg-language-go/src/main/golang/frontend/frontend.go
+++ b/cpg-language-go/src/main/golang/frontend/frontend.go
@@ -133,6 +133,16 @@ func (g *GoLanguageFrontend) GetLanguage() (l *cpg.Language, err error) {
 	return
 }
 
+func (g *GoLanguageFrontend) GetCtx() (ctx *cpg.TranslationContext) {
+	ctx = new(cpg.TranslationContext)
+	err := g.ObjectRef.CallMethod(env, "getCtx", ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	return
+}
+
 func updateCode(fset *token.FileSet, node *cpg.Node, astNode ast.Node) {
 	node.SetCode(code(fset, astNode))
 }

--- a/cpg-language-go/src/main/golang/frontend/handler.go
+++ b/cpg-language-go/src/main/golang/frontend/handler.go
@@ -1235,22 +1235,22 @@ func (this *GoLanguageFrontend) handleBasicLit(fset *token.FileSet, lit *ast.Bas
 	case token.STRING:
 		// strip the "
 		value = cpg.NewString(lit.Value[1 : len(lit.Value)-1])
-		t = cpg.TypeParser_createFrom("string", lang)
+		t = cpg.TypeParser_createFrom("string", lang, this.GetCtx())
 	case token.INT:
 		i, _ := strconv.ParseInt(lit.Value, 10, 64)
 		value = cpg.NewInteger(int(i))
-		t = cpg.TypeParser_createFrom("int", lang)
+		t = cpg.TypeParser_createFrom("int", lang, this.GetCtx())
 	case token.FLOAT:
 		// default seems to be float64
 		f, _ := strconv.ParseFloat(lit.Value, 64)
 		value = cpg.NewDouble(f)
-		t = cpg.TypeParser_createFrom("float64", lang)
+		t = cpg.TypeParser_createFrom("float64", lang, this.GetCtx())
 	case token.IMAG:
 		// TODO
 		t = &cpg.UnknownType_getUnknown(lang).Type
 	case token.CHAR:
 		value = cpg.NewString(lit.Value)
-		t = cpg.TypeParser_createFrom("rune", lang)
+		t = cpg.TypeParser_createFrom("rune", lang, this.GetCtx())
 		break
 	}
 
@@ -1384,12 +1384,12 @@ func (this *GoLanguageFrontend) handleType(fset *token.FileSet, typeExpr ast.Exp
 			this.LogTrace("fqn type: %s", name)
 		}
 
-		return cpg.TypeParser_createFrom(name, lang)
+		return cpg.TypeParser_createFrom(name, lang, this.GetCtx())
 	case *ast.SelectorExpr:
 		// small shortcut
 		fqn := fmt.Sprintf("%s.%s", v.X.(*ast.Ident).Name, v.Sel.Name)
 		this.LogTrace("FQN type: %s", fqn)
-		return cpg.TypeParser_createFrom(fqn, lang)
+		return cpg.TypeParser_createFrom(fqn, lang, this.GetCtx())
 	case *ast.StarExpr:
 		t := this.handleType(fset, v.X)
 
@@ -1417,7 +1417,7 @@ func (this *GoLanguageFrontend) handleType(fset *token.FileSet, typeExpr ast.Exp
 	case *ast.MapType:
 		// we cannot properly represent Golangs built-in map types, yet so we have
 		// to make a shortcut here and represent it as a Java-like map<K, V> type.
-		t := cpg.TypeParser_createFrom("map", lang)
+		t := cpg.TypeParser_createFrom("map", lang, this.GetCtx())
 		keyType := this.handleType(fset, v.Key)
 		valueType := this.handleType(fset, v.Value)
 
@@ -1428,7 +1428,7 @@ func (this *GoLanguageFrontend) handleType(fset *token.FileSet, typeExpr ast.Exp
 		return t
 	case *ast.ChanType:
 		// handle them similar to maps
-		t := cpg.TypeParser_createFrom("chan", lang)
+		t := cpg.TypeParser_createFrom("chan", lang, this.GetCtx())
 		chanType := this.handleType(fset, v.Value)
 
 		(*cpg.ObjectType)(t).AddGeneric(chanType)
@@ -1484,7 +1484,7 @@ func (this *GoLanguageFrontend) handleType(fset *token.FileSet, typeExpr ast.Exp
 
 		name += "}"
 
-		return cpg.TypeParser_createFrom(name, lang)
+		return cpg.TypeParser_createFrom(name, lang, this.GetCtx())
 	case *ast.IndexExpr:
 		// This is a type with one type parameter. First we need to parse the "X" expression as a type
 		var t = this.handleType(fset, v.X)

--- a/cpg-language-go/src/main/golang/language.go
+++ b/cpg-language-go/src/main/golang/language.go
@@ -31,6 +31,8 @@ import (
 
 type Language Node
 
+const TranslationContextClass = CPGPackage + "/TranslationContext"
+
 const FrontendsPackage = CPGPackage + "/frontends"
 const GolangPackage = FrontendsPackage + "/golang"
 const LanguageClass = FrontendsPackage + "/Language"
@@ -51,5 +53,22 @@ func (l *Language) GetClassName() string {
 }
 
 func (l *Language) IsArray() bool {
+	return false
+}
+
+func (ctx *TranslationContext) ConvertToGo(o *jnigi.ObjectRef) error {
+	*ctx = (TranslationContext)(*o)
+	return nil
+}
+
+func (ctx *TranslationContext) ConvertToJava() (obj *jnigi.ObjectRef, err error) {
+	return (*jnigi.ObjectRef)(ctx), nil
+}
+
+func (*TranslationContext) GetClassName() string {
+	return TranslationContextClass
+}
+
+func (*TranslationContext) IsArray() bool {
 	return false
 }

--- a/cpg-language-go/src/main/golang/types.go
+++ b/cpg-language-go/src/main/golang/types.go
@@ -39,6 +39,8 @@ var env *jnigi.Env
 type Type struct{ *jnigi.ObjectRef }
 type ObjectType Type
 
+type TranslationContext jnigi.ObjectRef
+
 const TypesPackage = GraphPackage + "/types"
 const TypeClass = TypesPackage + "/Type"
 const ObjectTypeClass = TypesPackage + "/ObjectType"
@@ -83,9 +85,9 @@ func InitEnv(e *jnigi.Env) {
 	env = e
 }
 
-func TypeParser_createFrom(s string, l *Language) *Type {
+func TypeParser_createFrom(s string, l *Language, ctx *TranslationContext) *Type {
 	var t Type
-	err := env.CallStaticMethod(TypeParserClass, "createFrom", &t, NewCharSequence(s), l)
+	err := env.CallStaticMethod(TypeParserClass, "createFrom", &t, NewString(s), l, false, ctx)
 	if err != nil {
 		log.Fatal(err)
 

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguage.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguage.kt
@@ -25,8 +25,6 @@
  */
 package de.fraunhofer.aisec.cpg.frontends.golang
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.frontends.HasGenerics
 import de.fraunhofer.aisec.cpg.frontends.HasShortCircuitOperators
 import de.fraunhofer.aisec.cpg.frontends.HasStructs
@@ -110,11 +108,4 @@ class GoLanguage :
             // https://pkg.go.dev/builtin#string
             "string" to StringType("string", this)
         )
-
-    override fun newFrontend(
-        config: TranslationConfiguration,
-        scopeManager: ScopeManager,
-    ): GoLanguageFrontend {
-        return GoLanguageFrontend(this, config, scopeManager)
-    }
 }

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontend.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontend.kt
@@ -25,8 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.frontends.golang
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.frontends.SupportsParallelParsing
@@ -40,11 +39,8 @@ import java.io.FileOutputStream
 
 @SupportsParallelParsing(false)
 @RegisterExtraPass(GoExtraPass::class)
-class GoLanguageFrontend(
-    language: Language<GoLanguageFrontend>,
-    config: TranslationConfiguration,
-    scopeManager: ScopeManager,
-) : LanguageFrontend(language, config, scopeManager) {
+class GoLanguageFrontend(language: Language<GoLanguageFrontend>, ctx: TranslationContext) :
+    LanguageFrontend(language, ctx) {
     companion object {
 
         init {

--- a/cpg-language-go/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
+++ b/cpg-language-go/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
@@ -38,7 +38,6 @@ import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.FunctionType
-import de.fraunhofer.aisec.cpg.graph.types.TypeParser
 import java.nio.file.Path
 import kotlin.test.*
 
@@ -129,7 +128,7 @@ class GoLanguageFrontendTest : BaseTest() {
         assertNotNull(decl)
 
         val new = assertIs<NewExpression>(decl.firstAssignment)
-        assertEquals(TypeParser.createFrom("p.MyStruct*", GoLanguage()), new.type)
+        assertEquals(tu.parseType("p.MyStruct*"), new.type)
 
         val construct = new.initializer as? ConstructExpression
         assertNotNull(construct)
@@ -142,7 +141,7 @@ class GoLanguageFrontendTest : BaseTest() {
 
         var make = assertIs<Expression>(decl.firstAssignment)
         assertNotNull(make)
-        assertEquals(TypeParser.createFrom("int[]", GoLanguage()), make.type)
+        assertEquals(tu.parseType("int[]"), make.type)
 
         assertTrue(make is ArrayCreationExpression)
 
@@ -160,7 +159,7 @@ class GoLanguageFrontendTest : BaseTest() {
         assertTrue(make is ConstructExpression)
         // TODO: Maps can have dedicated types and parsing them as a generic here is only a
         //  temporary solution. This should be fixed in the future.
-        assertEquals(TypeParser.createFrom("map[string,string]", GoLanguage()), make.type)
+        assertEquals(tu.parseType("map[string,string]"), make.type)
 
         // make channel
 
@@ -170,7 +169,7 @@ class GoLanguageFrontendTest : BaseTest() {
         make = assertIs(decl.firstAssignment)
         assertNotNull(make)
         assertTrue(make is ConstructExpression)
-        assertEquals(TypeParser.createFrom("chan[int]", GoLanguage()), make.type)
+        assertEquals(tu.parseType("chan[int]"), make.type)
     }
 
     @Test
@@ -191,26 +190,26 @@ class GoLanguageFrontendTest : BaseTest() {
         assertNotNull(a.location)
 
         assertLocalName("a", a)
-        assertEquals(TypeParser.createFrom("int", GoLanguage()), a.type)
+        assertEquals(tu.parseType("int"), a.type)
 
         val s = p.variables["s"]
         assertNotNull(s)
         assertLocalName("s", s)
-        assertEquals(TypeParser.createFrom("string", GoLanguage()), s.type)
+        assertEquals(tu.parseType("string"), s.type)
 
         val f = p.variables["f"]
         assertNotNull(f)
         assertLocalName("f", f)
-        assertEquals(TypeParser.createFrom("float64", GoLanguage()), f.type)
+        assertEquals(tu.parseType("float64"), f.type)
 
         val f32 = p.variables["f32"]
         assertNotNull(f32)
         assertLocalName("f32", f32)
-        assertEquals(TypeParser.createFrom("float32", GoLanguage()), f32.type)
+        assertEquals(tu.parseType("float32"), f32.type)
 
         val n = p.variables["n"]
         assertNotNull(n)
-        assertEquals(TypeParser.createFrom("int*", GoLanguage()), n.type)
+        assertEquals(tu.parseType("int*"), n.type)
 
         val nil = n.initializer as? Literal<*>
         assertNotNull(nil)
@@ -276,7 +275,7 @@ class GoLanguageFrontendTest : BaseTest() {
         val s = myTest.parameters.first()
         assertNotNull(s)
         assertLocalName("s", s)
-        assertEquals(TypeParser.createFrom("string", GoLanguage()), s.type)
+        assertEquals(tu.parseType("string"), s.type)
 
         assertLocalName("myTest", myTest)
 
@@ -293,7 +292,7 @@ class GoLanguageFrontendTest : BaseTest() {
         assertNotNull(literal)
 
         assertEquals("%s", literal.value)
-        assertEquals(TypeParser.createFrom("string", GoLanguage()), literal.type)
+        assertEquals(tu.parseType("string"), literal.type)
 
         val ref = callExpression.arguments[1] as? DeclaredReferenceExpression
         assertNotNull(ref)
@@ -360,7 +359,7 @@ class GoLanguageFrontendTest : BaseTest() {
         val myField = fields.first()
 
         assertLocalName("MyField", myField)
-        assertEquals(TypeParser.createFrom("int", GoLanguage()), myField.type)
+        assertEquals(tu.parseType("int"), myField.type)
 
         val myInterface =
             p.getDeclarationsByName("p.MyInterface", RecordDeclaration::class.java)
@@ -461,7 +460,7 @@ class GoLanguageFrontendTest : BaseTest() {
         assertNotNull(lhs)
         assertEquals(myFunc.receiver, (lhs.base as? DeclaredReferenceExpression)?.refersTo)
         assertLocalName("Field", lhs)
-        assertEquals(TypeParser.createFrom("int", GoLanguage()), lhs.type)
+        assertEquals(tu.parseType("int"), lhs.type)
 
         val rhs = assign.rhs.firstOrNull() as? DeclaredReferenceExpression
         assertNotNull(rhs)
@@ -489,7 +488,7 @@ class GoLanguageFrontendTest : BaseTest() {
 
         assertNotNull(b)
         assertLocalName("b", b)
-        assertEquals(TypeParser.createFrom("bool", GoLanguage()), b.type)
+        assertEquals(tu.parseType("bool"), b.type)
 
         // true, false are builtin variables, NOT literals in Golang
         // we might need to parse this special case differently
@@ -588,7 +587,7 @@ class GoLanguageFrontendTest : BaseTest() {
 
         assertNotNull(c)
         // type will be inferred from the function declaration
-        assertEquals(TypeParser.createFrom("p.MyStruct*", GoLanguage()), c.type)
+        assertEquals(tu.parseType("p.MyStruct*"), c.type)
 
         val newMyStruct = assertIs<CallExpression>(c.firstAssignment)
 

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.kt
@@ -125,11 +125,10 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
         )
         for (parameter in methodDecl.parameters) {
             var resolvedType: Type? =
-                TypeManager.getInstance()
-                    .getTypeParameter(
-                        functionDeclaration.recordDeclaration,
-                        parameter.type.toString()
-                    )
+                frontend.typeManager.getTypeParameter(
+                    functionDeclaration.recordDeclaration,
+                    parameter.type.toString()
+                )
             if (resolvedType == null) {
                 resolvedType = frontend.getTypeAsGoodAsPossible(parameter, parameter.resolve())
             }
@@ -196,11 +195,10 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
         recordDeclaration.implementedInterfaces =
             classInterDecl.implementedTypes.map { type -> frontend.getTypeAsGoodAsPossible(type) }
 
-        TypeManager.getInstance()
-            .addTypeParameter(
-                recordDeclaration,
-                classInterDecl.typeParameters.map { ParameterizedType(it.nameAsString, language) }
-            )
+        frontend.typeManager.addTypeParameter(
+            recordDeclaration,
+            classInterDecl.typeParameters.map { ParameterizedType(it.nameAsString, language) }
+        )
 
         // TODO: I cannot replicate the old partionedBy logic
         val staticImports =
@@ -334,11 +332,10 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
         try {
             // Resolve type first with ParameterizedType
             type =
-                TypeManager.getInstance()
-                    .getTypeParameter(
-                        frontend.scopeManager.currentRecord,
-                        variable.resolve().type.describe()
-                    )
+                frontend.typeManager.getTypeParameter(
+                    frontend.scopeManager.currentRecord,
+                    variable.resolve().type.describe()
+                )
                     ?: this.parseType(joinedModifiers + variable.resolve().type.describe())
         } catch (e: UnsolvedSymbolException) {
             val t = frontend.recoverTypeFromUnsolvedException(e)

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
@@ -379,11 +379,10 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
         try {
             val symbol = fieldAccessExpr.resolve()
             fieldType =
-                TypeManager.getInstance()
-                    .getTypeParameter(
-                        frontend.scopeManager.currentRecord,
-                        symbol.asField().type.describe()
-                    )
+                frontend.typeManager.getTypeParameter(
+                    frontend.scopeManager.currentRecord,
+                    symbol.asField().type.describe()
+                )
             if (fieldType == null) {
                 fieldType = this.parseType(symbol.asField().type.describe())
             }
@@ -583,11 +582,10 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
             } else {
                 // Resolve type first with ParameterizedType
                 var type: Type? =
-                    TypeManager.getInstance()
-                        .getTypeParameter(
-                            frontend.scopeManager.currentRecord,
-                            symbol.type.describe()
-                        )
+                    frontend.typeManager.getTypeParameter(
+                        frontend.scopeManager.currentRecord,
+                        symbol.type.describe()
+                    )
                 if (type == null) {
                     type = this.parseType(symbol.type.describe())
                 }
@@ -850,7 +848,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
 
             frontend.scopeManager.enterScope(anonymousRecord)
 
-            anonymousRecord.addSuperClass(TypeParser.createFrom(constructorName, language))
+            anonymousRecord.addSuperClass(parseType(constructorName))
             val anonymousClassBody = objectCreationExpr.anonymousClassBody.get()
             for (classBody in anonymousClassBody) {
                 // Whatever is implemented in the anonymous class has to be added to the record

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguage.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguage.kt
@@ -27,7 +27,6 @@ package de.fraunhofer.aisec.cpg.frontends.java
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.frontends.*
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
@@ -105,13 +104,6 @@ open class JavaLanguage :
         ) {
             getSimpleTypeOf("int") ?: UnknownType.getUnknownType(this)
         } else super.propagateTypeOfBinaryOperation(operation)
-    }
-
-    override fun newFrontend(
-        config: TranslationConfiguration,
-        scopeManager: ScopeManager,
-    ): JavaLanguageFrontend {
-        return JavaLanguageFrontend(this, config, scopeManager)
     }
 
     override fun handleSuperCall(

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
@@ -45,8 +45,7 @@ import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade
 import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver
 import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.frontends.TranslationException
@@ -71,11 +70,8 @@ import java.util.function.Consumer
 @RegisterExtraPass(
     JavaExternalTypeHierarchyResolver::class
 ) // this pass is always required for Java
-open class JavaLanguageFrontend(
-    language: Language<JavaLanguageFrontend>,
-    config: TranslationConfiguration,
-    scopeManager: ScopeManager,
-) : LanguageFrontend(language, config, scopeManager) {
+open class JavaLanguageFrontend(language: Language<JavaLanguageFrontend>, ctx: TranslationContext) :
+    LanguageFrontend(language, ctx) {
 
     var context: CompilationUnit? = null
     var javaSymbolResolver: JavaSymbolSolver?
@@ -351,8 +347,10 @@ open class JavaLanguageFrontend(
         return try {
             // Resolve type first with ParameterizedType
             var type: de.fraunhofer.aisec.cpg.graph.types.Type? =
-                TypeManager.getInstance()
-                    .getTypeParameter(scopeManager.currentRecord, resolved.returnType.describe())
+                typeManager.getTypeParameter(
+                    scopeManager.currentRecord,
+                    resolved.returnType.describe()
+                )
             if (type == null) {
                 type = parseType(resolved.returnType.describe())
             }

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaCallResolverHelper.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaCallResolverHelper.kt
@@ -30,10 +30,10 @@ import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguage
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
+import de.fraunhofer.aisec.cpg.graph.parseType
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.DeclaredReferenceExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberCallExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberExpression
-import de.fraunhofer.aisec.cpg.graph.types.TypeParser
 import de.fraunhofer.aisec.cpg.helpers.Util
 import de.fraunhofer.aisec.cpg.passes.CallResolver.Companion.LOGGER
 
@@ -111,9 +111,7 @@ class JavaCallResolverHelper {
         ): RecordDeclaration? {
             val baseName = callee.base.name.parent ?: return null
 
-            if (
-                TypeParser.createFrom(baseName, curClass.language) in curClass.implementedInterfaces
-            ) {
+            if (curClass.parseType(baseName) in curClass.implementedInterfaces) {
                 // Basename is an interface -> BaseName.super refers to BaseName itself
                 return recordMap[baseName]
             } else {

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.kt
@@ -27,7 +27,6 @@ package de.fraunhofer.aisec.cpg.frontends.java
 
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration
 import de.fraunhofer.aisec.cpg.*
-import de.fraunhofer.aisec.cpg.ScopeManager
 import de.fraunhofer.aisec.cpg.TestUtils.analyzeAndGetFirstTU
 import de.fraunhofer.aisec.cpg.TestUtils.analyzeWithBuilder
 import de.fraunhofer.aisec.cpg.TestUtils.findByUniqueName
@@ -38,7 +37,6 @@ import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.FunctionType
-import de.fraunhofer.aisec.cpg.graph.types.TypeParser
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.sarif.Region
 import java.io.File
@@ -144,7 +142,7 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val sDecl = s.singleDeclaration as? VariableDeclaration
         assertNotNull(sDecl)
         assertLocalName("s", sDecl)
-        assertEquals(createTypeFrom("java.lang.String"), sDecl.type)
+        assertEquals(tu.parseType("java.lang.String"), sDecl.type)
 
         // should contain a single statement
         val sce = forEachStatement.statement as? MemberCallExpression
@@ -191,11 +189,11 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         assertNotNull(scope)
 
         // first exception type was? resolved, so we can expect a FQN
-        assertEquals(createTypeFrom("java.lang.NumberFormatException"), firstCatch.parameter?.type)
+        assertEquals(tu.parseType("java.lang.NumberFormatException"), firstCatch.parameter?.type)
         // second one could not be resolved so we do not have an FQN
-        assertEquals(createTypeFrom("NotResolvableTypeException"), catchClauses[1].parameter?.type)
+        assertEquals(tu.parseType("NotResolvableTypeException"), catchClauses[1].parameter?.type)
         // third type should have been resolved through the import
-        assertEquals(createTypeFrom("some.ImportedException"), (catchClauses[2].parameter)?.type)
+        assertEquals(tu.parseType("some.ImportedException"), (catchClauses[2].parameter)?.type)
 
         // and 1 finally
         val finallyBlock = tryStatement.finallyBlock
@@ -285,14 +283,14 @@ internal class JavaLanguageFrontendTest : BaseTest() {
     @Test
     fun testRecordDeclaration() {
         val file = File("src/test/resources/compiling/RecordDeclaration.java")
-        val declaration =
+        val tu =
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
             }
         // TODO: Use GraphExamples here as well.
-        assertNotNull(declaration)
+        assertNotNull(tu)
 
-        val namespaceDeclaration = declaration.getDeclarationAs(0, NamespaceDeclaration::class.java)
+        val namespaceDeclaration = tu.getDeclarationAs(0, NamespaceDeclaration::class.java)
 
         val recordDeclaration =
             namespaceDeclaration?.getDeclarationAs(0, RecordDeclaration::class.java)
@@ -305,7 +303,7 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         assertNotNull(method)
         assertEquals(recordDeclaration, method.recordDeclaration)
         assertLocalName("method", method)
-        assertEquals(createTypeFrom("java.lang.Integer"), method.returnTypes.firstOrNull())
+        assertEquals(tu.parseType("java.lang.Integer"), method.returnTypes.firstOrNull())
 
         val functionType = method.type as? FunctionType
         assertNotNull(functionType)
@@ -427,7 +425,7 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         assertNotNull(a)
 
         // type should be Integer[]
-        assertEquals(createTypeFrom("int[]"), a.type)
+        assertEquals(tu.parseType("int[]"), a.type)
 
         // it has an array creation initializer
         val ace = a.initializer as? ArrayCreationExpression
@@ -635,17 +633,14 @@ internal class JavaLanguageFrontendTest : BaseTest() {
             (lhs?.base as? DeclaredReferenceExpression)?.refersTo as? VariableDeclaration?
         assertNotNull(receiver)
         assertLocalName("this", receiver)
-        assertEquals(createTypeFrom("my.Animal"), receiver.type)
+        assertEquals(tu.parseType("my.Animal"), receiver.type)
     }
 
     @Test
     fun testOverrideHandler() {
         /** A simple extension of the [JavaLanguageFrontend] to demonstrate handler overriding. */
-        class MyJavaLanguageFrontend(
-            language: JavaLanguage,
-            config: TranslationConfiguration,
-            scopeManager: ScopeManager,
-        ) : JavaLanguageFrontend(language, config, scopeManager) {
+        class MyJavaLanguageFrontend(language: JavaLanguage, ctx: TranslationContext) :
+            JavaLanguageFrontend(language, ctx) {
             init {
                 this.declarationHandler =
                     object : DeclarationHandler(this@MyJavaLanguageFrontend) {
@@ -673,13 +668,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
             override val namespaceDelimiter = "."
             override val superClassKeyword = "super"
             override val frontend = MyJavaLanguageFrontend::class
-
-            override fun newFrontend(
-                config: TranslationConfiguration,
-                scopeManager: ScopeManager,
-            ): MyJavaLanguageFrontend {
-                return MyJavaLanguageFrontend(this, config, scopeManager)
-            }
         }
 
         val file = File("src/test/resources/compiling/RecordDeclaration.java")
@@ -785,8 +773,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         assertNotNull(ref)
         assertSame(ref, thisOuterClass)
     }
-
-    private fun createTypeFrom(typename: String) = TypeParser.createFrom(typename, JavaLanguage())
 
     @Test
     fun testForEach() {

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypeTests.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypeTests.kt
@@ -25,14 +25,12 @@
  */
 package de.fraunhofer.aisec.cpg.graph.types
 
-import de.fraunhofer.aisec.cpg.BaseTest
+import de.fraunhofer.aisec.cpg.*
 import de.fraunhofer.aisec.cpg.TestUtils.analyze
-import de.fraunhofer.aisec.cpg.TestUtils.disableTypeManagerCleanup
 import de.fraunhofer.aisec.cpg.TestUtils.findByName
 import de.fraunhofer.aisec.cpg.TestUtils.findByUniqueName
-import de.fraunhofer.aisec.cpg.TranslationResult
-import de.fraunhofer.aisec.cpg.assertLocalName
 import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguage
+import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.*
 import java.nio.file.Path
 import java.util.*
@@ -45,78 +43,89 @@ internal class TypeTests : BaseTest() {
         var result: Type
         var expected: Type
 
-        // Test 1: Ignore Access Modifier Keyword (public, private, protected)
-        var typeString = "private int a"
-        result = TypeParser.createFrom(typeString, JavaLanguage())
-        expected = IntegerType("int", 32, JavaLanguage(), NumericType.Modifier.SIGNED)
-        assertEquals(expected, result)
-
-        // Test 2: constant type using final
-        typeString = "final int a"
-        result = TypeParser.createFrom(typeString, JavaLanguage())
-        expected = IntegerType("int", 32, JavaLanguage(), NumericType.Modifier.SIGNED)
-        assertEquals(expected, result)
-
-        // Test 3: static type
-        typeString = "static int a"
-        result = TypeParser.createFrom(typeString, JavaLanguage())
-        expected = IntegerType("int", 32, JavaLanguage(), NumericType.Modifier.SIGNED)
-        assertEquals(expected, result)
-
-        // Test 4: volatile type
-        typeString = "public volatile int a"
-        result = TypeParser.createFrom(typeString, JavaLanguage())
-        expected = IntegerType("int", 32, JavaLanguage(), NumericType.Modifier.SIGNED)
-        assertEquals(expected, result)
-
-        // Test 5: combining a storage type and a qualifier
-        typeString = "private static final String a"
-        result = TypeParser.createFrom(typeString, JavaLanguage())
-        expected = StringType("java.lang.String", JavaLanguage())
-        assertEquals(expected, result)
-
-        // Test 6: using two different qualifiers
-        typeString = "public final volatile int a"
-        result = TypeParser.createFrom(typeString, JavaLanguage())
-        expected = IntegerType("int", 32, JavaLanguage(), NumericType.Modifier.SIGNED)
-        assertEquals(expected, result)
-
-        // Test 7: Reference level using arrays
-        typeString = "int[] a"
-        result = TypeParser.createFrom(typeString, JavaLanguage())
-        expected =
-            PointerType(
-                IntegerType("int", 32, JavaLanguage(), NumericType.Modifier.SIGNED),
-                PointerType.PointerOrigin.ARRAY
+        with(
+            JavaLanguageFrontend(
+                JavaLanguage(),
+                TranslationContext(
+                    TranslationConfiguration.builder().build(),
+                    ScopeManager(),
+                    TypeManager()
+                )
             )
-        assertEquals(expected, result)
+        ) {
+            // Test 1: Ignore Access Modifier Keyword (public, private, protected)
+            var typeString = "private int a"
+            result = parseType(typeString)
+            expected = IntegerType("int", 32, JavaLanguage(), NumericType.Modifier.SIGNED)
+            assertEquals(expected, result)
 
-        // Test 8: generics
-        typeString = "List<String> list"
-        result = TypeParser.createFrom(typeString, JavaLanguage())
-        var generics = mutableListOf<Type>()
-        generics.add(StringType("java.lang.String", JavaLanguage()))
-        expected = ObjectType("List", generics, false, JavaLanguage())
-        assertEquals(expected, result)
+            // Test 2: constant type using final
+            typeString = "final int a"
+            result = parseType(typeString)
+            expected = IntegerType("int", 32, JavaLanguage(), NumericType.Modifier.SIGNED)
+            assertEquals(expected, result)
 
-        // Test 9: more generics
-        typeString = "List<List<List<String>>, List<String>> data"
-        result = TypeParser.createFrom(typeString, JavaLanguage())
-        val genericStringType = StringType("java.lang.String", JavaLanguage())
-        val generics3: MutableList<Type> = ArrayList()
-        generics3.add(genericStringType)
-        val genericElement3 = ObjectType("List", generics3, false, JavaLanguage())
-        val generics2a: MutableList<Type> = ArrayList()
-        generics2a.add(genericElement3)
-        val generics2b: MutableList<Type> = ArrayList()
-        generics2b.add(genericStringType)
-        val genericElement1 = ObjectType("List", generics2a, false, JavaLanguage())
-        val genericElement2 = ObjectType("List", generics2b, false, JavaLanguage())
-        generics = ArrayList()
-        generics.add(genericElement1)
-        generics.add(genericElement2)
-        expected = ObjectType("List", generics, false, JavaLanguage())
-        assertEquals(expected, result)
+            // Test 3: static type
+            typeString = "static int a"
+            result = parseType(typeString)
+            expected = IntegerType("int", 32, JavaLanguage(), NumericType.Modifier.SIGNED)
+            assertEquals(expected, result)
+
+            // Test 4: volatile type
+            typeString = "public volatile int a"
+            result = parseType(typeString)
+            expected = IntegerType("int", 32, JavaLanguage(), NumericType.Modifier.SIGNED)
+            assertEquals(expected, result)
+
+            // Test 5: combining a storage type and a qualifier
+            typeString = "private static final String a"
+            result = parseType(typeString)
+            expected = StringType("java.lang.String", JavaLanguage())
+            assertEquals(expected, result)
+
+            // Test 6: using two different qualifiers
+            typeString = "public final volatile int a"
+            result = parseType(typeString)
+            expected = IntegerType("int", 32, JavaLanguage(), NumericType.Modifier.SIGNED)
+            assertEquals(expected, result)
+
+            // Test 7: Reference level using arrays
+            typeString = "int[] a"
+            result = parseType(typeString)
+            expected =
+                PointerType(
+                    IntegerType("int", 32, JavaLanguage(), NumericType.Modifier.SIGNED),
+                    PointerType.PointerOrigin.ARRAY
+                )
+            assertEquals(expected, result)
+
+            // Test 8: generics
+            typeString = "List<String> list"
+            result = parseType(typeString)
+            var generics = mutableListOf<Type>()
+            generics.add(StringType("java.lang.String", JavaLanguage()))
+            expected = ObjectType("List", generics, false, JavaLanguage())
+            assertEquals(expected, result)
+
+            // Test 9: more generics
+            typeString = "List<List<List<String>>, List<String>> data"
+            result = parseType(typeString)
+            val genericStringType = StringType("java.lang.String", JavaLanguage())
+            val generics3: MutableList<Type> = ArrayList()
+            generics3.add(genericStringType)
+            val genericElement3 = ObjectType("List", generics3, false, JavaLanguage())
+            val generics2a: MutableList<Type> = ArrayList()
+            generics2a.add(genericElement3)
+            val generics2b: MutableList<Type> = ArrayList()
+            generics2b.add(genericStringType)
+            val genericElement1 = ObjectType("List", generics2a, false, JavaLanguage())
+            val genericElement2 = ObjectType("List", generics2b, false, JavaLanguage())
+            generics = ArrayList()
+            generics.add(genericElement1)
+            generics.add(genericElement2)
+            expected = ObjectType("List", generics, false, JavaLanguage())
+            assertEquals(expected, result)
+        }
     }
 
     // Tests on the resulting graph
@@ -127,12 +136,17 @@ internal class TypeTests : BaseTest() {
         val result = analyze("java", topLevel, true) { it.registerLanguage(JavaLanguage()) }
 
         // Check Parameterized
+        val recordDeclarations = result.records
+        val recordDeclarationBox = findByUniqueName(recordDeclarations, "Box")
+        val typeT = result.finalCtx.typeManager.getTypeParameter(recordDeclarationBox, "T")
+        assertNotNull(typeT)
+        assertIs<ParameterizedType>(typeT)
+        assertLocalName("T", typeT)
+        assertEquals(typeT, result.finalCtx.typeManager.getTypeParameter(recordDeclarationBox, "T"))
+
         // Type of field t
         val fieldDeclarations = result.fields
         val fieldDeclarationT = findByUniqueName(fieldDeclarations, "t")
-        val typeT = fieldDeclarationT.type
-        assertIs<ParameterizedType>(typeT)
-        assertLocalName("T", typeT)
         assertTrue(fieldDeclarationT.possibleSubTypes.contains(typeT))
 
         // Parameter of set Method
@@ -198,16 +212,34 @@ internal class TypeTests : BaseTest() {
     @Throws(Exception::class)
     @Test
     fun testCommonTypeTestJava() {
-        disableTypeManagerCleanup()
-        val topLevel = Path.of("src", "test", "resources", "compiling", "hierarchy")
-        val result = analyze("java", topLevel, true) { it.registerLanguage(JavaLanguage()) }
-        val root = TypeParser.createFrom("multistep.Root", JavaLanguage())
-        val level0 = TypeParser.createFrom("multistep.Level0", JavaLanguage())
-        val level1 = TypeParser.createFrom("multistep.Level1", JavaLanguage())
-        val level1b = TypeParser.createFrom("multistep.Level1B", JavaLanguage())
-        val level2 = TypeParser.createFrom("multistep.Level2", JavaLanguage())
-        val unrelated = TypeParser.createFrom("multistep.Unrelated", JavaLanguage())
-        getCommonTypeTestGeneral(root, level0, level1, level1b, level2, unrelated, result)
+        with(
+            JavaLanguageFrontend(
+                JavaLanguage(),
+                TranslationContext(
+                    TranslationConfiguration.builder().build(),
+                    ScopeManager(),
+                    TypeManager()
+                )
+            )
+        ) {
+            val topLevel = Path.of("src", "test", "resources", "compiling", "hierarchy")
+            val result = analyze("java", topLevel, true) { it.registerLanguage(JavaLanguage()) }
+            val root = parseType("multistep.Root")
+            val level0 = parseType("multistep.Level0")
+            val level1 = parseType("multistep.Level1")
+            val level1b = parseType("multistep.Level1B")
+            val level2 = parseType("multistep.Level2")
+            val unrelated = parseType("multistep.Unrelated")
+            getCommonTypeTestGeneral(
+                root,
+                level0,
+                level1,
+                level1b,
+                level2,
+                unrelated,
+                result.finalCtx
+            )
+        }
     }
 
     private fun getCommonTypeTestGeneral(
@@ -217,7 +249,7 @@ internal class TypeTests : BaseTest() {
         level1b: Type,
         level2: Type,
         unrelated: Type,
-        result: TranslationResult
+        ctx: TranslationContext
     ) {
         /*
         Type hierarchy:
@@ -229,56 +261,44 @@ internal class TypeTests : BaseTest() {
                |
              Level2
          */
-        val provider = result.scopeManager
+        val provider = ctx.scopeManager
 
         // A single type is its own least common ancestor
         for (t in listOf(root, level0, level1, level1b, level2)) {
-            assertEquals(
-                Optional.of(t),
-                TypeManager.getInstance().getCommonType(listOf(t), provider)
-            )
+            assertEquals(Optional.of(t), ctx.typeManager.getCommonType(listOf(t), ctx))
         }
 
         // Root is the root of all types
         for (t in listOf(level0, level1, level1b, level2)) {
-            assertEquals(
-                Optional.of(root),
-                TypeManager.getInstance().getCommonType(listOf(t, root), provider)
-            )
+            assertEquals(Optional.of(root), ctx.typeManager.getCommonType(listOf(t, root), ctx))
         }
 
         // Level0 is above all types but Root
         for (t in listOf(level1, level1b, level2)) {
-            assertEquals(
-                Optional.of(level0),
-                TypeManager.getInstance().getCommonType(listOf(t, level0), provider)
-            )
+            assertEquals(Optional.of(level0), ctx.typeManager.getCommonType(listOf(t, level0), ctx))
         }
 
         // Level1 and Level1B have Level0 as common ancestor
         assertEquals(
             Optional.of(level0),
-            TypeManager.getInstance().getCommonType(listOf(level1, level1b), provider)
+            ctx.typeManager.getCommonType(listOf(level1, level1b), ctx)
         )
 
         // Level2 and Level1B have Level0 as common ancestor
         assertEquals(
             Optional.of(level0),
-            TypeManager.getInstance().getCommonType(listOf(level2, level1b), provider)
+            ctx.typeManager.getCommonType(listOf(level2, level1b), ctx)
         )
 
         // Level1 and Level2 have Level1 as common ancestor
         assertEquals(
             Optional.of(level1),
-            TypeManager.getInstance().getCommonType(listOf(level1, level2), provider)
+            ctx.typeManager.getCommonType(listOf(level1, level2), ctx)
         )
 
         // Check unrelated type behavior: No common root class
         for (t in listOf(root, level0, level1, level1b, level2)) {
-            assertEquals(
-                Optional.empty(),
-                TypeManager.getInstance().getCommonType(listOf(unrelated, t), provider)
-            )
+            assertEquals(Optional.empty(), ctx.typeManager.getCommonType(listOf(unrelated, t), ctx))
         }
     }
 }

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/CallResolverTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/CallResolverTest.kt
@@ -36,7 +36,6 @@ import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
 import de.fraunhofer.aisec.cpg.graph.types.Type
-import de.fraunhofer.aisec.cpg.graph.types.TypeParser
 import java.nio.file.Path
 import kotlin.test.*
 
@@ -121,9 +120,12 @@ class CallResolverTest : BaseTest() {
     fun testJava() {
         val result =
             TestUtils.analyze("java", topLevel, true) { it.registerLanguage(JavaLanguage()) }
+        val tu = result.translationUnits.firstOrNull()
+        assertNotNull(tu)
+
         val records = result.records
-        val intType = TypeParser.createFrom("int", JavaLanguage())
-        val stringType = TypeParser.createFrom("java.lang.String", JavaLanguage())
+        val intType = tu.parseType("int")
+        val stringType = tu.parseType(("java.lang.String"))
         testMethods(records, intType, stringType)
         testOverriding(records)
         ensureNoUnknownClassDummies(records)

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguage.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguage.kt
@@ -25,8 +25,6 @@
  */
 package de.fraunhofer.aisec.cpg.frontends.llvm
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.types.FloatingPointType
 import de.fraunhofer.aisec.cpg.graph.types.IntegerType
@@ -60,11 +58,4 @@ class LLVMIRLanguage : Language<LLVMIRLanguageFrontend>() {
             "x86_fp80" to FloatingPointType("x86_fp80", 80, this, NumericType.Modifier.SIGNED),
             "ppc_fp128" to FloatingPointType("ppc_fp128", 128, this, NumericType.Modifier.SIGNED),
         )
-
-    override fun newFrontend(
-        config: TranslationConfiguration,
-        scopeManager: ScopeManager,
-    ): LLVMIRLanguageFrontend {
-        return LLVMIRLanguageFrontend(this, config, scopeManager)
-    }
 }

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CompressLLVMPass.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CompressLLVMPass.kt
@@ -25,13 +25,9 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.llvm.LLVMIRLanguageFrontend
-import de.fraunhofer.aisec.cpg.graph.Component
-import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.newDeclaredReferenceExpression
-import de.fraunhofer.aisec.cpg.graph.newVariableDeclaration
+import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.ProblemExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.UnaryOperator
@@ -43,8 +39,7 @@ import java.util.*
 
 @ExecuteFirst
 @RequiredFrontend(LLVMIRLanguageFrontend::class)
-class CompressLLVMPass(config: TranslationConfiguration, scopeManager: ScopeManager) :
-    ComponentPass(config, scopeManager) {
+class CompressLLVMPass(ctx: TranslationContext) : ComponentPass(ctx) {
     override fun accept(component: Component) {
         val flatAST = SubgraphWalker.flattenAST(component)
         // Get all goto statements

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -25,20 +25,17 @@
  */
 package de.fraunhofer.aisec.cpg.frontends.llvm
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TestUtils
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
-import de.fraunhofer.aisec.cpg.assertFullName
-import de.fraunhofer.aisec.cpg.assertLocalName
+import de.fraunhofer.aisec.cpg.*
+import de.fraunhofer.aisec.cpg.graph.TypeManager
 import de.fraunhofer.aisec.cpg.graph.bodyOrNull
 import de.fraunhofer.aisec.cpg.graph.byNameOrNull
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
+import de.fraunhofer.aisec.cpg.graph.parseType
 import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.ObjectType
-import de.fraunhofer.aisec.cpg.graph.types.TypeParser
 import java.nio.file.Path
 import kotlin.test.*
 import kotlin.test.Test
@@ -51,8 +48,11 @@ class LLVMIRLanguageFrontendTest {
         val frontend =
             LLVMIRLanguageFrontend(
                 LLVMIRLanguage(),
-                TranslationConfiguration.builder().build(),
-                ScopeManager(),
+                TranslationContext(
+                    TranslationConfiguration.builder().build(),
+                    ScopeManager(),
+                    TypeManager()
+                )
             )
         frontend.parse(topLevel.resolve("main.ll").toFile())
     }
@@ -312,10 +312,10 @@ class LLVMIRLanguageFrontendTest {
         val rhs = (comparison.rhs as Literal<*>)
         val lhs = (comparison.lhs as DeclaredReferenceExpression).refersTo as VariableDeclaration
         assertEquals(10L, (rhs.value as Long))
-        assertEquals(TypeParser.createFrom("i32", LLVMIRLanguage()), rhs.type)
+        assertEquals(tu.parseType("i32"), rhs.type)
         assertLocalName("x", comparison.lhs as DeclaredReferenceExpression)
         assertLocalName("x", lhs)
-        assertEquals(TypeParser.createFrom("i32", LLVMIRLanguage()), lhs.type)
+        assertEquals(tu.parseType("i32"), lhs.type)
 
         // Check that the jump targets are set correctly
         val ifStatement = main.bodyOrNull<IfStatement>(0)
@@ -346,11 +346,11 @@ class LLVMIRLanguageFrontendTest {
         assertTrue(ifBranchComp.lhs is CastExpression)
 
         val ifBranchCompRhs = ifBranchComp.rhs as CastExpression
-        assertEquals(TypeParser.createFrom("ui32", LLVMIRLanguage()), ifBranchCompRhs.castType)
-        assertEquals(TypeParser.createFrom("ui32", LLVMIRLanguage()), ifBranchCompRhs.type)
+        assertEquals(tu.parseType("ui32"), ifBranchCompRhs.castType)
+        assertEquals(tu.parseType("ui32"), ifBranchCompRhs.type)
         val ifBranchCompLhs = ifBranchComp.lhs as CastExpression
-        assertEquals(TypeParser.createFrom("ui32", LLVMIRLanguage()), ifBranchCompLhs.castType)
-        assertEquals(TypeParser.createFrom("ui32", LLVMIRLanguage()), ifBranchCompLhs.type)
+        assertEquals(tu.parseType("ui32"), ifBranchCompLhs.castType)
+        assertEquals(tu.parseType("ui32"), ifBranchCompLhs.type)
 
         val declRefExpr = ifBranchCompLhs.expression as DeclaredReferenceExpression
         assertEquals(-3, ((ifBranchCompRhs.expression as Literal<*>).value as Long))

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
@@ -25,8 +25,6 @@
  */
 package de.fraunhofer.aisec.cpg.frontends.python
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.frontends.HasShortCircuitOperators
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.BinaryOperator
@@ -78,13 +76,6 @@ class PythonLanguage : Language<PythonLanguageFrontend>(), HasShortCircuitOperat
                 ), // It's two floats
             "str" to StringType("str", this, listOf())
         )
-
-    override fun newFrontend(
-        config: TranslationConfiguration,
-        scopeManager: ScopeManager,
-    ): PythonLanguageFrontend {
-        return PythonLanguageFrontend(this, config, scopeManager)
-    }
 
     override fun propagateTypeOfBinaryOperation(operation: BinaryOperator): Type {
         val unknownType = UnknownType.getUnknownType(this)

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
@@ -25,8 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.frontends.python
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.frontends.TranslationException
@@ -37,11 +36,8 @@ import java.nio.file.Paths
 import jep.JepException
 import kotlin.io.path.absolutePathString
 
-class PythonLanguageFrontend(
-    language: Language<PythonLanguageFrontend>,
-    config: TranslationConfiguration,
-    scopeManager: ScopeManager,
-) : LanguageFrontend(language, config, scopeManager) {
+class PythonLanguageFrontend(language: Language<PythonLanguageFrontend>, ctx: TranslationContext) :
+    LanguageFrontend(language, ctx) {
     private val jep = JepSingleton // configure Jep
 
     @Throws(TranslationException::class)

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
@@ -37,7 +37,6 @@ import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.NumericType
 import de.fraunhofer.aisec.cpg.graph.types.ObjectType
-import de.fraunhofer.aisec.cpg.graph.types.TypeParser
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 import de.fraunhofer.aisec.cpg.sarif.Region
@@ -70,19 +69,19 @@ class PythonFrontendTest : BaseTest() {
         val b = p.variables["b"]
         assertNotNull(b)
         assertLocalName("b", b)
-        assertEquals(TypeParser.createFrom("bool", PythonLanguage()), b.type)
+        assertEquals(tu.parseType("bool"), b.type)
         assertEquals(true, (b.initializer as? Literal<*>)?.value)
 
         val i = p.variables["i"]
         assertNotNull(i)
         assertLocalName("i", i)
-        assertEquals(TypeParser.createFrom("int", PythonLanguage()), i.type)
+        assertEquals(tu.parseType("int"), i.type)
         assertEquals(42L, (i.initializer as? Literal<*>)?.value)
 
         val f = p.variables["f"]
         assertNotNull(f)
         assertLocalName("f", f)
-        assertEquals(TypeParser.createFrom("float", PythonLanguage()), f.type)
+        assertEquals(tu.parseType("float"), f.type)
         assertEquals(1.0, (f.initializer as? Literal<*>)?.value)
 
         val c = p.variables["c"]
@@ -97,13 +96,13 @@ class PythonFrontendTest : BaseTest() {
         val t = p.variables["t"]
         assertNotNull(t)
         assertLocalName("t", t)
-        assertEquals(TypeParser.createFrom("str", PythonLanguage()), t.type)
+        assertEquals(tu.parseType("str"), t.type)
         assertEquals("Hello", (t.initializer as? Literal<*>)?.value)
 
         val n = p.variables["n"]
         assertNotNull(n)
         assertLocalName("n", n)
-        assertEquals(TypeParser.createFrom("None", PythonLanguage()), n.type)
+        assertEquals(tu.parseType("None"), n.type)
         assertEquals(null, (n.initializer as? Literal<*>)?.value)
     }
 
@@ -143,7 +142,7 @@ class PythonFrontendTest : BaseTest() {
         val s = bar.parameters.first()
         assertNotNull(s)
         assertLocalName("s", s)
-        assertEquals(TypeParser.createFrom("str", PythonLanguage()), s.type)
+        assertEquals(tu.parseType("str"), s.type)
 
         assertLocalName("bar", bar)
 
@@ -160,7 +159,7 @@ class PythonFrontendTest : BaseTest() {
         assertNotNull(literal)
 
         assertEquals("bar(s) here: ", literal.value)
-        assertEquals(TypeParser.createFrom("str", PythonLanguage()), literal.type)
+        assertEquals(tu.parseType("str"), literal.type)
 
         val ref = callExpression.arguments[1] as? DeclaredReferenceExpression
         assertNotNull(ref)
@@ -220,11 +219,11 @@ class PythonFrontendTest : BaseTest() {
                 as? VariableDeclaration
         assertNotNull(sel)
         assertLocalName("sel", sel)
-        assertEquals(TypeParser.createFrom("bool", PythonLanguage()), sel.type)
+        assertEquals(tu.parseType("bool"), sel.type)
 
         val initializer = sel.initializer as? Literal<*>
         assertNotNull(initializer)
-        assertEquals(TypeParser.createFrom("bool", PythonLanguage()), initializer.type)
+        assertEquals(tu.parseType("bool"), initializer.type)
         assertEquals("True", initializer.code)
 
         val `if` = body.statements[1] as? IfStatement
@@ -309,11 +308,11 @@ class PythonFrontendTest : BaseTest() {
         val foo = body.singleDeclaration as? VariableDeclaration
         assertNotNull(foo)
         assertLocalName("foo", foo)
-        assertEquals(TypeParser.createFrom("int", PythonLanguage()), foo.type)
+        assertEquals(tu.parseType("int"), foo.type)
 
         val initializer = foo.initializer as? ConditionalExpression
         assertNotNull(initializer)
-        assertEquals(TypeParser.createFrom("int", PythonLanguage()), initializer.type)
+        assertEquals(tu.parseType("int"), initializer.type)
 
         val ifCond = initializer.condition as? Literal<*>
         assertNotNull(ifCond)
@@ -322,13 +321,13 @@ class PythonFrontendTest : BaseTest() {
         val elseExpr = initializer.elseExpr as? Literal<*>
         assertNotNull(elseExpr)
 
-        assertEquals(TypeParser.createFrom("bool", PythonLanguage()), ifCond.type)
+        assertEquals(tu.parseType("bool"), ifCond.type)
         assertEquals(false, ifCond.value)
 
-        assertEquals(TypeParser.createFrom("int", PythonLanguage()), thenExpr.type)
+        assertEquals(tu.parseType("int"), thenExpr.type)
         assertEquals(21, (thenExpr.value as? Long)?.toInt())
 
-        assertEquals(TypeParser.createFrom("int", PythonLanguage()), elseExpr.type)
+        assertEquals(tu.parseType("int"), elseExpr.type)
         assertEquals(42, (elseExpr.value as? Long)?.toInt())
     }
 
@@ -412,7 +411,7 @@ class PythonFrontendTest : BaseTest() {
         val somevar = recordFoo.fields[0]
         assertNotNull(somevar)
         assertLocalName("somevar", somevar)
-        // assertEquals(TypeParser.createFrom("int", false), somevar.type) TODO fix type deduction
+        // assertEquals(tu.parseType("int", false), somevar.type) TODO fix type deduction
 
         assertEquals(2, recordFoo.methods.size)
         val bar = recordFoo.methods[0]
@@ -434,7 +433,7 @@ class PythonFrontendTest : BaseTest() {
         assertNotNull(i)
 
         assertLocalName("i", i)
-        assertEquals(TypeParser.createFrom("int", PythonLanguage()), i.type)
+        assertEquals(tu.parseType("int"), i.type)
 
         // self.somevar = i
         val someVarDeclaration =

--- a/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/JavaScriptLanguage.kt
+++ b/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/JavaScriptLanguage.kt
@@ -25,8 +25,6 @@
  */
 package de.fraunhofer.aisec.cpg.frontends.typescript
 
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.frontends.HasShortCircuitOperators
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.types.*
@@ -78,11 +76,4 @@ open class JavaScriptLanguage : Language<TypeScriptLanguageFrontend>(), HasShort
             "bigint" to IntegerType("bigint", null, this, NumericType.Modifier.SIGNED),
             "string" to StringType("string", this),
         )
-
-    override fun newFrontend(
-        config: TranslationConfiguration,
-        scopeManager: ScopeManager,
-    ): TypeScriptLanguageFrontend {
-        return TypeScriptLanguageFrontend(this, config, scopeManager)
-    }
 }

--- a/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/TypeScriptLanguageFrontend.kt
+++ b/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/TypeScriptLanguageFrontend.kt
@@ -26,8 +26,7 @@
 package de.fraunhofer.aisec.cpg.frontends.typescript
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.FrontendUtils
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
@@ -58,24 +57,19 @@ import java.nio.file.StandardCopyOption
  */
 class TypeScriptLanguageFrontend(
     language: Language<TypeScriptLanguageFrontend>,
-    config: TranslationConfiguration,
-    scopeManager: ScopeManager,
-) : LanguageFrontend(language, config, scopeManager) {
+    ctx: TranslationContext
+) : LanguageFrontend(language, ctx) {
 
     val declarationHandler = DeclarationHandler(this)
     val statementHandler = StatementHandler(this)
     val expressionHandler = ExpressionHandler(this)
     val typeHandler = TypeHandler(this)
 
-    var currentFileContent: String? = null
+    private var currentFileContent: String? = null
 
-    val mapper = jacksonObjectMapper()
+    private val mapper = jacksonObjectMapper()
 
     companion object {
-        @JvmField var TYPESCRIPT_EXTENSIONS: List<String> = listOf(".ts", ".tsx")
-
-        @JvmField var JAVASCRIPT_EXTENSIONS: List<String> = listOf(".js", ".jsx")
-
         private val parserFile: File = createTempFile("parser", ".js")
 
         init {

--- a/cpg-language-typescript/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/TypescriptLanguageFrontendTest.kt
+++ b/cpg-language-typescript/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/TypescriptLanguageFrontendTest.kt
@@ -32,10 +32,10 @@ import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.get
+import de.fraunhofer.aisec.cpg.graph.parseType
 import de.fraunhofer.aisec.cpg.graph.statements.DeclarationStatement
 import de.fraunhofer.aisec.cpg.graph.statements.ReturnStatement
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
-import de.fraunhofer.aisec.cpg.graph.types.TypeParser
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import java.nio.file.Path
 import kotlin.test.Test
@@ -66,11 +66,11 @@ class TypeScriptLanguageFrontendTest {
 
         val someFunction = functions.first()
         assertLocalName("someFunction", someFunction)
-        assertEquals(TypeParser.createFrom("Number", TypeScriptLanguage()), someFunction.type)
+        assertEquals(tu.parseType("Number"), someFunction.type)
 
         val someOtherFunction = functions.last()
         assertLocalName("someOtherFunction", someOtherFunction)
-        assertEquals(TypeParser.createFrom("Number", TypeScriptLanguage()), someOtherFunction.type)
+        assertEquals(tu.parseType("Number"), someOtherFunction.type)
 
         val parameters = someOtherFunction.parameters
         assertNotNull(parameters)
@@ -79,7 +79,7 @@ class TypeScriptLanguageFrontendTest {
 
         val parameter = parameters.first()
         assertLocalName("s", parameter)
-        assertEquals(TypeParser.createFrom("String", TypeScriptLanguage()), parameter.type)
+        assertEquals(tu.parseType("String"), parameter.type)
     }
 
     @Test
@@ -278,7 +278,7 @@ class TypeScriptLanguageFrontendTest {
         val lastName = user.fields.lastOrNull()
         assertNotNull(lastName)
         assertLocalName("lastName", lastName)
-        assertEquals(TypeParser.createFrom("string", TypeScriptLanguage()), lastName.type)
+        assertEquals(tu.parseType("string"), lastName.type)
 
         val usersState =
             tu.getDeclarationsByName("UsersState", RecordDeclaration::class.java).iterator().next()
@@ -291,7 +291,7 @@ class TypeScriptLanguageFrontendTest {
         val users = usersState.fields.firstOrNull()
         assertNotNull(users)
         assertLocalName("users", users)
-        assertEquals(TypeParser.createFrom("User[]", TypeScriptLanguage()), users.type)
+        assertEquals(tu.parseType("User[]"), users.type)
 
         val usersComponent =
             tu.getDeclarationsByName("Users", RecordDeclaration::class.java).iterator().next()


### PR DESCRIPTION
This PR makes the `TypeManager` not a singleton anymore. This PR also changes the following:

- [x] Introduce a new `TranslationContext` which holds all necessary managers during translation, such as the `ScopeManager`, `TypeManager` as well as the `TranslationConfiguration`.
- [x] Functions that previously took a `TranslationResult` as an input, now take a `TranslationContext` (with very few exceptions in the `TranslationManager`)
- [x] One type manager is spawned for the `TranslationResult` instead of one global singleton. This should make testing easier and potentially make it easier for component-wise type managers in the future
- [x] Replaced all occurrences of `TypeParser.createFrom` (outside of the type parser/manager) with `parseType`