### PR TITLE
Only store one single unique `Type` nodes for each type

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Name.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Name.kt
@@ -131,6 +131,11 @@ fun LanguageProvider?.parseName(fqn: CharSequence) =
 
 /** Tries to parse the given fully qualified name using the specified [delimiter] into a [Name]. */
 internal fun parseName(fqn: CharSequence, delimiter: String, vararg splitDelimiters: String): Name {
+    // We can take a shortcut, if this is already a name
+    if (fqn is Name) {
+        return fqn
+    }
+
     val parts = fqn.split(delimiter, *splitDelimiters)
 
     var name: Name? = null

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
@@ -1175,13 +1175,8 @@ infix fun Expression.assignAsExpr(rhs: AssignExpression.() -> Unit): AssignExpre
 }
 
 /** Creates a new [Type] with the given [name] in the Fluent Node DSL. */
-fun LanguageFrontend<*, *>.t(name: CharSequence, init: (Type.() -> Unit)? = null): Type {
-    val type = objectType(name)
-    if (init != null) {
-        init(type)
-    }
-    return type
-}
+fun LanguageFrontend<*, *>.t(name: CharSequence, generics: List<Type> = listOf()) =
+    objectType(name, generics)
 
 /**
  * Internally used to enter a new scope if [needsScope] is true before invoking [init] and leaving

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/RecordDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/RecordDeclaration.kt
@@ -30,7 +30,6 @@ import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
 import de.fraunhofer.aisec.cpg.graph.statements.Statement
-import de.fraunhofer.aisec.cpg.graph.types.HasSecondaryTypeEdge
 import de.fraunhofer.aisec.cpg.graph.types.ObjectType
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import org.apache.commons.lang3.builder.ToStringBuilder
@@ -38,7 +37,7 @@ import org.neo4j.ogm.annotation.Relationship
 import org.neo4j.ogm.annotation.Transient
 
 /** Represents a C++ union/struct/class or Java class */
