### PR TITLE
Get rid of shell command when generating docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: build
 
-on: 
-  workflow_call:
+on:
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: build
 
-on:
+on: 
+  workflow_call:
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
           # make sure the previousDocs folder exists
           mkdir previousDocs && cd previousDocs 
           # retrieve the previous documentation folders for each published version (this also includes "main")
-          wget -O - https://github.com/Fraunhofer-AISEC/cpg/archive/gh-pages.tar.gz | tar -xz --strip=2 cpg-gh-pages/dokka
+          wget -O - https://github.com/Fraunhofer-AISEC/cpg/archive/gh-pages.tar.gz | tar -xz --strip=2 cpg-gh-pages/dokka || echo "No dokka directory present. Will continue as if nothing happened"
           # in order to avoid duplicate mains, remove the "main" version from the previous versions
           rm -rf main
       - name: Build ${{ env.version }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,13 +53,8 @@ allprojects {
 // configure dokka for the multi-module cpg project
 // this works together with the dokka configuration in the common-conventions plugin
 tasks.dokkaHtmlMultiModule {
-    val stdout = ByteArrayOutputStream()
-    exec {
-        commandLine("sh", "-c", "git tag --points-at HEAD | cat")
-            standardOutput = stdout
-    }
-    val configuredVersion = stdout.toString()
-    if(configuredVersion.isNotEmpty()) {
+    val configuredVersion = project.version.toString()
+    if(configuredVersion.isNotEmpty() && configuredVersion != "unspecified") {
         generateDokkaWithVersionTag(this, configuredVersion)
     } else {
         generateDokkaWithVersionTag(this, "main")


### PR DESCRIPTION
Try to get rid of shell command and replace it with the given "version" information of the project.