### PR TITLE
Add NodeEntity to abstract node classes to get them persisted to neo4j

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Declaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Declaration.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.graph.declarations
 
 import de.fraunhofer.aisec.cpg.graph.Node
+import org.neo4j.ogm.annotation.NodeEntity
 
 /**
  * Represents a single declaration or definition, i.e. of a variable ([VariableDeclaration]) or
@@ -36,4 +37,5 @@ import de.fraunhofer.aisec.cpg.graph.Node
  * currently have two [FunctionDeclaration] nodes. This is very similar to the behaviour of clang,
  * however clang does establish a connection between those nodes, we currently do not.
  */
+@NodeEntity
 abstract class Declaration : Node()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Declaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Declaration.kt
@@ -37,5 +37,4 @@ import org.neo4j.ogm.annotation.NodeEntity
  * currently have two [FunctionDeclaration] nodes. This is very similar to the behaviour of clang,
  * however clang does establish a connection between those nodes, we currently do not.
  */
-@NodeEntity
-abstract class Declaration : Node()
+@NodeEntity abstract class Declaration : Node()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TemplateDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TemplateDeclaration.kt
@@ -32,9 +32,11 @@ import de.fraunhofer.aisec.cpg.graph.edge.Properties
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
+import org.neo4j.ogm.annotation.NodeEntity
 import org.neo4j.ogm.annotation.Relationship
 
 /** Abstract class representing the template concept */
+@NodeEntity
 abstract class TemplateDeclaration : Declaration(), DeclarationHolder {
     enum class TemplateInitialization {
         /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ValueDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ValueDeclaration.kt
@@ -36,9 +36,11 @@ import de.fraunhofer.aisec.cpg.helpers.identitySetOf
 import de.fraunhofer.aisec.cpg.passes.SymbolResolver
 import java.util.stream.Collectors
 import org.apache.commons.lang3.builder.ToStringBuilder
+import org.neo4j.ogm.annotation.NodeEntity
 import org.neo4j.ogm.annotation.Relationship
 
 /** A declaration who has a type. */
+@NodeEntity
 abstract class ValueDeclaration : Declaration(), HasType {
     override val typeObservers: MutableSet<HasType.TypeObserver> = identitySetOf()
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/Statement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/Statement.kt
@@ -33,8 +33,8 @@ import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
-import org.neo4j.ogm.annotation.NodeEntity
 import java.util.*
+import org.neo4j.ogm.annotation.NodeEntity
 import org.neo4j.ogm.annotation.Relationship
 
 /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/Statement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/Statement.kt
@@ -33,6 +33,7 @@ import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
+import org.neo4j.ogm.annotation.NodeEntity
 import java.util.*
 import org.neo4j.ogm.annotation.Relationship
 
@@ -40,6 +41,7 @@ import org.neo4j.ogm.annotation.Relationship
  * This [Node] is the most basic node type that represents source code elements which represents
  * executable code.
  */
+@NodeEntity
 abstract class Statement : Node(), DeclarationHolder {
     /**
      * A list of local variables associated to this statement, defined by their [ ] extracted from

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Expression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Expression.kt
@@ -30,6 +30,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.Statement
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.helpers.identitySetOf
 import org.apache.commons.lang3.builder.ToStringBuilder
+import org.neo4j.ogm.annotation.NodeEntity
 import org.neo4j.ogm.annotation.Transient
 
 /**
@@ -43,6 +44,7 @@ import org.neo4j.ogm.annotation.Transient
  *
  * <p>This is not possible in Java, the aforementioned code example would prompt a compile error.
  */
+@NodeEntity
 abstract class Expression : Statement(), HasType {
     @Transient override val typeObservers: MutableSet<HasType.TypeObserver> = identitySetOf()
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/Type.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/Type.kt
@@ -36,6 +36,7 @@ import de.fraunhofer.aisec.cpg.graph.types.PointerType.PointerOrigin
 import de.fraunhofer.aisec.cpg.passes.TypeHierarchyResolver
 import java.util.*
 import org.apache.commons.lang3.builder.ToStringBuilder
+import org.neo4j.ogm.annotation.NodeEntity
 import org.neo4j.ogm.annotation.Relationship
 
 /**
@@ -43,6 +44,7 @@ import org.neo4j.ogm.annotation.Relationship
  * this class. Contains information which is included in any Type such as name, storage, qualifier
  * and origin
  */
+@NodeEntity
 abstract class Type : Node {
     /** All direct supertypes of this type. */
     @PopulatedByPass(TypeHierarchyResolver::class)

--- a/cpg-language-typescript/src/main/nodejs/package.json
+++ b/cpg-language-typescript/src/main/nodejs/package.json
@@ -13,7 +13,7 @@
     "@rollup/plugin-commonjs": "^25.0.3",
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@rollup/plugin-typescript": "^11.1.2",
-    "rollup": "^3.26.3",
+    "rollup": "^4.0.0",
     "tslib": "^2.6.0"
   }
 }


### PR DESCRIPTION
Solves #1373 

By adding the @NodeEntity to abstract classes of nodes, neo4j again persists labels like `Type`, `Expression`, `Declaration`. This is only necessary for abstract classes as super classes that are not abstract get the label persisted. 