### PR TITLE
Add fields to `Reference`s and `VariableDeclaration`s

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/HasAliases.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/HasAliases.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.graph
+
+/**
+ * Some nodes have aliases, i.e., it potentially references another variable. This means that
+ * writing to this node, also writes to its [aliases] and vice-versa.
+ */
+interface HasAliases {
+    /** The aliases which this node has. */
+    var aliases: MutableSet<HasAliases>
+}

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ValueDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ValueDeclaration.kt
@@ -61,7 +61,7 @@ abstract class ValueDeclaration : Declaration(), HasType, HasAliases {
             }
         }
 
-    override var aliases = mutableSetOf<Declaration>()
+    override var aliases = mutableSetOf<HasAliases>()
 
     override var assignedTypes: Set<Type> = mutableSetOf()
         set(value) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ValueDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ValueDeclaration.kt
@@ -61,6 +61,8 @@ abstract class ValueDeclaration : Declaration(), HasType {
             }
         }
 
+    var aliases = mutableSetOf<Node>()
+
     override var assignedTypes: Set<Type> = mutableSetOf()
         set(value) {
             if (field == value) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ValueDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ValueDeclaration.kt
@@ -39,7 +39,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.Relationship
 
 /** A declaration who has a type. */
-abstract class ValueDeclaration : Declaration(), HasType {
+abstract class ValueDeclaration : Declaration(), HasType, HasAliases {
     override val typeObservers: MutableSet<HasType.TypeObserver> = identitySetOf()
 
     /** The type of this declaration. */
@@ -61,7 +61,7 @@ abstract class ValueDeclaration : Declaration(), HasType {
             }
         }
 
-    var aliases = mutableSetOf<Node>()
+    override var aliases = mutableSetOf<Declaration>()
 
     override var assignedTypes: Set<Type> = mutableSetOf()
         set(value) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/VariableDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/VariableDeclaration.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.graph.declarations
 
 import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.scopes.GlobalScope
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.ConstructExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Reference
@@ -49,6 +50,10 @@ open class VariableDeclaration : ValueDeclaration(), HasInitializer, HasType.Typ
     @Relationship(value = "TEMPLATE_PARAMETERS", direction = Relationship.Direction.OUTGOING)
     @AST
     var templateParameters: List<Node>? = null
+
+    /** Determines if this is a global variable. */
+    val isGlobal: Boolean
+        get() = this.scope is GlobalScope
 
     /**
      * C++ uses implicit constructor calls for statements like `A a;` but this only applies to types

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Reference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Reference.kt
@@ -72,7 +72,9 @@ open class Reference : Expression(), HasType.TypeObserver {
                 value.registerTypeObserver(this)
             }
         }
-    // set the access
+
+    var aliases = mutableSetOf<Node>()
+
     /**
      * Is this reference used for writing data instead of just reading it? Determines dataflow
      * direction

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Reference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Reference.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.graph.statements.expressions
 
 import de.fraunhofer.aisec.cpg.PopulatedByPass
 import de.fraunhofer.aisec.cpg.graph.AccessValues
+import de.fraunhofer.aisec.cpg.graph.HasAliases
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
@@ -45,7 +46,7 @@ import org.neo4j.ogm.annotation.Relationship
  * expression `a = b`, which itself is an [AssignExpression], contains two [Reference]s, one for the
  * variable `a` and one for variable `b`, which have been previously been declared.
  */
-open class Reference : Expression(), HasType.TypeObserver {
+open class Reference : Expression(), HasType.TypeObserver, HasAliases {
     /**
      * The [Declaration]s this expression might refer to. This will influence the [declaredType] of
      * this expression.
@@ -73,7 +74,7 @@ open class Reference : Expression(), HasType.TypeObserver {
             }
         }
 
-    var aliases = mutableSetOf<Node>()
+    override var aliases = mutableSetOf<HasAliases>()
 
     /**
      * Is this reference used for writing data instead of just reading it? Determines dataflow


### PR DESCRIPTION
Adds the following fields:
* `isGlobal` (getter) to determine if a variable is a local or a global variable. This can make a difference ;)
* `aliases` a list collecting aliases of a reference or a variable (more precisely `ValueDeclaration`)