### PR TITLE
Infer DFG for calls to implicit functions

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
@@ -391,7 +391,7 @@ class DFGPass(ctx: TranslationContext) : ComponentPass(ctx) {
             handleUnresolvedCalls(call)
         } else if (call.invokes.isNotEmpty()) {
             call.invokes.forEach { funDecl ->
-                if (funDecl.isImplicit && inferDfgForUnresolvedSymbols) {
+                if (funDecl.isInferred && inferDfgForUnresolvedSymbols) {
                     if (call is MemberCallExpression && !call.isStatic) {
                         call.base?.let { funDecl.addPrevDFG(it) }
                     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
@@ -388,17 +388,14 @@ class DFGPass(ctx: TranslationContext) : ComponentPass(ctx) {
 
         if (call.invokes.isEmpty() && inferDfgForUnresolvedSymbols) {
             // Unresolved call expression
-            handleUnresolvedCalls(call)
+            handleUnresolvedCalls(call, call)
         } else if (call.invokes.isNotEmpty()) {
-            call.invokes.forEach { funDecl ->
-                if (funDecl.isInferred && inferDfgForUnresolvedSymbols) {
-                    if (call is MemberCallExpression && !call.isStatic) {
-                        call.base?.let { funDecl.addPrevDFG(it) }
-                    }
-                    call.arguments.forEach { funDecl.addPrevDFG(it) }
+            call.invokes.forEach {
+                if (it.isInferred && inferDfgForUnresolvedSymbols) {
+                    handleUnresolvedCalls(call, it)
                 } else {
-                    Util.attachCallParameters(funDecl, call.arguments)
-                    call.addPrevDFG(funDecl)
+                    Util.attachCallParameters(it, call.arguments)
+                    call.addPrevDFG(it)
                 }
             }
         }
@@ -409,11 +406,11 @@ class DFGPass(ctx: TranslationContext) : ComponentPass(ctx) {
      * - from base (if available) to the CallExpression
      * - from all arguments to the CallExpression
      */
-    private fun handleUnresolvedCalls(call: CallExpression) {
+    private fun handleUnresolvedCalls(call: CallExpression, dfgTarget: Node) {
         if (call is MemberCallExpression && !call.isStatic) {
-            call.base?.let { call.addPrevDFG(it) }
+            call.base?.let { dfgTarget.addPrevDFG(it) }
         }
 
-        call.arguments.forEach { call.addPrevDFG(it) }
+        call.arguments.forEach { dfgTarget.addPrevDFG(it) }
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
@@ -390,9 +390,16 @@ class DFGPass(ctx: TranslationContext) : ComponentPass(ctx) {
             // Unresolved call expression
             handleUnresolvedCalls(call)
         } else if (call.invokes.isNotEmpty()) {
-            call.invokes.forEach {
-                Util.attachCallParameters(it, call.arguments)
-                call.addPrevDFG(it)
+            call.invokes.forEach { funDecl ->
+                if (funDecl.isImplicit && inferDfgForUnresolvedSymbols) {
+                    if (call is MemberCallExpression && !call.isStatic) {
+                        call.base?.let { funDecl.addPrevDFG(it) }
+                    }
+                    call.arguments.forEach { funDecl.addPrevDFG(it) }
+                } else {
+                    Util.attachCallParameters(funDecl, call.arguments)
+                    call.addPrevDFG(funDecl)
+                }
             }
         }
     }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/UnresolvedDFGPassTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/UnresolvedDFGPassTest.kt
@@ -149,16 +149,14 @@ class UnresolvedDFGPassTest {
                                     }
                                     declare {
                                         variable("s2", t("String")) {
-                                            memberCall("get", ref("os")) {
-                                                addArgument(literal(4, t("int")))
-                                            }
+                                            memberCall("get", ref("os")) { literal(4, t("int")) }
                                         }
                                     }
                                     declare {
                                         variable("duc", t("DfgUnresolvedCalls")) {
                                             new {
                                                 construct("DfgUnresolvedCalls") {
-                                                    addArgument(literal(3, t("int")))
+                                                    literal(3, t("int"))
                                                 }
                                             }
                                         }
@@ -166,7 +164,7 @@ class UnresolvedDFGPassTest {
                                     declare {
                                         variable("i", t("int")) {
                                             memberCall("knownFunction", ref("duc")) {
-                                                addArgument(literal(2, t("int")))
+                                                literal(2, t("int"))
                                             }
                                         }
                                     }


### PR DESCRIPTION
Currently, we only infer dfg edges to calls for unresolved functions. This PR also generalizes it to implicit function declarations.