-class RecordDeclaration : Declaration(), DeclarationHolder, StatementHolder, HasSecondaryTypeEdge {
+class RecordDeclaration : Declaration(), DeclarationHolder, StatementHolder {
     /** The kind, i.e. struct, class, union or enum. */
     var kind: String? = null
 
@@ -171,22 +170,6 @@ class RecordDeclaration : Declaration(), DeclarationHolder, StatementHolder, Has
             .append("constructors", constructors)
             .append("records", records)
             .toString()
-    }
-
-    override fun updateType(typeState: Collection<Type>) {
-        // Replace occurrences of the super classes and interfaces with the one combined type
-        replaceType(superClasses, typeState)
-        replaceType(implementedInterfaces, typeState)
-    }
-
-    private fun replaceType(list: MutableList<Type>, typeState: Collection<Type>) {
-        for ((idx, t) in list.withIndex()) {
-            for (newType in typeState) {
-                if (newType == t) {
-                    list[idx] = newType
-                }
-            }
-        }
     }
 
     override fun equals(other: Any?): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TypeParamDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TypeParamDeclaration.kt
@@ -27,19 +27,13 @@ package de.fraunhofer.aisec.cpg.graph.declarations
 
 import de.fraunhofer.aisec.cpg.graph.AST
 import de.fraunhofer.aisec.cpg.graph.HasDefault
-import de.fraunhofer.aisec.cpg.graph.types.HasSecondaryTypeEdge
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import java.util.*
 import org.neo4j.ogm.annotation.Relationship
 
 /** A declaration of a type template parameter */
-class TypeParamDeclaration : ValueDeclaration(), HasSecondaryTypeEdge, HasDefault<Type?> {
-    /**
-     * TemplateParameters can define a default for the type parameter Since the primary type edge
-     * points to the ParameterizedType, the default edge is a secondary type edge. Therefore, the
-     * TypeResolver requires to implement the [HasSecondaryTypeEdge] to be aware of the edge to be
-     * able to merge the type nodes.
-     */
+class TypeParamDeclaration : ValueDeclaration(), HasDefault<Type?> {
+    /** TemplateParameters can define a default for the type parameter. */
     @Relationship(value = "DEFAULT", direction = Relationship.Direction.OUTGOING)
     @AST
     override var default: Type? = null
@@ -52,15 +46,4 @@ class TypeParamDeclaration : ValueDeclaration(), HasSecondaryTypeEdge, HasDefaul
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), default)
-
-    override fun updateType(typeState: Collection<Type>) {
-        val oldType = default
-        if (oldType != null) {
-            for (t in typeState) {
-                if (t == oldType) {
-                    default = t
-                }
-            }
-        }
-    }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
@@ -37,7 +37,6 @@ import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsL
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.unwrap
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.wrap
 import de.fraunhofer.aisec.cpg.graph.types.*
-import de.fraunhofer.aisec.cpg.graph.types.HasSecondaryTypeEdge
 import de.fraunhofer.aisec.cpg.passes.CallResolver
 import de.fraunhofer.aisec.cpg.passes.VariableUsageResolver
 import java.util.*
@@ -48,8 +47,7 @@ import org.neo4j.ogm.annotation.Relationship
  * An expression, which calls another function. It has a list of arguments (list of [Expression]s)
  * and is connected via the INVOKES edge to its [FunctionDeclaration].
  */
-open class CallExpression :
-    Expression(), HasType.TypeObserver, HasSecondaryTypeEdge, ArgumentHolder {
+open class CallExpression : Expression(), HasType.TypeObserver, ArgumentHolder {
     /**
      * Connection to its [FunctionDeclaration]. This will be populated by the [CallResolver]. This
      * will have an effect on the [type]
@@ -189,26 +187,6 @@ open class CallExpression :
             template = value != null
         }
 
-    private val typeTemplateParameters: List<Type>
-        get() {
-            val types: MutableList<Type> = ArrayList()
-            for (n in templateParameters) {
-                if (n is Type) {
-                    types.add(n)
-                }
-            }
-            return types
-        }
-
-    private fun replaceTypeTemplateParameter(oldType: Type?, newType: Type) {
-        for (i in templateParameterEdges?.indices ?: listOf()) {
-            val propertyEdge = templateParameterEdges?.get(i)
-            if (propertyEdge?.end == oldType) {
-                propertyEdge?.end = newType
-            }
-        }
-    }
-
     /**
      * Adds a template parameter to this call expression. A parameter can either be an [Expression]
      * (usually a [Literal]) or a [Type].
@@ -317,14 +295,4 @@ open class CallExpression :
     // TODO: Not sure if we can add the template, templateParameters, templateInstantiation fields
     //  here
     override fun hashCode() = Objects.hash(super.hashCode(), arguments)
-
-    override fun updateType(typeState: Collection<Type>) {
-        for (t in typeTemplateParameters) {
-            for (t2 in typeState) {
-                if (t2 == t) {
-                    replaceTypeTemplateParameter(t, t2)
-                }
-            }
-        }
-    }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/AutoType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/AutoType.kt
@@ -43,8 +43,4 @@ class AutoType(override var language: Language<*>?) : Type("auto", language) {
     override fun dereference(): Type {
         return unknownType()
     }
-
-    override fun duplicate(): Type {
-        return AutoType(this.language)
-    }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/BooleanType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/BooleanType.kt
@@ -33,9 +33,4 @@ class BooleanType(
     bitWidth: Int? = 1,
     language: Language<*>? = null,
     modifier: Modifier = Modifier.NOT_APPLICABLE
-) : NumericType(typeName, bitWidth, language, modifier) {
-
-    override fun duplicate(): Type {
-        return BooleanType(this.name, bitWidth, language, modifier)
-    }
-}
+) : NumericType(typeName, bitWidth, language, modifier)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FloatingPointType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FloatingPointType.kt
@@ -33,9 +33,4 @@ class FloatingPointType(
     bitWidth: Int? = null,
     language: Language<*>? = null,
     modifier: Modifier = Modifier.SIGNED
-) : NumericType(typeName, bitWidth, language, modifier) {
-
-    override fun duplicate(): Type {
-        return FloatingPointType(name, bitWidth, language, modifier)
-    }
-}
+) : NumericType(typeName, bitWidth, language, modifier)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionPointerType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionPointerType.kt
@@ -28,7 +28,6 @@ package de.fraunhofer.aisec.cpg.graph.types
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsList
-import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.unwrap
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.wrap
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
 import de.fraunhofer.aisec.cpg.graph.types.PointerType.PointerOrigin
@@ -80,11 +79,6 @@ class FunctionPointerType : Type {
 
     override fun dereference(): Type {
         return this
-    }
-
-    override fun duplicate(): Type {
-        val copiedParameters: List<Type> = ArrayList(unwrap(parametersPropertyEdge))
-        return FunctionPointerType(this, copiedParameters, language, returnType)
     }
 
     override fun isSimilar(t: Type?): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionType.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.frontends.Language
+import de.fraunhofer.aisec.cpg.frontends.TranslationException
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.unknownType
 
@@ -58,10 +59,6 @@ constructor(
         return unknownType()
     }
 
-    override fun duplicate(): Type {
-        return FunctionType(typeName, parameters.toList(), returnTypes.toList(), language)
-    }
-
     companion object {
         /**
          * This helper function computes a [FunctionType] out of an existing [FunctionDeclaration].
@@ -78,7 +75,8 @@ constructor(
                     func.language
                 )
 
-            return func.registerType(type)
+            val c = func.ctx ?: throw TranslationException("context not available")
+            return c.typeManager.registerType(type)
         }
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/HasType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/HasType.kt
@@ -25,7 +25,6 @@
  */
 package de.fraunhofer.aisec.cpg.graph.types
 
-import de.fraunhofer.aisec.cpg.frontends.TranslationException
 import de.fraunhofer.aisec.cpg.graph.ContextProvider
 import de.fraunhofer.aisec.cpg.graph.LanguageProvider
 import de.fraunhofer.aisec.cpg.graph.Node
@@ -183,9 +182,4 @@ interface HasType : ContextProvider, LanguageProvider {
     fun unregisterTypeObserver(typeObserver: TypeObserver) {
         typeObservers -= typeObserver
     }
-}
-
-fun <T : Type> Node.registerType(type: T): T {
-    val c = ctx ?: throw TranslationException("context not available")
-    return c.typeManager.registerType(type)
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/IncompleteType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/IncompleteType.kt
@@ -51,10 +51,6 @@ class IncompleteType : Type {
         return this
     }
 
-    override fun duplicate(): Type {
-        return IncompleteType(this)
-    }
-
     override fun equals(other: Any?): Boolean {
         return other is IncompleteType
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/IntegerType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/IntegerType.kt
@@ -33,9 +33,4 @@ class IntegerType(
     bitWidth: Int? = null,
     language: Language<*>? = null,
     modifier: Modifier = Modifier.SIGNED
-) : NumericType(typeName, bitWidth, language, modifier) {
-
-    override fun duplicate(): Type {
-        return IntegerType(this.name, bitWidth, language, modifier)
-    }
-}
+) : NumericType(typeName, bitWidth, language, modifier)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/NumericType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/NumericType.kt
@@ -35,11 +35,6 @@ open class NumericType(
     language: Language<*>? = null,
     val modifier: Modifier = Modifier.SIGNED
 ) : ObjectType(typeName, listOf(), true, language) {
-
-    override fun duplicate(): Type {
-        return NumericType(this.name, bitWidth, language, modifier)
-    }
-
     /**
      * NumericTypes can have a modifier. The default is signed. Some types (e.g. char in C) may be
      * neither of the signed/unsigned option.

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ParameterizedType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ParameterizedType.kt
@@ -29,8 +29,8 @@ import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.types.PointerType.PointerOrigin
 
 /**
- * ParameterizedTypes describe types, that are passed as Paramters to Classes E.g. uninitialized
- * generics in the graph are represented as ParameterizedTypes
+ * ParameterizedTypes describe types, that are passed as parameters to classes, e.g. uninitialized
+ * generics in the graph are represented as [ParameterizedType] nodes.
  */
 class ParameterizedType : Type {
     constructor(type: Type) : super(type) {
@@ -47,9 +47,5 @@ class ParameterizedType : Type {
 
     override fun dereference(): Type {
         return this
-    }
-
-    override fun duplicate(): Type {
-        return ParameterizedType(this)
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/PointerType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/PointerType.kt
@@ -103,10 +103,6 @@ class PointerType : Type, SecondOrderType {
         name = fullTypeName
     }
 
-    override fun duplicate(): Type {
-        return PointerType(this, elementType.duplicate(), pointerOrigin)
-    }
-
     val isArray: Boolean
         get() = pointerOrigin == PointerOrigin.ARRAY
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ProblemType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ProblemType.kt
@@ -33,8 +33,4 @@ class ProblemType : Type() {
     override fun dereference(): Type {
         return this
     }
-
-    override fun duplicate(): Type {
-        return this
-    }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ReferenceType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ReferenceType.kt
@@ -68,16 +68,8 @@ class ReferenceType : Type, SecondOrderType {
         return elementType.dereference()
     }
 
-    override fun duplicate(): Type {
-        return ReferenceType(this, elementType)
-    }
-
     override fun isSimilar(t: Type?): Boolean {
         return t is ReferenceType && t.elementType == this && super.isSimilar(t)
-    }
-
-    fun refreshName() {
-        name = elementType.name.append("&")
     }
 
     override fun equals(other: Any?): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/StringType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/StringType.kt
@@ -31,9 +31,4 @@ class StringType(
     typeName: CharSequence = "",
     language: Language<*>? = null,
     generics: List<Type> = listOf()
-) : ObjectType(typeName, generics, false, language) {
-
-    override fun duplicate(): Type {
-        return StringType(this.name, language, generics)
-    }
-}
+) : ObjectType(typeName, generics, false, language)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/TupleType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/TupleType.kt
@@ -50,8 +50,4 @@ class TupleType(types: List<Type>) : Type() {
     override fun dereference(): Type {
         return unknownType()
     }
-
-    override fun duplicate(): Type {
-        return TupleType(types.map { it.duplicate() })
-    }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/Type.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/Type.kt
@@ -139,9 +139,6 @@ abstract class Type : Node {
             }
         }
 
-    /** @return Creates an exact copy of the current type (chain) */
-    abstract fun duplicate(): Type
-
     val typeName: String
         get() = name.toString()
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/UnknownType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/UnknownType.kt
@@ -54,11 +54,6 @@ class UnknownType private constructor() : Type() {
         return this
     }
 
-    override fun duplicate(): Type {
-        // We don't duplicate because we cannot change any properties.
-        return this
-    }
-
     override fun hashCode() = Objects.hash(super.hashCode())
 
     override fun equals(other: Any?): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
@@ -30,200 +30,35 @@ import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.types.*
-import de.fraunhofer.aisec.cpg.graph.types.HasSecondaryTypeEdge
-import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker.IterativeGraphWalker
+import de.fraunhofer.aisec.cpg.processing.IVisitor
+import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 
+/**
+ * The purpose of this [Pass] is to establish a relationship between [Type] nodes (more specifically
+ * [ObjectType]s) and their [RecordDeclaration].
+ */
 open class TypeResolver(ctx: TranslationContext) : ComponentPass(ctx) {
-    protected val firstOrderTypes = mutableSetOf<Type>()
-    protected val typeState = mutableMapOf<Type, MutableList<Type>>()
-
-    /**
-     * Reduce the SecondOrderTypes to store only the unique SecondOrderTypes
-     *
-     * @param type SecondOrderType that is to be eliminated if an equal is already in typeState or
-     *   is added if not
-     */
-    protected fun processSecondOrderTypes(type: Type) {
-        val state = typeState.computeIfAbsent(type.root, ::mutableListOf)
-        if (state.contains(type)) return
-
-        state.add(type)
-
-        val element = ((type as? SecondOrderType)?.elementType as? SecondOrderType) ?: return
-
-        val newElement = state.find { it == element }
-        if (newElement != null) {
-            (type as SecondOrderType).elementType = newElement
-        } else {
-            processSecondOrderTypes(element as Type)
-        }
-    }
-
-    /**
-     * Ensures that two different Types that are created at different Points are still the same
-     * object in order to only store one node into the database
-     *
-     * @param type newly created Type
-     * @return If the same type was already stored in the typeState Map the stored one is returned.
-     *   In the other case the parameter type is stored into the map and the parameter type is
-     *   returned
-     */
-    protected fun obtainType(type: Type): Type {
-        return if (type.root == type && type in typeState) {
-            typeState.keys.first { it == type }
-        } else {
-            addType(type)
-            type
-        }
-    }
-
-    /**
-     * Responsible for storing new types into typeState
-     *
-     * @param type new type
-     */
-    protected fun addType(type: Type) {
-        if (type.root == type && type !in typeState) {
-            // This is a rootType and is included in the map as key with empty references
-            typeState[type] = mutableListOf()
-            return
-        }
-
-        // ReferencesTypes
-        if (type.root in typeState) {
-            if (type !in (typeState[type.root] ?: listOf())) {
-                typeState[type.root]?.add(type)
-                addType((type as SecondOrderType).elementType)
-            }
-        } else {
-            addType(type.root)
-            addType(type)
-        }
-    }
-
-    protected fun removeDuplicateTypes() {
-        // Remove duplicate firstOrderTypes
-        firstOrderTypes.addAll(typeManager.firstOrderTypes)
-
-        // Propagate new firstOrderTypes into secondOrderTypes
-        val secondOrderTypes = typeManager.secondOrderTypes
-        for (t in secondOrderTypes) {
-            t.root = firstOrderTypes.firstOrNull { it == t.root } ?: t.root
-        }
-
-        // Build Map from firstOrderTypes to list of secondOderTypes
-        for (t in firstOrderTypes) {
-            typeState[t] = mutableListOf()
-        }
-
-        // Remove duplicate secondOrderTypes
-        secondOrderTypes.forEach { processSecondOrderTypes(it) }
-
-        // Remove duplicates from fields
-        secondOrderTypes.forEach { removeDuplicatesInFields(it) }
-    }
-
-    /**
-     * Visits all FirstOrderTypes and replace all the fields like returnVal or parameters for
-     * FunctionPointertype or Generics for ObjectType
-     *
-     * @param t FirstOrderType
-     */
-    protected fun removeDuplicatesInFields(t: Type) {
-        // Remove duplicates from fields
-        if (t is FunctionPointerType) {
-            t.returnType = obtainType(t.returnType)
-            t.parameters = t.parameters.map(::obtainType)
-        } else if (t is ObjectType) {
-            t.generics = t.generics.map(::obtainType)
-        }
-    }
-
-    /**
-     * Pass on the TypeSystem: Sets RecordDeclaration Relationship from ObjectType to
-     * RecordDeclaration
-     *
-     * @param component
-     */
     override fun accept(component: Component) {
-        removeDuplicateTypes()
-        val walker = IterativeGraphWalker()
-        walker.registerOnNodeVisit(::ensureUniqueType)
-        walker.registerOnNodeVisit(::handle)
-        walker.registerOnNodeVisit(::ensureUniqueSecondaryTypeEdge)
-
-        for (tu in component.translationUnits) {
-            walker.iterate(tu)
-        }
-    }
-
-    protected fun ensureUniqueSubTypes(subTypes: Collection<Type>): List<Type> {
-        val uniqueTypes = mutableListOf<Type>()
-        for (subType in subTypes) {
-            val trackedTypes =
-                if (subType.isFirstOrderType) {
-                    typeState.keys
-                } else {
-                    typeState.computeIfAbsent(subType.root, ::mutableListOf)
-                }
-            val unique = trackedTypes.firstOrNull { it == subType }
-            // TODO Why do we only take the first one even if we don't add it?
-            if (unique != null && unique !in uniqueTypes) uniqueTypes.add(unique)
-        }
-        return uniqueTypes
-    }
-
-    protected fun ensureUniqueType(node: Node) {
-        // Avoid handling of ParameterizedType as they should be unique to each class and not
-        // globally unique
-        if (node is HasType && node.type !is ParameterizedType) {
-            val type = node.type
-            val newType =
-                if (type.isFirstOrderType) {
-                        typeState.keys
-                    } else {
-                        typeState.computeIfAbsent(type.root, ::mutableListOf)
+        component.accept(
+            Strategy::AST_FORWARD,
+            object : IVisitor<Node>() {
+                /**
+                 * Creates the [ObjectType.recordDeclaration] relationship between [ObjectType]s and
+                 * [RecordDeclaration] with the same [Node.name].
+                 */
+                fun visit(record: RecordDeclaration) {
+                    for (t in typeManager.firstOrderTypes) {
+                        if (t.name == record.name && t is ObjectType) {
+                            // The node is the class of the type t
+                            t.recordDeclaration = record
+                        }
                     }
-                    .firstOrNull { it == type }
-            if (newType != null) {
-                node.type = newType
-            }
-        }
-    }
-
-    /**
-     * ensures that the if a nodes contains secondary type edges, those types are also merged and no
-     * duplicate is left
-     *
-     * @param node implementing [HasSecondaryTypeEdge]
-     */
-    protected fun ensureUniqueSecondaryTypeEdge(node: Node) {
-        if (node is HasSecondaryTypeEdge) {
-            node.updateType(typeState.keys)
-        } else if (node is HasType && node.type is HasSecondaryTypeEdge) {
-            (node.type as HasSecondaryTypeEdge).updateType(typeState.keys)
-        }
-    }
-
-    /**
-     * Creates the recordDeclaration relationship between ObjectTypes and RecordDeclaration (from
-     * the Type to the Class)
-     *
-     * @param node
-     */
-    fun handle(node: Node) {
-        if (node is RecordDeclaration) {
-            for (t in typeState.keys) {
-                if (t.name == node.name && t is ObjectType) {
-                    // The node is the class of the type t
-                    t.recordDeclaration = node
                 }
             }
-        }
+        )
     }
 
     override fun cleanup() {
-        firstOrderTypes.clear()
-        typeState.clear()
+        // Nothing to do
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/UnresolvedDFGPassTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/UnresolvedDFGPassTest.kt
@@ -35,7 +35,6 @@ import de.fraunhofer.aisec.cpg.graph.builder.*
 import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.DeclaredReferenceExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Literal
-import de.fraunhofer.aisec.cpg.graph.types.ObjectType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -133,12 +132,7 @@ class UnresolvedDFGPassTest {
                                 param("args", t("String[]"))
                                 body {
                                     declare {
-                                        variable(
-                                            "os",
-                                            t("Optional") {
-                                                (this as ObjectType).generics = listOf(t("String"))
-                                            }
-                                        ) {
+                                        variable("os", t("Optional", listOf(t("String")))) {
                                             memberCall("getOptionalString", ref("RandomClass")) {
                                                 isStatic = true
                                             }

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/templates/ClassTemplateTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/templates/ClassTemplateTest.kt
@@ -155,7 +155,10 @@ internal class ClassTemplateTest : BaseTest() {
         val type2 = findByUniqueName(result.allChildren<TypeParamDeclaration>(), "class Type2")
         val first = findByUniqueName(result.fields, "first")
         val second = findByUniqueName(result.fields, "second")
-        val receiver = pair.byNameOrNull<MethodDeclaration>("Pair")?.receiver
+        val constructor = pair.constructors["Pair"]
+        assertNotNull(constructor)
+
+        val receiver = constructor.receiver
         assertNotNull(receiver)
 
         val pairConstructorDeclaration =


### PR DESCRIPTION
Instead of gathering individual type node objects and then squashing them back together, we just make sure that `registerType` only returns the single unique type object. To reduce the number of `Type` nodes needed as input to `registerType`, the `objectType` function does a pre-check now, if a `ObjectType` with the given name already exists, so no new `Type` object is even created at all.

This also removes the "secondary type edge" interface, which was only needed to merge extra usages of types in nodes. Now all type nodes are always referring to the single instance.
