### PR TITLE
Copy objects less frequently

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/LabelStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/LabelStatement.kt
@@ -51,9 +51,9 @@ class LabelStatement : Statement(), StatementHolder {
     }
 
     override var statementEdges: MutableList<PropertyEdge<Statement>>
-        get() = subStatement?.let { wrap(listOf(it), this) } ?: mutableListOf()
+        get() = subStatement?.let { PropertyEdge.wrap(listOf(it), this) } ?: mutableListOf()
         set(value) {
-            subStatement = unwrap(value).firstOrNull()
+            subStatement = PropertyEdge.unwrap(value).firstOrNull()
         }
 
     override fun equals(other: Any?): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/LabelStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/LabelStatement.kt
@@ -51,13 +51,10 @@ class LabelStatement : Statement(), StatementHolder {
     }
 
     override var statementEdges: MutableList<PropertyEdge<Statement>>
-        get() =
-            subStatement?.let { mutableListOf(PropertyEdge(this, it, mutableMapOf())) }
-                ?: mutableListOf()
+        get() = subStatement?.let { wrap(listOf(it), this) } ?: mutableListOf()
         set(value) {
-            subStatement = value.firstOrNull()?.end
+            subStatement = unwrap(value).firstOrNull()
         }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is LabelStatement) return false

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/LabelStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/LabelStatement.kt
@@ -26,6 +26,8 @@
 package de.fraunhofer.aisec.cpg.graph.statements
 
 import de.fraunhofer.aisec.cpg.graph.AST
+import de.fraunhofer.aisec.cpg.graph.StatementHolder
+import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import java.util.Objects
 import org.apache.commons.lang3.builder.ToStringBuilder
 
@@ -33,7 +35,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder
  * A label attached to a statement that is used to change control flow by labeled continue and
  * breaks (Java) or goto(C++).
  */
