### PR TITLE
Fixed rather intricate bug in property edge list

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/StatementHolder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/StatementHolder.kt
@@ -27,8 +27,9 @@ package de.fraunhofer.aisec.cpg.graph
 
 import de.fraunhofer.aisec.cpg.graph.edge.Properties
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
-import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.transformIntoOutgoingPropertyEdgeList
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.unwrap
+import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.wrap
+import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
 import de.fraunhofer.aisec.cpg.graph.statements.Statement
 
 /**
@@ -44,13 +45,17 @@ interface StatementHolder : Holder<Statement> {
     /** List of statements as property edges. */
     var statementEdges: MutableList<PropertyEdge<Statement>>
 
-    /** Virtual property to access [statementEdges] without property edges. */
+    /**
+     * Virtual property to access [statementEdges] without property edges.
+     *
+     * Note: We cannot use [PropertyEdgeDelegate] because delegates are not allowed in interfaces.
+     */
     var statements: List<Statement>
         get() {
             return unwrap(statementEdges)
         }
         set(value) {
-            statementEdges = transformIntoOutgoingPropertyEdgeList(value, this as Node)
+            statementEdges = wrap(value, this as Node)
         }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TranslationUnitDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TranslationUnitDeclaration.kt
@@ -27,11 +27,11 @@ package de.fraunhofer.aisec.cpg.graph.declarations
 
 import de.fraunhofer.aisec.cpg.graph.AST
 import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
-import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.StatementHolder
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.unwrap
+import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
 import de.fraunhofer.aisec.cpg.graph.statements.Statement
 import de.fraunhofer.aisec.cpg.passes.PassTarget
 import java.util.Objects
@@ -63,11 +63,8 @@ class TranslationUnitDeclaration : Declaration(), DeclarationHolder, StatementHo
     override val declarations: List<Declaration>
         get() = unwrap(declarationEdges)
 
-    override var statements: List<Statement>
-        get() = unwrap(statementEdges)
-        set(value) {
-            statementEdges = PropertyEdge.transformIntoOutgoingPropertyEdgeList(value, this as Node)
-        }
+    override var statements: List<Statement> by
+        PropertyEdgeDelegate(TranslationUnitDeclaration::statementEdges)
 
     val includes: List<IncludeDeclaration>
         get() = unwrap(includeEdges)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
@@ -34,8 +34,8 @@ import de.fraunhofer.aisec.cpg.graph.declarations.TemplateDeclaration.TemplateIn
 import de.fraunhofer.aisec.cpg.graph.edge.*
 import de.fraunhofer.aisec.cpg.graph.edge.Properties
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsList
-import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.transformIntoOutgoingPropertyEdgeList
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.unwrap
+import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.wrap
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.graph.types.HasSecondaryTypeEdge
 import de.fraunhofer.aisec.cpg.passes.CallResolver
@@ -74,7 +74,7 @@ open class CallExpression :
         }
         set(value) {
             unwrap(invokeEdges).forEach { it.unregisterTypeObserver(this) }
-            invokeEdges = transformIntoOutgoingPropertyEdgeList(value, this)
+            invokeEdges = wrap(value, this)
             value.forEach { it.registerTypeObserver(this) }
         }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionPointerType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionPointerType.kt
@@ -28,8 +28,8 @@ package de.fraunhofer.aisec.cpg.graph.types
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsList
-import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.transformIntoOutgoingPropertyEdgeList
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.unwrap
+import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.wrap
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
 import de.fraunhofer.aisec.cpg.graph.types.PointerType.PointerOrigin
 import java.util.*
@@ -59,7 +59,7 @@ class FunctionPointerType : Type {
         language: Language<*>? = null,
         returnType: Type = UnknownType.getUnknownType(language)
     ) : super(EMPTY_NAME, language) {
-        parametersPropertyEdge = transformIntoOutgoingPropertyEdgeList(parameters, this)
+        parametersPropertyEdge = wrap(parameters, this)
         this.returnType = returnType
     }
 
@@ -69,7 +69,7 @@ class FunctionPointerType : Type {
         language: Language<*>? = null,
         returnType: Type = UnknownType.getUnknownType(language)
     ) : super(type) {
-        parametersPropertyEdge = transformIntoOutgoingPropertyEdgeList(parameters, this)
+        parametersPropertyEdge = wrap(parameters, this)
         this.returnType = returnType
         this.language = language
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ObjectType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ObjectType.kt
@@ -31,7 +31,7 @@ import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.edge.Properties
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsList
-import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.transformIntoOutgoingPropertyEdgeList
+import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.wrap
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
 import de.fraunhofer.aisec.cpg.graph.types.PointerType.PointerOrigin
 import de.fraunhofer.aisec.cpg.graph.unknownType
@@ -61,7 +61,7 @@ open class ObjectType : Type, HasSecondaryTypeEdge {
         primitive: Boolean,
         language: Language<*>?
     ) : super(typeName, language) {
-        this.genericsPropertyEdges = transformIntoOutgoingPropertyEdgeList(generics, this)
+        this.genericsPropertyEdges = wrap(generics, this)
         isPrimitive = primitive
         this.language = language
     }
@@ -73,7 +73,7 @@ open class ObjectType : Type, HasSecondaryTypeEdge {
         language: Language<*>?
     ) : super(type) {
         this.language = language
-        this.genericsPropertyEdges = transformIntoOutgoingPropertyEdgeList(generics, this)
+        this.genericsPropertyEdges = wrap(generics, this)
         isPrimitive = primitive
     }
 


### PR DESCRIPTION
For some reason wrapping of property edges was always assuming that the edges are "outgoing". This of course created major problems if edges were incoming.
