### PR TITLE
Removed `parent` from `hashCode` of `Scope`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -76,10 +76,11 @@ class ScopeManager : ScopeProvider {
     data class Alias(var from: Name, var to: Name)
 
     /**
-     * A cache map of unique tags (computed with [Reference.buildUniqueTag]) and their respective
-     * [ValueDeclaration]. This is used by [resolveReference] as a caching mechanism.
+     * A cache map of reference tags (computed with [Reference.referenceTag]) and their respective
+     * pair of original [Reference] and resolved [ValueDeclaration]. This is used by
+     * [resolveReference] as a caching mechanism.
      */
-    private val symbolTable = mutableMapOf<ReferenceTag, ValueDeclaration>()
+    private val symbolTable = mutableMapOf<ReferenceTag, Pair<Reference, ValueDeclaration>>()
 
     /**
      * In some languages, we can define aliases for names. An example is renaming package imports in
@@ -623,18 +624,21 @@ class ScopeManager : ScopeProvider {
         val startScope = ref.scope
 
         // Retrieve a unique tag for the particular reference based on the current scope
-        val tag = ref.uniqueTag
+        val tag = ref.referenceTag
 
-        // If we find a match in our symbol table, we can immediately return the declaration
-        var decl = symbolTable[tag]
-        if (decl != null) {
-            return decl
+        // If we find a match in our symbol table, we can immediately return the declaration. We
+        // need to be careful about potential collisions in our tags, since they are based on the
+        // hash-code of the scope. We therefore take the extra precaution to compare the scope in
+        // case we get a hit. This should not take too much performance overhead.
+        val pair = symbolTable[tag]
+        if (pair != null && ref.scope == pair.first.scope) {
+            return pair.second
         }
 
         val (scope, name) = extractScope(ref, startScope)
 
         // Try to resolve value declarations according to our criteria
-        decl =
+        val decl =
             resolve<ValueDeclaration>(scope) {
                     if (it.name.lastPartsMatch(name)) {
                         val helper = ref.resolutionHelper
@@ -666,7 +670,7 @@ class ScopeManager : ScopeProvider {
 
         // Update the symbol cache, if we found a declaration for the tag
         if (decl != null) {
-            symbolTable[tag] = decl
+            symbolTable[tag] = Pair(ref, decl)
         }
 
         return decl

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
@@ -108,7 +108,8 @@ private constructor(
     inferenceConfiguration: InferenceConfiguration,
     compilationDatabase: CompilationDatabase?,
     matchCommentsToNodes: Boolean,
-    addIncludesToGraph: Boolean
+    addIncludesToGraph: Boolean,
+    passConfigurations: Map<KClass<out Pass<*>>, PassConfiguration>,
 ) {
     /** This list contains all languages which we want to translate. */
     val languages: List<Language<*>>
@@ -165,6 +166,8 @@ private constructor(
     /** This sub configuration object holds all information about inference and smart-guessing. */
     val inferenceConfiguration: InferenceConfiguration
 
+    val passConfigurations: Map<KClass<out Pass<*>>, PassConfiguration>
+
     init {
         registeredPasses = passes
         this.languages = languages
@@ -178,6 +181,7 @@ private constructor(
         this.compilationDatabase = compilationDatabase
         this.matchCommentsToNodes = matchCommentsToNodes
         this.addIncludesToGraph = addIncludesToGraph
+        this.passConfigurations = passConfigurations
     }
 
     /** Returns a list of all analyzed files. */
@@ -228,6 +232,8 @@ private constructor(
         private var matchCommentsToNodes = false
         private var addIncludesToGraph = true
         private var useDefaultPasses = false
+        private var passConfigurations: MutableMap<KClass<out Pass<*>>, PassConfiguration> =
+            mutableMapOf()
 
         fun symbols(symbols: Map<String, String>): Builder {
             this.symbols = symbols
@@ -407,6 +413,15 @@ private constructor(
         inline fun <reified T : Language<*>> registerLanguage(): Builder {
             T::class.primaryConstructor?.call()?.let { registerLanguage(it) }
             return this
+        }
+
+        fun <T : Pass<*>> configurePass(clazz: KClass<T>, config: PassConfiguration): Builder {
+            this.passConfigurations[clazz] = config
+            return this
+        }
+
+        inline fun <reified T : Pass<*>> configurePass(config: PassConfiguration): Builder {
+            return this.configurePass(T::class, config)
         }
 
         /**
@@ -594,7 +609,8 @@ private constructor(
                 inferenceConfiguration,
                 compilationDatabase,
                 matchCommentsToNodes,
-                addIncludesToGraph
+                addIncludesToGraph,
+                passConfigurations
             )
         }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
@@ -759,9 +759,9 @@ fun LanguageFrontend<*, *>.loopBody(init: Block.() -> Unit): Block {
 }
 
 /**
- * Creates a new [Block] in the Fluent Node DSL and sets it to the [WhileStatement.statement] of the
- * nearest enclosing [WhileStatement]. The [init] block can be used to create further sub-nodes as
- * well as configuring the created node itself.
+ * Creates a new [Block] in the Fluent Node DSL and sets it to the [ForEachStatement.statement] of
+ * the nearest enclosing [ForEachStatement]. The [init] block can be used to create further
+ * sub-nodes as well as configuring the created node itself.
  */
 context(ForEachStatement)
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
@@ -94,7 +94,6 @@ abstract class Scope(
 
     override fun hashCode(): Int {
         var result = astNode?.hashCode() ?: 0
-        result = 31 * result + (parent?.hashCode() ?: 0)
         result = 31 * result + (name?.hashCode() ?: 0)
         return result
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Reference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Reference.kt
@@ -32,6 +32,7 @@ import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.edge.Properties
+import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.graph.types.HasType
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.passes.SymbolResolver
@@ -155,11 +156,15 @@ open class Reference : Expression(), HasType.TypeObserver {
     }
 
     /**
-     * This function builds a unique tag for the particular reference, based on the [startScope].
-     * Its purpose is to cache symbol resolutions, similar to LLVMs system of Unified Symbol
-     * Resolution (USR).
+     * This function builds a tag for the particular reference, based on its [name],
+     * [resolutionHelper] and [scope]. Its purpose is to cache symbol resolutions, similar to LLVMs
+     * system of Unified Symbol Resolution (USR). Please be aware, that this tag is not guaranteed
+     * to be 100 % unique, especially if the language frontend is missing [Node.location]
+     * information (of the [Scope.astNode]. Therefore, its usage should be similar to a [hashCode],
+     * so that in case of an equal hash-code, a [equals] comparison (in this case of the [scope]) is
+     * needed.
      */
-    val uniqueTag: ReferenceTag
+    val referenceTag: ReferenceTag
         get() {
             return Objects.hash(this.name, this.resolutionHelper, this.scope)
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
@@ -63,6 +63,8 @@ abstract class TranslationUnitPass(ctx: TranslationContext) : Pass<TranslationUn
  */
 interface PassTarget
 
+open class PassConfiguration {}
+
 /**
  * Represents an abstract class that enhances the graph before it is persisted. Passes can exist at
  * three different levels:
@@ -108,6 +110,10 @@ sealed class Pass<T : PassTarget>(final override val ctx: TranslationContext) :
     companion object {
 
         val log: Logger = LoggerFactory.getLogger(Pass::class.java)
+    }
+
+    fun <T : PassConfiguration> passConfig(): T? {
+        return this.config.passConfigurations[this::class] as? T
     }
 }
 

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPassTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPassTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.passes
+
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.frontends.TestLanguage
+import de.fraunhofer.aisec.cpg.graph.builder.*
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class ControlFlowSensitiveDFGPassTest {
+    @Test
+    fun testConfiguration() {
+        val result = getForEachTest()
+        assertNotNull(result)
+    }
+
+    fun getForEachTest() =
+        ControlDependenceGraphPassTest.testFrontend(
+                TranslationConfiguration.builder()
+                    .registerLanguage(TestLanguage("::"))
+                    .defaultPasses()
+                    .registerPass<ControlFlowSensitiveDFGPass>()
+                    .configurePass<ControlFlowSensitiveDFGPass>(
+                        ControlFlowSensitiveDFGPass.Configuration(maxComplexity = 0)
+                    )
+                    .build()
+            )
+            .build {
+                translationResult {
+                    translationUnit("forEach.cpp") {
+                        // The main method
+                        function("main", t("int")) {
+                            body {
+                                declare { variable("i", t("int")) { literal(0, t("int")) } }
+                                forEachStmt {
+                                    declare { variable("loopVar", t("string")) }
+                                    call("magicFunction")
+                                    loopBody {
+                                        call("printf") {
+                                            literal("loop: \${}\n", t("string"))
+                                            ref("loopVar")
+                                        }
+                                    }
+                                }
+                                call("printf") { literal("1\n", t("string")) }
+
+                                returnStmt { ref("i") }
+                            }
+                        }
+                    }
+                }
+            }
+}

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolverTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolverTest.kt
@@ -84,7 +84,7 @@ class SymbolResolverTest {
         refs.forEach {
             // Build a unique tag based on the scope of the reference is in (since this is usually
             // the start scope)
-            val list = map.computeIfAbsent(it.uniqueTag) { mutableListOf() }
+            val list = map.computeIfAbsent(it.referenceTag) { mutableListOf() }
             list += it
 
             // All elements in the list must have the same scope and name


### PR DESCRIPTION
This was causing MAJOR performance problems, since we are using the `hashCode` in the symbol resolver for caching. This had the effect that on deeply nested scopes, performance dropped quite largely.
