### PR TITLE
Draft: Revert IncludeDeclaration hashCode overload

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/IncludeDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/IncludeDeclaration.kt
@@ -30,7 +30,6 @@ import de.fraunhofer.aisec.cpg.graph.edge.Properties
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
-import java.util.Objects
 import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.Relationship
 
@@ -93,6 +92,4 @@ class IncludeDeclaration : Declaration() {
             propertyEqualsList(problemEdges, other.problemEdges) &&
             filename == other.filename)
     }
-
-    override fun hashCode() = Objects.hash(super.hashCode(), includes, problems, filename)
 }


### PR DESCRIPTION
This PR reverts the changes introduced during conversion to kotlin.
The `hashCode` is not stable and results in uncontrolled recursion.