### PR TITLE
Fix code property for function declaration

### DIFF
--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclaratorHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclaratorHandler.kt
@@ -261,7 +261,7 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
                 )
         } else {
             // a plain old function, outside any named scope
-            declaration = newFunctionDeclaration(name, ctx.rawSignature, ctx.parent)
+            declaration = newFunctionDeclaration(name, null, ctx.parent)
         }
 
         // We want to determine, whether we are currently outside a named scope on the AST


### PR DESCRIPTION
The code property for function declarations must be taken from the parent node.
This is already handled by `applyMetadata`, thus it must not be set when calling `newFunctionDeclaration`.