### PR TITLE
Added `TupleDeclaration`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
@@ -181,7 +181,7 @@ fun LanguageProvider.newTupleDeclaration(
     elements: List<VariableDeclaration>,
     initializer: Expression?,
     rawNode: Any? = null
-): VariableDeclaration {
+): TupleDeclaration {
     val node = TupleDeclaration()
     node.applyMetadata(this, null, rawNode, null, true)
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
@@ -171,6 +171,34 @@ fun MetadataProvider.newVariableDeclaration(
 }
 
 /**
+ * Creates a new [TupleDeclaration]. The [MetadataProvider] receiver will be used to fill different
+ * meta-data using [Node.applyMetadata]. Calling this extension function outside of Kotlin requires
+ * an appropriate [MetadataProvider], such as a [LanguageFrontend] as an additional prepended
+ * argument.
+ */
+@JvmOverloads
+fun LanguageProvider.newTupleDeclaration(
+    elements: List<VariableDeclaration>,
+    initializer: Expression?,
+    rawNode: Any? = null
+): VariableDeclaration {
+    val node = TupleDeclaration()
+    node.applyMetadata(this, null, rawNode, null, true)
+
+    // Tuples always have an auto-type
+    node.type = autoType()
+
+    // Also all our elements need to have an auto-type
+    elements.forEach { it.type = autoType() }
+    node.elements = elements
+
+    node.initializer = initializer
+
+    log(node)
+    return node
+}
+
+/**
  * Creates a new [TypedefDeclaration]. The [MetadataProvider] receiver will be used to fill
  * different meta-data using [Node.applyMetadata]. Calling this extension function outside of Kotlin
  * requires an appropriate [MetadataProvider], such as a [LanguageFrontend] as an additional

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -535,10 +535,6 @@ val Node?.namespaces: List<NamespaceDeclaration>
 val Node?.variables: List<VariableDeclaration>
     get() = this.allChildren()
 
-/** Returns all [TupleDeclaration] children in this graph, starting with this [Node]. */
-val Node?.tuples: List<TupleDeclaration>
-    get() = this.allChildren()
-
 /** Returns all [Literal] children in this graph, starting with this [Node]. */
 val Node?.literals: List<Literal<*>>
     get() = this.allChildren()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -535,6 +535,10 @@ val Node?.namespaces: List<NamespaceDeclaration>
 val Node?.variables: List<VariableDeclaration>
     get() = this.allChildren()
 
+/** Returns all [TupleDeclaration] children in this graph, starting with this [Node]. */
+val Node?.tuples: List<TupleDeclaration>
+    get() = this.allChildren()
+
 /** Returns all [Literal] children in this graph, starting with this [Node]. */
 val Node?.literals: List<Literal<*>>
     get() = this.allChildren()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TupleDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TupleDeclaration.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.graph.declarations
+
+import de.fraunhofer.aisec.cpg.graph.AST
+import de.fraunhofer.aisec.cpg.graph.Name
+import de.fraunhofer.aisec.cpg.graph.newTupleDeclaration
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
+import de.fraunhofer.aisec.cpg.graph.types.AutoType
+import de.fraunhofer.aisec.cpg.graph.types.TupleType
+
+/**
+ * This declaration models a tuple of different [VariableDeclaration] nodes. This is primarily used
+ * in languages that support multiple assignments, such as Go as part of a top-level declaration.
+ * The tuple is needed because the initializer of this declaration is flowing into the tuple (and
+ * then split among its elements) rather than flowing into the declarations individually. For
+ * example the following code
+ *
+ * ```go
+ * var a,b = call()
+ * ```
+ *
+ * corresponds to:
+ * - two [VariableDeclaration] nodes `a` and `b`, with an empty [VariableDeclaration.initializer]
+ * - a [TupleDeclaration], with the auto-generated name `(a,b)` and [TupleDeclaration.elements] `a`
+ *   and `b`
+ * - an [TupleDeclaration.initializer] that holds a [CallExpression] to `call`.
+ *
+ * Note: Currently, we only support [TupleDeclaration] with an initial [AutoType] (set in
+ * [newTupleDeclaration]); its actual [TupleType] will be inferred by the
+ * [TupleDeclaration.initializer] (see [VariableDeclaration.typeChanged] for the implementation).
+ *
+ * The same applies to the elements in the tuple. They also need to have an [AutoType], and their
+ * respective type will be based on a registered type observer to their tuple and implemented also
+ * in [VariableDeclaration.typeChanged]
+ */
+class TupleDeclaration : VariableDeclaration() {
+    /** The list of elements in this tuple. */
+    @AST
+    var elements: List<VariableDeclaration> = mutableListOf()
+        set(value) {
+            field = value
+            // Make sure we inform our elements about our type changes
+            value.forEach { registerTypeObserver(it) }
+        }
+
+    override var name: Name
+        get() = Name(elements.joinToString(",", "(", ")") { it.name.toString() })
+        set(_) {}
+
+    operator fun plusAssign(element: VariableDeclaration) {
+        this.elements += element
+        // Make sure we inform the new element about our type changes
+        registerTypeObserver(element)
+    }
+}

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TupleDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TupleDeclaration.kt
@@ -34,10 +34,9 @@ import de.fraunhofer.aisec.cpg.graph.types.TupleType
 
 /**
  * This declaration models a tuple of different [VariableDeclaration] nodes. This is primarily used
- * in languages that support multiple assignments, such as Go as part of a top-level declaration.
- * The tuple is needed because the initializer of this declaration is flowing into the tuple (and
- * then split among its elements) rather than flowing into the declarations individually. For
- * example the following code
+ * in languages that support multiple assignments in a declaration, such as Go. The tuple is needed
+ * because the initializer of this declaration is flowing into the tuple (and then split among its
+ * elements) rather than flowing into the declarations individually. For example the following code
  *
  * ```go
  * var a,b = call()
@@ -49,8 +48,12 @@ import de.fraunhofer.aisec.cpg.graph.types.TupleType
  *   and `b`
  * - an [TupleDeclaration.initializer] that holds a [CallExpression] to `call`.
  *
- * Note: Currently, we only support [TupleDeclaration] with an initial [AutoType] (set in
- * [newTupleDeclaration]); its actual [TupleType] will be inferred by the
+ * Implementation Note #1: The [VariableDeclaration.initializer] of the element variables MUST be
+ * empty; only the [TupleDeclaration.initializer] must be set. Otherwise we are potentially parsing
+ * the initializer twice.
+ *
+ * Implementation Note #2: Currently, we only support [TupleDeclaration] with an initial [AutoType]
+ * (set in [newTupleDeclaration]); its actual [TupleType] will be inferred by the
  * [TupleDeclaration.initializer] (see [VariableDeclaration.typeChanged] for the implementation).
  *
  * The same applies to the elements in the tuple. They also need to have an [AutoType], and their

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ValueDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ValueDeclaration.kt
@@ -32,6 +32,7 @@ import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.unwrap
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.DeclaredReferenceExpression
 import de.fraunhofer.aisec.cpg.graph.types.*
+import de.fraunhofer.aisec.cpg.helpers.identitySetOf
 import de.fraunhofer.aisec.cpg.passes.VariableUsageResolver
 import java.util.stream.Collectors
 import org.apache.commons.lang3.builder.ToStringBuilder
@@ -39,7 +40,7 @@ import org.neo4j.ogm.annotation.Relationship
 
 /** A declaration who has a type. */
 abstract class ValueDeclaration : Declaration(), HasType {
-    override val typeObservers = mutableListOf<HasType.TypeObserver>()
+    override val typeObservers: MutableSet<HasType.TypeObserver> = identitySetOf()
 
     /** The type of this declaration. */
     override var type: Type = unknownType()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/VariableDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/VariableDeclaration.kt
@@ -31,6 +31,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.DeclaredReferenceExp
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.types.AutoType
 import de.fraunhofer.aisec.cpg.graph.types.HasType
+import de.fraunhofer.aisec.cpg.graph.types.TupleType
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.Relationship
@@ -85,19 +86,34 @@ open class VariableDeclaration : ValueDeclaration(), HasInitializer, HasType.Typ
     }
 
     override fun typeChanged(newType: Type, src: HasType) {
-        // Only accept type changes from our initializer, if any
-        if (src != initializer) {
+        // Only accept type changes from our initializer; or if the source is a tuple
+        if (src != initializer && src !is TupleDeclaration) {
             return
         }
 
-        // In the auto-inference case, we want to set the type of our declaration to the
-        // declared type of the initializer
+        // If our type is set to "auto", we want to derive our type from the initializer (or the
+        // tuple source)
         if (this.type is AutoType) {
-            type = newType
+            // If the source is a tuple, we need to check, if we are really part of the source tuple
+            // and if yes, on which position
+            if (src is TupleDeclaration && newType is TupleType) {
+                // We can then derive our appropriate type out of the tuple type based on the
+                // position in the tuple
+                val idx = src.elements.indexOf(this)
+                if (idx != -1) {
+                    type = newType.types.getOrElse(idx) { unknownType() }
+                }
+            } else {
+                // Otherwise, we can just set the type directly.
+                type = newType
+            }
         } else {
-            // Otherwise, we are at least interested in what the initializer's type is, to see
-            // whether we can fill our assigned types with that
-            addAssignedType(newType)
+            if (src !is TupleDeclaration) {
+                // If we are not in "auto" mode, we are at least interested in what the
+                // initializer's type is, to see
+                // whether we can fill our assigned types with that
+                addAssignedType(newType)
+            }
         }
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Expression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Expression.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.graph.statements.expressions
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.statements.Statement
 import de.fraunhofer.aisec.cpg.graph.types.*
+import de.fraunhofer.aisec.cpg.helpers.identitySetOf
 import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.Transient
 
@@ -43,7 +44,7 @@ import org.neo4j.ogm.annotation.Transient
  * <p>This is not possible in Java, the aforementioned code example would prompt a compile error.
  */
 abstract class Expression : Statement(), HasType {
-    @Transient override val typeObservers = mutableListOf<HasType.TypeObserver>()
+    @Transient override val typeObservers: MutableSet<HasType.TypeObserver> = identitySetOf()
 
     override var type: Type = unknownType()
         set(value) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/InitializerListExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/InitializerListExpression.kt
@@ -78,7 +78,7 @@ class InitializerListExpression : Expression(), ArgumentHolder, HasType.TypeObse
         // entries in generated code), we skip it here.
         //
         // So we just have to look what kind of object we are initializing (its type is stored in
-        // our "type), to see whether we need to propagate something at all. If it has an array
+        // our "type"), to see whether we need to propagate something at all. If it has an array
         // type, we need to propagate an array version of the incoming type. If our "target" is a
         // regular object type, we do NOT propagate anything at all, because in this case we get the
         // types of individual fields, and we are not interested in those (yet).

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/HasType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/HasType.kt
@@ -102,7 +102,7 @@ interface HasType : ContextProvider, LanguageProvider {
      * A list of [TypeObserver] objects that will be informed about type changes, usually by
      * [informObservers].
      */
-    val typeObservers: MutableList<TypeObserver>
+    val typeObservers: MutableSet<TypeObserver>
 
     /**
      * A [TypeObserver] can be used by its implementing class to observe changes to the

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/TupleType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/TupleType.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.graph.Name
+import de.fraunhofer.aisec.cpg.graph.unknownType
 
 /**
  * Represents a tuple of types. Primarily used in resolving function calls with multiple return
@@ -43,11 +44,11 @@ class TupleType(types: List<Type>) : Type() {
     }
 
     override fun reference(pointer: PointerType.PointerOrigin?): Type {
-        TODO("Not yet implemented")
+        return unknownType()
     }
 
     override fun dereference(): Type {
-        TODO("Not yet implemented")
+        return unknownType()
     }
 
     override fun duplicate(): Type {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
@@ -77,9 +77,18 @@ open class ControlFlowSensitiveDFGPass(ctx: TranslationContext) : TranslationUni
             )
 
             for ((key, value) in finalState.generalState) {
-                key.addAllPrevDFG(
-                    value.elements.filterNot { it is VariableDeclaration && key == it }
-                )
+                if (key is TupleDeclaration) {
+                    // We need a little hack for tuple statements to set the index. We have the
+                    // outer part (i.e., the tuple) here but we generate the DFG edges to the
+                    // elements. We have the indices here, so it's amazing.
+                    key.elements.forEachIndexed { i, element ->
+                        element.addPrevDFG(element, mutableMapOf(Properties.INDEX to i))
+                    }
+                } else {
+                    key.addAllPrevDFG(
+                        value.elements.filterNot { it is VariableDeclaration && key == it }
+                    )
+                }
             }
         }
     }
@@ -118,11 +127,22 @@ open class ControlFlowSensitiveDFGPass(ctx: TranslationContext) : TranslationUni
         val initializer = (currentNode as? VariableDeclaration)?.initializer
         if (initializer != null) {
             // A variable declaration with an initializer => The initializer flows to the
-            // declaration.
-            // We also wrote something to this variable declaration
+            // declaration. This also affects tuples. We split it up later.
             state.push(currentNode, PowersetLattice(setOf(initializer)))
 
-            doubleState.pushToDeclarationsState(currentNode, PowersetLattice(setOf(currentNode)))
+            if (currentNode is TupleDeclaration) {
+                // For a tuple declaration, we write the elements in this statement. We do not
+                // really care about the tuple when using the elements subsequently.
+                currentNode.elements.forEach {
+                    doubleState.pushToDeclarationsState(it, PowersetLattice(setOf(currentNode)))
+                }
+            } else {
+                // We also wrote something to this variable declaration here.
+                doubleState.pushToDeclarationsState(
+                    currentNode,
+                    PowersetLattice(setOf(currentNode))
+                )
+            }
         } else if (isSimpleAssignment(currentNode)) {
             // It's an assignment which can have one or multiple things on the lhs and on the
             // rhs. The lhs could be a declaration or a reference (or multiple of these things).

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
@@ -82,7 +82,10 @@ open class ControlFlowSensitiveDFGPass(ctx: TranslationContext) : TranslationUni
                     // outer part (i.e., the tuple) here but we generate the DFG edges to the
                     // elements. We have the indices here, so it's amazing.
                     key.elements.forEachIndexed { i, element ->
-                        element.addPrevDFG(element, mutableMapOf(Properties.INDEX to i))
+                        element.addAllPrevDFG(
+                            value.elements.filterNot { it is VariableDeclaration && key == it },
+                            mutableMapOf(Properties.INDEX to i)
+                        )
                     }
                 } else {
                     key.addAllPrevDFG(
@@ -134,7 +137,7 @@ open class ControlFlowSensitiveDFGPass(ctx: TranslationContext) : TranslationUni
                 // For a tuple declaration, we write the elements in this statement. We do not
                 // really care about the tuple when using the elements subsequently.
                 currentNode.elements.forEach {
-                    doubleState.pushToDeclarationsState(it, PowersetLattice(setOf(currentNode)))
+                    doubleState.pushToDeclarationsState(it, PowersetLattice(setOf(it)))
                 }
             } else {
                 // We also wrote something to this variable declaration here.

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
@@ -29,7 +29,9 @@ import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.FieldDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.TupleDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
+import de.fraunhofer.aisec.cpg.graph.edge.Properties
 import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker.IterativeGraphWalker
@@ -86,6 +88,7 @@ class DFGPass(ctx: TranslationContext) : ComponentPass(ctx) {
             // Declarations
             is FieldDeclaration -> handleFieldDeclaration(node)
             is FunctionDeclaration -> handleFunctionDeclaration(node)
+            is TupleDeclaration -> handleTupleDeclaration(node)
             is VariableDeclaration -> handleVariableDeclaration(node)
         }
     }
@@ -125,6 +128,18 @@ class DFGPass(ctx: TranslationContext) : ComponentPass(ctx) {
             node.addPrevDFG(node.base)
         } else {
             handleDeclaredReferenceExpression(node)
+        }
+    }
+
+    /**
+     * Adds the DFG edges for a [TupleDeclaration]. The data flows from initializer to the tuple
+     * elements.
+     */
+    protected fun handleTupleDeclaration(node: TupleDeclaration) {
+        node.initializer?.let { initializer ->
+            node.elements.withIndex().forEach {
+                it.value.addPrevDFG(initializer, mutableMapOf(Properties.INDEX to it.index))
+            }
         }
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
@@ -102,6 +102,7 @@ open class EvaluationOrderGraphPass(ctx: TranslationContext) : TranslationUnitPa
         map[FunctionDeclaration::class.java] = {
             handleFunctionDeclaration(it as FunctionDeclaration)
         }
+        map[TupleDeclaration::class.java] = { handleTupleDeclaration(it as TupleDeclaration) }
         map[VariableDeclaration::class.java] = {
             handleVariableDeclaration(it as VariableDeclaration)
         }
@@ -238,6 +239,13 @@ open class EvaluationOrderGraphPass(ctx: TranslationContext) : TranslationUnitPa
     protected fun handleVariableDeclaration(node: VariableDeclaration) {
         // analyze the initializer
         createEOG(node.initializer)
+        pushToEOG(node)
+    }
+
+    protected fun handleTupleDeclaration(node: TupleDeclaration) {
+        // analyze the initializer
+        createEOG(node.initializer)
+        node.elements.forEach { createEOG(it) }
         pushToEOG(node)
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeHierarchyResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeHierarchyResolver.kt
@@ -103,7 +103,7 @@ open class TypeHierarchyResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
     protected fun findSupertypeRecords(recordDecl: RecordDeclaration): Set<RecordDeclaration> {
         val superTypeDeclarations =
-            recordDecl.superTypes.mapNotNull { (it as ObjectType).recordDeclaration }.toSet()
+            recordDecl.superTypes.mapNotNull { (it as? ObjectType)?.recordDeclaration }.toSet()
         recordDecl.superTypeDeclarations = superTypeDeclarations
         return superTypeDeclarations
     }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TupleDeclarationTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TupleDeclarationTest.kt
@@ -79,8 +79,9 @@ class TupleDeclarationTest {
             val main = result.functions["main"]
             assertNotNull(main)
 
-            val tuple = result.tuples["(a,b)"]
+            val tuple = result.variables["(a,b)"]
             assertNotNull(tuple)
+            assertIs<TupleDeclaration>(tuple)
             assertIs<TupleType>(tuple.type)
 
             val call = tuple.initializer as? CallExpression
@@ -158,8 +159,9 @@ class TupleDeclarationTest {
             val main = result.functions["main"]
             assertNotNull(main)
 
-            val tuple = main.tuples["(a,b)"]
+            val tuple = main.variables["(a,b)"]
             assertNotNull(tuple)
+            assertIs<TupleDeclaration>(tuple)
             assertIs<TupleType>(tuple.type)
 
             val call = tuple.initializer as? CallExpression

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TupleDeclarationTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TupleDeclarationTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.graph.declarations
+
+import de.fraunhofer.aisec.cpg.*
+import de.fraunhofer.aisec.cpg.TestUtils.assertInvokes
+import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.builder.*
+import de.fraunhofer.aisec.cpg.graph.objectType
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
+import de.fraunhofer.aisec.cpg.graph.types.TupleType
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+
+class TupleDeclarationTest {
+    @Test
+    fun testTupleDeclaration() {
+        with(
+            TestLanguageFrontend(
+                ctx =
+                    TranslationContext(
+                        TranslationConfiguration.builder().defaultPasses().build(),
+                        ScopeManager(),
+                        TypeManager()
+                    )
+            )
+        ) {
+            val result = build {
+                translationResult {
+                    translationUnit {
+                        function(
+                            "func",
+                            returnTypes = listOf(objectType("MyClass"), objectType("error"))
+                        )
+
+                        // I fear this is too complex for the fluent DSL; so we just use the node
+                        // builder here
+                        val tuple =
+                            newTupleDeclaration(
+                                listOf(newVariableDeclaration("a"), newVariableDeclaration("b")),
+                                newCallExpression(newDeclaredReferenceExpression("func"))
+                            )
+                        scopeManager.addDeclaration(tuple)
+                    }
+                }
+            }
+
+            val tuple = result.tuples["(a,b)"]
+            assertNotNull(tuple)
+            assertIs<TupleType>(tuple.type)
+            assertInvokes(tuple.initializer as? CallExpression, result.functions["func"])
+            assertContains(tuple.prevDFG, tuple.initializer!!)
+
+            val a = tuple.elements["a"]
+            assertNotNull(a)
+            assertLocalName("MyClass", a.type)
+
+            val b = tuple.elements["b"]
+            assertNotNull(b)
+            assertLocalName("error", b.type)
+        }
+    }
+}

--- a/cpg-core/src/testFixtures/kotlin/de/fraunhofer/aisec/cpg/TestUtils.kt
+++ b/cpg-core/src/testFixtures/kotlin/de/fraunhofer/aisec/cpg/TestUtils.kt
@@ -221,7 +221,8 @@ object TestUtils {
      * Asserts, that the call expression given in [call] refers to the expected function declaration
      * [func].
      */
-    fun assertInvokes(call: CallExpression, func: FunctionDeclaration?) {
+    fun assertInvokes(call: CallExpression?, func: FunctionDeclaration?) {
+        assertNotNull(call)
         assertContains(call.invokes, func)
     }
 

--- a/docs/docs/CPG/specs/eog.md
+++ b/docs/docs/CPG/specs/eog.md
@@ -105,7 +105,8 @@ flowchart LR
   parent(["TupleDeclaration"]) --EOG--> next:::outer
   parent -.-> child["initializer"]
   child --EOG--> e0["elements[0]"]
-  e0 --"..."--> ei["elements[i]"]
+  e0 --EOG--> e.["..."]
+  e. --EOG--> ei["elements[i]"]
   ei --EOG--> parent
 
 ```
@@ -292,6 +293,30 @@ flowchart LR
   node -.-> rhs
   lhs --EOG--> rhs
   rhs --EOG--> node
+```
+
+## AssignExpression
+
+Interesting fields:
+
+* `lhs: List<Expression>`: All expressions on the left-hand side of the assignment (i.e., the target)
+* `rhs: List<Expression>`: All expressions on the right-hand side of the assignment (i.e., the value to be assigned)
+* `declarations: List<Declaration>`: All expressions on the left-hand side of the assignment (i.e., the target)
+
+Scheme:
+```mermaid
+flowchart LR
+  classDef outer fill:#fff,stroke:#ddd,stroke-dasharray:5 5;
+  prev:::outer --EOG--> decl0["declarations[0]"]
+  decl0 --EOG--> decl.["..."]
+  decl. --EOG--> decli["declarations[i]"]
+  decli --EOG--> lhs0["lhs[0]"]
+  lhs0 --EOG--> lhs.["..."]
+  lhs. --EOG--> lhsi["lhs[i]"]
+  lhsi--EOG--> rhs0["rhs[0]"]
+  rhs0 --EOG--> rhs.["..."]
+  rhs. --EOG--> rhsi["rhs[i]"]
+  rhsi --EOG--> node
 ```
 
 

--- a/docs/docs/CPG/specs/eog.md
+++ b/docs/docs/CPG/specs/eog.md
@@ -89,6 +89,27 @@ flowchart LR
   nblock1--EOG-->nblock2
 ```
 
+## TupleDeclaration
+Represents the declaration of a tuple of variables.
+
+Interesting fields:
+
+* `initializer: Expression`: The result of evaluation will initialize the variable.
+* `elements: List<VariableDeclaration>`: The result of evaluation will initialize the variable.
+
+Scheme:
+```mermaid
+flowchart LR
+  classDef outer fill:#fff,stroke:#ddd,stroke-dasharray:5 5;
+  prev:::outer --EOG--> child
+  parent(["TupleDeclaration"]) --EOG--> next:::outer
+  parent -.-> child["initializer"]
+  child --EOG--> e0["elements[0]"]
+  e0 --"..."--> ei["elements[i]"]
+  ei --EOG--> parent
+
+```
+
 ## VariableDeclaration
 Represents the declaration of a local variable.
 


### PR DESCRIPTION
This PR adds a new type of `Declaration`, which represenst a tuple of variable declarations. This is primarily needed for languages, such as Go, which support the assignment of multiple values in an initializer. In this case we cannot assign the initializer of the individual variables, but assigned it to the `TupleDeclaration` instead.

Currently, the type of the `TupleDeclaration` and its elements MUST be set to the `AutoType`.
