### PR TITLE
More precise types in arithmetic evaluation

### DIFF
--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/MultiValueEvaluator.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/MultiValueEvaluator.kt
@@ -181,9 +181,8 @@ class MultiValueEvaluator : ValueEvaluator() {
         return when (expr.operatorCode) {
             "-" -> {
                 when (val input = evaluateInternal(expr.input, depth + 1)) {
-                    is Collection<*> -> input.map { n -> (n as? Number)?.negate() }
-                    is Number -> input.negate()
-                    else -> cannotEvaluate(expr, this)
+                    is Collection<*> -> input.map { n -> (n as? Number)?.unaryMinus() }
+                    else -> super.handleUnaryOp(expr, depth)
                 }
             }
             "--" -> {
@@ -191,9 +190,8 @@ class MultiValueEvaluator : ValueEvaluator() {
                     evaluateInternal(expr.input, depth + 1)
                 } else {
                     when (val input = evaluateInternal(expr.input, depth + 1)) {
-                        is Number -> input.decrement()
-                        is Collection<*> -> input.map { n -> (n as? Number)?.decrement() }
-                        else -> cannotEvaluate(expr, this)
+                        is Collection<*> -> input.map { n -> (n as? Number)?.dec() }
+                        else -> super.handleUnaryOp(expr, depth)
                     }
                 }
             }
@@ -202,15 +200,14 @@ class MultiValueEvaluator : ValueEvaluator() {
                     evaluateInternal(expr.input, depth + 1)
                 } else {
                     when (val input = evaluateInternal(expr.input, depth + 1)) {
-                        is Number -> input.increment()
-                        is Collection<*> -> input.map { n -> (n as? Number)?.increment() }
-                        else -> cannotEvaluate(expr, this)
+                        is Collection<*> -> input.map { n -> (n as? Number)?.inc() }
+                        else -> super.handleUnaryOp(expr, depth)
                     }
                 }
             }
             "*" -> evaluateInternal(expr.input, depth + 1)
             "&" -> evaluateInternal(expr.input, depth + 1)
-            else -> cannotEvaluate(expr, this)
+            else -> super.handleUnaryOp(expr, depth)
         }
     }
 
