### PR TITLE
Fix `collectInitialPasses`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
@@ -701,8 +701,8 @@ private constructor(
                     workingList.addToWorkingList(
                         PassWithDependencies(
                             p,
-                            hardDependencies[p] ?: mutableSetOf(),
-                            softDependencies[p] ?: mutableSetOf()
+                            softDependencies[p] ?: mutableSetOf(),
+                            hardDependencies[p] ?: mutableSetOf()
                         )
                     )
                 }


### PR DESCRIPTION
This PR fixes `collectInitialPasses`. The `PassWithDependencies` were initialized with the `softDependencies` and `hardDependencies` switched (see [constructor](https://github.com/Fraunhofer-AISEC/cpg/blob/main/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/PassWithDependencies.kt#L35) of `PassWithDependencies`).