### PR TITLE
Removed SonarQube warnings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,3 @@
-import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
-import java.io.BufferedOutputStream
-import java.io.ByteArrayOutputStream
-
 /*
  * Copyright (c) 2019-2021, Fraunhofer AISEC. All rights reserved.
  *
@@ -76,7 +72,7 @@ fun generateDokkaWithVersionTag(dokkaMultiModuleTask: org.jetbrains.dokka.gradle
     val config = """{ "version": "$tag", "olderVersionsDir":"${oldOutputPath.path}" }"""
     val mapOf = mapOf(id to config)
 
-    dokkaMultiModuleTask.outputDirectory.set(file(buildDir.resolve("dokkaCustomMultiModuleOutput").resolve(tag)))
+    dokkaMultiModuleTask.outputDirectory.set(file(layout.buildDirectory.asFile.get().resolve("dokkaCustomMultiModuleOutput").resolve(tag)))
     dokkaMultiModuleTask.pluginsMapConfiguration.set(mapOf)
 }
 

--- a/gradle.properties.example
+++ b/gradle.properties.example
@@ -1,4 +1,5 @@
 org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m -Dkotlin.daemon.jvm.options=-Xmx4g
+systemProp.sonar.gradle.skipCompile=true
 
 enableJavaFrontend=true
 enableCXXFrontend=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "1.9.0"
 neo4j = "4.0.6"
 log4j = "2.21.0"
-sonarqube = "4.4.0.3356"
+sonarqube = "4.4.1.3373"
 spotless = "6.22.0"
 nexus-publish = "1.3.0"
 


### PR DESCRIPTION
One might need to copy the example grade.properties manually, since it seems the `sonar.gradle.skipCompile` is a system property, which needs to be set in `gradle.properties`.