@@ -418,22 +415,22 @@ class MultiValueEvaluator : ValueEvaluator() {
         return when (expr.operatorCode) {
             "-" -> {
                 when (input) {
-                    is Collection<*> -> input.map { n -> (n as? Number)?.negate() }
-                    is Number -> input.negate()
+                    is Collection<*> -> input.map { n -> (n as? Number)?.unaryMinus() }
+                    is Number -> -input
                     else -> cannotEvaluate(expr, this)
                 }
             }
             "--" -> {
                 when (input) {
-                    is Number -> input.decrement()
-                    is Collection<*> -> input.map { n -> (n as? Number)?.decrement() }
+                    is Number -> input.dec()
+                    is Collection<*> -> input.map { n -> (n as? Number)?.dec() }
                     else -> cannotEvaluate(expr, this)
                 }
             }
             "++" -> {
                 when (input) {
-                    is Number -> input.increment()
-                    is Collection<*> -> input.map { n -> (n as? Number)?.increment() }
+                    is Number -> input.inc()
+                    is Collection<*> -> input.map { n -> (n as? Number)?.inc() }
                     else -> cannotEvaluate(expr, this)
                 }
             }

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/NumberExtensions.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/NumberExtensions.kt
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2023, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.analysis
+
+internal operator fun Number.plus(other: Number): Number =
+    when (this) {
+        is Int -> this + other
+        is Byte -> this + other
+        is Long -> this + other
+        is Short -> this + other
+        is Float -> this + other
+        is Double -> this + other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Int.plus(other: Number): Number =
+    when (other) {
+        is Int -> this + other
+        is Byte -> this + other
+        is Long -> this + other
+        is Short -> this + other
+        is Float -> this + other
+        is Double -> this + other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Byte.plus(other: Number): Number =
+    when (other) {
+        is Int -> this + other
+        is Byte -> this + other
+        is Long -> this + other
+        is Short -> this + other
+        is Float -> this + other
+        is Double -> this + other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Long.plus(other: Number): Number =
+    when (other) {
+        is Int -> this + other
+        is Byte -> this + other
+        is Long -> this + other
+        is Short -> this + other
+        is Float -> this + other
+        is Double -> this + other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Short.plus(other: Number): Number =
+    when (other) {
+        is Int -> this + other
+        is Byte -> this + other
+        is Long -> this + other
+        is Short -> this + other
+        is Float -> this + other
+        is Double -> this + other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Float.plus(other: Number): Number =
+    when (other) {
+        is Int -> this + other
+        is Byte -> this + other
+        is Long -> this + other
+        is Short -> this + other
+        is Float -> this + other
+        is Double -> this + other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Double.plus(other: Number): Number =
+    when (other) {
+        is Int -> this + other
+        is Byte -> this + other
+        is Long -> this + other
+        is Short -> this + other
+        is Float -> this + other
+        is Double -> this + other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Number.minus(other: Number): Number =
+    when (this) {
+        is Int -> this + -other
+        is Byte -> this + -other
+        is Long -> this + -other
+        is Short -> this + -other
+        is Float -> this + -other
+        is Double -> this + -other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Number.times(other: Number): Number =
+    when (this) {
+        is Int -> this * other
+        is Byte -> this * other
+        is Long -> this * other
+        is Short -> this * other
+        is Float -> this * other
+        is Double -> this * other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Int.times(other: Number): Number =
+    when (other) {
+        is Int -> this * other
+        is Byte -> this * other
+        is Long -> this * other
+        is Short -> this * other
+        is Float -> this * other
+        is Double -> this * other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Byte.times(other: Number): Number =
+    when (other) {
+        is Int -> this * other
+        is Byte -> this * other
+        is Long -> this * other
+        is Short -> this * other
+        is Float -> this * other
+        is Double -> this * other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Long.times(other: Number): Number =
+    when (other) {
+        is Int -> this * other
+        is Byte -> this * other
+        is Long -> this * other
+        is Short -> this * other
+        is Float -> this * other
+        is Double -> this * other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Short.times(other: Number): Number =
+    when (other) {
+        is Int -> this * other
+        is Byte -> this * other
+        is Long -> this * other
+        is Short -> this * other
+        is Float -> this * other
+        is Double -> this * other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Float.times(other: Number): Number =
+    when (other) {
+        is Int -> this * other
+        is Byte -> this * other
+        is Long -> this * other
+        is Short -> this * other
+        is Float -> this * other
+        is Double -> this * other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Double.times(other: Number): Number =
+    when (other) {
+        is Int -> this * other
+        is Byte -> this * other
+        is Long -> this * other
+        is Short -> this * other
+        is Float -> this * other
+        is Double -> this * other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Number.div(other: Number): Number =
+    when (this) {
+        is Int -> this / other
+        is Byte -> this / other
+        is Long -> this / other
+        is Short -> this / other
+        is Float -> this / other
+        is Double -> this / other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Int.div(other: Number): Number =
+    when (other) {
+        is Int -> this / other
+        is Byte -> this / other
+        is Long -> this / other
+        is Short -> this / other
+        is Float -> this / other
+        is Double -> this / other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Byte.div(other: Number): Number =
+    when (other) {
+        is Int -> this / other
+        is Byte -> this / other
+        is Long -> this / other
+        is Short -> this / other
+        is Float -> this / other
+        is Double -> this / other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Long.div(other: Number): Number =
+    when (other) {
+        is Int -> this / other
+        is Byte -> this / other
+        is Long -> this / other
+        is Short -> this / other
+        is Float -> this / other
+        is Double -> this / other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Short.div(other: Number): Number =
+    when (other) {
+        is Int -> this / other
+        is Byte -> this / other
+        is Long -> this / other
+        is Short -> this / other
+        is Float -> this / other
+        is Double -> this / other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Float.div(other: Number): Number =
+    when (other) {
+        is Int -> this / other
+        is Byte -> this / other
+        is Long -> this / other
+        is Short -> this / other
+        is Float -> this / other
+        is Double -> this / other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Double.div(other: Number): Number =
+    when (other) {
+        is Int -> this / other
+        is Byte -> this / other
+        is Long -> this / other
+        is Short -> this / other
+        is Float -> this / other
+        is Double -> this / other
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Number.unaryMinus(): Number =
+    when (this) {
+        is Int -> -this
+        is Byte -> -this
+        is Long -> -this
+        is Short -> -this
+        is Float -> -this
+        is Double -> -this
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Number.inc(): Number =
+    when (this) {
+        is Int -> this + 1
+        is Byte -> this + 1
+        is Long -> this + 1
+        is Short -> this + 1
+        is Float -> this + 1
+        is Double -> this + 1
+        else -> throw UnsupportedOperationException()
+    }
+
+internal operator fun Number.dec(): Number =
+    when (this) {
+        is Int -> this - 1
+        is Byte -> this - 1
+        is Long -> this - 1
+        is Short -> this - 1
+        is Float -> this - 1
+        is Double -> this - 1
+        else -> throw UnsupportedOperationException()
+    }

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/NumberSet.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/NumberSet.kt
@@ -25,6 +25,9 @@
  */
 package de.fraunhofer.aisec.cpg.analysis
 
+import de.fraunhofer.aisec.cpg.graph.Node
+import org.apache.commons.lang3.builder.ToStringBuilder
+
 abstract class NumberSet {
     abstract fun min(): Long
 
@@ -87,5 +90,22 @@ class ConcreteNumberSet(var values: MutableSet<Long> = mutableSetOf()) : NumberS
 
     override fun clear() {
         values.clear()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ConcreteNumberSet
+
+        return values == other.values
+    }
+
+    override fun hashCode(): Int {
+        return values.hashCode()
+    }
+
+    override fun toString(): String {
+        return ToStringBuilder(this, Node.TO_STRING_STYLE).append(values).toString()
     }
 }

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/ValueEvaluator.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/ValueEvaluator.kt
@@ -175,40 +175,14 @@ open class ValueEvaluator(
     private fun handlePlus(lhsValue: Any?, rhsValue: Any?, expr: Expression?): Any? {
         return when {
             lhsValue is String -> lhsValue + rhsValue
-            lhsValue is Int && (rhsValue is Double || rhsValue is Float) ->
-                lhsValue + (rhsValue as Number).toDouble()
-            lhsValue is Int && rhsValue is Number -> lhsValue + rhsValue.toLong()
-            lhsValue is Long && (rhsValue is Double || rhsValue is Float) ->
-                lhsValue + (rhsValue as Number).toDouble()
-            lhsValue is Long && rhsValue is Number -> lhsValue + rhsValue.toLong()
-            lhsValue is Short && (rhsValue is Double || rhsValue is Float) ->
-                lhsValue + (rhsValue as Number).toDouble()
-            lhsValue is Short && rhsValue is Number -> lhsValue + rhsValue.toLong()
-            lhsValue is Byte && (rhsValue is Double || rhsValue is Float) ->
-                lhsValue + (rhsValue as Number).toDouble()
-            lhsValue is Byte && rhsValue is Number -> lhsValue + rhsValue.toLong()
-            lhsValue is Double && rhsValue is Number -> lhsValue + rhsValue.toDouble()
-            lhsValue is Float && rhsValue is Number -> lhsValue + rhsValue.toDouble()
+            lhsValue is Number && rhsValue is Number -> lhsValue + rhsValue
             else -> cannotEvaluate(expr, this)
         }
     }
 
     private fun handleMinus(lhsValue: Any?, rhsValue: Any?, expr: Expression?): Any? {
         return when {
-            lhsValue is Int && (rhsValue is Double || rhsValue is Float) ->
-                lhsValue - (rhsValue as Number).toDouble()
-            lhsValue is Int && rhsValue is Number -> lhsValue - rhsValue.toLong()
-            lhsValue is Long && (rhsValue is Double || rhsValue is Float) ->
-                lhsValue - (rhsValue as Number).toDouble()
-            lhsValue is Long && rhsValue is Number -> lhsValue - rhsValue.toLong()
-            lhsValue is Short && (rhsValue is Double || rhsValue is Float) ->
-                lhsValue - (rhsValue as Number).toDouble()
-            lhsValue is Short && rhsValue is Number -> lhsValue - rhsValue.toLong()
-            lhsValue is Byte && (rhsValue is Double || rhsValue is Float) ->
-                lhsValue - (rhsValue as Number).toDouble()
-            lhsValue is Byte && rhsValue is Number -> lhsValue - rhsValue.toLong()
-            lhsValue is Double && rhsValue is Number -> lhsValue - rhsValue.toDouble()
-            lhsValue is Float && rhsValue is Number -> lhsValue - rhsValue.toDouble()
+            lhsValue is Number && rhsValue is Number -> lhsValue - rhsValue
             else -> cannotEvaluate(expr, this)
         }
     }
@@ -216,40 +190,14 @@ open class ValueEvaluator(
     private fun handleDiv(lhsValue: Any?, rhsValue: Any?, expr: Expression?): Any? {
         return when {
             rhsValue == 0 -> cannotEvaluate(expr, this)
-            lhsValue is Int && (rhsValue is Double || rhsValue is Float) ->
-                lhsValue / (rhsValue as Number).toDouble()
-            lhsValue is Int && rhsValue is Number -> lhsValue / rhsValue.toLong()
-            lhsValue is Long && (rhsValue is Double || rhsValue is Float) ->
-                lhsValue / (rhsValue as Number).toDouble()
-            lhsValue is Long && rhsValue is Number -> lhsValue / rhsValue.toLong()
-            lhsValue is Short && (rhsValue is Double || rhsValue is Float) ->
-                lhsValue / (rhsValue as Number).toDouble()
-            lhsValue is Short && rhsValue is Number -> lhsValue / rhsValue.toLong()
-            lhsValue is Byte && (rhsValue is Double || rhsValue is Float) ->
-                lhsValue / (rhsValue as Number).toDouble()
-            lhsValue is Byte && rhsValue is Number -> lhsValue / rhsValue.toLong()
-            lhsValue is Double && rhsValue is Number -> lhsValue / rhsValue.toDouble()
-            lhsValue is Float && rhsValue is Number -> lhsValue / rhsValue.toDouble()
+            lhsValue is Number && rhsValue is Number -> lhsValue / rhsValue
             else -> cannotEvaluate(expr, this)
         }
     }
 
     private fun handleTimes(lhsValue: Any?, rhsValue: Any?, expr: Expression?): Any? {
         return when {
-            lhsValue is Int && (rhsValue is Double || rhsValue is Float) ->
-                lhsValue * (rhsValue as Number).toDouble()
-            lhsValue is Int && rhsValue is Number -> lhsValue * rhsValue.toLong()
-            lhsValue is Long && (rhsValue is Double || rhsValue is Float) ->
-                lhsValue * (rhsValue as Number).toDouble()
-            lhsValue is Long && rhsValue is Number -> lhsValue * rhsValue.toLong()
-            lhsValue is Short && (rhsValue is Double || rhsValue is Float) ->
-                lhsValue * (rhsValue as Number).toDouble()
-            lhsValue is Short && rhsValue is Number -> lhsValue * rhsValue.toLong()
-            lhsValue is Byte && (rhsValue is Double || rhsValue is Float) ->
-                lhsValue * (rhsValue as Number).toDouble()
-            lhsValue is Byte && rhsValue is Number -> lhsValue * rhsValue.toLong()
-            lhsValue is Double && rhsValue is Number -> lhsValue * rhsValue.toDouble()
-            lhsValue is Float && rhsValue is Number -> lhsValue * rhsValue.toDouble()
+            lhsValue is Number && rhsValue is Number -> lhsValue * rhsValue
             else -> cannotEvaluate(expr, this)
         }
     }
@@ -302,19 +250,19 @@ open class ValueEvaluator(
         return when (expr.operatorCode) {
             "-" -> {
                 when (val input = evaluateInternal(expr.input, depth + 1)) {
-                    is Number -> input.negate()
+                    is Number -> -input
                     else -> cannotEvaluate(expr, this)
                 }
             }
             "--" -> {
-                when (val input = evaluateInternal(expr.input, depth + 1)) {
-                    is Number -> input.decrement()
+                return when (val input = evaluateInternal(expr.input, depth + 1)) {
+                    is Number -> input.dec()
                     else -> cannotEvaluate(expr, this)
                 }
             }
             "++" -> {
                 when (val input = evaluateInternal(expr.input, depth + 1)) {
-                    is Number -> input.increment()
+                    is Number -> input.inc()
                     else -> cannotEvaluate(expr, this)
                 }
             }
@@ -446,40 +394,6 @@ open class ValueEvaluator(
         }
 
         return list
-    }
-}
-
-internal fun Number.negate(): Number {
-    return when (this) {
-        is Int -> -this
-        is Long -> -this
-        is Short -> -this
-        is Byte -> -this
-        is Double -> -this
-        is Float -> -this
-        else -> throw UnsupportedOperationException()
-    }
-}
-
-fun Number.increment(): Number {
-    return when (this) {
-        is Double -> this + 1
-        is Float -> this + 1
-        is Int -> this + 1
-        is Long -> this + 1
-        is Short -> this + 1
-        else -> throw UnsupportedOperationException()
-    }
-}
-
-fun Number.decrement(): Number {
-    return when (this) {
-        is Double -> this - 1
-        is Float -> this - 1
-        is Int -> this - 1
-        is Long -> this - 1
-        is Short -> this - 1
-        else -> throw UnsupportedOperationException()
     }
 }
 

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/MultiValueEvaluatorTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/MultiValueEvaluatorTest.kt
@@ -26,10 +26,10 @@
 package de.fraunhofer.aisec.cpg.analysis
 
 import de.fraunhofer.aisec.cpg.TestUtils
-import de.fraunhofer.aisec.cpg.graph.bodyOrNull
-import de.fraunhofer.aisec.cpg.graph.byNameOrNull
+import de.fraunhofer.aisec.cpg.frontends.TestHandler
+import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
-import de.fraunhofer.aisec.cpg.graph.evaluate
 import de.fraunhofer.aisec.cpg.graph.statements.CompoundStatement
 import de.fraunhofer.aisec.cpg.graph.statements.DeclarationStatement
 import de.fraunhofer.aisec.cpg.graph.statements.ForStatement
@@ -63,7 +63,7 @@ class MultiValueEvaluatorTest {
         assertNotNull(b)
 
         var value = b.evaluate()
-        assertEquals(2L, value)
+        assertEquals(2, value)
 
         val printB = main.bodyOrNull<CallExpression>()
         assertNotNull(printB)
@@ -71,7 +71,7 @@ class MultiValueEvaluatorTest {
         val evaluator = MultiValueEvaluator()
         value = evaluator.evaluate(printB.arguments.firstOrNull()) as ConcreteNumberSet
         assertEquals(value.min(), value.max())
-        assertEquals(2L, value.min())
+        assertEquals(2, value.min())
 
         val path = evaluator.path
         assertEquals(5, path.size)
@@ -87,13 +87,13 @@ class MultiValueEvaluatorTest {
         assertNotNull(c)
 
         value = evaluator.evaluate(c)
-        assertEquals(3L, value)
+        assertEquals(3, value)
 
         val d = main.bodyOrNull<DeclarationStatement>(3)?.singleDeclaration
         assertNotNull(d)
 
         value = evaluator.evaluate(d)
-        assertEquals(2L, value)
+        assertEquals(2, value)
 
         val e = main.bodyOrNull<DeclarationStatement>(4)?.singleDeclaration
         assertNotNull(e)
@@ -103,13 +103,13 @@ class MultiValueEvaluatorTest {
         val f = main.bodyOrNull<DeclarationStatement>(5)?.singleDeclaration
         assertNotNull(f)
         value = evaluator.evaluate(f)
-        assertEquals(10L, value)
+        assertEquals(10, value)
 
         val g = main.bodyOrNull<DeclarationStatement>(6)?.singleDeclaration
         assertNotNull(g)
         value = evaluator.evaluate(g) as ConcreteNumberSet
         assertEquals(value.min(), value.max())
-        assertEquals(-3L, value.min())
+        assertEquals(-3, value.min())
 
         val i = main.bodyOrNull<DeclarationStatement>(8)?.singleDeclaration
         assertNotNull(i)
@@ -217,6 +217,47 @@ class MultiValueEvaluatorTest {
         val iVar = iVarList.first()
         val value = evaluator.evaluate(iVar) as ConcreteNumberSet
         assertEquals(setOf<Long>(0, 1, 2, 3, 4, 5), value.values)
+    }
+
+    @Test
+    fun testHandleUnary() {
+        val evaluator = MultiValueEvaluator()
+
+        with(TestHandler(TestLanguageFrontend())) {
+            // Construct a fake DFG flow
+            val three = newLiteral(3, primitiveType("int"))
+            val four = newLiteral(4, primitiveType("int"))
+
+            val ref = newDeclaredReferenceExpression("a")
+            ref.prevDFG = mutableSetOf(three, four)
+
+            val neg = newUnaryOperator("-", false, true)
+            neg.input = ref
+            assertEquals(ConcreteNumberSet(mutableSetOf(-3, -4)), evaluator.evaluate(neg))
+
+            neg.input = newLiteral(3.5, primitiveType("double"))
+            assertEquals(-3.5, evaluator.evaluate(neg))
+
+            val plusplus = newUnaryOperator("++", true, false)
+            plusplus.input = newLiteral(3, primitiveType("int"))
+            assertEquals(4, evaluator.evaluate(plusplus))
+
+            plusplus.input = newLiteral(3.5, primitiveType("double"))
+            assertEquals(4.5, evaluator.evaluate(plusplus))
+
+            plusplus.input = newLiteral(3.5f, primitiveType("float"))
+            assertEquals(4.5f, evaluator.evaluate(plusplus))
+
+            val minusminus = newUnaryOperator("--", true, false)
+            minusminus.input = newLiteral(3, primitiveType("int"))
+            assertEquals(2, evaluator.evaluate(minusminus))
+
+            minusminus.input = newLiteral(3.5, primitiveType("double"))
+            assertEquals(2.5, evaluator.evaluate(minusminus))
+
+            minusminus.input = newLiteral(3.5f, primitiveType("float"))
+            assertEquals(2.5f, evaluator.evaluate(minusminus))
+        }
     }
 
     @Test

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/ValueEvaluatorTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/ValueEvaluatorTest.kt
@@ -38,6 +38,33 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import org.junit.jupiter.api.assertThrows
+
+class NotReallyANumber : Number() {
+    override fun toByte(): Byte {
+        TODO("Not yet implemented")
+    }
+
+    override fun toDouble(): Double {
+        TODO("Not yet implemented")
+    }
+
+    override fun toFloat(): Float {
+        TODO("Not yet implemented")
+    }
+
+    override fun toInt(): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun toLong(): Long {
+        TODO("Not yet implemented")
+    }
+
+    override fun toShort(): Short {
+        TODO("Not yet implemented")
+    }
+}
 
 class ValueEvaluatorTest {
 
@@ -60,14 +87,14 @@ class ValueEvaluatorTest {
         assertNotNull(b)
 
         var value = b.evaluate()
-        assertEquals(2L, value)
+        assertEquals(2, value)
 
         val printB = main.bodyOrNull<CallExpression>()
         assertNotNull(printB)
 
         val evaluator = ValueEvaluator()
         value = evaluator.evaluate(printB.arguments.firstOrNull())
-        assertEquals(2L, value)
+        assertEquals(2, value)
 
         val path = evaluator.path
         assertEquals(5, path.size)
@@ -82,13 +109,13 @@ class ValueEvaluatorTest {
         assertNotNull(c)
 
         value = c.evaluate()
-        assertEquals(3L, value)
+        assertEquals(3, value)
 
         val d = main.bodyOrNull<DeclarationStatement>(3)?.singleDeclaration
         assertNotNull(d)
 
         value = d.evaluate()
-        assertEquals(2L, value)
+        assertEquals(2, value)
 
         val e = main.bodyOrNull<DeclarationStatement>(4)?.singleDeclaration
         assertNotNull(e)
@@ -98,7 +125,7 @@ class ValueEvaluatorTest {
         val f = main.bodyOrNull<DeclarationStatement>(5)?.singleDeclaration
         assertNotNull(f)
         value = f.evaluate()
-        assertEquals(10L, value)
+        assertEquals(10, value)
 
         val printHelloWorld = main.bodyOrNull<CallExpression>(2)
         assertNotNull(printHelloWorld)
@@ -109,7 +136,7 @@ class ValueEvaluatorTest {
         val g = main.bodyOrNull<DeclarationStatement>(6)?.singleDeclaration
         assertNotNull(g)
         value = g.evaluate()
-        assertEquals(-3L, value)
+        assertEquals(-3, value)
 
         val h = main.bodyOrNull<DeclarationStatement>(7)?.singleDeclaration
         assertNotNull(h)
@@ -184,54 +211,157 @@ class ValueEvaluatorTest {
     fun testHandlePlus() {
         with(TestHandler(TestLanguageFrontend())) {
             val binOp = newBinaryOperator("+")
+            // Int.plus
             binOp.lhs = newLiteral(3, primitiveType("int"))
             binOp.rhs = newLiteral(2, primitiveType("int"))
+            assertEquals(5, ValueEvaluator().evaluate(binOp))
 
+            binOp.rhs = newLiteral(2.toByte(), primitiveType("byte"))
+            assertEquals(5, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2L, primitiveType("long"))
             assertEquals(5L, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.toShort(), primitiveType("short"))
+            assertEquals(5, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.4f, primitiveType("float"))
+            assertEquals(5.4f, ValueEvaluator().evaluate(binOp))
 
             binOp.rhs = newLiteral(2.4, primitiveType("double"))
             assertEquals(5.4, ValueEvaluator().evaluate(binOp))
 
+            assertThrows<UnsupportedOperationException> {
+                binOp.rhs = newLiteral(NotReallyANumber(), objectType("fake"))
+                ValueEvaluator().evaluate(binOp)
+            }
+
+            // Byte.plus
+            binOp.lhs = newLiteral(3.toByte(), primitiveType("byte"))
+            binOp.rhs = newLiteral(2, primitiveType("int"))
+            assertEquals(5, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.toByte(), primitiveType("byte"))
+            assertEquals(5, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2L, primitiveType("long"))
+            assertEquals(5L, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.toShort(), primitiveType("short"))
+            assertEquals(5, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.4f, primitiveType("float"))
+            assertEquals(5.4f, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.4, primitiveType("double"))
+            assertEquals(5.4, ValueEvaluator().evaluate(binOp))
+
+            assertThrows<UnsupportedOperationException> {
+                binOp.rhs = newLiteral(NotReallyANumber(), objectType("fake"))
+                ValueEvaluator().evaluate(binOp)
+            }
+
+            // Long.plus
             binOp.lhs = newLiteral(3L, primitiveType("long"))
             binOp.rhs = newLiteral(2, primitiveType("int"))
-
             assertEquals(5L, ValueEvaluator().evaluate(binOp))
 
-            binOp.rhs = newLiteral(2.4, primitiveType("double"))
-            assertEquals(5.4, ValueEvaluator().evaluate(binOp))
-
-            binOp.lhs = newLiteral((3).toShort(), primitiveType("short"))
-            binOp.rhs = newLiteral(2, primitiveType("int"))
-
+            binOp.rhs = newLiteral(2.toByte(), primitiveType("byte"))
             assertEquals(5L, ValueEvaluator().evaluate(binOp))
 
-            binOp.rhs = newLiteral(2.4, primitiveType("double"))
-            assertEquals(5.4, ValueEvaluator().evaluate(binOp))
-
-            binOp.lhs = newLiteral((3).toByte(), primitiveType("byte"))
-            binOp.rhs = newLiteral(2, primitiveType("int"))
-
+            binOp.rhs = newLiteral(2L, primitiveType("long"))
             assertEquals(5L, ValueEvaluator().evaluate(binOp))
 
+            binOp.rhs = newLiteral(2.toShort(), primitiveType("short"))
+            assertEquals(5L, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.4f, primitiveType("float"))
+            assertEquals(5.4f, ValueEvaluator().evaluate(binOp))
+
             binOp.rhs = newLiteral(2.4, primitiveType("double"))
             assertEquals(5.4, ValueEvaluator().evaluate(binOp))
 
-            binOp.lhs = newLiteral(3.0, primitiveType("double"))
+            assertThrows<UnsupportedOperationException> {
+                binOp.rhs = newLiteral(NotReallyANumber(), objectType("fake"))
+                ValueEvaluator().evaluate(binOp)
+            }
+
+            // Short.plus
+            binOp.lhs = newLiteral(3.toShort(), primitiveType("short"))
             binOp.rhs = newLiteral(2, primitiveType("int"))
+            assertEquals(5, ValueEvaluator().evaluate(binOp))
 
-            assertEquals(5.0, ValueEvaluator().evaluate(binOp))
+            binOp.rhs = newLiteral(2.toByte(), primitiveType("byte"))
+            assertEquals(5, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2L, primitiveType("long"))
+            assertEquals(5L, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.toShort(), primitiveType("short"))
+            assertEquals(5, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.4f, primitiveType("float"))
+            assertEquals(5.4f, ValueEvaluator().evaluate(binOp))
 
             binOp.rhs = newLiteral(2.4, primitiveType("double"))
             assertEquals(5.4, ValueEvaluator().evaluate(binOp))
 
+            assertThrows<UnsupportedOperationException> {
+                binOp.rhs = newLiteral(NotReallyANumber(), objectType("fake"))
+                ValueEvaluator().evaluate(binOp)
+            }
+
+            // Float.plus
             binOp.lhs = newLiteral(3.0f, primitiveType("float"))
             binOp.rhs = newLiteral(2, primitiveType("int"))
+            assertEquals(5.0f, ValueEvaluator().evaluate(binOp))
 
-            assertEquals(5.0, ValueEvaluator().evaluate(binOp))
+            binOp.rhs = newLiteral(2.toByte(), primitiveType("byte"))
+            assertEquals(5.0f, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2L, primitiveType("long"))
+            assertEquals(5.0f, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.toShort(), primitiveType("short"))
+            assertEquals(5.0f, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.4f, primitiveType("float"))
+            assertEquals(5.4f, ValueEvaluator().evaluate(binOp))
 
             binOp.rhs = newLiteral(2.4, primitiveType("double"))
             assertEquals(5.4, ValueEvaluator().evaluate(binOp))
 
+            assertThrows<UnsupportedOperationException> {
+                binOp.rhs = newLiteral(NotReallyANumber(), objectType("fake"))
+                ValueEvaluator().evaluate(binOp)
+            }
+
+            // Double.plus
+            binOp.lhs = newLiteral(3.0, primitiveType("double"))
+            binOp.rhs = newLiteral(2, primitiveType("int"))
+            assertEquals(5.0, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.toByte(), primitiveType("byte"))
+            assertEquals(5.0, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2L, primitiveType("long"))
+            assertEquals(5.0, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.toShort(), primitiveType("short"))
+            assertEquals(5.0, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.4f, primitiveType("float"))
+            assertEquals((3.0 + 2.4f), ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.4, primitiveType("double"))
+            assertEquals(5.4, ValueEvaluator().evaluate(binOp))
+
+            assertThrows<UnsupportedOperationException> {
+                binOp.rhs = newLiteral(NotReallyANumber(), objectType("fake"))
+                ValueEvaluator().evaluate(binOp)
+            }
+
+            // String.plus
             binOp.lhs = newLiteral("Hello", primitiveType("string"))
             binOp.rhs = newLiteral(" world", primitiveType("string"))
             assertEquals("Hello world", ValueEvaluator().evaluate(binOp))
@@ -248,7 +378,7 @@ class ValueEvaluatorTest {
             binOp.lhs = newLiteral(3, primitiveType("int"))
             binOp.rhs = newLiteral(2, primitiveType("int"))
 
-            assertEquals(1L, ValueEvaluator().evaluate(binOp))
+            assertEquals(1, ValueEvaluator().evaluate(binOp))
 
             binOp.rhs = newLiteral(2.4, primitiveType("double"))
             assertEquals(3 - 2.4, ValueEvaluator().evaluate(binOp))
@@ -264,7 +394,7 @@ class ValueEvaluatorTest {
             binOp.lhs = newLiteral((3).toShort(), primitiveType("short"))
             binOp.rhs = newLiteral(2, primitiveType("int"))
 
-            assertEquals(1L, ValueEvaluator().evaluate(binOp))
+            assertEquals(1, ValueEvaluator().evaluate(binOp))
 
             binOp.rhs = newLiteral(2.4, primitiveType("double"))
             assertEquals(3 - 2.4, ValueEvaluator().evaluate(binOp))
@@ -272,7 +402,7 @@ class ValueEvaluatorTest {
             binOp.lhs = newLiteral((3).toByte(), primitiveType("byte"))
             binOp.rhs = newLiteral(2, primitiveType("int"))
 
-            assertEquals(1L, ValueEvaluator().evaluate(binOp))
+            assertEquals(1, ValueEvaluator().evaluate(binOp))
 
             binOp.rhs = newLiteral(2.4, primitiveType("double"))
             assertEquals(3 - 2.4, ValueEvaluator().evaluate(binOp))
@@ -288,7 +418,7 @@ class ValueEvaluatorTest {
             binOp.lhs = newLiteral(3.0f, primitiveType("float"))
             binOp.rhs = newLiteral(2, primitiveType("int"))
 
-            assertEquals(1.0, ValueEvaluator().evaluate(binOp))
+            assertEquals(1.0f, ValueEvaluator().evaluate(binOp))
 
             binOp.rhs = newLiteral(2.4, primitiveType("double"))
             assertEquals(3 - 2.4, ValueEvaluator().evaluate(binOp))
@@ -302,55 +432,158 @@ class ValueEvaluatorTest {
     @Test
     fun testHandleTimes() {
         with(TestHandler(TestLanguageFrontend())) {
+            // Int.times
             val binOp = newBinaryOperator("*")
             binOp.lhs = newLiteral(3, primitiveType("int"))
             binOp.rhs = newLiteral(2, primitiveType("int"))
+            assertEquals(6, ValueEvaluator().evaluate(binOp))
 
+            binOp.rhs = newLiteral(2.toByte(), primitiveType("byte"))
+            assertEquals(6, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2L, primitiveType("long"))
             assertEquals(6L, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.toShort(), primitiveType("short"))
+            assertEquals(6, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.4f, primitiveType("float"))
+            assertEquals(3 * 2.4f, ValueEvaluator().evaluate(binOp))
 
             binOp.rhs = newLiteral(2.4, primitiveType("double"))
             assertEquals(3 * 2.4, ValueEvaluator().evaluate(binOp))
 
+            assertThrows<UnsupportedOperationException> {
+                binOp.rhs = newLiteral(NotReallyANumber(), objectType("fake"))
+                ValueEvaluator().evaluate(binOp)
+            }
+
+            // Byte.times
+            binOp.lhs = newLiteral(3.toByte(), primitiveType("byte"))
+            binOp.rhs = newLiteral(2, primitiveType("int"))
+            assertEquals(6, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.toByte(), primitiveType("byte"))
+            assertEquals(6, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2L, primitiveType("long"))
+            assertEquals(6L, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.toShort(), primitiveType("short"))
+            assertEquals(6, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.4f, primitiveType("float"))
+            assertEquals(3 * 2.4f, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.4, primitiveType("double"))
+            assertEquals(3 * 2.4, ValueEvaluator().evaluate(binOp))
+
+            assertThrows<UnsupportedOperationException> {
+                binOp.rhs = newLiteral(NotReallyANumber(), objectType("fake"))
+                ValueEvaluator().evaluate(binOp)
+            }
+
+            // Short.times
+            binOp.lhs = newLiteral(3.toShort(), primitiveType("short"))
+            binOp.rhs = newLiteral(2, primitiveType("int"))
+            assertEquals(6, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.toShort(), primitiveType("byte"))
+            assertEquals(6, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2L, primitiveType("long"))
+            assertEquals(6L, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.toShort(), primitiveType("short"))
+            assertEquals(6, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.4f, primitiveType("float"))
+            assertEquals(3 * 2.4f, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.4, primitiveType("double"))
+            assertEquals(3 * 2.4, ValueEvaluator().evaluate(binOp))
+
+            assertThrows<UnsupportedOperationException> {
+                binOp.rhs = newLiteral(NotReallyANumber(), objectType("fake"))
+                ValueEvaluator().evaluate(binOp)
+            }
+
+            // Long.times
             binOp.lhs = newLiteral(3L, primitiveType("long"))
             binOp.rhs = newLiteral(2, primitiveType("int"))
-
             assertEquals(6L, ValueEvaluator().evaluate(binOp))
 
-            binOp.rhs = newLiteral(2.4, primitiveType("double"))
-            assertEquals(3 * 2.4, ValueEvaluator().evaluate(binOp))
-
-            binOp.lhs = newLiteral((3).toShort(), primitiveType("short"))
-            binOp.rhs = newLiteral(2, primitiveType("int"))
-
+            binOp.rhs = newLiteral(2L, primitiveType("byte"))
             assertEquals(6L, ValueEvaluator().evaluate(binOp))
 
-            binOp.rhs = newLiteral(2.4, primitiveType("double"))
-            assertEquals(3 * 2.4, ValueEvaluator().evaluate(binOp))
-
-            binOp.lhs = newLiteral((3).toByte(), primitiveType("byte"))
-            binOp.rhs = newLiteral(2, primitiveType("int"))
-
+            binOp.rhs = newLiteral(2L, primitiveType("long"))
             assertEquals(6L, ValueEvaluator().evaluate(binOp))
 
-            binOp.rhs = newLiteral(2.4, primitiveType("double"))
-            assertEquals(3 * 2.4, ValueEvaluator().evaluate(binOp))
+            binOp.rhs = newLiteral(2L, primitiveType("short"))
+            assertEquals(6L, ValueEvaluator().evaluate(binOp))
 
-            binOp.lhs = newLiteral(3.0, primitiveType("double"))
-            binOp.rhs = newLiteral(2, primitiveType("int"))
-
-            assertEquals(6.0, ValueEvaluator().evaluate(binOp))
+            binOp.rhs = newLiteral(2.4f, primitiveType("float"))
+            assertEquals(3L * 2.4f, ValueEvaluator().evaluate(binOp))
 
             binOp.rhs = newLiteral(2.4, primitiveType("double"))
-            assertEquals(3 * 2.4, ValueEvaluator().evaluate(binOp))
+            assertEquals(3L * 2.4, ValueEvaluator().evaluate(binOp))
 
+            assertThrows<UnsupportedOperationException> {
+                binOp.rhs = newLiteral(NotReallyANumber(), objectType("fake"))
+                ValueEvaluator().evaluate(binOp)
+            }
+
+            // Float.times
             binOp.lhs = newLiteral(3.0f, primitiveType("float"))
             binOp.rhs = newLiteral(2, primitiveType("int"))
+            assertEquals(6.0f, ValueEvaluator().evaluate(binOp))
 
-            assertEquals(6.0, ValueEvaluator().evaluate(binOp))
+            binOp.rhs = newLiteral(2L, primitiveType("byte"))
+            assertEquals(6.0f, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2L, primitiveType("long"))
+            assertEquals(6.0f, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2L, primitiveType("short"))
+            assertEquals(6.0f, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.4f, primitiveType("float"))
+            assertEquals(3.0f * 2.4f, ValueEvaluator().evaluate(binOp))
 
             binOp.rhs = newLiteral(2.4, primitiveType("double"))
-            assertEquals(3 * 2.4, ValueEvaluator().evaluate(binOp))
+            assertEquals(3.0f * 2.4, ValueEvaluator().evaluate(binOp))
 
+            assertThrows<UnsupportedOperationException> {
+                binOp.rhs = newLiteral(NotReallyANumber(), objectType("fake"))
+                ValueEvaluator().evaluate(binOp)
+            }
+
+            // Double.times
+            binOp.lhs = newLiteral(3.0, primitiveType("double"))
+            binOp.rhs = newLiteral(2, primitiveType("int"))
+            assertEquals(6.0, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2L, primitiveType("byte"))
+            assertEquals(6.0, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2L, primitiveType("long"))
+            assertEquals(6.0, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2L, primitiveType("short"))
+            assertEquals(6.0, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.4f, primitiveType("float"))
+            assertEquals(3.0 * 2.4f, ValueEvaluator().evaluate(binOp))
+
+            binOp.rhs = newLiteral(2.4, primitiveType("double"))
+            assertEquals(3.0 * 2.4, ValueEvaluator().evaluate(binOp))
+
+            assertThrows<UnsupportedOperationException> {
+                binOp.rhs = newLiteral(NotReallyANumber(), objectType("fake"))
+                ValueEvaluator().evaluate(binOp)
+            }
+
+            // String.times
             binOp.lhs = newLiteral("Hello", primitiveType("string"))
             binOp.rhs = newLiteral(" world", primitiveType("string"))
             assertEquals("{*}", ValueEvaluator().evaluate(binOp))
@@ -369,7 +602,7 @@ class ValueEvaluatorTest {
             binOp.lhs = newLiteral(3, primitiveType("int"))
             binOp.rhs = newLiteral(2, primitiveType("int"))
 
-            assertEquals(1L, ValueEvaluator().evaluate(binOp))
+            assertEquals(1, ValueEvaluator().evaluate(binOp))
 
             binOp.rhs = newLiteral(2.4, primitiveType("double"))
             assertEquals(3 / 2.4, ValueEvaluator().evaluate(binOp))
@@ -385,7 +618,7 @@ class ValueEvaluatorTest {
             binOp.lhs = newLiteral((3).toShort(), primitiveType("short"))
             binOp.rhs = newLiteral(2, primitiveType("int"))
 
-            assertEquals(1L, ValueEvaluator().evaluate(binOp))
+            assertEquals(1, ValueEvaluator().evaluate(binOp))
 
             binOp.rhs = newLiteral(2.4, primitiveType("double"))
             assertEquals(3 / 2.4, ValueEvaluator().evaluate(binOp))
@@ -393,7 +626,7 @@ class ValueEvaluatorTest {
             binOp.lhs = newLiteral((3).toByte(), primitiveType("byte"))
             binOp.rhs = newLiteral(2, primitiveType("int"))
 
-            assertEquals(1L, ValueEvaluator().evaluate(binOp))
+            assertEquals(1, ValueEvaluator().evaluate(binOp))
 
             binOp.rhs = newLiteral(2.4, primitiveType("double"))
             assertEquals(3 / 2.4, ValueEvaluator().evaluate(binOp))
@@ -409,7 +642,7 @@ class ValueEvaluatorTest {
             binOp.lhs = newLiteral(3.0f, primitiveType("float"))
             binOp.rhs = newLiteral(2, primitiveType("int"))
 
-            assertEquals(1.5, ValueEvaluator().evaluate(binOp))
+            assertEquals(1.5f, ValueEvaluator().evaluate(binOp))
 
             binOp.rhs = newLiteral(2.4, primitiveType("double"))
             assertEquals(3 / 2.4, ValueEvaluator().evaluate(binOp))


### PR DESCRIPTION
Previously, we just casted most of our numeric types to `Long` when doing arithmetic operations in the `ValueEvalutor`. This PR tries to optimize that by introducing a number of extension functions that under the hood call the necessary Kotlin functions to properly deal with the resulting type based on the bit width.
