### PR TITLE
Trying to reduce loops in `equals`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/FunctionDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/FunctionDeclaration.kt
@@ -233,12 +233,10 @@ open class FunctionDeclaration : ValueDeclaration(), DeclarationHolder {
             body == other.body &&
             parameters == other.parameters &&
             propertyEqualsList(parameterEdges, other.parameterEdges) &&
-            throwsTypes == other.throwsTypes &&
-            overriddenBy == other.overriddenBy &&
-            overrides == other.overrides)
+            throwsTypes == other.throwsTypes)
     }
 
-    override fun hashCode() = Objects.hash(super.hashCode(), parameters, throwsTypes, overrides)
+    override fun hashCode() = Objects.hash(super.hashCode(), body, parameters, throwsTypes)
 
     override fun addDeclaration(declaration: Declaration) {
         if (declaration is ParamVariableDeclaration) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/GotoStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/GotoStatement.kt
@@ -38,9 +38,7 @@ class GotoStatement : Statement() {
         if (other !is GotoStatement) {
             return false
         }
-        return super.equals(other) &&
-            labelName == other.labelName &&
-            targetLabel == other.targetLabel
+        return super.equals(other) && labelName == other.labelName
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), labelName, targetLabel)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
@@ -303,8 +303,6 @@ open class CallExpression : Expression(), HasType.TypeObserver, SecondaryTypeEdg
         return super.equals(other) &&
             arguments == other.arguments &&
             propertyEqualsList(argumentEdges, other.argumentEdges) &&
-            invokes == other.invokes &&
-            propertyEqualsList(invokeEdges, other.invokeEdges) &&
             templateParameters == other.templateParameters &&
             propertyEqualsList(templateParameterEdges, other.templateParameterEdges) &&
             templateInstantiation == other.templateInstantiation &&
@@ -312,8 +310,8 @@ open class CallExpression : Expression(), HasType.TypeObserver, SecondaryTypeEdg
     }
 
     // TODO: Not sure if we can add the template, templateParameters, templateInstantiation fields
-    // here
-    override fun hashCode() = Objects.hash(super.hashCode(), arguments, invokes)
+    //  here
+    override fun hashCode() = Objects.hash(super.hashCode(), arguments)
 
     override fun updateType(typeState: Collection<Type>) {
         for (t in typeTemplateParameters) {

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
@@ -1592,4 +1592,22 @@ internal class CXXLanguageFrontendTest : BaseTest() {
         assertNotNull(ptr)
         assertLocalName("decltype(nullptr)", ptr.type)
     }
+
+    @Test
+    fun testRecursiveHeaderFunction() {
+        val file = File("src/test/resources/cxx/fix-1226")
+        val result =
+            analyze(
+                listOf(file.resolve("main1.cpp"), file.resolve("main2.cpp")),
+                file.toPath(),
+                true
+            )
+        assertNotNull(result)
+
+        // For now, we have duplicate functions because we include the header twice. This might
+        // change in the future. The important thing is that this gets parsed at all because we
+        // previously had a loop in our equals method
+        val functions = result.functions { it.name.localName == "foo" && it.isDefinition }
+        assertEquals(2, functions.size)
+    }
 }

--- a/cpg-language-cxx/src/test/resources/cxx/fix-1226/header.h
+++ b/cpg-language-cxx/src/test/resources/cxx/fix-1226/header.h
@@ -1,0 +1,9 @@
+template<class K>
+struct A {
+    int foo(int i);
+};
+
+template<class K>
+int A<K>::foo(int i) {
+    return foo(i + 1);
+}

--- a/cpg-language-cxx/src/test/resources/cxx/fix-1226/main1.cpp
+++ b/cpg-language-cxx/src/test/resources/cxx/fix-1226/main1.cpp
@@ -1,0 +1,7 @@
+#include "header.h"
+
+int main() {
+    int i = 1;
+    A<int> a;
+    return a.foo(i);
+}

--- a/cpg-language-cxx/src/test/resources/cxx/fix-1226/main2.cpp
+++ b/cpg-language-cxx/src/test/resources/cxx/fix-1226/main2.cpp
@@ -1,0 +1,7 @@
+#include "header.h"
+
+int main() {
+    int i = 1;
+    A<int> a;
+    return a.foo(i);
+}


### PR DESCRIPTION
Some nodes were using an exhaustive list of properties in their `equals` method. However, this also included property, which could loop back to the node itself. For example a function declaration includes all body nodes, which could include a call expression, which included the `invoke` property, which could loop back to the function declaration.

Fixes #1226