-class LabelStatement : Statement() {
+class LabelStatement : Statement(), StatementHolder {
     /** Statement that the label is attached to. Can be a simple or compound statement. */
     @AST var subStatement: Statement? = null
 
@@ -47,6 +49,14 @@ class LabelStatement : Statement() {
             .append("label", label)
             .toString()
     }
+
+    override var statementEdges: MutableList<PropertyEdge<Statement>>
+        get() =
+            subStatement?.let { mutableListOf(PropertyEdge(this, it, mutableMapOf())) }
+                ?: mutableListOf()
+        set(value) {
+            subStatement = value.firstOrNull()?.end
+        }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/LabelStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/LabelStatement.kt
@@ -55,6 +55,7 @@ class LabelStatement : Statement(), StatementHolder {
         set(value) {
             subStatement = unwrap(value).firstOrNull()
         }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is LabelStatement) return false

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/EOGWorklist.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/EOGWorklist.kt
@@ -248,7 +248,12 @@ inline fun <reified K : Node, V> iterateEOG(
     while (worklist.isNotEmpty()) {
         val (nextNode, state) = worklist.pop()
 
-        val newState = transformation(nextNode, state.duplicate(), worklist)
+        val insideBB =
+            (nextNode.nextEOG.size == 1 &&
+                nextNode.prevEOG.size == 1 &&
+                nextNode.prevEOG.first().nextEOG.size == 1)
+        val newState =
+            transformation(nextNode, if (insideBB) state else state.duplicate(), worklist)
         if (worklist.update(nextNode, newState)) {
             nextNode.nextEOG.forEach {
                 if (it is K) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/EOGWorklist.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/EOGWorklist.kt
@@ -248,6 +248,11 @@ inline fun <reified K : Node, V> iterateEOG(
     while (worklist.isNotEmpty()) {
         val (nextNode, state) = worklist.pop()
 
+        // This should check if we're not near the beginning/end of a basic block (i.e., there are
+        // no merge points or branches of the EOG nearby). If that's the case, we just parse the
+        // whole basic block and do not want to duplicate the state. Near the beginning/end, we do
+        // want to copy the state to avoid terminating the iteration too early by messing up with
+        // the state-changing checks.
         val insideBB =
             (nextNode.nextEOG.size == 1 && nextNode.prevEOG.singleOrNull()?.nextEOG?.size == 1)
         val newState =
@@ -278,6 +283,11 @@ inline fun <reified K : PropertyEdge<Node>, N : Any, V> iterateEOG(
     while (worklist.isNotEmpty()) {
         val (nextEdge, state) = worklist.pop()
 
+        // This should check if we're not near the beginning/end of a basic block (i.e., there are
+        // no merge points or branches of the EOG nearby). If that's the case, we just parse the
+        // whole basic block and do not want to duplicate the state. Near the beginning/end, we do
+        // want to copy the state to avoid terminating the iteration too early by messing up with
+        // the state-changing checks.
         val insideBB =
             (nextEdge.end.nextEOG.size == 1 &&
                 nextEdge.end.prevEOG.size == 1 &&

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/EOGWorklist.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/EOGWorklist.kt
@@ -249,9 +249,7 @@ inline fun <reified K : Node, V> iterateEOG(
         val (nextNode, state) = worklist.pop()
 
         val insideBB =
-            (nextNode.nextEOG.size == 1 &&
-                nextNode.prevEOG.size == 1 &&
-                nextNode.prevEOG.first().nextEOG.size == 1)
+            (nextNode.nextEOG.size == 1 && nextNode.prevEOG.singleOrNull()?.nextEOG?.size == 1)
         val newState =
             transformation(nextNode, if (insideBB) state else state.duplicate(), worklist)
         if (worklist.update(nextNode, newState)) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/EOGWorklist.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/EOGWorklist.kt
@@ -275,8 +275,13 @@ inline fun <reified K : PropertyEdge<Node>, N : Any, V> iterateEOG(
     while (worklist.isNotEmpty()) {
         val (nextEdge, state) = worklist.pop()
 
-        val newState = transformation(nextEdge, state.duplicate(), worklist)
-        if (worklist.update(nextEdge, newState)) {
+        val insideBB =
+            (nextEdge.end.nextEOG.size == 1 &&
+                nextEdge.end.prevEOG.size == 1 &&
+                nextEdge.start.nextEOG.size == 1)
+        val newState =
+            transformation(nextEdge, if (insideBB) state else state.duplicate(), worklist)
+        if (insideBB || worklist.update(nextEdge, newState)) {
             nextEdge.end.nextEOGEdges.forEach {
                 if (it is K) {
                     worklist.push(it, newState)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/EOGWorklist.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/EOGWorklist.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.helpers
 
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.edge.Properties
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import java.util.IdentityHashMap
 
@@ -58,7 +57,7 @@ abstract class LatticeElement<T>(open val elements: T) : Comparable<LatticeEleme
  */
 class PowersetLattice(override val elements: Set<Node>) : LatticeElement<Set<Node>>(elements) {
     override fun lub(other: LatticeElement<Set<Node>>) =
-        PowersetLattice((other.elements).union(this.elements))
+        PowersetLattice(other.elements.union(this.elements))
 
     override fun duplicate() = PowersetLattice(this.elements.toSet())
 
@@ -228,15 +227,6 @@ class Worklist<K : Any, N : Any, V>() {
     }
 }
 
-fun Node.isBasicBlockStartOrEnd(): Boolean {
-    return this.nextEOGEdges.size > 1 ||
-        this.prevEOGEdges.size > 1 ||
-        this.prevEOGEdges.any {
-            val branch = it.getProperty(Properties.BRANCH)
-            branch == true || branch == false
-        }
-}
-
 /**
  * Iterates through the worklist of the Evaluation Order Graph starting at [startNode] and with the
  * [State] [startState]. For each node, the [transformation] is applied which should update the
@@ -262,11 +252,7 @@ inline fun <reified K : Node, V> iterateEOG(
         if (worklist.update(nextNode, newState)) {
             nextNode.nextEOG.forEach {
                 if (it is K) {
-                    if (!nextNode.isBasicBlockStartOrEnd()) {
-                        worklist.push(it, newState)
-                    } else {
-                        worklist.push(it, newState.duplicate())
-                    }
+                    worklist.push(it, newState)
                 }
             }
         }
@@ -293,11 +279,7 @@ inline fun <reified K : PropertyEdge<Node>, N : Any, V> iterateEOG(
         if (worklist.update(nextEdge, newState)) {
             nextEdge.end.nextEOGEdges.forEach {
                 if (it is K) {
-                    if (!nextEdge.end.isBasicBlockStartOrEnd()) {
-                        worklist.push(it, newState)
-                    } else {
-                        worklist.push(it, newState.duplicate())
-                    }
+                    worklist.push(it, newState)
                 }
             }
         }


### PR DESCRIPTION
Currently, the EOG iteration copies the state for each step in the EOG. This consumes quite some resources and it would be great to copy the objects less frequently. One idea is to copy them only when entering/exiting a new basic block and otherwise operate on the same object.

Fixes #1194 