### PR TITLE
Avoid using `rawSignature` directly when creating nodes

### DIFF
--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
@@ -81,7 +81,7 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
      * done yet.
      */
     private fun handleUsingDirective(using: CPPASTUsingDirective): Declaration {
-        return newUsingDeclaration(using.rawSignature, using.qualifiedName.toString())
+        return newUsingDeclaration(qualifiedName = using.qualifiedName.toString(), rawNode = using)
     }
 
     /**
@@ -700,11 +700,7 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
 
     fun handleTranslationUnit(translationUnit: IASTTranslationUnit): TranslationUnitDeclaration {
         val node =
-            newTranslationUnitDeclaration(
-                translationUnit.filePath,
-                translationUnit.rawSignature,
-                translationUnit
-            )
+            newTranslationUnitDeclaration(translationUnit.filePath, rawNode = translationUnit)
 
         // There might have been errors in the previous translation unit and in any case
         // we need to reset the scope manager scope to global, to avoid spilling scope errors into

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclaratorHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclaratorHandler.kt
@@ -117,8 +117,8 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
                     ctx.name.toString(),
                     unknownType(), // Type will be filled out later by
                     // handleSimpleDeclaration
-                    ctx.rawSignature,
-                    implicitInitializerAllowed,
+                    implicitInitializerAllowed = implicitInitializerAllowed,
+                    rawNode = ctx
                 )
 
             // Add this declaration to the current scope
@@ -142,10 +142,10 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
                 name.localName,
                 unknownType(),
                 emptyList(),
-                ctx.rawSignature,
-                frontend.locationOf(ctx),
-                initializer,
-                true
+                location = frontend.locationOf(ctx),
+                initializer = initializer,
+                implicitInitializerAllowed = true,
+                rawNode = ctx
             )
 
         frontend.scopeManager.addDeclaration(declaration)
@@ -401,19 +401,24 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
         val recordDeclaration = frontend.scopeManager.currentRecord
         if (recordDeclaration == null) {
             // variable
-            result = newVariableDeclaration(name, unknownType(), ctx.rawSignature, true)
+            result =
+                newVariableDeclaration(
+                    name,
+                    unknownType(),
+                    implicitInitializerAllowed = true,
+                    rawNode = ctx
+                )
         } else {
             // field
-            val code = ctx.rawSignature
             result =
                 newFieldDeclaration(
                     name,
                     unknownType(),
                     emptyList(),
-                    code,
-                    frontend.locationOf(ctx),
-                    null,
-                    false,
+                    location = frontend.locationOf(ctx),
+                    initializer = null,
+                    implicitInitializerAllowed = false,
+                    rawNode = ctx
                 )
         }
 
@@ -435,7 +440,7 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
             newRecordDeclaration(
                 ctx.name.toString(),
                 kind,
-                ctx.rawSignature,
+                rawNode = ctx,
             )
 
         // Handle C++ classes
@@ -483,7 +488,7 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
     private fun handleTemplateTypeParameter(
         ctx: CPPASTSimpleTypeTemplateParameter
     ): TypeParameterDeclaration {
-        return newTypeParameterDeclaration(ctx.rawSignature, ctx.rawSignature, ctx)
+        return newTypeParameterDeclaration(ctx.rawSignature, rawNode = ctx)
     }
 
     private fun processMembers(ctx: IASTCompositeTypeSpecifier) {

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/InitializerHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/InitializerHandler.kt
@@ -57,7 +57,7 @@ class InitializerHandler(lang: CXXLanguageFrontend) :
     }
 
     private fun handleConstructorInitializer(ctx: CPPASTConstructorInitializer): Expression {
-        val constructExpression = newConstructExpression(ctx.rawSignature)
+        val constructExpression = newConstructExpression(rawNode = ctx)
         constructExpression.type =
             (frontend.declaratorHandler.lastNode as? VariableDeclaration)?.type ?: unknownType()
 
@@ -79,7 +79,7 @@ class InitializerHandler(lang: CXXLanguageFrontend) :
         val targetType =
             (frontend.declaratorHandler.lastNode as? ValueDeclaration)?.type ?: unknownType()
 
-        val expression = newInitializerListExpression(targetType, ctx.rawSignature)
+        val expression = newInitializerListExpression(targetType, rawNode = ctx)
 
         for (clause in ctx.clauses) {
             frontend.expressionHandler.handle(clause)?.let {

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/ParameterDeclarationHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/ParameterDeclarationHandler.kt
@@ -52,7 +52,7 @@ class ParameterDeclarationHandler(lang: CXXLanguageFrontend) :
         val type = frontend.typeOf(ctx.declarator, ctx.declSpecifier)
 
         val paramVariableDeclaration =
-            newParameterDeclaration(ctx.declarator.name.toString(), type, false, ctx.rawSignature)
+            newParameterDeclaration(ctx.declarator.name.toString(), type, false, rawNode = ctx)
 
         // Add default values
         if (ctx.declarator.initializer != null) {

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/StatementHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/StatementHandler.kt
@@ -88,7 +88,7 @@ class StatementHandler(lang: CXXLanguageFrontend) :
     }
 
     private fun handleEmptyStatement(nullStatement: IASTNullStatement): EmptyStatement {
-        return newEmptyStatement(nullStatement.rawSignature)
+        return newEmptyStatement(rawNode = nullStatement)
     }
 
     private fun handleTryBlockStatement(tryBlockStatement: CPPASTTryBlockStatement): TryStatement {
@@ -106,7 +106,7 @@ class StatementHandler(lang: CXXLanguageFrontend) :
     }
 
     private fun handleCatchHandler(catchHandler: ICPPASTCatchHandler): CatchClause {
-        val catchClause = newCatchClause(catchHandler.rawSignature)
+        val catchClause = newCatchClause(rawNode = catchHandler)
         frontend.scopeManager.enterScope(catchClause)
 
         val body = frontend.statementHandler.handle(catchHandler.catchBody)
@@ -127,7 +127,7 @@ class StatementHandler(lang: CXXLanguageFrontend) :
     }
 
     private fun handleIfStatement(ctx: IASTIfStatement): IfStatement {
-        val statement = newIfStatement(ctx.rawSignature)
+        val statement = newIfStatement(rawNode = ctx)
 
         frontend.scopeManager.enterScope(statement)
 
@@ -157,14 +157,14 @@ class StatementHandler(lang: CXXLanguageFrontend) :
     }
 
     private fun handleLabelStatement(ctx: IASTLabelStatement): LabelStatement {
-        val statement = newLabelStatement(ctx.rawSignature)
+        val statement = newLabelStatement(rawNode = ctx)
         statement.subStatement = handle(ctx.nestedStatement)
         statement.label = ctx.name.toString()
         return statement
     }
 
     private fun handleGotoStatement(ctx: IASTGotoStatement): GotoStatement {
-        val statement = newGotoStatement(ctx.rawSignature)
+        val statement = newGotoStatement(rawNode = ctx)
         val assigneeTargetLabel = BiConsumer { _: Any, to: Node ->
             statement.targetLabel = to as LabelStatement
         }
@@ -189,7 +189,7 @@ class StatementHandler(lang: CXXLanguageFrontend) :
     }
 
     private fun handleWhileStatement(ctx: IASTWhileStatement): WhileStatement {
-        val statement = newWhileStatement(ctx.rawSignature)
+        val statement = newWhileStatement(rawNode = ctx)
 
         frontend.scopeManager.enterScope(statement)
 
@@ -211,7 +211,7 @@ class StatementHandler(lang: CXXLanguageFrontend) :
     }
 
     private fun handleDoStatement(ctx: IASTDoStatement): DoStatement {
-        val statement = newDoStatement(ctx.rawSignature)
+        val statement = newDoStatement(rawNode = ctx)
         frontend.scopeManager.enterScope(statement)
         statement.condition = frontend.expressionHandler.handle(ctx.condition)
         statement.statement = handle(ctx.body)
@@ -220,7 +220,7 @@ class StatementHandler(lang: CXXLanguageFrontend) :
     }
 
     private fun handleForStatement(ctx: IASTForStatement): ForStatement {
-        val statement = newForStatement(ctx.rawSignature)
+        val statement = newForStatement(rawNode = ctx)
 
         frontend.scopeManager.enterScope(statement)
 
@@ -256,7 +256,7 @@ class StatementHandler(lang: CXXLanguageFrontend) :
     }
 
     private fun handleForEachStatement(ctx: CPPASTRangeBasedForStatement): ForEachStatement {
-        val statement = newForEachStatement(ctx.rawSignature)
+        val statement = newForEachStatement(rawNode = ctx)
         frontend.scopeManager.enterScope(statement)
         val decl = frontend.declarationHandler.handle(ctx.declaration)
         val `var` = newDeclarationStatement(decl?.code)
@@ -270,12 +270,12 @@ class StatementHandler(lang: CXXLanguageFrontend) :
     }
 
     private fun handleBreakStatement(ctx: IASTBreakStatement): BreakStatement {
-        return newBreakStatement(ctx.rawSignature)
+        return newBreakStatement(rawNode = ctx)
         // C++ has no labeled break
     }
 
     private fun handleContinueStatement(ctx: IASTContinueStatement): ContinueStatement {
-        return newContinueStatement(ctx.rawSignature)
+        return newContinueStatement(rawNode = ctx)
         // C++ has no labeled continue
     }
 
@@ -292,9 +292,9 @@ class StatementHandler(lang: CXXLanguageFrontend) :
 
     private fun handleDeclarationStatement(ctx: IASTDeclarationStatement): DeclarationStatement {
         return if (ctx.declaration is IASTASMDeclaration) {
-            newASMDeclarationStatement(ctx.rawSignature)
+            newASMDeclarationStatement(rawNode = ctx)
         } else {
-            val declarationStatement = newDeclarationStatement(ctx.rawSignature)
+            val declarationStatement = newDeclarationStatement(rawNode = ctx)
             val declaration = frontend.declarationHandler.handle(ctx.declaration)
             if (declaration is DeclarationSequence) {
                 declarationStatement.declarations = declaration.asList()
@@ -306,7 +306,7 @@ class StatementHandler(lang: CXXLanguageFrontend) :
     }
 
     private fun handleReturnStatement(ctx: IASTReturnStatement): ReturnStatement {
-        val returnStatement = newReturnStatement(ctx.rawSignature)
+        val returnStatement = newReturnStatement(rawNode = ctx)
 
         // Parse the return value
         if (ctx.returnValue != null) {
@@ -317,7 +317,7 @@ class StatementHandler(lang: CXXLanguageFrontend) :
     }
 
     private fun handleCompoundStatement(ctx: IASTCompoundStatement): Block {
-        val block = newBlock(ctx.rawSignature)
+        val block = newBlock(rawNode = ctx)
 
         frontend.scopeManager.enterScope(block)
 
@@ -334,7 +334,7 @@ class StatementHandler(lang: CXXLanguageFrontend) :
     }
 
     private fun handleSwitchStatement(ctx: IASTSwitchStatement): SwitchStatement {
-        val switchStatement = newSwitchStatement(ctx.rawSignature)
+        val switchStatement = newSwitchStatement(rawNode = ctx)
 
         frontend.scopeManager.enterScope(switchStatement)
 
@@ -361,12 +361,12 @@ class StatementHandler(lang: CXXLanguageFrontend) :
     }
 
     private fun handleCaseStatement(ctx: IASTCaseStatement): CaseStatement {
-        val caseStatement = newCaseStatement(ctx.rawSignature)
+        val caseStatement = newCaseStatement(rawNode = ctx)
         caseStatement.caseExpression = frontend.expressionHandler.handle(ctx.expression)
         return caseStatement
     }
 
     private fun handleDefaultStatement(ctx: IASTDefaultStatement): DefaultStatement {
-        return newDefaultStatement(ctx.rawSignature)
+        return newDefaultStatement(rawNode = ctx)
     }
 }


### PR DESCRIPTION
Previously, in the CXX frontend, we were supplying the `rawSignature` as code(override) to almost all functions that created nodes. The issue with that is, that this does not respect the `codeInNodes` config option, which might be turned on to save memory.

This PR consequently uses the `rawNode` parameter, which forwards setting code and location to the language frontend, which DOES respect the `codeInNodes` option.
