### PR TITLE
Removing hidden dependency between `yarnInstall` and `spotlessPython`

### DIFF
--- a/buildSrc/src/main/kotlin/cpg.formatting-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cpg.formatting-conventions.gradle.kts
@@ -108,6 +108,11 @@ spotless {
     }
 
     python {
+        targetExclude(
+            fileTree(project.projectDir) {
+                include("**/node_modules")
+            }
+        )
         target("src/main/**/*.py")
         licenseHeader(headerWithHashes, "from").yearSeparator(" - ")
     }


### PR DESCRIPTION
Fixes #1240
