### PR TITLE
Add generic parameters for `LanguageFrontend`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Prepare test and coverage reports
         if: ${{ always() }}
         run: |
-          zip reports.zip **/build/reports/**
+          zip reports.zip **/build/reports/**/** || true
       - name: Archive test and coverage reports
         if: ${{ always() }}
         uses: actions/upload-artifact@v3

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -75,7 +75,7 @@ class ScopeManager : ScopeProvider {
      * The language frontend tied to the scope manager. Can be used to implement language specific
      * scope resolution or lookup.
      */
-    var lang: LanguageFrontend? = null
+    var lang: LanguageFrontend<*, *>? = null
 
     /** True, if the scope manager is currently in a [BlockScope]. */
     val isInBlock: Boolean

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
@@ -99,7 +99,7 @@ private constructor(
      */
     val replacedPasses:
         Map<Pair<KClass<out Pass<*>>, KClass<out Language<*>>>, KClass<out Pass<*>>>,
-    languages: List<Language<out LanguageFrontend>>,
+    languages: List<Language<*>>,
     codeInNodes: Boolean,
     processAnnotations: Boolean,
     disableCleanup: Boolean,
@@ -112,7 +112,7 @@ private constructor(
     addIncludesToGraph: Boolean
 ) {
     /** This list contains all languages which we want to translate. */
-    val languages: List<Language<out LanguageFrontend>>
+    val languages: List<Language<*>>
 
     /**
      * Switch off cleaning up TypeManager memory after analysis.
@@ -215,7 +215,7 @@ private constructor(
      */
     class Builder {
         private var softwareComponents: MutableMap<String, List<File>> = HashMap()
-        private val languages = mutableListOf<Language<out LanguageFrontend>>()
+        private val languages = mutableListOf<Language<*>>()
         private var topLevel: File? = null
         private var debugParser = false
         private var failOnError = false
@@ -405,7 +405,7 @@ private constructor(
         }
 
         /** Registers an additional [Language]. */
-        fun registerLanguage(language: Language<out LanguageFrontend>): Builder {
+        fun registerLanguage(language: Language<*>): Builder {
             languages.add(language)
             log.info(
                 "Registered language frontend '${language::class.simpleName}' for following file types: ${language.fileExtensions}"
@@ -414,7 +414,7 @@ private constructor(
         }
 
         /** Registers an additional [Language]. */
-        inline fun <reified T : Language<out LanguageFrontend>> registerLanguage(): Builder {
+        inline fun <reified T : Language<*>> registerLanguage(): Builder {
             T::class.primaryConstructor?.call()?.let { registerLanguage(it) }
             return this
         }
@@ -443,8 +443,8 @@ private constructor(
         }
 
         /** Unregisters a registered [de.fraunhofer.aisec.cpg.frontends.Language]. */
-        fun unregisterLanguage(language: Class<out Language<out LanguageFrontend>?>): Builder {
-            languages.removeIf { obj: Language<out LanguageFrontend>? -> language.isInstance(obj) }
+        fun unregisterLanguage(language: Class<out Language<*>?>): Builder {
+            languages.removeIf { obj: Language<*>? -> language.isInstance(obj) }
             return this
         }
 
@@ -490,7 +490,7 @@ private constructor(
                 return
             }
 
-            for (frontend in languages.map(Language<out LanguageFrontend>::frontend)) {
+            for (frontend in languages.map(Language<*>::frontend)) {
                 val extraPasses = frontend.findAnnotations<RegisterExtraPass>()
                 if (extraPasses.isNotEmpty()) {
                     for (p in extraPasses) {
@@ -505,7 +505,7 @@ private constructor(
         }
 
         private fun registerReplacedPasses() {
-            for (frontend in languages.map(Language<out LanguageFrontend>::frontend)) {
+            for (frontend in languages.map(Language<*>::frontend)) {
                 val replacedPasses = frontend.findAnnotations<ReplacePass>()
                 if (replacedPasses.isNotEmpty()) {
                     for (p in replacedPasses) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Handler.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Handler.kt
@@ -25,14 +25,11 @@
  */
 package de.fraunhofer.aisec.cpg.frontends
 
-import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.graph.*
-import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.helpers.Util.errorWithFileLocation
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import java.util.function.Supplier
-import org.eclipse.cdt.internal.core.dom.parser.ASTNode
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -47,24 +44,29 @@ import org.slf4j.LoggerFactory
  * @param <T> the raw ast node specific to the parser
  * @param <L> the language frontend </L></T></S>
  */
-abstract class Handler<S : Node, T, L : LanguageFrontend>(
-    protected val configConstructor: Supplier<S>,
+abstract class Handler<ResultNode : Node, HandlerNode, L : LanguageFrontend<HandlerNode, *>>(
+    protected val configConstructor: Supplier<ResultNode>,
     /** Returns the frontend which used this handler. */
-    var frontend: L
-) : LanguageProvider, CodeAndLocationProvider, ScopeProvider, NamespaceProvider, ContextProvider {
-    protected val map = HashMap<Class<out T>, HandlerInterface<S, T>>()
+    val frontend: L
+) :
+    LanguageProvider by frontend,
+    CodeAndLocationProvider<HandlerNode> by frontend,
+    ScopeProvider by frontend,
+    NamespaceProvider by frontend,
+    ContextProvider by frontend {
+    protected val map = HashMap<Class<out HandlerNode>, HandlerInterface<ResultNode, HandlerNode>>()
     private val typeOfT: Class<*>?
 
     /**
-     * Searches for a handler matching the most specific superclass of [T]. The created map should
-     * thus contain a handler for every semantically different AST node and can reuse handler code
-     * as long as the handled AST nodes have a common ancestor.
+     * Searches for a handler matching the most specific superclass of [HandlerNode]. The created
+     * map should thus contain a handler for every semantically different AST node and can reuse
+     * handler code as long as the handled AST nodes have a common ancestor.
      *
      * @param ctx The AST node, whose handler is matched with respect to the AST node class.
      * @return most specific handler.
      */
-    open fun handle(ctx: T): S? {
-        var ret: S?
+    open fun handle(ctx: HandlerNode): ResultNode? {
+        var ret: ResultNode?
         if (ctx == null) {
             log.error(
                 "ctx is NULL. This can happen when ast children are optional in ${this.javaClass}. Called by ${Thread.currentThread().stackTrace[2]}"
@@ -72,17 +74,6 @@ abstract class Handler<S : Node, T, L : LanguageFrontend>(
             return null
         }
 
-        // If we do not want to load includes into the CPG and the current fileLocation was included
-        if (!frontend.config.loadIncludes && ctx is ASTNode) {
-            val astNode = ctx as ASTNode
-            if (
-                astNode.fileLocation != null &&
-                    astNode.fileLocation.contextInclusionStatement != null
-            ) {
-                log.debug("Skip parsing include file ${astNode.containingFilename}")
-                return null
-            }
-        }
         var toHandle: Class<*> = ctx.javaClass
         var handler = map[toHandle]
         while (handler == null) {
@@ -92,7 +83,7 @@ abstract class Handler<S : Node, T, L : LanguageFrontend>(
                 handler != null && // always ok to handle as generic literal expr
                 !ctx.javaClass.simpleName.contains("LiteralExpr")
             ) {
-                errorWithFileLocation<T>(
+                errorWithFileLocation(
                     frontend,
                     ctx,
                     log,
@@ -110,13 +101,13 @@ abstract class Handler<S : Node, T, L : LanguageFrontend>(
                 // we will
                 // set the location here.
                 if (s.location == null) {
-                    frontend.setCodeAndLocation<S, T>(s, ctx)
+                    frontend.setCodeAndLocation(s, ctx)
                 }
-                frontend.setComment<S, T>(s, ctx)
+                frontend.setComment(s, ctx)
             }
             ret = s
         } else {
-            errorWithFileLocation<T>(
+            errorWithFileLocation(
                 frontend,
                 ctx,
                 log,
@@ -132,7 +123,7 @@ abstract class Handler<S : Node, T, L : LanguageFrontend>(
 
         // In case the node is empty, we report a problem
         if (ret == null) {
-            errorWithFileLocation<T>(
+            errorWithFileLocation(
                 frontend,
                 ctx,
                 log,
@@ -166,23 +157,6 @@ abstract class Handler<S : Node, T, L : LanguageFrontend>(
         }
         return null
     }
-
-    /** Returns the language which this handler is parsing. */
-    override val language: Language<L>
-        get() = frontend.language as Language<L>
-
-    override fun <N, S> setCodeAndLocation(cpgNode: N, astNode: S?) {
-        frontend.setCodeAndLocation<N, S>(cpgNode, astNode)
-    }
-
-    override val scope: Scope?
-        get() = frontend.scope
-
-    override val namespace: Name?
-        get() = frontend.namespace
-
-    override val ctx: TranslationContext
-        get() = frontend.ctx
 
     companion object {
         @JvmStatic protected val log: Logger = LoggerFactory.getLogger(Handler::class.java)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
@@ -48,7 +48,7 @@ import kotlin.reflect.full.primaryConstructor
  * persisted in the final graph (database) and each node links to its corresponding language using
  * the [Node.language] property.
  */
-abstract class Language<T : LanguageFrontend> : Node() {
+abstract class Language<T : LanguageFrontend<*, *>> : Node() {
     /** The file extensions without the dot */
     abstract val fileExtensions: List<String>
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.kt
@@ -32,6 +32,7 @@ import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
+import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 import de.fraunhofer.aisec.cpg.sarif.Region
 import java.io.File
@@ -47,9 +48,9 @@ import org.slf4j.LoggerFactory
  * More information can be found in the
  * [github wiki page](https://github.com/Fraunhofer-AISEC/cpg/wiki/Language-Frontends).
  */
-abstract class LanguageFrontend(
+abstract class LanguageFrontend<in AstNode, TypeNode>(
     /** The language this frontend works for. */
-    override val language: Language<out LanguageFrontend>,
+    override val language: Language<out LanguageFrontend<AstNode, TypeNode>>,
 
     /**
      * The translation context, which contains all necessary managers used in this frontend parsing
@@ -59,7 +60,7 @@ abstract class LanguageFrontend(
     final override var ctx: TranslationContext,
 ) :
     ProcessedListener(),
-    CodeAndLocationProvider,
+    CodeAndLocationProvider<AstNode>,
     LanguageProvider,
     ScopeProvider,
     NamespaceProvider,
@@ -91,9 +92,21 @@ abstract class LanguageFrontend(
      * This function returns a [TranslationResult], but rather than parsing source code, the
      * function [init] is used to build nodes in the Node Fluent DSL.
      */
-    fun build(init: LanguageFrontend.() -> TranslationResult): TranslationResult {
+    fun build(init: LanguageFrontend<*, *>.() -> TranslationResult): TranslationResult {
         return init(this)
     }
+
+    /**
+     * This function serves as an entry-point to type parsing in the language frontend. It needs to
+     * return a [Type] object based on the ast type object used by the language frontend, e.g., the
+     * parser.
+     *
+     * A language frontend will usually de-construct the ast type object, e.g., in case of pointer
+     * or array types and then either recursively call this function or call other helper functions
+     * similar to this one. Ideally, they should share the [typeOf] name, but have different method
+     * signatures.
+     */
+    abstract fun typeOf(type: TypeNode): Type
 
     /**
      * Returns the raw code of the ast node, generic for java or c++ ast nodes.
@@ -102,7 +115,7 @@ abstract class LanguageFrontend(
      * @param astNode the ast node
      * @return the source code </T>
      */
-    abstract fun <T> getCodeFromRawNode(astNode: T): String?
+    abstract fun codeOf(astNode: AstNode): String?
 
     /**
      * Returns the [Region] of the code with line and column, index starting at 1, generic for java
@@ -112,21 +125,19 @@ abstract class LanguageFrontend(
      * @param astNode the ast node
      * @return the location </T>
      */
-    abstract fun <T> getLocationFromRawNode(astNode: T): PhysicalLocation?
+    abstract fun locationOf(astNode: AstNode): PhysicalLocation?
 
-    override fun <N, S> setCodeAndLocation(cpgNode: N, astNode: S?) {
-        if (cpgNode is Node && astNode != null) {
-            if (config.codeInNodes) {
-                // only set code, if it's not already set or empty
-                val code = getCodeFromRawNode<S?>(astNode)
-                if (code != null) {
-                    (cpgNode as Node).code = code
-                } else {
-                    log.warn("Unexpected: No code for node {}", astNode)
-                }
+    override fun setCodeAndLocation(cpgNode: Node, astNode: AstNode) {
+        if (config.codeInNodes) {
+            // only set code, if it's not already set or empty
+            val code = codeOf(astNode)
+            if (code != null) {
+                cpgNode.code = code
+            } else {
+                log.warn("Unexpected: No code for node {}", astNode)
             }
-            (cpgNode as Node).location = getLocationFromRawNode<S?>(astNode)
         }
+        cpgNode.location = locationOf(astNode)
     }
 
     /**
@@ -225,7 +236,7 @@ abstract class LanguageFrontend(
         clearProcessed()
     }
 
-    abstract fun <S, T> setComment(s: S, ctx: T)
+    abstract fun setComment(node: Node, astNode: AstNode)
 
     companion object {
         // Allow non-Java frontends to access the logger (i.e. jep)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Name.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Name.kt
@@ -46,7 +46,7 @@ class Name(
     constructor(
         localName: String,
         parent: Name? = null,
-        language: Language<out LanguageFrontend>?
+        language: Language<*>?
     ) : this(localName, parent, language?.namespaceDelimiter ?: ".")
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -31,7 +31,6 @@ import de.fraunhofer.aisec.cpg.PopulatedByPass
 import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.Handler
 import de.fraunhofer.aisec.cpg.frontends.Language
-import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
@@ -89,7 +88,7 @@ open class Node : IVisitable<Node>, Persistable, LanguageProvider, ScopeProvider
      */
     @Relationship(value = "LANGUAGE", direction = Relationship.Direction.OUTGOING)
     @JsonBackReference
-    override var language: Language<out LanguageFrontend>? = null
+    override var language: Language<*>? = null
 
     /**
      * The scope this node "lives" in / in which it is defined. This property is set in

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -56,15 +56,15 @@ interface MetadataProvider
  * each [Node], but also transformation steps, such as [Handler].
  */
 interface LanguageProvider : MetadataProvider {
-    val language: Language<out LanguageFrontend>?
+    val language: Language<*>?
 }
 
 /**
  * This interface denotes that the class is able to provide source code and location information for
  * a specific node and set it using the [setCodeAndLocation] function.
  */
-interface CodeAndLocationProvider : MetadataProvider {
-    fun <N, S> setCodeAndLocation(cpgNode: N, astNode: S?)
+interface CodeAndLocationProvider<in AstNode> : MetadataProvider {
+    fun setCodeAndLocation(cpgNode: Node, astNode: AstNode)
 }
 
 /**
@@ -103,8 +103,8 @@ fun Node.applyMetadata(
     localNameOnly: Boolean = false,
     defaultNamespace: Name? = null,
 ) {
-    if (provider is CodeAndLocationProvider) {
-        provider.setCodeAndLocation(this, rawNode)
+    if (provider is CodeAndLocationProvider<*> && rawNode != null) {
+        (provider as CodeAndLocationProvider<Any>).setCodeAndLocation(this, rawNode)
     }
 
     if (provider is LanguageProvider) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
@@ -35,7 +35,9 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.passes.executePassSequential
 
-fun LanguageFrontend.translationResult(init: TranslationResult.() -> Unit): TranslationResult {
+fun LanguageFrontend<*, *>.translationResult(
+    init: TranslationResult.() -> Unit
+): TranslationResult {
     val node =
         TranslationResult(
             TranslationManager.builder().config(ctx.config).build(),
@@ -57,7 +59,7 @@ fun LanguageFrontend.translationResult(init: TranslationResult.() -> Unit): Tran
  */
 context(TranslationResult)
 
-fun LanguageFrontend.translationUnit(
+fun LanguageFrontend<*, *>.translationUnit(
     name: CharSequence = Node.EMPTY_NAME,
     init: TranslationUnitDeclaration.() -> Unit
 ): TranslationUnitDeclaration {
@@ -77,7 +79,7 @@ fun LanguageFrontend.translationUnit(
  */
 context(DeclarationHolder)
 
-fun LanguageFrontend.namespace(
+fun LanguageFrontend<*, *>.namespace(
     name: CharSequence,
     init: NamespaceDeclaration.() -> Unit
 ): NamespaceDeclaration {
@@ -97,7 +99,7 @@ fun LanguageFrontend.namespace(
  */
 context(DeclarationHolder)
 
-fun LanguageFrontend.record(
+fun LanguageFrontend<*, *>.record(
     name: CharSequence,
     kind: String = "class",
     init: RecordDeclaration.() -> Unit
@@ -119,7 +121,7 @@ fun LanguageFrontend.record(
  */
 context(DeclarationHolder)
 
-fun LanguageFrontend.field(
+fun LanguageFrontend<*, *>.field(
     name: CharSequence,
     type: Type = newUnknownType(),
     init: FieldDeclaration.() -> Unit
@@ -141,7 +143,7 @@ fun LanguageFrontend.field(
  */
 context(DeclarationHolder)
 
-fun LanguageFrontend.function(
+fun LanguageFrontend<*, *>.function(
     name: CharSequence,
     returnType: Type = newUnknownType(),
     returnTypes: List<Type>? = null,
@@ -171,7 +173,7 @@ fun LanguageFrontend.function(
  */
 context(RecordDeclaration)
 
-fun LanguageFrontend.method(
+fun LanguageFrontend<*, *>.method(
     name: CharSequence,
     returnType: Type = newUnknownType(),
     init: MethodDeclaration.() -> Unit
@@ -196,7 +198,9 @@ fun LanguageFrontend.method(
  */
 context(RecordDeclaration)
 
-fun LanguageFrontend.constructor(init: ConstructorDeclaration.() -> Unit): ConstructorDeclaration {
+fun LanguageFrontend<*, *>.constructor(
+    init: ConstructorDeclaration.() -> Unit
+): ConstructorDeclaration {
     val recordDecl: RecordDeclaration = this@RecordDeclaration
     val node = newConstructorDeclaration(recordDecl.name, recordDeclaration = recordDecl)
 
@@ -217,7 +221,7 @@ fun LanguageFrontend.constructor(init: ConstructorDeclaration.() -> Unit): Const
  */
 context(FunctionDeclaration)
 
-fun LanguageFrontend.body(
+fun LanguageFrontend<*, *>.body(
     needsScope: Boolean = true,
     init: CompoundStatement.() -> Unit
 ): CompoundStatement {
@@ -236,7 +240,7 @@ fun LanguageFrontend.body(
  */
 context(FunctionDeclaration)
 
-fun LanguageFrontend.param(
+fun LanguageFrontend<*, *>.param(
     name: CharSequence,
     type: Type = newUnknownType(),
     init: (ParamVariableDeclaration.() -> Unit)? = null
@@ -260,7 +264,7 @@ fun LanguageFrontend.param(
  */
 context(StatementHolder)
 
-fun LanguageFrontend.returnStmt(init: ReturnStatement.() -> Unit): ReturnStatement {
+fun LanguageFrontend<*, *>.returnStmt(init: ReturnStatement.() -> Unit): ReturnStatement {
     val node = (this@LanguageFrontend).newReturnStatement()
     init(node)
 
@@ -276,7 +280,7 @@ fun LanguageFrontend.returnStmt(init: ReturnStatement.() -> Unit): ReturnStateme
  */
 context(StatementHolder)
 
-fun LanguageFrontend.declare(init: DeclarationStatement.() -> Unit): DeclarationStatement {
+fun LanguageFrontend<*, *>.declare(init: DeclarationStatement.() -> Unit): DeclarationStatement {
     val node = (this@LanguageFrontend).newDeclarationStatement()
     init(node)
 
@@ -292,7 +296,7 @@ fun LanguageFrontend.declare(init: DeclarationStatement.() -> Unit): Declaration
  */
 context(DeclarationStatement)
 
-fun LanguageFrontend.variable(
+fun LanguageFrontend<*, *>.variable(
     name: String,
     type: Type = newUnknownType(),
     init: (VariableDeclaration.() -> Unit)? = null
@@ -321,7 +325,7 @@ fun LanguageFrontend.variable(
  */
 context(Holder<out Statement>)
 
-fun LanguageFrontend.call(
+fun LanguageFrontend<*, *>.call(
     name: CharSequence,
     isStatic: Boolean = false,
     init: (CallExpression.() -> Unit)? = null
@@ -364,7 +368,7 @@ fun LanguageFrontend.call(
  */
 context(Holder<out Statement>)
 
-fun LanguageFrontend.memberCall(
+fun LanguageFrontend<*, *>.memberCall(
     localName: CharSequence,
     member: Expression,
     isStatic: Boolean = false,
@@ -395,7 +399,7 @@ fun LanguageFrontend.memberCall(
  */
 context(Holder<out Statement>)
 
-fun LanguageFrontend.construct(
+fun LanguageFrontend<*, *>.construct(
     name: CharSequence,
     init: (ConstructExpression.() -> Unit)? = null
 ): ConstructExpression {
@@ -418,7 +422,7 @@ fun LanguageFrontend.construct(
 
 context(Holder<out Statement>)
 
-fun LanguageFrontend.new(init: (NewExpression.() -> Unit)? = null): NewExpression {
+fun LanguageFrontend<*, *>.new(init: (NewExpression.() -> Unit)? = null): NewExpression {
     val node = newNewExpression()
     if (init != null) init(node)
 
@@ -431,7 +435,7 @@ fun LanguageFrontend.new(init: (NewExpression.() -> Unit)? = null): NewExpressio
     return node
 }
 
-fun LanguageFrontend.memberOrRef(name: Name, type: Type = newUnknownType()): Expression {
+fun LanguageFrontend<*, *>.memberOrRef(name: Name, type: Type = newUnknownType()): Expression {
     val node =
         if (name.parent != null) {
             newMemberExpression(name.localName, memberOrRef(name.parent))
@@ -450,7 +454,7 @@ fun LanguageFrontend.memberOrRef(name: Name, type: Type = newUnknownType()): Exp
  */
 context(StatementHolder)
 
-fun LanguageFrontend.ifStmt(init: IfStatement.() -> Unit): IfStatement {
+fun LanguageFrontend<*, *>.ifStmt(init: IfStatement.() -> Unit): IfStatement {
     val node = newIfStatement()
     init(node)
 
@@ -466,7 +470,7 @@ fun LanguageFrontend.ifStmt(init: IfStatement.() -> Unit): IfStatement {
  */
 context(StatementHolder)
 
-fun LanguageFrontend.forEachStmt(init: ForEachStatement.() -> Unit): ForEachStatement {
+fun LanguageFrontend<*, *>.forEachStmt(init: ForEachStatement.() -> Unit): ForEachStatement {
     val node = newForEachStatement()
 
     init(node)
@@ -483,7 +487,7 @@ fun LanguageFrontend.forEachStmt(init: ForEachStatement.() -> Unit): ForEachStat
  */
 context(StatementHolder)
 
-fun LanguageFrontend.switchStmt(
+fun LanguageFrontend<*, *>.switchStmt(
     selector: Expression,
     needsScope: Boolean = true,
     init: SwitchStatement.() -> Unit
@@ -504,7 +508,7 @@ fun LanguageFrontend.switchStmt(
  */
 context(StatementHolder)
 
-fun LanguageFrontend.whileStmt(
+fun LanguageFrontend<*, *>.whileStmt(
     needsScope: Boolean = true,
     init: WhileStatement.() -> Unit
 ): WhileStatement {
@@ -525,7 +529,7 @@ fun LanguageFrontend.whileStmt(
  */
 context(IfStatement)
 
-fun LanguageFrontend.condition(init: IfStatement.() -> BinaryOperator): BinaryOperator {
+fun LanguageFrontend<*, *>.condition(init: IfStatement.() -> BinaryOperator): BinaryOperator {
     return init(this@IfStatement)
 }
 
@@ -536,7 +540,9 @@ fun LanguageFrontend.condition(init: IfStatement.() -> BinaryOperator): BinaryOp
  */
 context(WhileStatement)
 
-fun LanguageFrontend.whileCondition(init: WhileStatement.() -> BinaryOperator): BinaryOperator {
+fun LanguageFrontend<*, *>.whileCondition(
+    init: WhileStatement.() -> BinaryOperator
+): BinaryOperator {
     return init(this@WhileStatement)
 }
 
@@ -547,7 +553,7 @@ fun LanguageFrontend.whileCondition(init: WhileStatement.() -> BinaryOperator): 
  */
 context(IfStatement)
 
-fun LanguageFrontend.thenStmt(
+fun LanguageFrontend<*, *>.thenStmt(
     needsScope: Boolean = true,
     init: CompoundStatement.() -> Unit
 ): CompoundStatement {
@@ -566,7 +572,7 @@ fun LanguageFrontend.thenStmt(
  */
 context(IfStatement)
 
-fun LanguageFrontend.elseIf(init: IfStatement.() -> Unit): IfStatement {
+fun LanguageFrontend<*, *>.elseIf(init: IfStatement.() -> Unit): IfStatement {
     val node = newIfStatement()
     init(node)
 
@@ -584,7 +590,7 @@ fun LanguageFrontend.elseIf(init: IfStatement.() -> Unit): IfStatement {
  */
 context(WhileStatement)
 
-fun LanguageFrontend.loopBody(init: CompoundStatement.() -> Unit): CompoundStatement {
+fun LanguageFrontend<*, *>.loopBody(init: CompoundStatement.() -> Unit): CompoundStatement {
     val node = newCompoundStatement()
     init(node)
     statement = node
@@ -598,7 +604,7 @@ fun LanguageFrontend.loopBody(init: CompoundStatement.() -> Unit): CompoundState
  */
 context(ForEachStatement)
 
-fun LanguageFrontend.loopBody(init: CompoundStatement.() -> Unit): CompoundStatement {
+fun LanguageFrontend<*, *>.loopBody(init: CompoundStatement.() -> Unit): CompoundStatement {
     val node = newCompoundStatement()
     init(node)
     statement = node
@@ -613,7 +619,7 @@ fun LanguageFrontend.loopBody(init: CompoundStatement.() -> Unit): CompoundState
  */
 context(SwitchStatement)
 
-fun LanguageFrontend.switchBody(init: CompoundStatement.() -> Unit): CompoundStatement {
+fun LanguageFrontend<*, *>.switchBody(init: CompoundStatement.() -> Unit): CompoundStatement {
     val node = newCompoundStatement()
     init(node)
     statement = node
@@ -628,7 +634,7 @@ fun LanguageFrontend.switchBody(init: CompoundStatement.() -> Unit): CompoundSta
  */
 context(IfStatement)
 
-fun LanguageFrontend.elseStmt(
+fun LanguageFrontend<*, *>.elseStmt(
     needsScope: Boolean = true,
     init: CompoundStatement.() -> Unit
 ): CompoundStatement {
@@ -646,7 +652,7 @@ fun LanguageFrontend.elseStmt(
  */
 context(Holder<out Statement>)
 
-fun LanguageFrontend.label(
+fun LanguageFrontend<*, *>.label(
     label: String,
     init: (LabelStatement.() -> Statement)? = null
 ): LabelStatement {
@@ -671,7 +677,7 @@ fun LanguageFrontend.label(
  */
 context(StatementHolder)
 
-fun LanguageFrontend.continueStmt(label: String? = null): ContinueStatement {
+fun LanguageFrontend<*, *>.continueStmt(label: String? = null): ContinueStatement {
     val node = newContinueStatement()
     node.label = label
 
@@ -686,7 +692,7 @@ fun LanguageFrontend.continueStmt(label: String? = null): ContinueStatement {
  */
 context(Holder<out Statement>)
 
-fun LanguageFrontend.breakStmt(label: String? = null): BreakStatement {
+fun LanguageFrontend<*, *>.breakStmt(label: String? = null): BreakStatement {
     val node = newBreakStatement()
     node.label = label
 
@@ -705,7 +711,7 @@ fun LanguageFrontend.breakStmt(label: String? = null): BreakStatement {
  */
 context(Holder<out Statement>)
 
-fun LanguageFrontend.case(caseExpr: Expression? = null): CaseStatement {
+fun LanguageFrontend<*, *>.case(caseExpr: Expression? = null): CaseStatement {
     val node = newCaseStatement()
     node.caseExpression = caseExpr
 
@@ -724,7 +730,7 @@ fun LanguageFrontend.case(caseExpr: Expression? = null): CaseStatement {
  */
 context(Holder<out Statement>)
 
-fun LanguageFrontend.default(): DefaultStatement {
+fun LanguageFrontend<*, *>.default(): DefaultStatement {
     val node = newDefaultStatement()
 
     // Only add this to a statement holder if the nearest holder is a statement holder
@@ -742,7 +748,7 @@ fun LanguageFrontend.default(): DefaultStatement {
  */
 context(Holder<out Statement>)
 
-fun <N> LanguageFrontend.literal(value: N, type: Type = newUnknownType()): Literal<N> {
+fun <N> LanguageFrontend<*, *>.literal(value: N, type: Type = newUnknownType()): Literal<N> {
     val node = newLiteral(value, type)
 
     // Only add this to an argument holder if the nearest holder is an argument holder
@@ -761,7 +767,7 @@ fun <N> LanguageFrontend.literal(value: N, type: Type = newUnknownType()): Liter
  */
 context(Holder<out Statement>)
 
-fun LanguageFrontend.ref(
+fun LanguageFrontend<*, *>.ref(
     name: CharSequence,
     type: Type = newUnknownType(),
     init: (DeclaredReferenceExpression.() -> Unit)? = null
@@ -789,7 +795,7 @@ fun LanguageFrontend.ref(
  */
 context(Holder<out Statement>)
 
-fun LanguageFrontend.member(
+fun LanguageFrontend<*, *>.member(
     name: CharSequence,
     base: Expression? = null,
     operatorCode: String = "."
@@ -823,7 +829,7 @@ fun LanguageFrontend.member(
  * Creates a new [BinaryOperator] with a `*` [BinaryOperator.operatorCode] in the Fluent Node DSL
  * and invokes [ArgumentHolder.addArgument] of the nearest enclosing [ArgumentHolder].
  */
-context(LanguageFrontend, ArgumentHolder)
+context(LanguageFrontend<*, *>, ArgumentHolder)
 
 operator fun Expression.times(rhs: Expression): BinaryOperator {
     val node = (this@LanguageFrontend).newBinaryOperator("*")
@@ -845,7 +851,7 @@ operator fun Expression.times(rhs: Expression): BinaryOperator {
  * Creates a new [BinaryOperator] with a `+` [BinaryOperator.operatorCode] in the Fluent Node DSL
  * and invokes [ArgumentHolder.addArgument] of the nearest enclosing [ArgumentHolder].
  */
-context(LanguageFrontend, ArgumentHolder)
+context(LanguageFrontend<*, *>, ArgumentHolder)
 
 operator fun Expression.plus(rhs: Expression): BinaryOperator {
     val node = (this@LanguageFrontend).newBinaryOperator("+")
@@ -867,7 +873,7 @@ operator fun Expression.plus(rhs: Expression): BinaryOperator {
  * Creates a new [BinaryOperator] with a `+` [BinaryOperator.operatorCode] in the Fluent Node DSL
  * and invokes [StatementHolder.addStatement] of the nearest enclosing [StatementHolder].
  */
-context(LanguageFrontend, StatementHolder)
+context(LanguageFrontend<*, *>, StatementHolder)
 
 operator fun Expression.plusAssign(rhs: Expression): Unit {
     val node = (this@LanguageFrontend).newBinaryOperator("+=")
@@ -881,7 +887,7 @@ operator fun Expression.plusAssign(rhs: Expression): Unit {
  * Creates a new [BinaryOperator] with a `+` [BinaryOperator.operatorCode] in the Fluent Node DSL
  * and invokes [ArgumentHolder.addArgument] of the nearest enclosing [ArgumentHolder].
  */
-context(LanguageFrontend, ArgumentHolder)
+context(LanguageFrontend<*, *>, ArgumentHolder)
 
 operator fun Expression.rem(rhs: Expression): BinaryOperator {
     val node = (this@LanguageFrontend).newBinaryOperator("%")
@@ -903,7 +909,7 @@ operator fun Expression.rem(rhs: Expression): BinaryOperator {
  * Creates a new [BinaryOperator] with a `-` [BinaryOperator.operatorCode] in the Fluent Node DSL
  * and invokes [ArgumentHolder.addArgument] of the nearest enclosing [ArgumentHolder].
  */
-context(LanguageFrontend, ArgumentHolder)
+context(LanguageFrontend<*, *>, ArgumentHolder)
 
 operator fun Expression.minus(rhs: Expression): BinaryOperator {
     val node = (this@LanguageFrontend).newBinaryOperator("-")
@@ -919,7 +925,7 @@ operator fun Expression.minus(rhs: Expression): BinaryOperator {
  * Creates a new [UnaryOperator] with a `&` [UnaryOperator.operatorCode] in the Fluent Node DSL and
  * invokes [ArgumentHolder.addArgument] of the nearest enclosing [ArgumentHolder].
  */
-context(LanguageFrontend, ArgumentHolder)
+context(LanguageFrontend<*, *>, ArgumentHolder)
 
 fun reference(input: Expression): UnaryOperator {
     val node = (this@LanguageFrontend).newUnaryOperator("&", false, false)
@@ -934,7 +940,7 @@ fun reference(input: Expression): UnaryOperator {
  * Creates a new [UnaryOperator] with a `--` [UnaryOperator.operatorCode] in the Fluent Node DSL and
  * invokes [StatementHolder.addStatement] of the nearest enclosing [StatementHolder].
  */
-context(LanguageFrontend, Holder<out Statement>)
+context(LanguageFrontend<*, *>, Holder<out Statement>)
 
 operator fun Expression.dec(): UnaryOperator {
     val node = (this@LanguageFrontend).newUnaryOperator("--", true, false)
@@ -951,7 +957,7 @@ operator fun Expression.dec(): UnaryOperator {
  * Creates a new [UnaryOperator] with a `++` [UnaryOperator.operatorCode] in the Fluent Node DSL and
  * invokes [ArgumentHolder.addArgument] of the nearest enclosing [ArgumentHolder].
  */
-context(LanguageFrontend, Holder<out Statement>)
+context(LanguageFrontend<*, *>, Holder<out Statement>)
 
 operator fun Expression.inc(): UnaryOperator {
     val node = (this@LanguageFrontend).newUnaryOperator("++", true, false)
@@ -968,7 +974,7 @@ operator fun Expression.inc(): UnaryOperator {
  * Creates a new [BinaryOperator] with a `==` [BinaryOperator.operatorCode] in the Fluent Node DSL
  * and invokes [ArgumentHolder.addArgument] of the nearest enclosing [ArgumentHolder].
  */
-context(LanguageFrontend, ArgumentHolder)
+context(LanguageFrontend<*, *>, ArgumentHolder)
 
 infix fun Expression.eq(rhs: Expression): BinaryOperator {
     val node = (this@LanguageFrontend).newBinaryOperator("==")
@@ -984,7 +990,7 @@ infix fun Expression.eq(rhs: Expression): BinaryOperator {
  * Creates a new [BinaryOperator] with a `>` [BinaryOperator.operatorCode] in the Fluent Node DSL
  * and invokes [ArgumentHolder.addArgument] of the nearest enclosing [ArgumentHolder].
  */
-context(LanguageFrontend, ArgumentHolder)
+context(LanguageFrontend<*, *>, ArgumentHolder)
 
 infix fun Expression.gt(rhs: Expression): BinaryOperator {
     val node = (this@LanguageFrontend).newBinaryOperator(">")
@@ -1000,7 +1006,7 @@ infix fun Expression.gt(rhs: Expression): BinaryOperator {
  * Creates a new [BinaryOperator] with a `<` [BinaryOperator.operatorCode] in the Fluent Node DSL
  * and invokes [ArgumentHolder.addArgument] of the nearest enclosing [ArgumentHolder].
  */
-context(LanguageFrontend, ArgumentHolder)
+context(LanguageFrontend<*, *>, ArgumentHolder)
 
 infix fun Expression.lt(rhs: Expression): BinaryOperator {
     val node = (this@LanguageFrontend).newBinaryOperator("<")
@@ -1016,7 +1022,7 @@ infix fun Expression.lt(rhs: Expression): BinaryOperator {
  * Creates a new [ConditionalExpression] with a `=` [BinaryOperator.operatorCode] in the Fluent Node
  * DSL and invokes [StatementHolder.addStatement] of the nearest enclosing [StatementHolder].
  */
-context(LanguageFrontend, StatementHolder)
+context(LanguageFrontend<*, *>, StatementHolder)
 
 fun Expression.conditional(
     condition: Expression,
@@ -1034,7 +1040,7 @@ fun Expression.conditional(
  * Creates a new [BinaryOperator] with a `=` [BinaryOperator.operatorCode] in the Fluent Node DSL
  * and invokes [StatementHolder.addStatement] of the nearest enclosing [StatementHolder].
  */
-context(LanguageFrontend, StatementHolder)
+context(LanguageFrontend<*, *>, StatementHolder)
 
 infix fun Expression.assign(init: BinaryOperator.() -> Expression): BinaryOperator {
     val node = (this@LanguageFrontend).newBinaryOperator("=")
@@ -1050,7 +1056,7 @@ infix fun Expression.assign(init: BinaryOperator.() -> Expression): BinaryOperat
  * Creates a new [BinaryOperator] with a `=` [BinaryOperator.operatorCode] in the Fluent Node DSL
  * and invokes [StatementHolder.addStatement] of the nearest enclosing [StatementHolder].
  */
-context(LanguageFrontend, Holder<out Node>)
+context(LanguageFrontend<*, *>, Holder<out Node>)
 
 infix fun Expression.assign(rhs: Expression): BinaryOperator {
     val node = (this@LanguageFrontend).newBinaryOperator("=")
@@ -1065,7 +1071,7 @@ infix fun Expression.assign(rhs: Expression): BinaryOperator {
 }
 
 /** Creates a new [Type] with the given [name] in the Fluent Node DSL. */
-fun LanguageFrontend.t(name: CharSequence, init: (Type.() -> Unit)? = null): Type {
+fun LanguageFrontend<*, *>.t(name: CharSequence, init: (Type.() -> Unit)? = null): Type {
     val type = parseType(name)
     if (init != null) {
         init(type)
@@ -1077,7 +1083,7 @@ fun LanguageFrontend.t(name: CharSequence, init: (Type.() -> Unit)? = null): Typ
  * Internally used to enter a new scope if [needsScope] is true before invoking [init] and leaving
  * it afterwards.
  */
-private fun <T : Node> LanguageFrontend.scopeIfNecessary(
+private fun <T : Node> LanguageFrontend<*, *>.scopeIfNecessary(
     needsScope: Boolean,
     node: T,
     init: T.() -> Unit

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/BooleanType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/BooleanType.kt
@@ -26,13 +26,12 @@
 package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.frontends.Language
-import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 
 /** Instances of this class represent boolean types. */
 class BooleanType(
     typeName: CharSequence = "bool",
     bitWidth: Int? = 1,
-    language: Language<out LanguageFrontend>? = null,
+    language: Language<*>? = null,
     modifier: Modifier = Modifier.NOT_APPLICABLE
 ) : NumericType(typeName, bitWidth, language, modifier) {
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FloatingPointType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FloatingPointType.kt
@@ -26,13 +26,12 @@
 package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.frontends.Language
-import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 
 /** Instances of this class represent floating point types. */
 class FloatingPointType(
     typeName: CharSequence = "",
     bitWidth: Int? = null,
-    language: Language<out LanguageFrontend>? = null,
+    language: Language<*>? = null,
     modifier: Modifier = Modifier.SIGNED
 ) : NumericType(typeName, bitWidth, language, modifier) {
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionPointerType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionPointerType.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.frontends.Language
-import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.transformIntoOutgoingPropertyEdgeList
@@ -57,7 +56,7 @@ class FunctionPointerType : Type {
 
     constructor(
         parameters: List<Type> = listOf(),
-        language: Language<out LanguageFrontend>? = null,
+        language: Language<*>? = null,
         returnType: Type = UnknownType.getUnknownType(language)
     ) : super(EMPTY_NAME, language) {
         parametersPropertyEdge = transformIntoOutgoingPropertyEdgeList(parameters, this)
@@ -67,7 +66,7 @@ class FunctionPointerType : Type {
     constructor(
         type: Type,
         parameters: List<Type> = listOf(),
-        language: Language<out LanguageFrontend>? = null,
+        language: Language<*>? = null,
         returnType: Type = UnknownType.getUnknownType(language)
     ) : super(type) {
         parametersPropertyEdge = transformIntoOutgoingPropertyEdgeList(parameters, this)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionType.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.frontends.Language
-import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.newUnknownType
 import de.fraunhofer.aisec.cpg.graph.registerType
@@ -43,7 +42,7 @@ constructor(
     typeName: String = "",
     var parameters: List<Type> = listOf(),
     var returnTypes: List<Type> = listOf(),
-    language: Language<out LanguageFrontend>? = null
+    language: Language<*>? = null
 ) : Type(typeName, language) {
 
     override fun reference(pointer: PointerType.PointerOrigin?): Type {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/IntegerType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/IntegerType.kt
@@ -26,13 +26,12 @@
 package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.frontends.Language
-import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 
 /** Instances of this class represent integer types. */
 class IntegerType(
     typeName: CharSequence = "",
     bitWidth: Int? = null,
-    language: Language<out LanguageFrontend>? = null,
+    language: Language<*>? = null,
     modifier: Modifier = Modifier.SIGNED
 ) : NumericType(typeName, bitWidth, language, modifier) {
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/NumericType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/NumericType.kt
@@ -26,14 +26,13 @@
 package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.frontends.Language
-import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import java.util.*
 
 /** This type collects all kind of numeric types. */
 open class NumericType(
     typeName: CharSequence = "",
     val bitWidth: Int? = null,
-    language: Language<out LanguageFrontend>? = null,
+    language: Language<*>? = null,
     val modifier: Modifier = Modifier.SIGNED
 ) : ObjectType(typeName, listOf(), true, language) {
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ObjectType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ObjectType.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.frontends.Language
-import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.HasType.SecondaryTypeEdge
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.edge.Properties
@@ -58,7 +57,7 @@ open class ObjectType : Type, SecondaryTypeEdge {
         typeName: CharSequence,
         generics: List<Type>,
         primitive: Boolean,
-        language: Language<out LanguageFrontend>?
+        language: Language<*>?
     ) : super(typeName, language) {
         this.genericsPropertyEdges = transformIntoOutgoingPropertyEdgeList(generics, this)
         isPrimitive = primitive
@@ -69,7 +68,7 @@ open class ObjectType : Type, SecondaryTypeEdge {
         type: Type?,
         generics: List<Type>,
         primitive: Boolean,
-        language: Language<out LanguageFrontend>?
+        language: Language<*>?
     ) : super(type) {
         this.language = language
         this.genericsPropertyEdges = transformIntoOutgoingPropertyEdgeList(generics, this)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ParameterizedType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ParameterizedType.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.frontends.Language
-import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.types.PointerType.PointerOrigin
 
 /**
@@ -38,7 +37,7 @@ class ParameterizedType : Type {
         language = type.language
     }
 
-    constructor(typeName: String?, language: Language<out LanguageFrontend>?) : super(typeName) {
+    constructor(typeName: String?, language: Language<*>?) : super(typeName) {
         this.language = language
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/StringType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/StringType.kt
@@ -26,11 +26,10 @@
 package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.frontends.Language
-import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 
 class StringType(
     typeName: CharSequence = "",
-    language: Language<out LanguageFrontend>? = null,
+    language: Language<*>? = null,
     generics: List<Type> = listOf()
 ) : ObjectType(typeName, generics, false, language) {
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/Type.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/Type.kt
@@ -27,7 +27,6 @@ package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.PopulatedByPass
 import de.fraunhofer.aisec.cpg.frontends.Language
-import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.parseName
@@ -68,7 +67,7 @@ abstract class Type : Node {
         typeOrigin = type?.typeOrigin
     }
 
-    constructor(typeName: CharSequence, language: Language<out LanguageFrontend>?) {
+    constructor(typeName: CharSequence, language: Language<*>?) {
         name =
             if (this is FunctionType) {
                 Name(typeName.toString(), null, language)
@@ -79,7 +78,7 @@ abstract class Type : Node {
         typeOrigin = Origin.UNRESOLVED
     }
 
-    constructor(fullTypeName: Name, language: Language<out LanguageFrontend>?) {
+    constructor(fullTypeName: Name, language: Language<*>?) {
         name = fullTypeName.clone()
         typeOrigin = Origin.UNRESOLVED
         this.language = language

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/UnknownType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/UnknownType.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.frontends.Language
-import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.types.PointerType.PointerOrigin
 import java.util.*
@@ -88,7 +87,7 @@ class UnknownType : Type {
 
         /** Use this function to obtain an [UnknownType] for the particular [language]. */
         @JvmStatic
-        fun getUnknownType(language: Language<out LanguageFrontend>?): UnknownType {
+        fun getUnknownType(language: Language<*>?): UnknownType {
             if (language == null) return unknownTypeNull
 
             return unknownTypes.computeIfAbsent(language) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.kt
@@ -393,7 +393,7 @@ object SubgraphWalker {
         private var walker: IterativeGraphWalker? = null
         private val scopeManager: ScopeManager
 
-        constructor(lang: LanguageFrontend) {
+        constructor(lang: LanguageFrontend<*, *>) {
             scopeManager = lang.scopeManager
         }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/Util.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/Util.kt
@@ -177,9 +177,9 @@ object Util {
     }
 
     @JvmStatic
-    fun <S> warnWithFileLocation(
-        lang: LanguageFrontend,
-        astNode: S,
+    fun <AstNode> warnWithFileLocation(
+        lang: LanguageFrontend<AstNode, *>,
+        astNode: AstNode,
         log: Logger,
         format: String?,
         vararg arguments: Any?
@@ -187,7 +187,7 @@ object Util {
         log.warn(
             String.format(
                 "%s: %s",
-                PhysicalLocation.locationLink(lang.getLocationFromRawNode(astNode)),
+                PhysicalLocation.locationLink(lang.locationOf(astNode)),
                 format
             ),
             *arguments
@@ -195,9 +195,9 @@ object Util {
     }
 
     @JvmStatic
-    fun <S> errorWithFileLocation(
-        lang: LanguageFrontend,
-        astNode: S,
+    fun <AstNode> errorWithFileLocation(
+        lang: LanguageFrontend<AstNode, *>,
+        astNode: AstNode,
         log: Logger,
         format: String?,
         vararg arguments: Any?
@@ -205,7 +205,7 @@ object Util {
         log.error(
             String.format(
                 "%s: %s",
-                PhysicalLocation.locationLink(lang.getLocationFromRawNode(astNode)),
+                PhysicalLocation.locationLink(lang.locationOf(astNode)),
                 format
             ),
             *arguments

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CallResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CallResolver.kt
@@ -553,7 +553,7 @@ open class CallResolver(ctx: TranslationContext) : SymbolResolverPass(ctx) {
         }
     }
 
-    protected val Language<out LanguageFrontend>?.isCPP: Boolean
+    protected val Language<*>?.isCPP: Boolean
         get() {
             return this != null && this::class.simpleName == "CPPLanguage"
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
@@ -99,7 +99,7 @@ sealed class Pass<T : PassTarget>(final override val ctx: TranslationContext) :
      * @return true, if the pass does not require a specific language frontend or if it matches the
      *   [RequiredFrontend]
      */
-    fun runsWithCurrentFrontend(usedFrontends: Collection<LanguageFrontend>): Boolean {
+    fun runsWithCurrentFrontend(usedFrontends: Collection<LanguageFrontend<*, *>>): Boolean {
         if (!this.javaClass.isAnnotationPresent(RequiredFrontend::class.java)) return true
         val requiredFrontend = this.javaClass.getAnnotation(RequiredFrontend::class.java).value
         for (used in usedFrontends) {
@@ -123,7 +123,7 @@ fun executePassSequential(
     cls: KClass<out Pass<*>>,
     ctx: TranslationContext,
     result: TranslationResult,
-    executedFrontends: Collection<LanguageFrontend>
+    executedFrontends: Collection<LanguageFrontend<*, *>>
 ) {
     // This is a bit tricky but actually better than other reflection magic. We are creating a
     // "prototype" instance of our pass class, so we can deduce certain type information more
@@ -160,7 +160,7 @@ inline fun <reified T : PassTarget> executePass(
     cls: KClass<out Pass<T>>,
     ctx: TranslationContext,
     target: T,
-    executedFrontends: Collection<LanguageFrontend>
+    executedFrontends: Collection<LanguageFrontend<*, *>>
 ): Pass<T>? {
     val language =
         if (target is LanguageProvider) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
@@ -28,7 +28,6 @@ package de.fraunhofer.aisec.cpg.passes.inference
 import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.HasClasses
 import de.fraunhofer.aisec.cpg.frontends.Language
-import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
@@ -54,7 +53,7 @@ class Inference(val start: Node, override val ctx: TranslationContext) :
     LanguageProvider, ScopeProvider, IsInferredProvider, ContextProvider {
     val log: Logger = LoggerFactory.getLogger(Inference::class.java)
 
-    override val language: Language<out LanguageFrontend>?
+    override val language: Language<*>?
         get() = start.language
 
     override val isInferred: Boolean

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/RequiredFrontend.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/RequiredFrontend.kt
@@ -34,4 +34,4 @@ import kotlin.reflect.KClass
  */
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
-annotation class RequiredFrontend(val value: KClass<out LanguageFrontend>)
+annotation class RequiredFrontend(val value: KClass<out LanguageFrontend<*, *>>)

--- a/cpg-core/src/testFixtures/kotlin/de/fraunhofer/aisec/cpg/frontends/TestLanguage.kt
+++ b/cpg-core/src/testFixtures/kotlin/de/fraunhofer/aisec/cpg/frontends/TestLanguage.kt
@@ -29,6 +29,7 @@ import de.fraunhofer.aisec.cpg.*
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.TypeManager
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
+import de.fraunhofer.aisec.cpg.graph.newUnknownType
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.ProblemExpression
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
@@ -74,27 +75,32 @@ class StructTestLanguage(namespaceDelimiter: String = "::") :
 
 open class TestLanguageFrontend(
     namespaceDelimiter: String = "::",
-    language: Language<out LanguageFrontend> = TestLanguage(namespaceDelimiter),
+    language: Language<TestLanguageFrontend> = TestLanguage(namespaceDelimiter),
     ctx: TranslationContext =
         TranslationContext(
             TranslationConfiguration.builder().build(),
             ScopeManager(),
             TypeManager()
         ),
-) : LanguageFrontend(language, ctx) {
+) : LanguageFrontend<Any, Any>(language, ctx) {
     override fun parse(file: File): TranslationUnitDeclaration {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Any?> getCodeFromRawNode(astNode: T): String? {
+    override fun typeOf(type: Any): Type {
+        // reserved for future use
+        return newUnknownType()
+    }
+
+    override fun codeOf(astNode: Any): String? {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Any?> getLocationFromRawNode(astNode: T): PhysicalLocation? {
+    override fun locationOf(astNode: Any): PhysicalLocation? {
         TODO("Not yet implemented")
     }
 
-    override fun <S : Any?, T : Any?> setComment(s: S, ctx: T) {
+    override fun setComment(node: Node, astNode: Any) {
         TODO("Not yet implemented")
     }
 }

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXHandler.kt
@@ -30,9 +30,10 @@ import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.ProblemNode
 import de.fraunhofer.aisec.cpg.helpers.Util
 import java.util.function.Supplier
+import org.eclipse.cdt.core.dom.ast.IASTNode
 import org.eclipse.cdt.internal.core.dom.parser.ASTNode
 
-abstract class CXXHandler<S : Node, T : Any>(
+abstract class CXXHandler<S : Node, T : IASTNode>(
     configConstructor: Supplier<S>,
     lang: CXXLanguageFrontend
 ) : Handler<S, T, CXXLanguageFrontend>(configConstructor, lang) {
@@ -58,7 +59,7 @@ abstract class CXXHandler<S : Node, T : Any>(
         // The language frontend might set a location, which we should respect. Otherwise, we will
         // set the location here.
         if (node.location == null) {
-            frontend.setCodeAndLocation<S, T>(node, ctx)
+            frontend.setCodeAndLocation(node, ctx)
         }
 
         frontend.setComment(node, ctx)

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
@@ -87,8 +87,7 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
      * into a [NamespaceDeclaration].
      */
     private fun handleNamespace(ctx: CPPASTNamespaceDefinition): NamespaceDeclaration {
-        val declaration =
-            newNamespaceDeclaration(ctx.name.toString(), frontend.getCodeFromRawNode(ctx))
+        val declaration = newNamespaceDeclaration(ctx.name.toString(), frontend.codeOf(ctx))
 
         frontend.scopeManager.addDeclaration(declaration)
 
@@ -270,12 +269,12 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
 
         val templateDeclaration: TemplateDeclaration =
             if (ctx.declaration is CPPASTFunctionDefinition) {
-                newFunctionTemplateDeclaration(name, frontend.getCodeFromRawNode(ctx))
+                newFunctionTemplateDeclaration(name, frontend.codeOf(ctx))
             } else {
-                newClassTemplateDeclaration(name, frontend.getCodeFromRawNode(ctx))
+                newClassTemplateDeclaration(name, frontend.codeOf(ctx))
             }
 
-        templateDeclaration.location = frontend.getLocationFromRawNode(ctx)
+        templateDeclaration.location = frontend.locationOf(ctx)
         frontend.scopeManager.addDeclaration(templateDeclaration)
         frontend.scopeManager.enterScope(templateDeclaration)
         addTemplateParameters(ctx, templateDeclaration)
@@ -543,7 +542,7 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
         val declaration =
             frontend.typeManager.createTypeAlias(
                 frontend,
-                frontend.getCodeFromRawNode(ctx),
+                frontend.codeOf(ctx),
                 type,
                 nameDecl.name.toString()
             )
@@ -562,7 +561,7 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
         val enum =
             newEnumDeclaration(
                 name = declSpecifier.name.toString(),
-                location = frontend.getLocationFromRawNode(ctx),
+                location = frontend.locationOf(ctx),
             )
 
         // Loop through its members
@@ -570,8 +569,8 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
             val enumConst =
                 newEnumConstantDeclaration(
                     enumerator.name.toString(),
-                    frontend.getCodeFromRawNode(enumerator),
-                    frontend.getLocationFromRawNode(enumerator),
+                    frontend.codeOf(enumerator),
+                    frontend.locationOf(enumerator),
                 )
 
             // In C/C++, default enums are of type int

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/ExpressionHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/ExpressionHandler.kt
@@ -82,7 +82,7 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
     }
 
     private fun handleLambdaExpression(node: CPPASTLambdaExpression): Expression {
-        val lambda = newLambdaExpression(frontend.getCodeFromRawNode(node))
+        val lambda = newLambdaExpression(frontend.codeOf(node))
 
         // Variables passed by reference are mutable. If we have initializers, we have to model the
         // variable explicitly.
@@ -206,8 +206,7 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
             }
 
             // new returns a pointer, so we need to reference the type by pointer
-            val newExpression =
-                newNewExpression(code, t.reference(PointerOrigin.POINTER), frontend.language)
+            val newExpression = newNewExpression(code, t.reference(PointerOrigin.POINTER), ctx)
             newExpression.templateParameters = templateParameters
             val initializer: Expression?
             if (init != null) {
@@ -357,10 +356,10 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
                     // this can either be just a meaningless bracket or it can be a cast expression
                     val typeName = (ctx.operand as IASTIdExpression).name.toString()
                     if (frontend.typeManager.typeExists(typeName)) {
-                        val cast = newCastExpression(frontend.getCodeFromRawNode<Any>(ctx))
+                        val cast = newCastExpression(frontend.codeOf(ctx))
                         cast.castType = parseType(typeName)
                         cast.expression = input ?: newProblemExpression("could not parse input")
-                        cast.location = frontend.getLocationFromRawNode<Any>(ctx)
+                        cast.location = frontend.locationOf(ctx)
                         return cast
                     }
                 }

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/PerformanceRegressionTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/PerformanceRegressionTest.kt
@@ -53,7 +53,7 @@ class PerformanceRegressionTest {
      *   in reasonable time. We had issues with literals and their hashcode when they were inserted
      *   into a set.
      * * Second, we want to make that list essentially a one-liner because we had issues when
-     *   populating the [Node.location] property using [CXXLanguageFrontend.getLocationFromRawNode].
+     *   populating the [Node.location] property using [CXXLanguageFrontend.locationOf].
      */
     @Test
     fun testParseLargeList() {

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
@@ -1076,10 +1076,10 @@ internal class CXXLanguageFrontendTest : BaseTest() {
     fun testLocation() {
         val file = File("src/test/resources/components/foreachstmt.cpp")
         val tu = analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true)
-        val main = tu.getDeclarationsByName("main", FunctionDeclaration::class.java)
-        assertFalse(main.isEmpty())
+        val main = tu.functions["main"]
+        assertNotNull(main)
 
-        val location = main.iterator().next().location
+        val location = main.location
         assertNotNull(location)
 
         val path = Path.of(location.artifactLocation.uri)

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontend.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontend.kt
@@ -30,7 +30,10 @@ import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.frontends.SupportsParallelParsing
 import de.fraunhofer.aisec.cpg.frontends.TranslationException
+import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
+import de.fraunhofer.aisec.cpg.graph.newUnknownType
+import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.passes.GoExtraPass
 import de.fraunhofer.aisec.cpg.passes.order.RegisterExtraPass
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
@@ -40,7 +43,7 @@ import java.io.FileOutputStream
 @SupportsParallelParsing(false)
 @RegisterExtraPass(GoExtraPass::class)
 class GoLanguageFrontend(language: Language<GoLanguageFrontend>, ctx: TranslationContext) :
-    LanguageFrontend(language, ctx) {
+    LanguageFrontend<Any, Any>(language, ctx) {
     companion object {
 
         init {
@@ -88,17 +91,24 @@ class GoLanguageFrontend(language: Language<GoLanguageFrontend>, ctx: Translatio
         )
     }
 
-    override fun <T> getCodeFromRawNode(astNode: T): String? {
+    override fun typeOf(type: Any): Type {
+        // this is handled by native code
+        return newUnknownType()
+    }
+
+    override fun codeOf(astNode: Any): String? {
         // this is handled by native code
         return null
     }
 
-    override fun <T> getLocationFromRawNode(astNode: T): PhysicalLocation? {
+    override fun locationOf(astNode: Any): PhysicalLocation? {
         // this is handled by native code
         return null
     }
 
-    override fun <S, T> setComment(s: S, ctx: T) {}
+    override fun setComment(node: Node, astNode: Any) {
+        // this is handled by native code
+    }
 
     private external fun parseInternal(
         s: String?,

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.kt
@@ -323,7 +323,7 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
         val variable = fieldDecl.getVariable(0)
         val modifiers = fieldDecl.modifiers.map { modifier -> modifier.keyword.asString() }
         val joinedModifiers = java.lang.String.join(" ", modifiers) + " "
-        val location = frontend.getLocationFromRawNode(fieldDecl)
+        val location = frontend.locationOf(fieldDecl)
         val initializer =
             variable.initializer
                 .map { ctx: Expression -> frontend.expressionHandler.handle(ctx) }
@@ -374,7 +374,7 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
         enumDecl: com.github.javaparser.ast.body.EnumDeclaration
     ): EnumDeclaration {
         val name = enumDecl.nameAsString
-        val location = frontend.getLocationFromRawNode(enumDecl)
+        val location = frontend.locationOf(enumDecl)
         val enumDeclaration = this.newEnumDeclaration(name, enumDecl.toString(), location)
         val entries = enumDecl.entries.mapNotNull { handle(it) as EnumConstantDeclaration? }
 
@@ -392,7 +392,7 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
         return this.newEnumConstantDeclaration(
             enumConstDecl.nameAsString,
             enumConstDecl.toString(),
-            frontend.getLocationFromRawNode(enumConstDecl)
+            frontend.locationOf(enumConstDecl)
         )
     }
 

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
@@ -49,8 +49,8 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
 
     private fun handleLambdaExpr(expr: Expression): Statement {
         val lambdaExpr = expr.asLambdaExpr()
-        val lambda = newLambdaExpression(frontend.getCodeFromRawNode(lambdaExpr))
-        val anonymousFunction = newFunctionDeclaration("", frontend.getCodeFromRawNode(lambdaExpr))
+        val lambda = newLambdaExpression(frontend.codeOf(lambdaExpr))
+        val anonymousFunction = newFunctionDeclaration("", frontend.codeOf(lambdaExpr))
         frontend.scopeManager.enterScope(anonymousFunction)
         for (parameter in lambdaExpr.parameters) {
             val resolvedType = frontend.getTypeAsGoodAsPossible(parameter.type)
@@ -326,12 +326,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
                     scope.toString()
                 )
             base.isStaticAccess = isStaticAccess
-            frontend.setCodeAndLocation<
-                de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression, Expression
-            >(
-                base,
-                fieldAccessExpr.scope
-            )
+            frontend.setCodeAndLocation(base, fieldAccessExpr.scope)
         } else if (scope.isFieldAccessExpr) {
             base =
                 handle(scope) as de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression?
@@ -423,7 +418,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
             return memberExpression
         }
         if (base.location == null) {
-            base.location = frontend.getLocationFromRawNode(fieldAccessExpr)
+            base.location = frontend.locationOf(fieldAccessExpr)
         }
         return this.newMemberExpression(fieldAccessExpr.name.identifier, base, fieldType, ".")
     }
@@ -838,7 +833,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
         if (objectCreationExpr.anonymousClassBody.isPresent) {
             // We have an anonymous class and will create a RecordDeclaration for it and add all the
             // implemented methods.
-            val locationHash = frontend.getLocationFromRawNode(objectCreationExpr)?.hashCode()
+            val locationHash = frontend.locationOf(objectCreationExpr)?.hashCode()
 
             // We use the hash of the location to distinguish multiple instances of the anonymous
             // class' superclass

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
@@ -46,9 +46,6 @@ import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 import de.fraunhofer.aisec.cpg.sarif.Region
 import java.util.function.Supplier
 import java.util.stream.Collectors
-import kotlin.collections.ArrayList
-import kotlin.collections.MutableList
-import kotlin.collections.mapNotNull
 import kotlin.collections.set
 import org.slf4j.LoggerFactory
 
@@ -63,7 +60,10 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
         val expression = frontend.expressionHandler.handle(stmt.asExpressionStmt().expression)
 
         // update expression's code and location to match the statement
-        frontend.setCodeAndLocation(expression, stmt)
+        if (expression != null) {
+            frontend.setCodeAndLocation(expression, stmt)
+        }
+
         return expression
     }
 
@@ -189,10 +189,11 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
             val initExprList = this.newExpressionList()
             for (initExpr in forStmt.initialization) {
                 val s = frontend.expressionHandler.handle(initExpr)
-
-                // make sure location is set
-                frontend.setCodeAndLocation(s, initExpr)
-                s?.let { initExprList.addExpression(it) }
+                s?.let {
+                    // make sure location is set
+                    frontend.setCodeAndLocation(it, initExpr)
+                    initExprList.addExpression(it)
+                }
 
                 // can not update location
                 if (s?.location == null) {
@@ -242,10 +243,11 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
             val iterationExprList = this.newExpressionList()
             for (updateExpr in forStmt.update) {
                 val s = frontend.expressionHandler.handle(updateExpr)
-
-                // make sure location is set
-                frontend.setCodeAndLocation(s, updateExpr)
-                s?.let { iterationExprList.addExpression(it) }
+                s?.let {
+                    // make sure location is set
+                    frontend.setCodeAndLocation(s, updateExpr)
+                    iterationExprList.addExpression(it)
+                }
 
                 // can not update location
                 if (s?.location == null) {
@@ -353,7 +355,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
         caseExpression: Expression?,
         sEntry: SwitchEntry
     ): de.fraunhofer.aisec.cpg.graph.statements.Statement {
-        val parentLocation = frontend.getLocationFromRawNode(sEntry)
+        val parentLocation = frontend.locationOf(sEntry)
         val optionalTokenRange = sEntry.tokenRange
         var caseTokens = Pair<JavaToken?, JavaToken?>(null, null)
         if (optionalTokenRange.isEmpty) {

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/DeclarationHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/DeclarationHandler.kt
@@ -58,7 +58,7 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
                 newProblemDeclaration(
                     "Not handling declaration kind $kind yet.",
                     ProblemNode.ProblemType.TRANSLATION,
-                    frontend.getCodeFromRawNode(value)
+                    frontend.codeOf(value)
                 )
             }
         }
@@ -75,7 +75,7 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
         val type = frontend.typeOf(valueRef)
 
         val variableDeclaration =
-            newVariableDeclaration(name, type, frontend.getCodeFromRawNode(valueRef), false)
+            newVariableDeclaration(name, type, frontend.codeOf(valueRef), false)
 
         // cache binding
         frontend.bindingsCache[valueRef.symbolName] = variableDeclaration
@@ -98,8 +98,7 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
      */
     private fun handleFunction(func: LLVMValueRef): FunctionDeclaration {
         val name = LLVMGetValueName(func)
-        val functionDeclaration =
-            newFunctionDeclaration(name.string, frontend.getCodeFromRawNode(func))
+        val functionDeclaration = newFunctionDeclaration(name.string, frontend.codeOf(func))
 
         // return types are a bit tricky, because the type of the function is a pointer to the
         // function type, which then has the return type in it
@@ -120,13 +119,7 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
             val type = frontend.typeOf(param)
 
             // TODO: support variardic
-            val decl =
-                newParamVariableDeclaration(
-                    paramName,
-                    type,
-                    false,
-                    frontend.getCodeFromRawNode(param)
-                )
+            val decl = newParamVariableDeclaration(paramName, type, false, frontend.codeOf(param))
 
             frontend.scopeManager.addDeclaration(decl)
             frontend.bindingsCache[paramSymbolName] = decl
@@ -227,17 +220,7 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
             // there are no names, so we need to invent some dummy ones for easier reading
             val fieldName = "field_$i"
 
-            val field =
-                newFieldDeclaration(
-                    fieldName,
-                    fieldType,
-                    listOf(),
-                    "",
-                    null,
-                    null,
-                    false,
-                    frontend.language
-                )
+            val field = newFieldDeclaration(fieldName, fieldType, listOf(), "", null, null, false)
 
             frontend.scopeManager.addDeclaration(field)
         }

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
@@ -29,7 +29,10 @@ import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.frontends.TranslationException
+import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
+import de.fraunhofer.aisec.cpg.graph.newUnknownType
+import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 import java.io.File
 import java.nio.file.Paths
@@ -37,7 +40,7 @@ import jep.JepException
 import kotlin.io.path.absolutePathString
 
 class PythonLanguageFrontend(language: Language<PythonLanguageFrontend>, ctx: TranslationContext) :
-    LanguageFrontend(language, ctx) {
+    LanguageFrontend<Any, Any>(language, ctx) {
     private val jep = JepSingleton // configure Jep
 
     @Throws(TranslationException::class)
@@ -45,17 +48,22 @@ class PythonLanguageFrontend(language: Language<PythonLanguageFrontend>, ctx: Tr
         return parseInternal(file.readText(Charsets.UTF_8), file.path)
     }
 
-    override fun <T> getCodeFromRawNode(astNode: T): String? {
+    override fun typeOf(type: Any): Type {
+        // will be invoked by native function
+        return newUnknownType()
+    }
+
+    override fun codeOf(astNode: Any): String? {
         // will be invoked by native function
         return null
     }
 
-    override fun <T> getLocationFromRawNode(astNode: T): PhysicalLocation? {
+    override fun locationOf(astNode: Any): PhysicalLocation? {
         // will be invoked by native function
         return null
     }
 
-    override fun <S, T> setComment(s: S, ctx: T) {
+    override fun setComment(node: Node, astNode: Any) {
         // will be invoked by native function
     }
 

--- a/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/ExpressionHandler.kt
+++ b/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/ExpressionHandler.kt
@@ -65,12 +65,12 @@ class ExpressionHandler(lang: TypeScriptLanguageFrontend) :
         val key = node.children?.first()?.let { this.handle(it) }
         val value = node.children?.last()?.let { this.handle(it) }
 
-        return newKeyValueExpression(key, value, this.frontend.getCodeFromRawNode(node))
+        return newKeyValueExpression(key, value, this.frontend.codeOf(node))
     }
 
     private fun handleJsxClosingElement(node: TypeScriptNode): Expression {
         // this basically represents an HTML tag with attributes
-        val tag = newExpressionList(this.frontend.getCodeFromRawNode(node))
+        val tag = newExpressionList(this.frontend.codeOf(node))
 
         // it contains an Identifier node, we map this into the name
         this.frontend.getIdentifierName(node).let { tag.name = Name("</$it>") }
@@ -86,7 +86,7 @@ class ExpressionHandler(lang: TypeScriptLanguageFrontend) :
 
     private fun handleJsxOpeningElement(node: TypeScriptNode): ExpressionList {
         // this basically represents an HTML tag with attributes
-        val tag = newExpressionList(this.frontend.getCodeFromRawNode(node))
+        val tag = newExpressionList(this.frontend.codeOf(node))
 
         // it contains an Identifier node, we map this into the name
         this.frontend.getIdentifierName(node).let { tag.name = Name("<$it>") }
@@ -100,7 +100,7 @@ class ExpressionHandler(lang: TypeScriptLanguageFrontend) :
     }
 
     private fun handeJsxElement(node: TypeScriptNode): ExpressionList {
-        val jsx = newExpressionList(this.frontend.getCodeFromRawNode(node))
+        val jsx = newExpressionList(this.frontend.codeOf(node))
 
         jsx.expressions = node.children?.mapNotNull { this.handle(it) } ?: emptyList()
 
@@ -129,7 +129,7 @@ class ExpressionHandler(lang: TypeScriptLanguageFrontend) :
 
         // we cannot directly return a function declaration as an expression, so we
         // wrap it into a lambda expression
-        val lambda = newLambdaExpression(frontend.getCodeFromRawNode(node))
+        val lambda = newLambdaExpression(frontend.codeOf(node))
         lambda.function = func
 
         return lambda
@@ -139,11 +139,11 @@ class ExpressionHandler(lang: TypeScriptLanguageFrontend) :
         val key = node.children?.first()?.let { this.handle(it) }
         val value = node.children?.last()?.let { this.handle(it) }
 
-        return newKeyValueExpression(key, value, this.frontend.getCodeFromRawNode(node))
+        return newKeyValueExpression(key, value, this.frontend.codeOf(node))
     }
 
     private fun handleObjectLiteralExpression(node: TypeScriptNode): InitializerListExpression {
-        val ile = newInitializerListExpression(this.frontend.getCodeFromRawNode(node))
+        val ile = newInitializerListExpression(this.frontend.codeOf(node))
 
         ile.initializers = node.children?.mapNotNull { this.handle(it) } ?: emptyList()
 
@@ -156,24 +156,20 @@ class ExpressionHandler(lang: TypeScriptLanguageFrontend) :
         // https://github.com/Fraunhofer-AISEC/cpg/issues/463
         val value =
             this.frontend
-                .getCodeFromRawNode(node)
+                .codeOf(node)
                 ?.trim()
                 ?.replace("\"", "")
                 ?.replace("`", "")
                 ?.replace("'", "")
                 ?: ""
 
-        return newLiteral(value, parseType("String"), frontend.getCodeFromRawNode(node))
+        return newLiteral(value, parseType("String"), frontend.codeOf(node))
     }
 
     private fun handleIdentifier(node: TypeScriptNode): Expression {
-        val name = this.frontend.getCodeFromRawNode(node)?.trim() ?: ""
+        val name = this.frontend.codeOf(node)?.trim() ?: ""
 
-        return newDeclaredReferenceExpression(
-            name,
-            newUnknownType(),
-            this.frontend.getCodeFromRawNode(node)
-        )
+        return newDeclaredReferenceExpression(name, newUnknownType(), this.frontend.codeOf(node))
     }
 
     private fun handlePropertyAccessExpression(node: TypeScriptNode): Expression {
@@ -181,15 +177,9 @@ class ExpressionHandler(lang: TypeScriptLanguageFrontend) :
             node.children?.first()?.let { this.handle(it) }
                 ?: ProblemExpression("problem parsing base")
 
-        val name = this.frontend.getCodeFromRawNode(node.children?.last()) ?: ""
+        val name = node.children?.last()?.let { this.frontend.codeOf(it) } ?: ""
 
-        return newMemberExpression(
-            name,
-            base,
-            newUnknownType(),
-            ".",
-            this.frontend.getCodeFromRawNode(node)
-        )
+        return newMemberExpression(name, base, newUnknownType(), ".", this.frontend.codeOf(node))
     }
 
     private fun handleCallExpression(node: TypeScriptNode): Expression {
@@ -198,25 +188,22 @@ class ExpressionHandler(lang: TypeScriptLanguageFrontend) :
         // peek at the children, to check whether it is a call expression or member call expression
         val propertyAccess = node.firstChild("PropertyAccessExpression")
 
-        if (propertyAccess != null) {
-            val memberExpression =
-                this.handle(propertyAccess) as? MemberExpression
-                    ?: return ProblemExpression("node is not a member expression")
+        call =
+            if (propertyAccess != null) {
+                val memberExpression =
+                    this.handle(propertyAccess) as? MemberExpression
+                        ?: return ProblemExpression("node is not a member expression")
 
-            call =
-                newMemberCallExpression(
-                    memberExpression,
-                    code = this.frontend.getCodeFromRawNode(node)
-                )
-        } else {
-            // TODO: fqn - how?
-            val fqn = this.frontend.getIdentifierName(node)
-            // regular function call
+                newMemberCallExpression(memberExpression, code = this.frontend.codeOf(node))
+            } else {
+                // TODO: fqn - how?
+                val fqn = this.frontend.getIdentifierName(node)
+                // regular function call
 
-            val ref = newDeclaredReferenceExpression(fqn)
+                val ref = newDeclaredReferenceExpression(fqn)
 
-            call = newCallExpression(ref, fqn, this.frontend.getCodeFromRawNode(node), false)
-        }
+                newCallExpression(ref, fqn, this.frontend.codeOf(node), false)
+            }
 
         // parse the arguments. the first node is the identifier, so we skip that
         val remainingNodes = node.children?.drop(1)

--- a/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/StatementHandler.kt
+++ b/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/StatementHandler.kt
@@ -58,7 +58,7 @@ class StatementHandler(lang: TypeScriptLanguageFrontend) :
     private fun handleFunctionDeclaration(node: TypeScriptNode): Statement {
         // typescript allows to declare function on a statement level, e.g. within a compound
         // statement. We can wrap it into a declaration statement
-        val statement = newDeclarationStatement(this.frontend.getCodeFromRawNode(node))
+        val statement = newDeclarationStatement(this.frontend.codeOf(node))
 
         val decl = this.frontend.declarationHandler.handle(node)
 
@@ -72,7 +72,7 @@ class StatementHandler(lang: TypeScriptLanguageFrontend) :
     }
 
     private fun handleReturnStatement(node: TypeScriptNode): ReturnStatement {
-        val returnStmt = newReturnStatement(this.frontend.getCodeFromRawNode(node))
+        val returnStmt = newReturnStatement(this.frontend.codeOf(node))
 
         node.children?.first()?.let {
             returnStmt.returnValue = this.frontend.expressionHandler.handle(it)
@@ -82,7 +82,7 @@ class StatementHandler(lang: TypeScriptLanguageFrontend) :
     }
 
     private fun handleBlock(node: TypeScriptNode): CompoundStatement {
-        val block = newCompoundStatement(this.frontend.getCodeFromRawNode(node))
+        val block = newCompoundStatement(this.frontend.codeOf(node))
 
         node.children?.forEach { this.handle(it)?.let { it1 -> block.addStatement(it1) } }
 
@@ -98,7 +98,7 @@ class StatementHandler(lang: TypeScriptLanguageFrontend) :
     }
 
     private fun handleVariableStatement(node: TypeScriptNode): DeclarationStatement {
-        val statement = newDeclarationStatement(this.frontend.getCodeFromRawNode(node))
+        val statement = newDeclarationStatement(this.frontend.codeOf(node))
 
         // the declarations are contained in a VariableDeclarationList
         val nodes = node.firstChild("VariableDeclarationList")?.children


### PR DESCRIPTION
This PR adds generic parameters representing AST node types and type node types of the original parser. This also allows us to have a much cleaner approach to the methods that return location and code within the frontend.

This breaks the public API because the type parameters are necessary in order to implement a language frontend. This is a preparatory step for #1199