### PR TITLE
Fixed a bug in `ScopeManager::mergeFrom`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -172,7 +172,10 @@ class ScopeManager : ScopeProvider {
                 }
             }
 
-            scopeMap.putAll(manager.scopeMap)
+            // We need to make sure that we do not put the "null" key (aka the global scope) of the
+            // individual scope manager into our map, otherwise we would overwrite our merged global
+            // scope.
+            scopeMap.putAll(manager.scopeMap.filter { it.key != null })
 
             // free the maps, just to clear up some things. this scope manager will not be used
             // anymore

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/DeclaredReferenceExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/DeclaredReferenceExpression.kt
@@ -116,8 +116,7 @@ open class DeclaredReferenceExpression : Expression(), HasType.TypeListener {
         }
 
         // since we want to update the sub types, we need to exclude ourselves from the root,
-        // otherwise
-        // it won't work. What a weird and broken system!
+        // otherwise it won't work. What a weird and broken system!
         root.remove(this)
         val subTypes: MutableList<Type> = ArrayList(possibleSubTypes)
         subTypes.addAll(src.possibleSubTypes)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CallResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CallResolver.kt
@@ -399,7 +399,7 @@ open class CallResolver(ctx: TranslationContext) : SymbolResolverPass(ctx) {
         return possibleContainingTypes
             .mapNotNull {
                 var record = recordMap[it.root.name]
-                if (record == null && config?.inferenceConfiguration?.inferRecords == true) {
+                if (record == null && config.inferenceConfiguration.inferRecords == true) {
                     record = it.startInference(ctx).inferRecordDeclaration(it, currentTU)
                     // update the record map
                     if (record != null) it.root.name.let { name -> recordMap[name] = record }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManagerTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManagerTest.kt
@@ -94,6 +94,10 @@ internal class ScopeManagerTest : BaseTest() {
         assertEquals(scopeA, final.lookupScope(namespaceA1))
         assertEquals(scopeA, final.lookupScope(namespaceA2))
 
+        // in the final scope manager, the global scope should not be any of the merged scope
+        // managers' original global scopes
+        assertFalse(listOf(s1, s2).map { it.globalScope }.contains(final.globalScope))
+
         // resolve symbol
         val call =
             frontend.newCallExpression(

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/ExpressionHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/ExpressionHandler.kt
@@ -484,7 +484,7 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
         return expressionList
     }
 
-    private fun handleBinaryExpression(ctx: IASTBinaryExpression): Expression {
+    private fun handleBinaryExpression(ctx: IASTBinaryExpression): BinaryOperator {
         var operatorCode = ""
         when (ctx.operator) {
             op_multiply -> operatorCode = "*"
@@ -503,17 +503,17 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
             op_binaryOr -> operatorCode = "|"
             op_logicalAnd -> operatorCode = "&&"
             op_logicalOr -> operatorCode = "||"
-            op_assign,
-            op_multiplyAssign,
-            op_divideAssign,
-            op_moduloAssign,
-            op_plusAssign,
-            op_minusAssign,
-            op_shiftLeftAssign,
-            op_shiftRightAssign,
-            op_binaryAndAssign,
-            op_binaryXorAssign,
-            op_binaryOrAssign -> return handleAssignment(ctx)
+            op_assign -> operatorCode = "="
+            op_multiplyAssign -> operatorCode = "*="
+            op_divideAssign -> operatorCode = "/="
+            op_moduloAssign -> operatorCode = "%="
+            op_plusAssign -> operatorCode = "+="
+            op_minusAssign -> operatorCode = "-="
+            op_shiftLeftAssign -> operatorCode = "<<="
+            op_shiftRightAssign -> operatorCode = ">>="
+            op_binaryAndAssign -> operatorCode = "&="
+            op_binaryXorAssign -> operatorCode = "^="
+            op_binaryOrAssign -> operatorCode = "|="
             op_equals -> operatorCode = "=="
             op_notequals -> operatorCode = "!="
             op_pmdot -> operatorCode = ".*"
@@ -537,39 +537,6 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
         binaryOperator.rhs = rhs
 
         return binaryOperator
-    }
-
-    private fun handleAssignment(ctx: IASTBinaryExpression): AssignExpression {
-        var operatorCode = ""
-        when (ctx.operator) {
-            op_assign -> operatorCode = "="
-            op_multiplyAssign -> operatorCode = "*="
-            op_divideAssign -> operatorCode = "/="
-            op_moduloAssign -> operatorCode = "%="
-            op_plusAssign -> operatorCode = "+="
-            op_minusAssign -> operatorCode = "-="
-            op_shiftLeftAssign -> operatorCode = "<<="
-            op_shiftRightAssign -> operatorCode = ">>="
-            op_binaryAndAssign -> operatorCode = "&="
-            op_binaryXorAssign -> operatorCode = "^="
-            op_binaryOrAssign -> operatorCode = "|="
-            else ->
-                Util.errorWithFileLocation(frontend, ctx, log, "unknown operator {}", ctx.operator)
-        }
-
-        val lhs = handle(ctx.operand1) ?: newProblemExpression("could not parse lhs")
-        val rhs =
-            if (ctx.operand2 != null) {
-                handle(ctx.operand2)
-            } else {
-                handle(ctx.initOperand2)
-            }
-                ?: newProblemExpression("could not parse rhs")
-
-        val assign =
-            newAssignExpression(operatorCode, lhs = listOf(lhs), rhs = listOf(rhs), rawNode = ctx)
-
-        return assign
     }
 
     private fun handleLiteralExpression(ctx: IASTLiteralExpression): Expression {

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/ExpressionHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/ExpressionHandler.kt
@@ -484,7 +484,7 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
         return expressionList
     }
 
-    private fun handleBinaryExpression(ctx: IASTBinaryExpression): BinaryOperator {
+    private fun handleBinaryExpression(ctx: IASTBinaryExpression): Expression {
         var operatorCode = ""
         when (ctx.operator) {
             op_multiply -> operatorCode = "*"
@@ -503,17 +503,17 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
             op_binaryOr -> operatorCode = "|"
             op_logicalAnd -> operatorCode = "&&"
             op_logicalOr -> operatorCode = "||"
-            op_assign -> operatorCode = "="
-            op_multiplyAssign -> operatorCode = "*="
-            op_divideAssign -> operatorCode = "/="
-            op_moduloAssign -> operatorCode = "%="
-            op_plusAssign -> operatorCode = "+="
-            op_minusAssign -> operatorCode = "-="
-            op_shiftLeftAssign -> operatorCode = "<<="
-            op_shiftRightAssign -> operatorCode = ">>="
-            op_binaryAndAssign -> operatorCode = "&="
-            op_binaryXorAssign -> operatorCode = "^="
-            op_binaryOrAssign -> operatorCode = "|="
+            op_assign,
+            op_multiplyAssign,
+            op_divideAssign,
+            op_moduloAssign,
+            op_plusAssign,
+            op_minusAssign,
+            op_shiftLeftAssign,
+            op_shiftRightAssign,
+            op_binaryAndAssign,
+            op_binaryXorAssign,
+            op_binaryOrAssign -> return handleAssignment(ctx)
             op_equals -> operatorCode = "=="
             op_notequals -> operatorCode = "!="
             op_pmdot -> operatorCode = ".*"
@@ -537,6 +537,39 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
         binaryOperator.rhs = rhs
 
         return binaryOperator
+    }
+
+    private fun handleAssignment(ctx: IASTBinaryExpression): AssignExpression {
+        var operatorCode = ""
+        when (ctx.operator) {
+            op_assign -> operatorCode = "="
+            op_multiplyAssign -> operatorCode = "*="
+            op_divideAssign -> operatorCode = "/="
+            op_moduloAssign -> operatorCode = "%="
+            op_plusAssign -> operatorCode = "+="
+            op_minusAssign -> operatorCode = "-="
+            op_shiftLeftAssign -> operatorCode = "<<="
+            op_shiftRightAssign -> operatorCode = ">>="
+            op_binaryAndAssign -> operatorCode = "&="
+            op_binaryXorAssign -> operatorCode = "^="
+            op_binaryOrAssign -> operatorCode = "|="
+            else ->
+                Util.errorWithFileLocation(frontend, ctx, log, "unknown operator {}", ctx.operator)
+        }
+
+        val lhs = handle(ctx.operand1) ?: newProblemExpression("could not parse lhs")
+        val rhs =
+            if (ctx.operand2 != null) {
+                handle(ctx.operand2)
+            } else {
+                handle(ctx.initOperand2)
+            }
+                ?: newProblemExpression("could not parse rhs")
+
+        val assign =
+            newAssignExpression(operatorCode, lhs = listOf(lhs), rhs = listOf(rhs), rawNode = ctx)
+
+        return assign
     }
 
     private fun handleLiteralExpression(ctx: IASTLiteralExpression): Expression {


### PR DESCRIPTION
There was a rather delicate bug in the merging functionality of the ScopeManager, that always resulted in a wrong merged global scope.
