### PR TITLE
Caching symbols on symbol resolution

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -614,16 +614,16 @@ class ScopeManager : ScopeProvider {
      * Resolves only references to Values in the current scope, static references to other visible
      * records are not resolved over the ScopeManager.
      *
-     * @param scope
      * @param ref
      * @return
      *
      * TODO: We should merge this function with [.resolveFunction]
      */
-    @JvmOverloads
-    fun resolveReference(ref: Reference, startScope: Scope? = currentScope): ValueDeclaration? {
+    fun resolveReference(ref: Reference): ValueDeclaration? {
+        val startScope = ref.scope
+
         // Retrieve a unique tag for the particular reference based on the current scope
-        val tag = ref.buildUniqueTag(startScope)
+        val tag = ref.uniqueTag
 
         // If we find a match in our symbol table, we can immediately return the declaration
         var decl = symbolTable[tag]

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
@@ -82,6 +82,23 @@ abstract class Scope(
         return this is LoopScope
     }
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Scope
+
+        if (astNode != other.astNode) return false
+        return name == other.name
+    }
+
+    override fun hashCode(): Int {
+        var result = astNode?.hashCode() ?: 0
+        result = 31 * result + (parent?.hashCode() ?: 0)
+        result = 31 * result + (name?.hashCode() ?: 0)
+        return result
+    }
+
     /** Returns the [GlobalScope] of this scope by traversing its parents upwards. */
     val globalScope: Scope?
         get() {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Reference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Reference.kt
@@ -32,6 +32,7 @@ import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.edge.Properties
+import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.graph.types.HasType
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.passes.SymbolResolver
@@ -153,4 +154,15 @@ open class Reference : Expression(), HasType.TypeObserver {
             prev.registerTypeObserver(this)
         }
     }
+
+    /**
+     * This function builds a unique tag for the particular reference, based on the [startScope].
+     * Its purpose is to cache symbol resolutions, similar to LLVMs system of Unified Symbol
+     * Resolution (USR).
+     */
+    fun buildUniqueTag(startScope: Scope?): ReferenceTag {
+        return Objects.hash(this.name, this.resolutionHelper, startScope)
+    }
 }
+
+typealias ReferenceTag = Int

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Reference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Reference.kt
@@ -32,7 +32,6 @@ import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.edge.Properties
-import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.graph.types.HasType
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.passes.SymbolResolver
@@ -160,9 +159,10 @@ open class Reference : Expression(), HasType.TypeObserver {
      * Its purpose is to cache symbol resolutions, similar to LLVMs system of Unified Symbol
      * Resolution (USR).
      */
-    fun buildUniqueTag(startScope: Scope?): ReferenceTag {
-        return Objects.hash(this.name, this.resolutionHelper, startScope)
-    }
+    val uniqueTag: ReferenceTag
+        get() {
+            return Objects.hash(this.name, this.resolutionHelper, this.scope)
+        }
 }
 
 typealias ReferenceTag = Int

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -205,7 +205,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
             // Peek into the declaration, and if it is a variable, we can proceed normally, as we
             // are running into the special case explained above. Otherwise, we abort here (for
             // now).
-            wouldResolveTo = scopeManager.resolveReference(current, current.scope)
+            wouldResolveTo = scopeManager.resolveReference(current)
             if (wouldResolveTo !is VariableDeclaration && wouldResolveTo !is ParameterDeclaration) {
                 return
             }
@@ -214,9 +214,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         // Only consider resolving, if the language frontend did not specify a resolution. If we
         // already have populated the wouldResolveTo variable, we can re-use this instead of
         // resolving again
-        var refersTo =
-            current.refersTo
-                ?: wouldResolveTo ?: scopeManager.resolveReference(current, current.scope)
+        var refersTo = current.refersTo ?: wouldResolveTo ?: scopeManager.resolveReference(current)
 
         var recordDeclType: Type? = null
         if (currentClass != null) {

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolverTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolverTest.kt
@@ -31,6 +31,8 @@ import de.fraunhofer.aisec.cpg.TestUtils.assertRefersTo
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.ConstructExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberCallExpression
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.Reference
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.ReferenceTag
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -70,5 +72,24 @@ class SymbolResolverTest {
         val construct = method1.calls { it is ConstructExpression }.firstOrNull()
         assertNotNull(construct)
         assertInvokes(construct, constructor)
+    }
+
+    @Test
+    fun testUniqueTags() {
+        val result = GraphExamples.getConditionalExpression()
+
+        val map = mutableMapOf<ReferenceTag, MutableList<Reference>>()
+
+        val refs = result.refs
+        refs.forEach {
+            // Build a unique tag based on the scope of the reference is in (since this is usually
+            // the start scope)
+            val list = map.computeIfAbsent(it.uniqueTag) { mutableListOf() }
+            list += it
+
+            // All elements in the list must have the same scope and name
+            assertEquals(1, list.map { ref -> ref.scope }.toSet().size)
+            assertEquals(1, list.map { ref -> ref.name }.toSet().size)
+        }
     }
 }


### PR DESCRIPTION
This PR caches symbol resolutions. This can can significantly speed up the resolution process.
