### PR TITLE
Cleanup NodeBuilder

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TypeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TypeManager.kt
@@ -241,11 +241,10 @@ class TypeManager {
      */
     fun createTypeAlias(
         frontend: LanguageFrontend<*, *>,
-        rawCode: String?,
         target: Type,
         alias: Type,
     ): Declaration {
-        val typedef = frontend.newTypedefDeclaration(target, alias, rawCode)
+        val typedef = frontend.newTypedefDeclaration(target, alias)
         frontend.scopeManager.addTypedef(typedef)
         return typedef
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Handler.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Handler.kt
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory
  * @param <T> the raw ast node specific to the parser
  * @param <L> the language frontend </L></T></S>
  */
-abstract class Handler<ResultNode : Node?, HandlerNode, L : LanguageFrontend<HandlerNode, *>>(
+abstract class Handler<ResultNode : Node?, HandlerNode, L : LanguageFrontend<in HandlerNode, *>>(
     protected val configConstructor: Supplier<ResultNode>,
     /** Returns the frontend which used this handler. */
     val frontend: L
@@ -53,7 +53,8 @@ abstract class Handler<ResultNode : Node?, HandlerNode, L : LanguageFrontend<Han
     CodeAndLocationProvider<HandlerNode> by frontend,
     ScopeProvider by frontend,
     NamespaceProvider by frontend,
-    ContextProvider by frontend {
+    ContextProvider by frontend,
+    RawNodeTypeProvider<HandlerNode> {
     protected val map = HashMap<Class<out HandlerNode>, HandlerInterface<ResultNode, HandlerNode>>()
     private val typeOfT: Class<*>?
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.kt
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory
  * More information can be found in the
  * [github wiki page](https://github.com/Fraunhofer-AISEC/cpg/wiki/Language-Frontends).
  */
-abstract class LanguageFrontend<in AstNode, TypeNode>(
+abstract class LanguageFrontend<AstNode, TypeNode>(
     /** The language this frontend works for. */
     override val language: Language<out LanguageFrontend<AstNode, TypeNode>>,
 
@@ -61,7 +61,8 @@ abstract class LanguageFrontend<in AstNode, TypeNode>(
     LanguageProvider,
     ScopeProvider,
     NamespaceProvider,
-    ContextProvider {
+    ContextProvider,
+    RawNodeTypeProvider<AstNode> {
     val scopeManager: ScopeManager = ctx.scopeManager
     val typeManager: TypeManager = ctx.typeManager
     val config: TranslationConfiguration = ctx.config

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
@@ -42,9 +42,9 @@ import de.fraunhofer.aisec.cpg.graph.types.Type
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newTranslationUnitDeclaration(
+fun <T> RawNodeTypeProvider<T>.newTranslationUnitDeclaration(
     name: CharSequence?,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): TranslationUnitDeclaration {
     val node = TranslationUnitDeclaration()
     node.applyMetadata(this, name, rawNode, true)
@@ -60,10 +60,10 @@ fun MetadataProvider.newTranslationUnitDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newFunctionDeclaration(
+fun <T> RawNodeTypeProvider<T>.newFunctionDeclaration(
     name: CharSequence?,
     localNameOnly: Boolean = false,
-    rawNode: Any? = null,
+    rawNode: T? = null,
 ): FunctionDeclaration {
     val node = FunctionDeclaration()
     node.applyMetadata(this, name, rawNode, localNameOnly)
@@ -79,11 +79,11 @@ fun MetadataProvider.newFunctionDeclaration(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newMethodDeclaration(
+fun <T> RawNodeTypeProvider<T>.newMethodDeclaration(
     name: CharSequence?,
     isStatic: Boolean = false,
     recordDeclaration: RecordDeclaration? = null,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): MethodDeclaration {
     val node = MethodDeclaration()
     node.applyMetadata(this, name, rawNode, defaultNamespace = recordDeclaration?.name)
@@ -102,10 +102,10 @@ fun MetadataProvider.newMethodDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newConstructorDeclaration(
+fun <T> RawNodeTypeProvider<T>.newConstructorDeclaration(
     name: CharSequence?,
     recordDeclaration: RecordDeclaration?,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): ConstructorDeclaration {
     val node = ConstructorDeclaration()
 
@@ -124,11 +124,11 @@ fun MetadataProvider.newConstructorDeclaration(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newParameterDeclaration(
+fun <T> RawNodeTypeProvider<T>.newParameterDeclaration(
     name: CharSequence?,
     type: Type = unknownType(),
     variadic: Boolean = false,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): ParameterDeclaration {
     val node = ParameterDeclaration()
     node.applyMetadata(this, name, rawNode, localNameOnly = true)
@@ -147,11 +147,11 @@ fun MetadataProvider.newParameterDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newVariableDeclaration(
+fun <T> RawNodeTypeProvider<T>.newVariableDeclaration(
     name: CharSequence?,
     type: Type = unknownType(),
     implicitInitializerAllowed: Boolean = false,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): VariableDeclaration {
     val node = VariableDeclaration()
     node.applyMetadata(this, name, rawNode, true)
@@ -169,11 +169,13 @@ fun MetadataProvider.newVariableDeclaration(
  * an appropriate [MetadataProvider], such as a [LanguageFrontend] as an additional prepended
  * argument.
  */
+context(LanguageProvider)
+
 @JvmOverloads
-fun LanguageProvider.newTupleDeclaration(
+fun <T> RawNodeTypeProvider<T>.newTupleDeclaration(
     elements: List<VariableDeclaration>,
     initializer: Expression?,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): TupleDeclaration {
     val node = TupleDeclaration()
     node.applyMetadata(this, null, rawNode, true)
@@ -198,10 +200,10 @@ fun LanguageProvider.newTupleDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newTypedefDeclaration(
+fun <T> RawNodeTypeProvider<T>.newTypedefDeclaration(
     targetType: Type,
     alias: Type,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): TypedefDeclaration {
     val node = TypedefDeclaration()
     node.applyMetadata(this, alias.typeName, rawNode, true)
@@ -220,9 +222,9 @@ fun MetadataProvider.newTypedefDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newTypeParameterDeclaration(
+fun <T> RawNodeTypeProvider<T>.newTypeParameterDeclaration(
     name: CharSequence?,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): TypeParameterDeclaration {
     val node = TypeParameterDeclaration()
     node.applyMetadata(this, name, rawNode, true)
@@ -238,10 +240,10 @@ fun MetadataProvider.newTypeParameterDeclaration(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newRecordDeclaration(
+fun <T> RawNodeTypeProvider<T>.newRecordDeclaration(
     name: CharSequence,
     kind: String,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): RecordDeclaration {
     val node = RecordDeclaration()
     node.applyMetadata(this, name, rawNode, false)
@@ -259,9 +261,9 @@ fun MetadataProvider.newRecordDeclaration(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newEnumDeclaration(
+fun <T> RawNodeTypeProvider<T>.newEnumDeclaration(
     name: CharSequence?,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): EnumDeclaration {
     val node = EnumDeclaration()
     node.applyMetadata(this, name, rawNode)
@@ -277,9 +279,9 @@ fun MetadataProvider.newEnumDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newFunctionTemplateDeclaration(
+fun <T> RawNodeTypeProvider<T>.newFunctionTemplateDeclaration(
     name: CharSequence?,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): FunctionTemplateDeclaration {
     val node = FunctionTemplateDeclaration()
     node.applyMetadata(this, name, rawNode, true)
@@ -295,9 +297,9 @@ fun MetadataProvider.newFunctionTemplateDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newRecordTemplateDeclaration(
+fun <T> RawNodeTypeProvider<T>.newRecordTemplateDeclaration(
     name: CharSequence?,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): RecordTemplateDeclaration {
     val node = RecordTemplateDeclaration()
     node.applyMetadata(this, name, rawNode, true)
@@ -313,9 +315,9 @@ fun MetadataProvider.newRecordTemplateDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newEnumConstantDeclaration(
+fun <T> RawNodeTypeProvider<T>.newEnumConstantDeclaration(
     name: CharSequence?,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): EnumConstantDeclaration {
     val node = EnumConstantDeclaration()
     node.applyMetadata(this, name, rawNode)
@@ -331,13 +333,13 @@ fun MetadataProvider.newEnumConstantDeclaration(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newFieldDeclaration(
+fun <T> RawNodeTypeProvider<T>.newFieldDeclaration(
     name: CharSequence?,
     type: Type = unknownType(),
     modifiers: List<String>? = listOf(),
     initializer: Expression? = null,
     implicitInitializerAllowed: Boolean = false,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): FieldDeclaration {
     val node = FieldDeclaration()
     node.applyMetadata(this, name, rawNode)
@@ -363,10 +365,10 @@ fun MetadataProvider.newFieldDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newProblemDeclaration(
+fun <T> RawNodeTypeProvider<T>.newProblemDeclaration(
     problem: String = "",
     problemType: ProblemNode.ProblemType = ProblemNode.ProblemType.PARSING,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): ProblemDeclaration {
     val node = ProblemDeclaration()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -385,9 +387,9 @@ fun MetadataProvider.newProblemDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newIncludeDeclaration(
+fun <T> RawNodeTypeProvider<T>.newIncludeDeclaration(
     includeFilename: CharSequence,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): IncludeDeclaration {
     val node = IncludeDeclaration()
     node.applyMetadata(this, includeFilename, rawNode, true)
@@ -404,9 +406,9 @@ fun MetadataProvider.newIncludeDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newNamespaceDeclaration(
+fun <T> RawNodeTypeProvider<T>.newNamespaceDeclaration(
     name: CharSequence,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): NamespaceDeclaration {
     val node = NamespaceDeclaration()
     node.applyMetadata(this, name, rawNode)
@@ -422,9 +424,9 @@ fun MetadataProvider.newNamespaceDeclaration(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newUsingDeclaration(
+fun <T> RawNodeTypeProvider<T>.newUsingDeclaration(
     qualifiedName: CharSequence?,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): UsingDeclaration {
     val node = UsingDeclaration()
     node.applyMetadata(this, qualifiedName, rawNode)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
@@ -42,9 +42,9 @@ import de.fraunhofer.aisec.cpg.graph.types.Type
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newTranslationUnitDeclaration(
+fun MetadataProvider.newTranslationUnitDeclaration(
     name: CharSequence?,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): TranslationUnitDeclaration {
     val node = TranslationUnitDeclaration()
     node.applyMetadata(this, name, rawNode, true)
@@ -60,13 +60,13 @@ fun <T> RawNodeTypeProvider<T>.newTranslationUnitDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newFunctionDeclaration(
+fun MetadataProvider.newFunctionDeclaration(
     name: CharSequence?,
     localNameOnly: Boolean = false,
-    rawNode: T? = null,
+    rawNode: Any? = null,
 ): FunctionDeclaration {
     val node = FunctionDeclaration()
-    node.applyMetadata(this, name, rawNode, localNameOnly)
+    node.applyMetadata(this@MetadataProvider, name, rawNode, localNameOnly)
 
     log(node)
     return node
@@ -79,11 +79,11 @@ fun <T> RawNodeTypeProvider<T>.newFunctionDeclaration(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newMethodDeclaration(
+fun MetadataProvider.newMethodDeclaration(
     name: CharSequence?,
     isStatic: Boolean = false,
     recordDeclaration: RecordDeclaration? = null,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): MethodDeclaration {
     val node = MethodDeclaration()
     node.applyMetadata(this, name, rawNode, defaultNamespace = recordDeclaration?.name)
@@ -102,10 +102,10 @@ fun <T> RawNodeTypeProvider<T>.newMethodDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newConstructorDeclaration(
+fun MetadataProvider.newConstructorDeclaration(
     name: CharSequence?,
     recordDeclaration: RecordDeclaration?,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): ConstructorDeclaration {
     val node = ConstructorDeclaration()
 
@@ -124,11 +124,11 @@ fun <T> RawNodeTypeProvider<T>.newConstructorDeclaration(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newParameterDeclaration(
+fun MetadataProvider.newParameterDeclaration(
     name: CharSequence?,
     type: Type = unknownType(),
     variadic: Boolean = false,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): ParameterDeclaration {
     val node = ParameterDeclaration()
     node.applyMetadata(this, name, rawNode, localNameOnly = true)
@@ -147,11 +147,11 @@ fun <T> RawNodeTypeProvider<T>.newParameterDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newVariableDeclaration(
+fun MetadataProvider.newVariableDeclaration(
     name: CharSequence?,
     type: Type = unknownType(),
     implicitInitializerAllowed: Boolean = false,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): VariableDeclaration {
     val node = VariableDeclaration()
     node.applyMetadata(this, name, rawNode, true)
@@ -169,13 +169,11 @@ fun <T> RawNodeTypeProvider<T>.newVariableDeclaration(
  * an appropriate [MetadataProvider], such as a [LanguageFrontend] as an additional prepended
  * argument.
  */
-context(LanguageProvider)
-
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newTupleDeclaration(
+fun LanguageProvider.newTupleDeclaration(
     elements: List<VariableDeclaration>,
     initializer: Expression?,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): TupleDeclaration {
     val node = TupleDeclaration()
     node.applyMetadata(this, null, rawNode, true)
@@ -200,10 +198,10 @@ fun <T> RawNodeTypeProvider<T>.newTupleDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newTypedefDeclaration(
+fun MetadataProvider.newTypedefDeclaration(
     targetType: Type,
     alias: Type,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): TypedefDeclaration {
     val node = TypedefDeclaration()
     node.applyMetadata(this, alias.typeName, rawNode, true)
@@ -222,9 +220,9 @@ fun <T> RawNodeTypeProvider<T>.newTypedefDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newTypeParameterDeclaration(
+fun MetadataProvider.newTypeParameterDeclaration(
     name: CharSequence?,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): TypeParameterDeclaration {
     val node = TypeParameterDeclaration()
     node.applyMetadata(this, name, rawNode, true)
@@ -240,10 +238,10 @@ fun <T> RawNodeTypeProvider<T>.newTypeParameterDeclaration(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newRecordDeclaration(
+fun MetadataProvider.newRecordDeclaration(
     name: CharSequence,
     kind: String,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): RecordDeclaration {
     val node = RecordDeclaration()
     node.applyMetadata(this, name, rawNode, false)
@@ -261,9 +259,9 @@ fun <T> RawNodeTypeProvider<T>.newRecordDeclaration(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newEnumDeclaration(
+fun MetadataProvider.newEnumDeclaration(
     name: CharSequence?,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): EnumDeclaration {
     val node = EnumDeclaration()
     node.applyMetadata(this, name, rawNode)
@@ -279,9 +277,9 @@ fun <T> RawNodeTypeProvider<T>.newEnumDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newFunctionTemplateDeclaration(
+fun MetadataProvider.newFunctionTemplateDeclaration(
     name: CharSequence?,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): FunctionTemplateDeclaration {
     val node = FunctionTemplateDeclaration()
     node.applyMetadata(this, name, rawNode, true)
@@ -297,9 +295,9 @@ fun <T> RawNodeTypeProvider<T>.newFunctionTemplateDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newRecordTemplateDeclaration(
+fun MetadataProvider.newRecordTemplateDeclaration(
     name: CharSequence?,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): RecordTemplateDeclaration {
     val node = RecordTemplateDeclaration()
     node.applyMetadata(this, name, rawNode, true)
@@ -315,9 +313,9 @@ fun <T> RawNodeTypeProvider<T>.newRecordTemplateDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newEnumConstantDeclaration(
+fun MetadataProvider.newEnumConstantDeclaration(
     name: CharSequence?,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): EnumConstantDeclaration {
     val node = EnumConstantDeclaration()
     node.applyMetadata(this, name, rawNode)
@@ -333,13 +331,13 @@ fun <T> RawNodeTypeProvider<T>.newEnumConstantDeclaration(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newFieldDeclaration(
+fun MetadataProvider.newFieldDeclaration(
     name: CharSequence?,
     type: Type = unknownType(),
     modifiers: List<String>? = listOf(),
     initializer: Expression? = null,
     implicitInitializerAllowed: Boolean = false,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): FieldDeclaration {
     val node = FieldDeclaration()
     node.applyMetadata(this, name, rawNode)
@@ -365,10 +363,10 @@ fun <T> RawNodeTypeProvider<T>.newFieldDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newProblemDeclaration(
+fun MetadataProvider.newProblemDeclaration(
     problem: String = "",
     problemType: ProblemNode.ProblemType = ProblemNode.ProblemType.PARSING,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): ProblemDeclaration {
     val node = ProblemDeclaration()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -387,9 +385,9 @@ fun <T> RawNodeTypeProvider<T>.newProblemDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newIncludeDeclaration(
+fun MetadataProvider.newIncludeDeclaration(
     includeFilename: CharSequence,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): IncludeDeclaration {
     val node = IncludeDeclaration()
     node.applyMetadata(this, includeFilename, rawNode, true)
@@ -406,9 +404,9 @@ fun <T> RawNodeTypeProvider<T>.newIncludeDeclaration(
  * prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newNamespaceDeclaration(
+fun MetadataProvider.newNamespaceDeclaration(
     name: CharSequence,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): NamespaceDeclaration {
     val node = NamespaceDeclaration()
     node.applyMetadata(this, name, rawNode)
@@ -424,9 +422,9 @@ fun <T> RawNodeTypeProvider<T>.newNamespaceDeclaration(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newUsingDeclaration(
+fun MetadataProvider.newUsingDeclaration(
     qualifiedName: CharSequence?,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): UsingDeclaration {
     val node = UsingDeclaration()
     node.applyMetadata(this, qualifiedName, rawNode)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
@@ -33,7 +33,6 @@ import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.NewArrayExpression
 import de.fraunhofer.aisec.cpg.graph.types.Type
-import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 
 /**
  * Creates a new [TranslationUnitDeclaration]. This is the top-most [Node] that a [LanguageFrontend]
@@ -272,13 +271,10 @@ fun MetadataProvider.newRecordDeclaration(
 fun MetadataProvider.newEnumDeclaration(
     name: CharSequence?,
     code: String? = null,
-    location: PhysicalLocation?,
     rawNode: Any? = null
 ): EnumDeclaration {
     val node = EnumDeclaration()
     node.applyMetadata(this, name, rawNode, code)
-
-    node.location = location
 
     log(node)
     return node
@@ -332,13 +328,10 @@ fun MetadataProvider.newRecordTemplateDeclaration(
 fun MetadataProvider.newEnumConstantDeclaration(
     name: CharSequence?,
     code: String? = null,
-    location: PhysicalLocation?,
     rawNode: Any? = null
 ): EnumConstantDeclaration {
     val node = EnumConstantDeclaration()
     node.applyMetadata(this, name, rawNode, code)
-
-    node.location = location
 
     log(node)
     return node
@@ -356,7 +349,6 @@ fun MetadataProvider.newFieldDeclaration(
     type: Type = unknownType(),
     modifiers: List<String>? = listOf(),
     code: String? = null,
-    location: PhysicalLocation? = null,
     initializer: Expression? = null,
     implicitInitializerAllowed: Boolean = false,
     rawNode: Any? = null
@@ -366,7 +358,6 @@ fun MetadataProvider.newFieldDeclaration(
 
     node.type = type
     node.modifiers = modifiers ?: listOf()
-    node.location = location
     node.isImplicitInitializerAllowed = implicitInitializerAllowed
     if (initializer != null) {
         if (initializer is NewArrayExpression) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
@@ -62,8 +62,8 @@ fun MetadataProvider.newTranslationUnitDeclaration(
 @JvmOverloads
 fun MetadataProvider.newFunctionDeclaration(
     name: CharSequence?,
+    localNameOnly: Boolean = false,
     rawNode: Any? = null,
-    localNameOnly: Boolean = false
 ): FunctionDeclaration {
     val node = FunctionDeclaration()
     node.applyMetadata(this, name, rawNode, localNameOnly)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
@@ -47,7 +47,7 @@ fun MetadataProvider.newTranslationUnitDeclaration(
     rawNode: Any? = null
 ): TranslationUnitDeclaration {
     val node = TranslationUnitDeclaration()
-    node.applyMetadata(this, name, rawNode, null, true)
+    node.applyMetadata(this, name, rawNode, true)
 
     log(node)
     return node
@@ -66,7 +66,7 @@ fun MetadataProvider.newFunctionDeclaration(
     localNameOnly: Boolean = false
 ): FunctionDeclaration {
     val node = FunctionDeclaration()
-    node.applyMetadata(this, name, rawNode, null, localNameOnly)
+    node.applyMetadata(this, name, rawNode, localNameOnly)
 
     log(node)
     return node
@@ -86,7 +86,7 @@ fun MetadataProvider.newMethodDeclaration(
     rawNode: Any? = null
 ): MethodDeclaration {
     val node = MethodDeclaration()
-    node.applyMetadata(this, name, rawNode, null, defaultNamespace = recordDeclaration?.name)
+    node.applyMetadata(this, name, rawNode, defaultNamespace = recordDeclaration?.name)
 
     node.isStatic = isStatic
     node.recordDeclaration = recordDeclaration
@@ -109,7 +109,7 @@ fun MetadataProvider.newConstructorDeclaration(
 ): ConstructorDeclaration {
     val node = ConstructorDeclaration()
 
-    node.applyMetadata(this, name, rawNode, null, defaultNamespace = recordDeclaration?.name)
+    node.applyMetadata(this, name, rawNode, defaultNamespace = recordDeclaration?.name)
 
     node.recordDeclaration = recordDeclaration
 
@@ -131,7 +131,7 @@ fun MetadataProvider.newParameterDeclaration(
     rawNode: Any? = null
 ): ParameterDeclaration {
     val node = ParameterDeclaration()
-    node.applyMetadata(this, name, rawNode, null, localNameOnly = true)
+    node.applyMetadata(this, name, rawNode, localNameOnly = true)
 
     node.type = type
     node.isVariadic = variadic
@@ -154,7 +154,7 @@ fun MetadataProvider.newVariableDeclaration(
     rawNode: Any? = null
 ): VariableDeclaration {
     val node = VariableDeclaration()
-    node.applyMetadata(this, name, rawNode, null, true)
+    node.applyMetadata(this, name, rawNode, true)
 
     node.type = type
     node.isImplicitInitializerAllowed = implicitInitializerAllowed
@@ -176,7 +176,7 @@ fun LanguageProvider.newTupleDeclaration(
     rawNode: Any? = null
 ): TupleDeclaration {
     val node = TupleDeclaration()
-    node.applyMetadata(this, null, rawNode, null, true)
+    node.applyMetadata(this, null, rawNode, true)
 
     // Tuples always have an auto-type
     node.type = autoType()
@@ -204,7 +204,7 @@ fun MetadataProvider.newTypedefDeclaration(
     rawNode: Any? = null
 ): TypedefDeclaration {
     val node = TypedefDeclaration()
-    node.applyMetadata(this, alias.typeName, rawNode, null, true)
+    node.applyMetadata(this, alias.typeName, rawNode, true)
 
     node.type = targetType
     node.alias = alias
@@ -225,7 +225,7 @@ fun MetadataProvider.newTypeParameterDeclaration(
     rawNode: Any? = null
 ): TypeParameterDeclaration {
     val node = TypeParameterDeclaration()
-    node.applyMetadata(this, name, rawNode, null, true)
+    node.applyMetadata(this, name, rawNode, true)
 
     log(node)
     return node
@@ -244,7 +244,7 @@ fun MetadataProvider.newRecordDeclaration(
     rawNode: Any? = null
 ): RecordDeclaration {
     val node = RecordDeclaration()
-    node.applyMetadata(this, name, rawNode, null, false)
+    node.applyMetadata(this, name, rawNode, false)
 
     node.kind = kind
 
@@ -264,7 +264,7 @@ fun MetadataProvider.newEnumDeclaration(
     rawNode: Any? = null
 ): EnumDeclaration {
     val node = EnumDeclaration()
-    node.applyMetadata(this, name, rawNode, null)
+    node.applyMetadata(this, name, rawNode)
 
     log(node)
     return node
@@ -282,7 +282,7 @@ fun MetadataProvider.newFunctionTemplateDeclaration(
     rawNode: Any? = null
 ): FunctionTemplateDeclaration {
     val node = FunctionTemplateDeclaration()
-    node.applyMetadata(this, name, rawNode, null, true)
+    node.applyMetadata(this, name, rawNode, true)
 
     log(node)
     return node
@@ -300,7 +300,7 @@ fun MetadataProvider.newRecordTemplateDeclaration(
     rawNode: Any? = null
 ): RecordTemplateDeclaration {
     val node = RecordTemplateDeclaration()
-    node.applyMetadata(this, name, rawNode, null, true)
+    node.applyMetadata(this, name, rawNode, true)
 
     log(node)
     return node
@@ -318,7 +318,7 @@ fun MetadataProvider.newEnumConstantDeclaration(
     rawNode: Any? = null
 ): EnumConstantDeclaration {
     val node = EnumConstantDeclaration()
-    node.applyMetadata(this, name, rawNode, null)
+    node.applyMetadata(this, name, rawNode)
 
     log(node)
     return node
@@ -340,7 +340,7 @@ fun MetadataProvider.newFieldDeclaration(
     rawNode: Any? = null
 ): FieldDeclaration {
     val node = FieldDeclaration()
-    node.applyMetadata(this, name, rawNode, null)
+    node.applyMetadata(this, name, rawNode)
 
     node.type = type
     node.modifiers = modifiers ?: listOf()
@@ -369,7 +369,7 @@ fun MetadataProvider.newProblemDeclaration(
     rawNode: Any? = null
 ): ProblemDeclaration {
     val node = ProblemDeclaration()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     node.problem = problem
     node.problemType = problemType
@@ -390,7 +390,7 @@ fun MetadataProvider.newIncludeDeclaration(
     rawNode: Any? = null
 ): IncludeDeclaration {
     val node = IncludeDeclaration()
-    node.applyMetadata(this, includeFilename, rawNode, null, true)
+    node.applyMetadata(this, includeFilename, rawNode, true)
     node.filename = includeFilename.toString()
 
     log(node)
@@ -409,7 +409,7 @@ fun MetadataProvider.newNamespaceDeclaration(
     rawNode: Any? = null
 ): NamespaceDeclaration {
     val node = NamespaceDeclaration()
-    node.applyMetadata(this, name, rawNode, null)
+    node.applyMetadata(this, name, rawNode)
 
     log(node)
     return node
@@ -427,7 +427,7 @@ fun MetadataProvider.newUsingDeclaration(
     rawNode: Any? = null
 ): UsingDeclaration {
     val node = UsingDeclaration()
-    node.applyMetadata(this, qualifiedName, rawNode, null)
+    node.applyMetadata(this, qualifiedName, rawNode)
 
     node.qualifiedName = qualifiedName.toString()
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
@@ -44,11 +44,10 @@ import de.fraunhofer.aisec.cpg.graph.types.Type
 @JvmOverloads
 fun MetadataProvider.newTranslationUnitDeclaration(
     name: CharSequence?,
-    code: String? = null,
     rawNode: Any? = null
 ): TranslationUnitDeclaration {
     val node = TranslationUnitDeclaration()
-    node.applyMetadata(this, name, rawNode, code, true)
+    node.applyMetadata(this, name, rawNode, null, true)
 
     log(node)
     return node
@@ -63,12 +62,11 @@ fun MetadataProvider.newTranslationUnitDeclaration(
 @JvmOverloads
 fun MetadataProvider.newFunctionDeclaration(
     name: CharSequence?,
-    code: String? = null,
     rawNode: Any? = null,
     localNameOnly: Boolean = false
 ): FunctionDeclaration {
     val node = FunctionDeclaration()
-    node.applyMetadata(this, name, rawNode, code, localNameOnly)
+    node.applyMetadata(this, name, rawNode, null, localNameOnly)
 
     log(node)
     return node
@@ -83,13 +81,12 @@ fun MetadataProvider.newFunctionDeclaration(
 @JvmOverloads
 fun MetadataProvider.newMethodDeclaration(
     name: CharSequence?,
-    code: String? = null,
     isStatic: Boolean = false,
     recordDeclaration: RecordDeclaration? = null,
     rawNode: Any? = null
 ): MethodDeclaration {
     val node = MethodDeclaration()
-    node.applyMetadata(this, name, rawNode, code, defaultNamespace = recordDeclaration?.name)
+    node.applyMetadata(this, name, rawNode, null, defaultNamespace = recordDeclaration?.name)
 
     node.isStatic = isStatic
     node.recordDeclaration = recordDeclaration
@@ -107,13 +104,12 @@ fun MetadataProvider.newMethodDeclaration(
 @JvmOverloads
 fun MetadataProvider.newConstructorDeclaration(
     name: CharSequence?,
-    code: String? = null,
     recordDeclaration: RecordDeclaration?,
     rawNode: Any? = null
 ): ConstructorDeclaration {
     val node = ConstructorDeclaration()
 
-    node.applyMetadata(this, name, rawNode, code, defaultNamespace = recordDeclaration?.name)
+    node.applyMetadata(this, name, rawNode, null, defaultNamespace = recordDeclaration?.name)
 
     node.recordDeclaration = recordDeclaration
 
@@ -132,11 +128,10 @@ fun MetadataProvider.newParameterDeclaration(
     name: CharSequence?,
     type: Type = unknownType(),
     variadic: Boolean = false,
-    code: String? = null,
     rawNode: Any? = null
 ): ParameterDeclaration {
     val node = ParameterDeclaration()
-    node.applyMetadata(this, name, rawNode, code, localNameOnly = true)
+    node.applyMetadata(this, name, rawNode, null, localNameOnly = true)
 
     node.type = type
     node.isVariadic = variadic
@@ -155,12 +150,11 @@ fun MetadataProvider.newParameterDeclaration(
 fun MetadataProvider.newVariableDeclaration(
     name: CharSequence?,
     type: Type = unknownType(),
-    code: String? = null,
     implicitInitializerAllowed: Boolean = false,
     rawNode: Any? = null
 ): VariableDeclaration {
     val node = VariableDeclaration()
-    node.applyMetadata(this, name, rawNode, code, true)
+    node.applyMetadata(this, name, rawNode, null, true)
 
     node.type = type
     node.isImplicitInitializerAllowed = implicitInitializerAllowed
@@ -207,11 +201,10 @@ fun LanguageProvider.newTupleDeclaration(
 fun MetadataProvider.newTypedefDeclaration(
     targetType: Type,
     alias: Type,
-    code: String? = null,
     rawNode: Any? = null
 ): TypedefDeclaration {
     val node = TypedefDeclaration()
-    node.applyMetadata(this, alias.typeName, rawNode, code, true)
+    node.applyMetadata(this, alias.typeName, rawNode, null, true)
 
     node.type = targetType
     node.alias = alias
@@ -229,11 +222,10 @@ fun MetadataProvider.newTypedefDeclaration(
 @JvmOverloads
 fun MetadataProvider.newTypeParameterDeclaration(
     name: CharSequence?,
-    code: String? = null,
     rawNode: Any? = null
 ): TypeParameterDeclaration {
     val node = TypeParameterDeclaration()
-    node.applyMetadata(this, name, rawNode, code, true)
+    node.applyMetadata(this, name, rawNode, null, true)
 
     log(node)
     return node
@@ -249,11 +241,10 @@ fun MetadataProvider.newTypeParameterDeclaration(
 fun MetadataProvider.newRecordDeclaration(
     name: CharSequence,
     kind: String,
-    code: String? = null,
     rawNode: Any? = null
 ): RecordDeclaration {
     val node = RecordDeclaration()
-    node.applyMetadata(this, name, rawNode, code, false)
+    node.applyMetadata(this, name, rawNode, null, false)
 
     node.kind = kind
 
@@ -270,11 +261,10 @@ fun MetadataProvider.newRecordDeclaration(
 @JvmOverloads
 fun MetadataProvider.newEnumDeclaration(
     name: CharSequence?,
-    code: String? = null,
     rawNode: Any? = null
 ): EnumDeclaration {
     val node = EnumDeclaration()
-    node.applyMetadata(this, name, rawNode, code)
+    node.applyMetadata(this, name, rawNode, null)
 
     log(node)
     return node
@@ -289,11 +279,10 @@ fun MetadataProvider.newEnumDeclaration(
 @JvmOverloads
 fun MetadataProvider.newFunctionTemplateDeclaration(
     name: CharSequence?,
-    code: String? = null,
     rawNode: Any? = null
 ): FunctionTemplateDeclaration {
     val node = FunctionTemplateDeclaration()
-    node.applyMetadata(this, name, rawNode, code, true)
+    node.applyMetadata(this, name, rawNode, null, true)
 
     log(node)
     return node
@@ -308,11 +297,10 @@ fun MetadataProvider.newFunctionTemplateDeclaration(
 @JvmOverloads
 fun MetadataProvider.newRecordTemplateDeclaration(
     name: CharSequence?,
-    code: String? = null,
     rawNode: Any? = null
 ): RecordTemplateDeclaration {
     val node = RecordTemplateDeclaration()
-    node.applyMetadata(this, name, rawNode, code, true)
+    node.applyMetadata(this, name, rawNode, null, true)
 
     log(node)
     return node
@@ -327,11 +315,10 @@ fun MetadataProvider.newRecordTemplateDeclaration(
 @JvmOverloads
 fun MetadataProvider.newEnumConstantDeclaration(
     name: CharSequence?,
-    code: String? = null,
     rawNode: Any? = null
 ): EnumConstantDeclaration {
     val node = EnumConstantDeclaration()
-    node.applyMetadata(this, name, rawNode, code)
+    node.applyMetadata(this, name, rawNode, null)
 
     log(node)
     return node
@@ -348,13 +335,12 @@ fun MetadataProvider.newFieldDeclaration(
     name: CharSequence?,
     type: Type = unknownType(),
     modifiers: List<String>? = listOf(),
-    code: String? = null,
     initializer: Expression? = null,
     implicitInitializerAllowed: Boolean = false,
     rawNode: Any? = null
 ): FieldDeclaration {
     val node = FieldDeclaration()
-    node.applyMetadata(this, name, rawNode, code)
+    node.applyMetadata(this, name, rawNode, null)
 
     node.type = type
     node.modifiers = modifiers ?: listOf()
@@ -380,11 +366,10 @@ fun MetadataProvider.newFieldDeclaration(
 fun MetadataProvider.newProblemDeclaration(
     problem: String = "",
     problemType: ProblemNode.ProblemType = ProblemNode.ProblemType.PARSING,
-    code: String? = null,
     rawNode: Any? = null
 ): ProblemDeclaration {
     val node = ProblemDeclaration()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
 
     node.problem = problem
     node.problemType = problemType
@@ -402,11 +387,10 @@ fun MetadataProvider.newProblemDeclaration(
 @JvmOverloads
 fun MetadataProvider.newIncludeDeclaration(
     includeFilename: CharSequence,
-    code: String? = null,
     rawNode: Any? = null
 ): IncludeDeclaration {
     val node = IncludeDeclaration()
-    node.applyMetadata(this, includeFilename, rawNode, code, true)
+    node.applyMetadata(this, includeFilename, rawNode, null, true)
     node.filename = includeFilename.toString()
 
     log(node)
@@ -422,11 +406,10 @@ fun MetadataProvider.newIncludeDeclaration(
 @JvmOverloads
 fun MetadataProvider.newNamespaceDeclaration(
     name: CharSequence,
-    code: String? = null,
     rawNode: Any? = null
 ): NamespaceDeclaration {
     val node = NamespaceDeclaration()
-    node.applyMetadata(this, name, rawNode, code)
+    node.applyMetadata(this, name, rawNode, null)
 
     log(node)
     return node
@@ -440,12 +423,11 @@ fun MetadataProvider.newNamespaceDeclaration(
  */
 @JvmOverloads
 fun MetadataProvider.newUsingDeclaration(
-    code: String? = null,
     qualifiedName: CharSequence?,
     rawNode: Any? = null
 ): UsingDeclaration {
     val node = UsingDeclaration()
-    node.applyMetadata(this, qualifiedName, rawNode, code)
+    node.applyMetadata(this, qualifiedName, rawNode, null)
 
     node.qualifiedName = qualifiedName.toString()
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilder.kt
@@ -280,10 +280,10 @@ fun MetadataProvider.newCallExpression(
 }
 
 /**
- * Creates a new [MemberCallExpression]. The [MetadataProvider] receiver will be used to fill different
- * meta-data using [Node.applyMetadata]. Calling this extension function outside of Kotlin requires
- * an appropriate [MetadataProvider], such as a [LanguageFrontend] as an additional prepended
- * argument.
+ * Creates a new [MemberCallExpression]. The [MetadataProvider] receiver will be used to fill
+ * different meta-data using [Node.applyMetadata]. Calling this extension function outside of Kotlin
+ * requires an appropriate [MetadataProvider], such as a [LanguageFrontend] as an additional
+ * prepended argument.
  */
 @JvmOverloads
 fun MetadataProvider.newMemberCallExpression(

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilder.kt
@@ -48,7 +48,7 @@ fun <T> MetadataProvider.newLiteral(
     rawNode: Any? = null,
 ): Literal<T> {
     val node = Literal<T>()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     node.value = value
     node.type = type
@@ -78,7 +78,7 @@ fun MetadataProvider.newBinaryOperator(operatorCode: String, rawNode: Any? = nul
         } else {
             BinaryOperator()
         }
-    node.applyMetadata(this, operatorCode, rawNode, null, true)
+    node.applyMetadata(this, operatorCode, rawNode, true)
 
     node.operatorCode = operatorCode
 
@@ -101,7 +101,7 @@ fun MetadataProvider.newUnaryOperator(
     rawNode: Any? = null
 ): UnaryOperator {
     val node = UnaryOperator()
-    node.applyMetadata(this, operatorCode, rawNode, null, true)
+    node.applyMetadata(this, operatorCode, rawNode, true)
 
     node.operatorCode = operatorCode
     node.isPostfix = postfix
@@ -126,7 +126,7 @@ fun MetadataProvider.newAssignExpression(
     rawNode: Any? = null
 ): AssignExpression {
     val node = AssignExpression()
-    node.applyMetadata(this, operatorCode, rawNode, null, true)
+    node.applyMetadata(this, operatorCode, rawNode, true)
     node.operatorCode = operatorCode
     node.lhs = lhs
     node.rhs = rhs
@@ -148,7 +148,7 @@ fun MetadataProvider.newNewExpression(
     rawNode: Any? = null
 ): NewExpression {
     val node = NewExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     node.type = type
 
@@ -168,7 +168,7 @@ fun MetadataProvider.newConstructExpression(
     rawNode: Any? = null
 ): ConstructExpression {
     val node = ConstructExpression()
-    node.applyMetadata(this, name, rawNode, null, true)
+    node.applyMetadata(this, name, rawNode, true)
 
     log(node)
     return node
@@ -189,7 +189,7 @@ fun MetadataProvider.newConditionalExpression(
     rawNode: Any? = null
 ): ConditionalExpression {
     val node = ConditionalExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     node.type = type
     node.condition = condition
@@ -213,7 +213,7 @@ fun MetadataProvider.newKeyValueExpression(
     rawNode: Any? = null
 ): KeyValueExpression {
     val node = KeyValueExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     node.key = key
     node.value = value
@@ -231,7 +231,7 @@ fun MetadataProvider.newKeyValueExpression(
 @JvmOverloads
 fun MetadataProvider.newLambdaExpression(rawNode: Any? = null): LambdaExpression {
     val node = LambdaExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -245,7 +245,7 @@ fun MetadataProvider.newLambdaExpression(rawNode: Any? = null): LambdaExpression
 @JvmOverloads
 fun MetadataProvider.newBlock(rawNode: Any? = null): Block {
     val node = Block()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -265,7 +265,7 @@ fun MetadataProvider.newCallExpression(
     rawNode: Any? = null
 ): CallExpression {
     val node = CallExpression()
-    node.applyMetadata(this, fqn, rawNode, null, true)
+    node.applyMetadata(this, fqn, rawNode, true)
 
     // Set the call expression as resolution helper for the callee
     if (callee is Reference) {
@@ -280,7 +280,31 @@ fun MetadataProvider.newCallExpression(
 }
 
 /**
+<<<<<<< HEAD
  * Creates a new [MemberCallExpression]. The [MetadataProvider] receiver will be used to fill different
+=======
+ * Creates a new [CallExpression]. The [MetadataProvider] receiver will be used to fill different
+ * meta-data using [Node.applyMetadata]. Calling this extension function outside of Kotlin requires
+ * an appropriate [MetadataProvider], such as a [LanguageFrontend] as an additional prepended
+ * argument.
+ */
+@JvmOverloads
+fun MetadataProvider.newConstructorCallExpression(
+    containingClass: String?,
+    rawNode: Any? = null
+): ConstructorCallExpression {
+    val node = ConstructorCallExpression()
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
+
+    node.containingClass = containingClass
+
+    log(node)
+    return node
+}
+
+/**
+ * Creates a new [CallExpression]. The [MetadataProvider] receiver will be used to fill different
+>>>>>>> 9c7ac6cf2 (remove code from applyMetadata)
  * meta-data using [Node.applyMetadata]. Calling this extension function outside of Kotlin requires
  * an appropriate [MetadataProvider], such as a [LanguageFrontend] as an additional prepended
  * argument.
@@ -295,8 +319,7 @@ fun MetadataProvider.newMemberCallExpression(
     node.applyMetadata(
         this,
         null, // the name will be updated later based on the callee
-        rawNode,
-        null
+        rawNode
     )
 
     // Set the call expression as resolution helper for the callee
@@ -326,7 +349,7 @@ fun MetadataProvider.newMemberExpression(
     rawNode: Any? = null
 ): MemberExpression {
     val node = MemberExpression()
-    node.applyMetadata(this, name, rawNode, null, true)
+    node.applyMetadata(this, name, rawNode, true)
 
     node.base = base
     node.operatorCode = operatorCode
@@ -345,7 +368,7 @@ fun MetadataProvider.newMemberExpression(
 @JvmOverloads
 fun MetadataProvider.newCastExpression(rawNode: Any? = null): CastExpression {
     val node = CastExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -365,7 +388,7 @@ fun MetadataProvider.newTypeIdExpression(
     rawNode: Any? = null
 ): TypeIdExpression {
     val node = TypeIdExpression()
-    node.applyMetadata(this, operatorCode, rawNode, null, true)
+    node.applyMetadata(this, operatorCode, rawNode, true)
 
     node.operatorCode = operatorCode
     node.type = type
@@ -384,7 +407,7 @@ fun MetadataProvider.newTypeIdExpression(
 @JvmOverloads
 fun MetadataProvider.newSubscriptExpression(rawNode: Any? = null): SubscriptExpression {
     val node = SubscriptExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -403,7 +426,7 @@ fun MetadataProvider.newRangeExpression(
     rawNode: Any? = null
 ): RangeExpression {
     val node = RangeExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     node.floor = floor
     node.ceiling = ceiling
@@ -421,7 +444,7 @@ fun MetadataProvider.newRangeExpression(
 @JvmOverloads
 fun MetadataProvider.newNewArrayExpression(rawNode: Any? = null): NewArrayExpression {
     val node = NewArrayExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -440,7 +463,7 @@ fun MetadataProvider.newReference(
     rawNode: Any? = null
 ): Reference {
     val node = Reference()
-    node.applyMetadata(this, name, rawNode, null, true)
+    node.applyMetadata(this, name, rawNode, true)
 
     node.type = type
 
@@ -457,7 +480,7 @@ fun MetadataProvider.newReference(
 @JvmOverloads
 fun MetadataProvider.newDeleteExpression(rawNode: Any? = null): DeleteExpression {
     val node = DeleteExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -472,7 +495,7 @@ fun MetadataProvider.newDeleteExpression(rawNode: Any? = null): DeleteExpression
 @JvmOverloads
 fun MetadataProvider.newExpressionList(rawNode: Any? = null): ExpressionList {
     val node = ExpressionList()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -491,7 +514,7 @@ fun MetadataProvider.newInitializerListExpression(
     rawNode: Any? = null
 ): InitializerListExpression {
     val node = InitializerListExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     node.type = targetType
 
@@ -512,7 +535,7 @@ fun MetadataProvider.newTypeExpression(
     rawNode: Any? = null
 ): TypeExpression {
     val node = TypeExpression()
-    node.applyMetadata(this, name, rawNode, null)
+    node.applyMetadata(this, name, rawNode)
 
     node.type = type
 
@@ -533,7 +556,7 @@ fun MetadataProvider.newProblemExpression(
     rawNode: Any? = null
 ): ProblemExpression {
     val node = ProblemExpression(problem, type)
-    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -541,7 +564,7 @@ fun MetadataProvider.newProblemExpression(
 
 fun MetadataProvider.newProblemType(rawNode: Any? = null): ProblemType {
     val node = ProblemType()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilder.kt
@@ -42,12 +42,12 @@ import de.fraunhofer.aisec.cpg.graph.types.Type
  * [MetadataProvider], such as a [LanguageFrontend] as an additional prepended argument.
  */
 @JvmOverloads
-fun <T> MetadataProvider.newLiteral(
-    value: T,
+fun <T, V> RawNodeTypeProvider<T>.newLiteral(
+    value: V,
     type: Type = unknownType(),
-    rawNode: Any? = null,
-): Literal<T> {
-    val node = Literal<T>()
+    rawNode: T? = null,
+): Literal<V> {
+    val node = Literal<V>()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     node.value = value
@@ -66,7 +66,10 @@ fun <T> MetadataProvider.newLiteral(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newBinaryOperator(operatorCode: String, rawNode: Any? = null): BinaryOperator {
+fun <T> RawNodeTypeProvider<T>.newBinaryOperator(
+    operatorCode: String,
+    rawNode: T? = null
+): BinaryOperator {
     val node =
         if (
             this is LanguageProvider &&
@@ -94,11 +97,11 @@ fun MetadataProvider.newBinaryOperator(operatorCode: String, rawNode: Any? = nul
  * [MetadataProvider], such as a [LanguageFrontend] as an additional prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newUnaryOperator(
+fun <T> RawNodeTypeProvider<T>.newUnaryOperator(
     operatorCode: String,
     postfix: Boolean,
     prefix: Boolean,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): UnaryOperator {
     val node = UnaryOperator()
     node.applyMetadata(this, operatorCode, rawNode, true)
@@ -119,11 +122,11 @@ fun MetadataProvider.newUnaryOperator(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newAssignExpression(
+fun <T> RawNodeTypeProvider<T>.newAssignExpression(
     operatorCode: String = "=",
     lhs: List<Expression> = listOf(),
     rhs: List<Expression> = listOf(),
-    rawNode: Any? = null
+    rawNode: T? = null
 ): AssignExpression {
     val node = AssignExpression()
     node.applyMetadata(this, operatorCode, rawNode, true)
@@ -143,9 +146,9 @@ fun MetadataProvider.newAssignExpression(
  * [MetadataProvider], such as a [LanguageFrontend] as an additional prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newNewExpression(
+fun <T> RawNodeTypeProvider<T>.newNewExpression(
     type: Type = unknownType(),
-    rawNode: Any? = null
+    rawNode: T? = null
 ): NewExpression {
     val node = NewExpression()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -163,9 +166,9 @@ fun MetadataProvider.newNewExpression(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newConstructExpression(
+fun <T> RawNodeTypeProvider<T>.newConstructExpression(
     name: CharSequence? = EMPTY_NAME,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): ConstructExpression {
     val node = ConstructExpression()
     node.applyMetadata(this, name, rawNode, true)
@@ -181,12 +184,12 @@ fun MetadataProvider.newConstructExpression(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newConditionalExpression(
+fun <T> RawNodeTypeProvider<T>.newConditionalExpression(
     condition: Expression,
     thenExpression: Expression?,
     elseExpression: Expression?,
     type: Type = unknownType(),
-    rawNode: Any? = null
+    rawNode: T? = null
 ): ConditionalExpression {
     val node = ConditionalExpression()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -207,10 +210,10 @@ fun MetadataProvider.newConditionalExpression(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newKeyValueExpression(
+fun <T> RawNodeTypeProvider<T>.newKeyValueExpression(
     key: Expression? = null,
     value: Expression? = null,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): KeyValueExpression {
     val node = KeyValueExpression()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -229,7 +232,7 @@ fun MetadataProvider.newKeyValueExpression(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newLambdaExpression(rawNode: Any? = null): LambdaExpression {
+fun <T> RawNodeTypeProvider<T>.newLambdaExpression(rawNode: T? = null): LambdaExpression {
     val node = LambdaExpression()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -243,7 +246,7 @@ fun MetadataProvider.newLambdaExpression(rawNode: Any? = null): LambdaExpression
  * appropriate [MetadataProvider], such as a [LanguageFrontend] as an additional prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newBlock(rawNode: Any? = null): Block {
+fun <T> RawNodeTypeProvider<T>.newBlock(rawNode: T? = null): Block {
     val node = Block()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -258,11 +261,11 @@ fun MetadataProvider.newBlock(rawNode: Any? = null): Block {
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newCallExpression(
+fun <T> RawNodeTypeProvider<T>.newCallExpression(
     callee: Expression? = null,
     fqn: CharSequence? = null,
     template: Boolean = false,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): CallExpression {
     val node = CallExpression()
     node.applyMetadata(this, fqn, rawNode, true)
@@ -280,40 +283,16 @@ fun MetadataProvider.newCallExpression(
 }
 
 /**
-<<<<<<< HEAD
  * Creates a new [MemberCallExpression]. The [MetadataProvider] receiver will be used to fill different
-=======
- * Creates a new [CallExpression]. The [MetadataProvider] receiver will be used to fill different
  * meta-data using [Node.applyMetadata]. Calling this extension function outside of Kotlin requires
  * an appropriate [MetadataProvider], such as a [LanguageFrontend] as an additional prepended
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newConstructorCallExpression(
-    containingClass: String?,
-    rawNode: Any? = null
-): ConstructorCallExpression {
-    val node = ConstructorCallExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
-
-    node.containingClass = containingClass
-
-    log(node)
-    return node
-}
-
-/**
- * Creates a new [CallExpression]. The [MetadataProvider] receiver will be used to fill different
->>>>>>> 9c7ac6cf2 (remove code from applyMetadata)
- * meta-data using [Node.applyMetadata]. Calling this extension function outside of Kotlin requires
- * an appropriate [MetadataProvider], such as a [LanguageFrontend] as an additional prepended
- * argument.
- */
-@JvmOverloads
-fun MetadataProvider.newMemberCallExpression(
+fun <T> RawNodeTypeProvider<T>.newMemberCallExpression(
     callee: Expression?,
     isStatic: Boolean = false,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): MemberCallExpression {
     val node = MemberCallExpression()
     node.applyMetadata(
@@ -341,12 +320,12 @@ fun MetadataProvider.newMemberCallExpression(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newMemberExpression(
+fun <T> RawNodeTypeProvider<T>.newMemberExpression(
     name: CharSequence?,
     base: Expression,
     memberType: Type = unknownType(),
     operatorCode: String? = ".",
-    rawNode: Any? = null
+    rawNode: T? = null
 ): MemberExpression {
     val node = MemberExpression()
     node.applyMetadata(this, name, rawNode, true)
@@ -366,7 +345,7 @@ fun MetadataProvider.newMemberExpression(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newCastExpression(rawNode: Any? = null): CastExpression {
+fun <T> RawNodeTypeProvider<T>.newCastExpression(rawNode: T? = null): CastExpression {
     val node = CastExpression()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -381,11 +360,11 @@ fun MetadataProvider.newCastExpression(rawNode: Any? = null): CastExpression {
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newTypeIdExpression(
+fun <T> RawNodeTypeProvider<T>.newTypeIdExpression(
     operatorCode: String,
     type: Type = unknownType(),
     referencedType: Type = unknownType(),
-    rawNode: Any? = null
+    rawNode: T? = null
 ): TypeIdExpression {
     val node = TypeIdExpression()
     node.applyMetadata(this, operatorCode, rawNode, true)
@@ -405,7 +384,7 @@ fun MetadataProvider.newTypeIdExpression(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newSubscriptExpression(rawNode: Any? = null): SubscriptExpression {
+fun <T> RawNodeTypeProvider<T>.newSubscriptExpression(rawNode: T? = null): SubscriptExpression {
     val node = SubscriptExpression()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -420,10 +399,10 @@ fun MetadataProvider.newSubscriptExpression(rawNode: Any? = null): SubscriptExpr
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newRangeExpression(
+fun <T> RawNodeTypeProvider<T>.newRangeExpression(
     floor: Expression? = null,
     ceiling: Expression? = null,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): RangeExpression {
     val node = RangeExpression()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -442,7 +421,7 @@ fun MetadataProvider.newRangeExpression(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newNewArrayExpression(rawNode: Any? = null): NewArrayExpression {
+fun <T> RawNodeTypeProvider<T>.newNewArrayExpression(rawNode: T? = null): NewArrayExpression {
     val node = NewArrayExpression()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -457,10 +436,10 @@ fun MetadataProvider.newNewArrayExpression(rawNode: Any? = null): NewArrayExpres
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newReference(
+fun <T> RawNodeTypeProvider<T>.newReference(
     name: CharSequence?,
     type: Type = unknownType(),
-    rawNode: Any? = null
+    rawNode: T? = null
 ): Reference {
     val node = Reference()
     node.applyMetadata(this, name, rawNode, true)
@@ -478,7 +457,7 @@ fun MetadataProvider.newReference(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newDeleteExpression(rawNode: Any? = null): DeleteExpression {
+fun <T> RawNodeTypeProvider<T>.newDeleteExpression(rawNode: T? = null): DeleteExpression {
     val node = DeleteExpression()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -493,7 +472,7 @@ fun MetadataProvider.newDeleteExpression(rawNode: Any? = null): DeleteExpression
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newExpressionList(rawNode: Any? = null): ExpressionList {
+fun <T> RawNodeTypeProvider<T>.newExpressionList(rawNode: T? = null): ExpressionList {
     val node = ExpressionList()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -509,9 +488,9 @@ fun MetadataProvider.newExpressionList(rawNode: Any? = null): ExpressionList {
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newInitializerListExpression(
+fun <T> RawNodeTypeProvider<T>.newInitializerListExpression(
     targetType: Type = unknownType(),
-    rawNode: Any? = null
+    rawNode: T? = null
 ): InitializerListExpression {
     val node = InitializerListExpression()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -550,10 +529,10 @@ fun MetadataProvider.newTypeExpression(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newProblemExpression(
+fun <T> RawNodeTypeProvider<T>.newProblemExpression(
     problem: String = "",
     type: ProblemNode.ProblemType = ProblemNode.ProblemType.PARSING,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): ProblemExpression {
     val node = ProblemExpression(problem, type)
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -562,7 +541,7 @@ fun MetadataProvider.newProblemExpression(
     return node
 }
 
-fun MetadataProvider.newProblemType(rawNode: Any? = null): ProblemType {
+fun <T> RawNodeTypeProvider<T>.newProblemType(rawNode: T? = null): ProblemType {
     val node = ProblemType()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilder.kt
@@ -45,7 +45,7 @@ import de.fraunhofer.aisec.cpg.graph.types.Type
 fun <T, V> RawNodeTypeProvider<T>.newLiteral(
     value: V,
     type: Type = unknownType(),
-    rawNode: T? = null,
+    rawNode: Any? = null,
 ): Literal<V> {
     val node = Literal<V>()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -66,10 +66,7 @@ fun <T, V> RawNodeTypeProvider<T>.newLiteral(
  * prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newBinaryOperator(
-    operatorCode: String,
-    rawNode: T? = null
-): BinaryOperator {
+fun MetadataProvider.newBinaryOperator(operatorCode: String, rawNode: Any? = null): BinaryOperator {
     val node =
         if (
             this is LanguageProvider &&
@@ -97,11 +94,11 @@ fun <T> RawNodeTypeProvider<T>.newBinaryOperator(
  * [MetadataProvider], such as a [LanguageFrontend] as an additional prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newUnaryOperator(
+fun MetadataProvider.newUnaryOperator(
     operatorCode: String,
     postfix: Boolean,
     prefix: Boolean,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): UnaryOperator {
     val node = UnaryOperator()
     node.applyMetadata(this, operatorCode, rawNode, true)
@@ -122,11 +119,11 @@ fun <T> RawNodeTypeProvider<T>.newUnaryOperator(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newAssignExpression(
+fun MetadataProvider.newAssignExpression(
     operatorCode: String = "=",
     lhs: List<Expression> = listOf(),
     rhs: List<Expression> = listOf(),
-    rawNode: T? = null
+    rawNode: Any? = null
 ): AssignExpression {
     val node = AssignExpression()
     node.applyMetadata(this, operatorCode, rawNode, true)
@@ -146,9 +143,9 @@ fun <T> RawNodeTypeProvider<T>.newAssignExpression(
  * [MetadataProvider], such as a [LanguageFrontend] as an additional prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newNewExpression(
+fun MetadataProvider.newNewExpression(
     type: Type = unknownType(),
-    rawNode: T? = null
+    rawNode: Any? = null
 ): NewExpression {
     val node = NewExpression()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -166,9 +163,9 @@ fun <T> RawNodeTypeProvider<T>.newNewExpression(
  * prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newConstructExpression(
+fun MetadataProvider.newConstructExpression(
     name: CharSequence? = EMPTY_NAME,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): ConstructExpression {
     val node = ConstructExpression()
     node.applyMetadata(this, name, rawNode, true)
@@ -184,12 +181,12 @@ fun <T> RawNodeTypeProvider<T>.newConstructExpression(
  * prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newConditionalExpression(
+fun MetadataProvider.newConditionalExpression(
     condition: Expression,
     thenExpression: Expression?,
     elseExpression: Expression?,
     type: Type = unknownType(),
-    rawNode: T? = null
+    rawNode: Any? = null
 ): ConditionalExpression {
     val node = ConditionalExpression()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -210,10 +207,10 @@ fun <T> RawNodeTypeProvider<T>.newConditionalExpression(
  * prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newKeyValueExpression(
+fun MetadataProvider.newKeyValueExpression(
     key: Expression? = null,
     value: Expression? = null,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): KeyValueExpression {
     val node = KeyValueExpression()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -232,7 +229,7 @@ fun <T> RawNodeTypeProvider<T>.newKeyValueExpression(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newLambdaExpression(rawNode: T? = null): LambdaExpression {
+fun MetadataProvider.newLambdaExpression(rawNode: Any? = null): LambdaExpression {
     val node = LambdaExpression()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -246,7 +243,7 @@ fun <T> RawNodeTypeProvider<T>.newLambdaExpression(rawNode: T? = null): LambdaEx
  * appropriate [MetadataProvider], such as a [LanguageFrontend] as an additional prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newBlock(rawNode: T? = null): Block {
+fun MetadataProvider.newBlock(rawNode: Any? = null): Block {
     val node = Block()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -261,11 +258,11 @@ fun <T> RawNodeTypeProvider<T>.newBlock(rawNode: T? = null): Block {
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newCallExpression(
+fun MetadataProvider.newCallExpression(
     callee: Expression? = null,
     fqn: CharSequence? = null,
     template: Boolean = false,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): CallExpression {
     val node = CallExpression()
     node.applyMetadata(this, fqn, rawNode, true)
@@ -289,10 +286,10 @@ fun <T> RawNodeTypeProvider<T>.newCallExpression(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newMemberCallExpression(
+fun MetadataProvider.newMemberCallExpression(
     callee: Expression?,
     isStatic: Boolean = false,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): MemberCallExpression {
     val node = MemberCallExpression()
     node.applyMetadata(
@@ -320,12 +317,12 @@ fun <T> RawNodeTypeProvider<T>.newMemberCallExpression(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newMemberExpression(
+fun MetadataProvider.newMemberExpression(
     name: CharSequence?,
     base: Expression,
     memberType: Type = unknownType(),
     operatorCode: String? = ".",
-    rawNode: T? = null
+    rawNode: Any? = null
 ): MemberExpression {
     val node = MemberExpression()
     node.applyMetadata(this, name, rawNode, true)
@@ -345,7 +342,7 @@ fun <T> RawNodeTypeProvider<T>.newMemberExpression(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newCastExpression(rawNode: T? = null): CastExpression {
+fun MetadataProvider.newCastExpression(rawNode: Any? = null): CastExpression {
     val node = CastExpression()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -360,11 +357,11 @@ fun <T> RawNodeTypeProvider<T>.newCastExpression(rawNode: T? = null): CastExpres
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newTypeIdExpression(
+fun MetadataProvider.newTypeIdExpression(
     operatorCode: String,
     type: Type = unknownType(),
     referencedType: Type = unknownType(),
-    rawNode: T? = null
+    rawNode: Any? = null
 ): TypeIdExpression {
     val node = TypeIdExpression()
     node.applyMetadata(this, operatorCode, rawNode, true)
@@ -384,7 +381,7 @@ fun <T> RawNodeTypeProvider<T>.newTypeIdExpression(
  * prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newSubscriptExpression(rawNode: T? = null): SubscriptExpression {
+fun MetadataProvider.newSubscriptExpression(rawNode: Any? = null): SubscriptExpression {
     val node = SubscriptExpression()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -399,10 +396,10 @@ fun <T> RawNodeTypeProvider<T>.newSubscriptExpression(rawNode: T? = null): Subsc
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newRangeExpression(
+fun MetadataProvider.newRangeExpression(
     floor: Expression? = null,
     ceiling: Expression? = null,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): RangeExpression {
     val node = RangeExpression()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -421,7 +418,7 @@ fun <T> RawNodeTypeProvider<T>.newRangeExpression(
  * prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newNewArrayExpression(rawNode: T? = null): NewArrayExpression {
+fun MetadataProvider.newNewArrayExpression(rawNode: Any? = null): NewArrayExpression {
     val node = NewArrayExpression()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -436,10 +433,10 @@ fun <T> RawNodeTypeProvider<T>.newNewArrayExpression(rawNode: T? = null): NewArr
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newReference(
+fun MetadataProvider.newReference(
     name: CharSequence?,
     type: Type = unknownType(),
-    rawNode: T? = null
+    rawNode: Any? = null
 ): Reference {
     val node = Reference()
     node.applyMetadata(this, name, rawNode, true)
@@ -457,7 +454,7 @@ fun <T> RawNodeTypeProvider<T>.newReference(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newDeleteExpression(rawNode: T? = null): DeleteExpression {
+fun MetadataProvider.newDeleteExpression(rawNode: Any? = null): DeleteExpression {
     val node = DeleteExpression()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -472,7 +469,7 @@ fun <T> RawNodeTypeProvider<T>.newDeleteExpression(rawNode: T? = null): DeleteEx
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newExpressionList(rawNode: T? = null): ExpressionList {
+fun MetadataProvider.newExpressionList(rawNode: Any? = null): ExpressionList {
     val node = ExpressionList()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -488,9 +485,9 @@ fun <T> RawNodeTypeProvider<T>.newExpressionList(rawNode: T? = null): Expression
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newInitializerListExpression(
+fun MetadataProvider.newInitializerListExpression(
     targetType: Type = unknownType(),
-    rawNode: T? = null
+    rawNode: Any? = null
 ): InitializerListExpression {
     val node = InitializerListExpression()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -529,10 +526,10 @@ fun MetadataProvider.newTypeExpression(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newProblemExpression(
+fun MetadataProvider.newProblemExpression(
     problem: String = "",
     type: ProblemNode.ProblemType = ProblemNode.ProblemType.PARSING,
-    rawNode: T? = null
+    rawNode: Any? = null
 ): ProblemExpression {
     val node = ProblemExpression(problem, type)
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -541,7 +538,7 @@ fun <T> RawNodeTypeProvider<T>.newProblemExpression(
     return node
 }
 
-fun <T> RawNodeTypeProvider<T>.newProblemType(rawNode: T? = null): ProblemType {
+fun MetadataProvider.newProblemType(rawNode: Any? = null): ProblemType {
     val node = ProblemType()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilder.kt
@@ -45,11 +45,10 @@ import de.fraunhofer.aisec.cpg.graph.types.Type
 fun <T> MetadataProvider.newLiteral(
     value: T,
     type: Type = unknownType(),
-    code: String? = null,
     rawNode: Any? = null,
 ): Literal<T> {
     val node = Literal<T>()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
 
     node.value = value
     node.type = type
@@ -67,11 +66,7 @@ fun <T> MetadataProvider.newLiteral(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newBinaryOperator(
-    operatorCode: String,
-    code: String? = null,
-    rawNode: Any? = null
-): BinaryOperator {
+fun MetadataProvider.newBinaryOperator(operatorCode: String, rawNode: Any? = null): BinaryOperator {
     val node =
         if (
             this is LanguageProvider &&
@@ -83,7 +78,7 @@ fun MetadataProvider.newBinaryOperator(
         } else {
             BinaryOperator()
         }
-    node.applyMetadata(this, operatorCode, rawNode, code, true)
+    node.applyMetadata(this, operatorCode, rawNode, null, true)
 
     node.operatorCode = operatorCode
 
@@ -103,11 +98,10 @@ fun MetadataProvider.newUnaryOperator(
     operatorCode: String,
     postfix: Boolean,
     prefix: Boolean,
-    code: String? = null,
     rawNode: Any? = null
 ): UnaryOperator {
     val node = UnaryOperator()
-    node.applyMetadata(this, operatorCode, rawNode, code, true)
+    node.applyMetadata(this, operatorCode, rawNode, null, true)
 
     node.operatorCode = operatorCode
     node.isPostfix = postfix
@@ -129,11 +123,10 @@ fun MetadataProvider.newAssignExpression(
     operatorCode: String = "=",
     lhs: List<Expression> = listOf(),
     rhs: List<Expression> = listOf(),
-    code: String? = null,
     rawNode: Any? = null
 ): AssignExpression {
     val node = AssignExpression()
-    node.applyMetadata(this, operatorCode, rawNode, code, true)
+    node.applyMetadata(this, operatorCode, rawNode, null, true)
     node.operatorCode = operatorCode
     node.lhs = lhs
     node.rhs = rhs
@@ -151,12 +144,11 @@ fun MetadataProvider.newAssignExpression(
  */
 @JvmOverloads
 fun MetadataProvider.newNewExpression(
-    code: String? = null,
     type: Type = unknownType(),
     rawNode: Any? = null
 ): NewExpression {
     val node = NewExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
 
     node.type = type
 
@@ -173,11 +165,10 @@ fun MetadataProvider.newNewExpression(
 @JvmOverloads
 fun MetadataProvider.newConstructExpression(
     name: CharSequence? = EMPTY_NAME,
-    code: String? = null,
     rawNode: Any? = null
 ): ConstructExpression {
     val node = ConstructExpression()
-    node.applyMetadata(this, name, rawNode, code, true)
+    node.applyMetadata(this, name, rawNode, null, true)
 
     log(node)
     return node
@@ -195,11 +186,10 @@ fun MetadataProvider.newConditionalExpression(
     thenExpression: Expression?,
     elseExpression: Expression?,
     type: Type = unknownType(),
-    code: String? = null,
     rawNode: Any? = null
 ): ConditionalExpression {
     val node = ConditionalExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
 
     node.type = type
     node.condition = condition
@@ -220,11 +210,10 @@ fun MetadataProvider.newConditionalExpression(
 fun MetadataProvider.newKeyValueExpression(
     key: Expression? = null,
     value: Expression? = null,
-    code: String? = null,
     rawNode: Any? = null
 ): KeyValueExpression {
     val node = KeyValueExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
 
     node.key = key
     node.value = value
@@ -240,12 +229,9 @@ fun MetadataProvider.newKeyValueExpression(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newLambdaExpression(
-    code: String? = null,
-    rawNode: Any? = null
-): LambdaExpression {
+fun MetadataProvider.newLambdaExpression(rawNode: Any? = null): LambdaExpression {
     val node = LambdaExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
 
     log(node)
     return node
@@ -257,9 +243,9 @@ fun MetadataProvider.newLambdaExpression(
  * appropriate [MetadataProvider], such as a [LanguageFrontend] as an additional prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newBlock(code: String? = null, rawNode: Any? = null): Block {
+fun MetadataProvider.newBlock(rawNode: Any? = null): Block {
     val node = Block()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
 
     log(node)
     return node
@@ -275,12 +261,11 @@ fun MetadataProvider.newBlock(code: String? = null, rawNode: Any? = null): Block
 fun MetadataProvider.newCallExpression(
     callee: Expression? = null,
     fqn: CharSequence? = null,
-    code: String? = null,
     template: Boolean = false,
     rawNode: Any? = null
 ): CallExpression {
     val node = CallExpression()
-    node.applyMetadata(this, fqn, rawNode, code, true)
+    node.applyMetadata(this, fqn, rawNode, null, true)
 
     // Set the call expression as resolution helper for the callee
     if (callee is Reference) {
@@ -295,7 +280,7 @@ fun MetadataProvider.newCallExpression(
 }
 
 /**
- * Creates a new [CallExpression]. The [MetadataProvider] receiver will be used to fill different
+ * Creates a new [MemberCallExpression]. The [MetadataProvider] receiver will be used to fill different
  * meta-data using [Node.applyMetadata]. Calling this extension function outside of Kotlin requires
  * an appropriate [MetadataProvider], such as a [LanguageFrontend] as an additional prepended
  * argument.
@@ -304,7 +289,6 @@ fun MetadataProvider.newCallExpression(
 fun MetadataProvider.newMemberCallExpression(
     callee: Expression?,
     isStatic: Boolean = false,
-    code: String? = null,
     rawNode: Any? = null
 ): MemberCallExpression {
     val node = MemberCallExpression()
@@ -312,7 +296,7 @@ fun MetadataProvider.newMemberCallExpression(
         this,
         null, // the name will be updated later based on the callee
         rawNode,
-        code,
+        null
     )
 
     // Set the call expression as resolution helper for the callee
@@ -339,11 +323,10 @@ fun MetadataProvider.newMemberExpression(
     base: Expression,
     memberType: Type = unknownType(),
     operatorCode: String? = ".",
-    code: String? = null,
     rawNode: Any? = null
 ): MemberExpression {
     val node = MemberExpression()
-    node.applyMetadata(this, name, rawNode, code, true)
+    node.applyMetadata(this, name, rawNode, null, true)
 
     node.base = base
     node.operatorCode = operatorCode
@@ -360,9 +343,9 @@ fun MetadataProvider.newMemberExpression(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newCastExpression(code: String? = null, rawNode: Any? = null): CastExpression {
+fun MetadataProvider.newCastExpression(rawNode: Any? = null): CastExpression {
     val node = CastExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
 
     log(node)
     return node
@@ -379,11 +362,10 @@ fun MetadataProvider.newTypeIdExpression(
     operatorCode: String,
     type: Type = unknownType(),
     referencedType: Type = unknownType(),
-    code: String? = null,
     rawNode: Any? = null
 ): TypeIdExpression {
     val node = TypeIdExpression()
-    node.applyMetadata(this, operatorCode, rawNode, code, true)
+    node.applyMetadata(this, operatorCode, rawNode, null, true)
 
     node.operatorCode = operatorCode
     node.type = type
@@ -400,12 +382,9 @@ fun MetadataProvider.newTypeIdExpression(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newSubscriptExpression(
-    code: String? = null,
-    rawNode: Any? = null
-): SubscriptExpression {
+fun MetadataProvider.newSubscriptExpression(rawNode: Any? = null): SubscriptExpression {
     val node = SubscriptExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
 
     log(node)
     return node
@@ -421,11 +400,10 @@ fun MetadataProvider.newSubscriptExpression(
 fun MetadataProvider.newRangeExpression(
     floor: Expression? = null,
     ceiling: Expression? = null,
-    code: String? = null,
     rawNode: Any? = null
 ): RangeExpression {
     val node = RangeExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
 
     node.floor = floor
     node.ceiling = ceiling
@@ -441,12 +419,9 @@ fun MetadataProvider.newRangeExpression(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newNewArrayExpression(
-    code: String? = null,
-    rawNode: Any? = null
-): NewArrayExpression {
+fun MetadataProvider.newNewArrayExpression(rawNode: Any? = null): NewArrayExpression {
     val node = NewArrayExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
 
     log(node)
     return node
@@ -462,11 +437,10 @@ fun MetadataProvider.newNewArrayExpression(
 fun MetadataProvider.newReference(
     name: CharSequence?,
     type: Type = unknownType(),
-    code: String? = null,
     rawNode: Any? = null
 ): Reference {
     val node = Reference()
-    node.applyMetadata(this, name, rawNode, code, true)
+    node.applyMetadata(this, name, rawNode, null, true)
 
     node.type = type
 
@@ -481,12 +455,9 @@ fun MetadataProvider.newReference(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newDeleteExpression(
-    code: String? = null,
-    rawNode: Any? = null
-): DeleteExpression {
+fun MetadataProvider.newDeleteExpression(rawNode: Any? = null): DeleteExpression {
     val node = DeleteExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
 
     log(node)
     return node
@@ -499,9 +470,9 @@ fun MetadataProvider.newDeleteExpression(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newExpressionList(code: String? = null, rawNode: Any? = null): ExpressionList {
+fun MetadataProvider.newExpressionList(rawNode: Any? = null): ExpressionList {
     val node = ExpressionList()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
 
     log(node)
     return node
@@ -517,11 +488,10 @@ fun MetadataProvider.newExpressionList(code: String? = null, rawNode: Any? = nul
 @JvmOverloads
 fun MetadataProvider.newInitializerListExpression(
     targetType: Type = unknownType(),
-    code: String? = null,
     rawNode: Any? = null
 ): InitializerListExpression {
     val node = InitializerListExpression()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
 
     node.type = targetType
 
@@ -560,19 +530,18 @@ fun MetadataProvider.newTypeExpression(
 fun MetadataProvider.newProblemExpression(
     problem: String = "",
     type: ProblemNode.ProblemType = ProblemNode.ProblemType.PARSING,
-    code: String? = null,
     rawNode: Any? = null
 ): ProblemExpression {
     val node = ProblemExpression(problem, type)
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
 
     log(node)
     return node
 }
 
-fun MetadataProvider.newProblemType(code: String? = null, rawNode: Any? = null): ProblemType {
+fun MetadataProvider.newProblemType(rawNode: Any? = null): ProblemType {
     val node = ProblemType()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, null, true)
 
     log(node)
     return node

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -103,7 +103,12 @@ fun Node.applyMetadata(
     localNameOnly: Boolean = false,
     defaultNamespace: Name? = null,
 ) {
-    if (provider is CodeAndLocationProvider<*> && rawNode != null) {
+    // First, check if our raw node is a location provider, because in this case we can use the
+    // information directly. This is mostly used to deal with implicit()
+    if (rawNode is CodeAndLocationProvider<*>) {
+        (rawNode as CodeAndLocationProvider<Any>).setCodeAndLocation(this, rawNode)
+    } else if (provider is CodeAndLocationProvider<*> && rawNode != null) {
+        // Otherwise, we try to forward it to the provider
         (provider as CodeAndLocationProvider<Any>).setCodeAndLocation(this, rawNode)
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -232,6 +232,9 @@ interface ContextProvider : MetadataProvider {
  * This [MetadataProvider] makes sure that we can type our node builder functions correctly. For
  * language frontend and handlers, [T] should be set to the type of the raw node. For passes, [T]
  * should be set to [Nothing], since we do not have raw nodes there.
+ *
+ * Note: This does not work yet to 100 % satisfaction and is therefore not yet activated in the
+ * builders.
  */
 interface RawNodeTypeProvider<T> : MetadataProvider
 
@@ -250,7 +253,14 @@ fun <T : Node> T.implicit(code: String? = null, location: PhysicalLocation? = nu
     return this
 }
 
-fun <T : Node, S> T.locationAndCodeFrom(frontend: LanguageFrontend<S, *>, rawNode: S): T {
+fun <T : Node> T.codeAndLocationFrom(other: Node): T {
+    this.code = other.code
+    this.location = other.location
+
+    return this
+}
+
+fun <T : Node, S> T.codeAndLocationFrom(frontend: LanguageFrontend<S, *>, rawNode: S): T {
     frontend.setCodeAndLocation(this, rawNode)
 
     return this

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -98,7 +98,6 @@ fun Node.applyMetadata(
     provider: MetadataProvider?,
     name: CharSequence? = EMPTY_NAME,
     rawNode: Any? = null,
-    codeOverride: String? = null,
     localNameOnly: Boolean = false,
     defaultNamespace: Name? = null,
 ) {
@@ -141,10 +140,6 @@ fun Node.applyMetadata(
                 defaultNamespace
             }
         this.name = this.newName(name, localNameOnly, namespace)
-    }
-
-    if (codeOverride != null) {
-        this.code = codeOverride
     }
 }
 
@@ -189,13 +184,9 @@ fun LanguageProvider.newName(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newAnnotation(
-    name: CharSequence?,
-    code: String? = null,
-    rawNode: Any? = null
-): Annotation {
+fun MetadataProvider.newAnnotation(name: CharSequence?, rawNode: Any? = null): Annotation {
     val node = Annotation()
-    node.applyMetadata(this, name, rawNode, code)
+    node.applyMetadata(this, name, rawNode)
 
     log(node)
     return node
@@ -211,11 +202,10 @@ fun MetadataProvider.newAnnotation(
 fun MetadataProvider.newAnnotationMember(
     name: CharSequence?,
     value: Expression?,
-    code: String? = null,
     rawNode: Any? = null
 ): AnnotationMember {
     val node = AnnotationMember()
-    node.applyMetadata(this, name, rawNode, code, true)
+    node.applyMetadata(this, name, rawNode, true)
 
     node.value = value
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/StatementBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/StatementBuilder.kt
@@ -37,10 +37,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.*
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newReturnStatement(
-    code: String? = null,
-    rawNode: T? = null
-): ReturnStatement {
+fun MetadataProvider.newReturnStatement(rawNode: Any? = null): ReturnStatement {
     val node = ReturnStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -55,10 +52,7 @@ fun <T> RawNodeTypeProvider<T>.newReturnStatement(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newCatchClause(
-    code: String? = null,
-    rawNode: T? = null
-): CatchClause {
+fun MetadataProvider.newCatchClause(rawNode: Any? = null): CatchClause {
     val node = CatchClause()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -73,10 +67,7 @@ fun <T> RawNodeTypeProvider<T>.newCatchClause(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newTryStatement(
-    code: String? = null,
-    rawNode: T? = null
-): TryStatement {
+fun MetadataProvider.newTryStatement(rawNode: Any? = null): TryStatement {
     val node = TryStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -91,10 +82,7 @@ fun <T> RawNodeTypeProvider<T>.newTryStatement(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newAssertStatement(
-    code: String? = null,
-    rawNode: T? = null
-): AssertStatement {
+fun MetadataProvider.newAssertStatement(rawNode: Any? = null): AssertStatement {
     val node = AssertStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -127,10 +115,7 @@ fun MetadataProvider.newDistinctLanguageBlock(
  * prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newSynchronizedStatement(
-    code: String? = null,
-    rawNode: T? = null
-): SynchronizedStatement {
+fun MetadataProvider.newSynchronizedStatement(rawNode: Any? = null): SynchronizedStatement {
     val node = SynchronizedStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -145,10 +130,7 @@ fun <T> RawNodeTypeProvider<T>.newSynchronizedStatement(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newEmptyStatement(
-    code: String? = null,
-    rawNode: T? = null
-): EmptyStatement {
+fun MetadataProvider.newEmptyStatement(rawNode: Any? = null): EmptyStatement {
     val node = EmptyStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -163,10 +145,7 @@ fun <T> RawNodeTypeProvider<T>.newEmptyStatement(
  * prepended argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newDeclarationStatement(
-    code: String? = null,
-    rawNode: T? = null
-): DeclarationStatement {
+fun MetadataProvider.newDeclarationStatement(rawNode: Any? = null): DeclarationStatement {
     val node = DeclarationStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -181,10 +160,7 @@ fun <T> RawNodeTypeProvider<T>.newDeclarationStatement(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newIfStatement(
-    code: String? = null,
-    rawNode: T? = null
-): IfStatement {
+fun MetadataProvider.newIfStatement(rawNode: Any? = null): IfStatement {
     val node = IfStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -199,10 +175,7 @@ fun <T> RawNodeTypeProvider<T>.newIfStatement(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newLabelStatement(
-    code: String? = null,
-    rawNode: T? = null
-): LabelStatement {
+fun MetadataProvider.newLabelStatement(rawNode: Any? = null): LabelStatement {
     val node = LabelStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -217,10 +190,7 @@ fun <T> RawNodeTypeProvider<T>.newLabelStatement(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newGotoStatement(
-    code: String? = null,
-    rawNode: T? = null
-): GotoStatement {
+fun MetadataProvider.newGotoStatement(rawNode: Any? = null): GotoStatement {
     val node = GotoStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -235,10 +205,7 @@ fun <T> RawNodeTypeProvider<T>.newGotoStatement(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newWhileStatement(
-    code: String? = null,
-    rawNode: T? = null
-): WhileStatement {
+fun MetadataProvider.newWhileStatement(rawNode: Any? = null): WhileStatement {
     val node = WhileStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -253,10 +220,7 @@ fun <T> RawNodeTypeProvider<T>.newWhileStatement(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newDoStatement(
-    code: String? = null,
-    rawNode: T? = null
-): DoStatement {
+fun MetadataProvider.newDoStatement(rawNode: Any? = null): DoStatement {
     val node = DoStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -271,10 +235,7 @@ fun <T> RawNodeTypeProvider<T>.newDoStatement(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newForEachStatement(
-    code: String? = null,
-    rawNode: T? = null
-): ForEachStatement {
+fun MetadataProvider.newForEachStatement(rawNode: Any? = null): ForEachStatement {
     val node = ForEachStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -289,10 +250,7 @@ fun <T> RawNodeTypeProvider<T>.newForEachStatement(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newForStatement(
-    code: String? = null,
-    rawNode: T? = null
-): ForStatement {
+fun MetadataProvider.newForStatement(rawNode: Any? = null): ForStatement {
     val node = ForStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -307,10 +265,7 @@ fun <T> RawNodeTypeProvider<T>.newForStatement(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newContinueStatement(
-    code: String? = null,
-    rawNode: T? = null
-): ContinueStatement {
+fun MetadataProvider.newContinueStatement(rawNode: Any? = null): ContinueStatement {
     val node = ContinueStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -325,10 +280,7 @@ fun <T> RawNodeTypeProvider<T>.newContinueStatement(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newBreakStatement(
-    code: String? = null,
-    rawNode: T? = null
-): BreakStatement {
+fun MetadataProvider.newBreakStatement(rawNode: Any? = null): BreakStatement {
     val node = BreakStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -343,10 +295,7 @@ fun <T> RawNodeTypeProvider<T>.newBreakStatement(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newSwitchStatement(
-    code: String? = null,
-    rawNode: T? = null
-): SwitchStatement {
+fun MetadataProvider.newSwitchStatement(rawNode: Any? = null): SwitchStatement {
     val node = SwitchStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -361,10 +310,7 @@ fun <T> RawNodeTypeProvider<T>.newSwitchStatement(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newCaseStatement(
-    code: String? = null,
-    rawNode: T? = null
-): CaseStatement {
+fun MetadataProvider.newCaseStatement(rawNode: Any? = null): CaseStatement {
     val node = CaseStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -379,10 +325,7 @@ fun <T> RawNodeTypeProvider<T>.newCaseStatement(
  * argument.
  */
 @JvmOverloads
-fun <T> RawNodeTypeProvider<T>.newDefaultStatement(
-    code: String? = null,
-    rawNode: T? = null
-): DefaultStatement {
+fun MetadataProvider.newDefaultStatement(rawNode: Any? = null): DefaultStatement {
     val node = DefaultStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/StatementBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/StatementBuilder.kt
@@ -97,12 +97,9 @@ fun MetadataProvider.newAssertStatement(rawNode: Any? = null): AssertStatement {
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newDistinctLanguageBlock(
-    code: String? = null,
-    rawNode: Any? = null
-): DistinctLanguageBlock {
+fun MetadataProvider.newDistinctLanguageBlock(rawNode: Any? = null): DistinctLanguageBlock {
     val node = DistinctLanguageBlock()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/StatementBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/StatementBuilder.kt
@@ -42,7 +42,7 @@ fun MetadataProvider.newReturnStatement(
     rawNode: Any? = null
 ): ReturnStatement {
     val node = ReturnStatement()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -57,7 +57,7 @@ fun MetadataProvider.newReturnStatement(
 @JvmOverloads
 fun MetadataProvider.newCatchClause(code: String? = null, rawNode: Any? = null): CatchClause {
     val node = CatchClause()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -72,7 +72,7 @@ fun MetadataProvider.newCatchClause(code: String? = null, rawNode: Any? = null):
 @JvmOverloads
 fun MetadataProvider.newTryStatement(code: String? = null, rawNode: Any? = null): TryStatement {
     val node = TryStatement()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -90,7 +90,7 @@ fun MetadataProvider.newAssertStatement(
     rawNode: Any? = null
 ): AssertStatement {
     val node = AssertStatement()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -126,7 +126,7 @@ fun MetadataProvider.newSynchronizedStatement(
     rawNode: Any? = null
 ): SynchronizedStatement {
     val node = SynchronizedStatement()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -141,7 +141,7 @@ fun MetadataProvider.newSynchronizedStatement(
 @JvmOverloads
 fun MetadataProvider.newEmptyStatement(code: String? = null, rawNode: Any? = null): EmptyStatement {
     val node = EmptyStatement()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -159,7 +159,7 @@ fun MetadataProvider.newDeclarationStatement(
     rawNode: Any? = null
 ): DeclarationStatement {
     val node = DeclarationStatement()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -174,7 +174,7 @@ fun MetadataProvider.newDeclarationStatement(
 @JvmOverloads
 fun MetadataProvider.newIfStatement(code: String? = null, rawNode: Any? = null): IfStatement {
     val node = IfStatement()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -189,7 +189,7 @@ fun MetadataProvider.newIfStatement(code: String? = null, rawNode: Any? = null):
 @JvmOverloads
 fun MetadataProvider.newLabelStatement(code: String? = null, rawNode: Any? = null): LabelStatement {
     val node = LabelStatement()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -204,7 +204,7 @@ fun MetadataProvider.newLabelStatement(code: String? = null, rawNode: Any? = nul
 @JvmOverloads
 fun MetadataProvider.newGotoStatement(code: String? = null, rawNode: Any? = null): GotoStatement {
     val node = GotoStatement()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -219,7 +219,7 @@ fun MetadataProvider.newGotoStatement(code: String? = null, rawNode: Any? = null
 @JvmOverloads
 fun MetadataProvider.newWhileStatement(code: String? = null, rawNode: Any? = null): WhileStatement {
     val node = WhileStatement()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -234,7 +234,7 @@ fun MetadataProvider.newWhileStatement(code: String? = null, rawNode: Any? = nul
 @JvmOverloads
 fun MetadataProvider.newDoStatement(code: String? = null, rawNode: Any? = null): DoStatement {
     val node = DoStatement()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -252,7 +252,7 @@ fun MetadataProvider.newForEachStatement(
     rawNode: Any? = null
 ): ForEachStatement {
     val node = ForEachStatement()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -267,7 +267,7 @@ fun MetadataProvider.newForEachStatement(
 @JvmOverloads
 fun MetadataProvider.newForStatement(code: String? = null, rawNode: Any? = null): ForStatement {
     val node = ForStatement()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -285,7 +285,7 @@ fun MetadataProvider.newContinueStatement(
     rawNode: Any? = null
 ): ContinueStatement {
     val node = ContinueStatement()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -300,7 +300,7 @@ fun MetadataProvider.newContinueStatement(
 @JvmOverloads
 fun MetadataProvider.newBreakStatement(code: String? = null, rawNode: Any? = null): BreakStatement {
     val node = BreakStatement()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -318,7 +318,7 @@ fun MetadataProvider.newSwitchStatement(
     rawNode: Any? = null
 ): SwitchStatement {
     val node = SwitchStatement()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -333,7 +333,7 @@ fun MetadataProvider.newSwitchStatement(
 @JvmOverloads
 fun MetadataProvider.newCaseStatement(code: String? = null, rawNode: Any? = null): CaseStatement {
     val node = CaseStatement()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node
@@ -351,7 +351,7 @@ fun MetadataProvider.newDefaultStatement(
     rawNode: Any? = null
 ): DefaultStatement {
     val node = DefaultStatement()
-    node.applyMetadata(this, EMPTY_NAME, rawNode, code, true)
+    node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
     log(node)
     return node

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/StatementBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/StatementBuilder.kt
@@ -37,9 +37,9 @@ import de.fraunhofer.aisec.cpg.graph.statements.*
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newReturnStatement(
+fun <T> RawNodeTypeProvider<T>.newReturnStatement(
     code: String? = null,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): ReturnStatement {
     val node = ReturnStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -55,7 +55,10 @@ fun MetadataProvider.newReturnStatement(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newCatchClause(code: String? = null, rawNode: Any? = null): CatchClause {
+fun <T> RawNodeTypeProvider<T>.newCatchClause(
+    code: String? = null,
+    rawNode: T? = null
+): CatchClause {
     val node = CatchClause()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -70,7 +73,10 @@ fun MetadataProvider.newCatchClause(code: String? = null, rawNode: Any? = null):
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newTryStatement(code: String? = null, rawNode: Any? = null): TryStatement {
+fun <T> RawNodeTypeProvider<T>.newTryStatement(
+    code: String? = null,
+    rawNode: T? = null
+): TryStatement {
     val node = TryStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -85,9 +91,9 @@ fun MetadataProvider.newTryStatement(code: String? = null, rawNode: Any? = null)
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newAssertStatement(
+fun <T> RawNodeTypeProvider<T>.newAssertStatement(
     code: String? = null,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): AssertStatement {
     val node = AssertStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -121,9 +127,9 @@ fun MetadataProvider.newDistinctLanguageBlock(
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newSynchronizedStatement(
+fun <T> RawNodeTypeProvider<T>.newSynchronizedStatement(
     code: String? = null,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): SynchronizedStatement {
     val node = SynchronizedStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -139,7 +145,10 @@ fun MetadataProvider.newSynchronizedStatement(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newEmptyStatement(code: String? = null, rawNode: Any? = null): EmptyStatement {
+fun <T> RawNodeTypeProvider<T>.newEmptyStatement(
+    code: String? = null,
+    rawNode: T? = null
+): EmptyStatement {
     val node = EmptyStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -154,9 +163,9 @@ fun MetadataProvider.newEmptyStatement(code: String? = null, rawNode: Any? = nul
  * prepended argument.
  */
 @JvmOverloads
-fun MetadataProvider.newDeclarationStatement(
+fun <T> RawNodeTypeProvider<T>.newDeclarationStatement(
     code: String? = null,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): DeclarationStatement {
     val node = DeclarationStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -172,7 +181,10 @@ fun MetadataProvider.newDeclarationStatement(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newIfStatement(code: String? = null, rawNode: Any? = null): IfStatement {
+fun <T> RawNodeTypeProvider<T>.newIfStatement(
+    code: String? = null,
+    rawNode: T? = null
+): IfStatement {
     val node = IfStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -187,7 +199,10 @@ fun MetadataProvider.newIfStatement(code: String? = null, rawNode: Any? = null):
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newLabelStatement(code: String? = null, rawNode: Any? = null): LabelStatement {
+fun <T> RawNodeTypeProvider<T>.newLabelStatement(
+    code: String? = null,
+    rawNode: T? = null
+): LabelStatement {
     val node = LabelStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -202,7 +217,10 @@ fun MetadataProvider.newLabelStatement(code: String? = null, rawNode: Any? = nul
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newGotoStatement(code: String? = null, rawNode: Any? = null): GotoStatement {
+fun <T> RawNodeTypeProvider<T>.newGotoStatement(
+    code: String? = null,
+    rawNode: T? = null
+): GotoStatement {
     val node = GotoStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -217,7 +235,10 @@ fun MetadataProvider.newGotoStatement(code: String? = null, rawNode: Any? = null
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newWhileStatement(code: String? = null, rawNode: Any? = null): WhileStatement {
+fun <T> RawNodeTypeProvider<T>.newWhileStatement(
+    code: String? = null,
+    rawNode: T? = null
+): WhileStatement {
     val node = WhileStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -232,7 +253,10 @@ fun MetadataProvider.newWhileStatement(code: String? = null, rawNode: Any? = nul
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newDoStatement(code: String? = null, rawNode: Any? = null): DoStatement {
+fun <T> RawNodeTypeProvider<T>.newDoStatement(
+    code: String? = null,
+    rawNode: T? = null
+): DoStatement {
     val node = DoStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -247,9 +271,9 @@ fun MetadataProvider.newDoStatement(code: String? = null, rawNode: Any? = null):
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newForEachStatement(
+fun <T> RawNodeTypeProvider<T>.newForEachStatement(
     code: String? = null,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): ForEachStatement {
     val node = ForEachStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -265,7 +289,10 @@ fun MetadataProvider.newForEachStatement(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newForStatement(code: String? = null, rawNode: Any? = null): ForStatement {
+fun <T> RawNodeTypeProvider<T>.newForStatement(
+    code: String? = null,
+    rawNode: T? = null
+): ForStatement {
     val node = ForStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -280,9 +307,9 @@ fun MetadataProvider.newForStatement(code: String? = null, rawNode: Any? = null)
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newContinueStatement(
+fun <T> RawNodeTypeProvider<T>.newContinueStatement(
     code: String? = null,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): ContinueStatement {
     val node = ContinueStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -298,7 +325,10 @@ fun MetadataProvider.newContinueStatement(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newBreakStatement(code: String? = null, rawNode: Any? = null): BreakStatement {
+fun <T> RawNodeTypeProvider<T>.newBreakStatement(
+    code: String? = null,
+    rawNode: T? = null
+): BreakStatement {
     val node = BreakStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -313,9 +343,9 @@ fun MetadataProvider.newBreakStatement(code: String? = null, rawNode: Any? = nul
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newSwitchStatement(
+fun <T> RawNodeTypeProvider<T>.newSwitchStatement(
     code: String? = null,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): SwitchStatement {
     val node = SwitchStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
@@ -331,7 +361,10 @@ fun MetadataProvider.newSwitchStatement(
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newCaseStatement(code: String? = null, rawNode: Any? = null): CaseStatement {
+fun <T> RawNodeTypeProvider<T>.newCaseStatement(
+    code: String? = null,
+    rawNode: T? = null
+): CaseStatement {
     val node = CaseStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)
 
@@ -346,9 +379,9 @@ fun MetadataProvider.newCaseStatement(code: String? = null, rawNode: Any? = null
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newDefaultStatement(
+fun <T> RawNodeTypeProvider<T>.newDefaultStatement(
     code: String? = null,
-    rawNode: Any? = null
+    rawNode: T? = null
 ): DefaultStatement {
     val node = DefaultStatement()
     node.applyMetadata(this, EMPTY_NAME, rawNode, true)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/ForEachStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/ForEachStatement.kt
@@ -74,7 +74,8 @@ class ForEachStatement : Statement(), BranchingNode, StatementHolder {
         } else if (statement == null) {
             statement = s
         } else if (statement !is Block) {
-            val block = newBlock()
+            val block = Block()
+            block.language = this.language
             statement?.let { block.addStatement(it) }
             block.addStatement(s)
             statement = block

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
@@ -137,7 +137,6 @@ open class ImportResolver(ctx: TranslationContext) : ComponentPass(ctx) {
                     ArrayList(),
                     "",
                     null,
-                    null,
                     false,
                     base.language
                 )

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
@@ -135,13 +135,12 @@ open class ImportResolver(ctx: TranslationContext) : ComponentPass(ctx) {
                     name,
                     UnknownType.getUnknownType(base.language),
                     ArrayList(),
-                    "",
                     null,
                     false,
                     base.language
                 )
             targetField.isInferred = true
-            val targetMethod = base.newMethodDeclaration(name, "", true, base)
+            val targetMethod = base.newMethodDeclaration(name, true, base)
             targetMethod.isInferred = true
             base.addField(targetField)
             base.addMethod(targetMethod)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
@@ -125,23 +125,27 @@ open class ImportResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
         // now it gets weird: you can import a field and a number of methods that have the same
         // name, all with a *single* static import...
+        // TODO(oxisto): Move all of the following code to the [Inference] class
         val result = mutableSetOf<ValueDeclaration>()
         result.addAll(memberMethods)
         result.addAll(memberFields)
         if (result.isEmpty()) {
             // the target might be a field or a method, we don't know. Thus, we need to create both
             val targetField =
-                base.newFieldDeclaration(
+                newFieldDeclaration(
                     name,
                     UnknownType.getUnknownType(base.language),
                     ArrayList(),
                     null,
                     false,
-                    base.language
                 )
+            targetField.language = base.language
             targetField.isInferred = true
-            val targetMethod = base.newMethodDeclaration(name, true, base)
+
+            val targetMethod = newMethodDeclaration(name, true, base)
+            targetMethod.language = base.language
             targetMethod.isInferred = true
+
             base.addField(targetField)
             base.addMethod(targetMethod)
             result.add(targetField)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
@@ -82,7 +82,7 @@ open class PassConfiguration {}
  * [ComponentPass] or [TranslationUnitPass] must be used.
  */
 sealed class Pass<T : Node>(final override val ctx: TranslationContext) :
-    Consumer<T>, ContextProvider, ScopeProvider {
+    Consumer<T>, ContextProvider, RawNodeTypeProvider<Nothing>, ScopeProvider {
     var name: String
         protected set
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -424,7 +424,6 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
                     listOf(),
                     "",
                     null,
-                    null,
                     false,
                 )
             record.addField(declaration)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -422,7 +422,6 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
                     // we will set the type later through the type inference observer
                     unknownType(),
                     listOf(),
-                    "",
                     null,
                     false,
                 )

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -417,7 +417,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
             target
         } else {
             val declaration =
-                record.newFieldDeclaration(
+                newFieldDeclaration(
                     name.localName,
                     // we will set the type later through the type inference observer
                     unknownType(),
@@ -426,6 +426,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
                     false,
                 )
             record.addField(declaration)
+            declaration.language = record.language
             declaration.isInferred = true
 
             // We might be able to resolve the type later (or better), if a type is

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
@@ -51,7 +51,11 @@ import org.slf4j.LoggerFactory
  * builder functions, will automatically have [Node.isInferred] set to true.
  */
 class Inference(val start: Node, override val ctx: TranslationContext) :
-    LanguageProvider, ScopeProvider, IsInferredProvider, ContextProvider {
+    LanguageProvider,
+    ScopeProvider,
+    IsInferredProvider,
+    ContextProvider,
+    RawNodeTypeProvider<Nothing> {
 
     override val language: Language<*>?
         get() = start.language
@@ -164,7 +168,7 @@ class Inference(val start: Node, override val ctx: TranslationContext) :
             for (i in signature.indices) {
                 val targetType = signature[i] ?: UnknownType.getUnknownType(function.language)
                 val paramName = generateParamName(i, targetType)
-                val param = newParameterDeclaration(paramName, targetType, false, "")
+                val param = newParameterDeclaration(paramName, targetType, false)
                 param.argumentIndex = i
 
                 scopeManager.addDeclaration(param)
@@ -226,7 +230,7 @@ class Inference(val start: Node, override val ctx: TranslationContext) :
                 )
 
         // Non-Type Template Parameter
-        return newParameterDeclaration(name, expr.type, false, name)
+        return newParameterDeclaration(name, expr.type, false)
     }
 
     private fun inferTemplateParameter(
@@ -235,7 +239,7 @@ class Inference(val start: Node, override val ctx: TranslationContext) :
         val parameterizedType = ParameterizedType(name, language)
         typeManager.addTypeParameter(start as FunctionTemplateDeclaration, parameterizedType)
 
-        val decl = newTypeParameterDeclaration(name, name)
+        val decl = newTypeParameterDeclaration(name)
         decl.type = parameterizedType
 
         return decl
@@ -262,7 +266,7 @@ class Inference(val start: Node, override val ctx: TranslationContext) :
 
         val name = call.name.localName
         val code = call.code
-        val inferred = newFunctionTemplateDeclaration(name, code)
+        val inferred = newFunctionTemplateDeclaration(name)
         inferred.isInferred = true
 
         val inferredRealization =
@@ -321,7 +325,7 @@ class Inference(val start: Node, override val ctx: TranslationContext) :
 
         // This could be a class or a struct. We start with a class and may have to fine-tune this
         // later.
-        val declaration = currentTU.newRecordDeclaration(type.typeName, kind, "")
+        val declaration = newRecordDeclaration(type.typeName, kind)
         declaration.isInferred = true
 
         // update the type

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
@@ -88,9 +88,9 @@ class Inference(val start: Node, override val ctx: TranslationContext) :
         return inferInScopeOf(start) {
             val inferred: FunctionDeclaration =
                 if (record != null) {
-                    newMethodDeclaration(name ?: "", code, isStatic, record)
+                    newMethodDeclaration(name ?: "", isStatic, record)
                 } else {
-                    newFunctionDeclaration(name ?: "", code)
+                    newFunctionDeclaration(name ?: "")
                 }
 
             debugWithFileLocation(
@@ -136,11 +136,7 @@ class Inference(val start: Node, override val ctx: TranslationContext) :
     fun createInferredConstructor(signature: List<Type?>): ConstructorDeclaration {
         return inferInScopeOf(start) {
             val inferred =
-                newConstructorDeclaration(
-                    start.name.localName,
-                    "",
-                    start as? RecordDeclaration,
-                )
+                newConstructorDeclaration(start.name.localName, start as? RecordDeclaration)
             createInferredParameters(inferred, signature)
 
             scopeManager.addDeclaration(inferred)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
@@ -413,6 +413,11 @@ interface IsInferredProvider : MetadataProvider {
     val isInferred: Boolean
 }
 
+/** Provides information about the implicit status of a node. */
+interface IsImplicitProvider : MetadataProvider {
+    val isImplicit: Boolean
+}
+
 /** Returns a new [Inference] object starting from this node. */
 fun Node.startInference(ctx: TranslationContext) = Inference(this, ctx)
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
@@ -96,6 +96,7 @@ class Inference(val start: Node, override val ctx: TranslationContext) :
                 } else {
                     newFunctionDeclaration(name ?: "")
                 }
+            inferred.code = code
 
             debugWithFileLocation(
                 hint,
@@ -230,7 +231,9 @@ class Inference(val start: Node, override val ctx: TranslationContext) :
                 )
 
         // Non-Type Template Parameter
-        return newParameterDeclaration(name, expr.type, false)
+        val param = newParameterDeclaration(name, expr.type, false)
+        param.code = name
+        return param
     }
 
     private fun inferTemplateParameter(
@@ -240,6 +243,7 @@ class Inference(val start: Node, override val ctx: TranslationContext) :
         typeManager.addTypeParameter(start as FunctionTemplateDeclaration, parameterizedType)
 
         val decl = newTypeParameterDeclaration(name)
+        decl.code = name
         decl.type = parameterizedType
 
         return decl
@@ -267,6 +271,7 @@ class Inference(val start: Node, override val ctx: TranslationContext) :
         val name = call.name.localName
         val code = call.code
         val inferred = newFunctionTemplateDeclaration(name)
+        inferred.code = code
         inferred.isInferred = true
 
         val inferredRealization =

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManagerTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManagerTest.kt
@@ -96,8 +96,7 @@ internal class ScopeManagerTest : BaseTest() {
         assertFalse(listOf(s1, s2).map { it.globalScope }.contains(final.globalScope))
 
         // resolve symbol
-        val call =
-            frontend.newCallExpression(frontend.newReference("A::func1"), "A::func1", null, false)
+        val call = frontend.newCallExpression(frontend.newReference("A::func1"), "A::func1", false)
         val func = final.resolveFunction(call).firstOrNull()
 
         assertEquals(func1, func)

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManagerTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManagerTest.kt
@@ -49,9 +49,9 @@ internal class ScopeManagerTest : BaseTest() {
         s1.resetToGlobal(frontend1.newTranslationUnitDeclaration("f1.cpp", null))
 
         // build a namespace declaration in f1.cpp with the namespace A
-        val namespaceA1 = frontend1.newNamespaceDeclaration("A", null)
+        val namespaceA1 = frontend1.newNamespaceDeclaration("A")
         s1.enterScope(namespaceA1)
-        val func1 = frontend1.newFunctionDeclaration("func1", null)
+        val func1 = frontend1.newFunctionDeclaration("func1")
         s1.addDeclaration(func1)
         s1.leaveScope(namespaceA1)
 
@@ -61,9 +61,9 @@ internal class ScopeManagerTest : BaseTest() {
         s2.resetToGlobal(frontend2.newTranslationUnitDeclaration("f1.cpp", null))
 
         // and do the same in the other file
-        val namespaceA2 = frontend2.newNamespaceDeclaration("A", null)
+        val namespaceA2 = frontend2.newNamespaceDeclaration("A")
         s2.enterScope(namespaceA2)
-        val func2 = frontend2.newFunctionDeclaration("func2", null)
+        val func2 = frontend2.newFunctionDeclaration("func2")
         s2.addDeclaration(func2)
         s2.leaveScope(namespaceA2)
 
@@ -122,7 +122,7 @@ internal class ScopeManagerTest : BaseTest() {
 
         assertEquals("A::B", s.currentNamespace.toString())
 
-        val func = frontend.newFunctionDeclaration("func", null)
+        val func = frontend.newFunctionDeclaration("func")
         s.addDeclaration(func)
 
         s.leaveScope(namespaceB)

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontend.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontend.kt
@@ -364,7 +364,7 @@ open class CXXLanguageFrontend(language: Language<CXXLanguageFrontend>, ctx: Tra
     private fun handleAttributes(owner: IASTAttributeOwner): List<Annotation> {
         val list: MutableList<Annotation> = ArrayList()
         for (attribute in owner.attributes) {
-            val annotation = newAnnotation(String(attribute.name), attribute.rawSignature)
+            val annotation = newAnnotation(String(attribute.name))
 
             // go over the parameters
             if (attribute.argumentClause is IASTTokenList) {
@@ -404,7 +404,7 @@ open class CXXLanguageFrontend(language: Language<CXXLanguageFrontend>, ctx: Tra
                     )
                 else -> newLiteral(code, primitiveType("char").pointer(), code)
             }
-        return newAnnotationMember("", expression, code)
+        return newAnnotationMember("", expression)
     }
 
     @Throws(NoSuchFieldException::class)

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontend.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontend.kt
@@ -393,16 +393,16 @@ open class CXXLanguageFrontend(language: Language<CXXLanguageFrontend>, ctx: Tra
         val expression: Expression =
             when (token.tokenType) {
                 1 -> // a variable
-                newReference(code, unknownType(), code)
+                newReference(code, unknownType(), rawNode = token)
                 2 -> // an integer
-                newLiteral(code.toInt(), primitiveType("int"), code)
+                newLiteral(code.toInt(), primitiveType("int"), rawNode = token)
                 130 -> // a string
                 newLiteral(
                         if (code.length >= 2) code.substring(1, code.length - 1) else "",
                         primitiveType("char").pointer(),
-                        code
+                        rawNode = token
                     )
-                else -> newLiteral(code, primitiveType("char").pointer(), code)
+                else -> newLiteral(code, primitiveType("char").pointer(), rawNode = token)
             }
         return newAnnotationMember("", expression, rawNode = token)
     }

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontend.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontend.kt
@@ -364,7 +364,7 @@ open class CXXLanguageFrontend(language: Language<CXXLanguageFrontend>, ctx: Tra
     private fun handleAttributes(owner: IASTAttributeOwner): List<Annotation> {
         val list: MutableList<Annotation> = ArrayList()
         for (attribute in owner.attributes) {
-            val annotation = newAnnotation(String(attribute.name))
+            val annotation = newAnnotation(String(attribute.name), rawNode = owner)
 
             // go over the parameters
             if (attribute.argumentClause is IASTTokenList) {
@@ -404,7 +404,7 @@ open class CXXLanguageFrontend(language: Language<CXXLanguageFrontend>, ctx: Tra
                     )
                 else -> newLiteral(code, primitiveType("char").pointer(), code)
             }
-        return newAnnotationMember("", expression)
+        return newAnnotationMember("", expression, rawNode = token)
     }
 
     @Throws(NoSuchFieldException::class)

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
@@ -58,9 +58,9 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.*
  * and the [DeclarationHandler] modifies the declaration depending on the declaration specifiers.
  */
 class DeclarationHandler(lang: CXXLanguageFrontend) :
-    CXXHandler<Declaration, IASTDeclaration>(Supplier(::ProblemDeclaration), lang) {
+    CXXHandler<Declaration, IASTNode>(Supplier(::ProblemDeclaration), lang) {
 
-    override fun handleNode(node: IASTDeclaration): Declaration {
+    override fun handleNode(node: IASTNode): Declaration {
         return when (node) {
             is IASTSimpleDeclaration -> handleSimpleDeclaration(node)
             is IASTFunctionDefinition -> handleFunctionDefinition(node)
@@ -89,7 +89,7 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
      * into a [NamespaceDeclaration].
      */
     private fun handleNamespace(ctx: CPPASTNamespaceDefinition): NamespaceDeclaration {
-        val declaration = newNamespaceDeclaration(ctx.name.toString(), frontend.codeOf(ctx))
+        val declaration = newNamespaceDeclaration(ctx.name.toString(), rawNode = ctx)
 
         frontend.scopeManager.addDeclaration(declaration)
 
@@ -275,9 +275,9 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
 
         val templateDeclaration: TemplateDeclaration =
             if (ctx.declaration is CPPASTFunctionDefinition) {
-                newFunctionTemplateDeclaration(name, frontend.codeOf(ctx))
+                newFunctionTemplateDeclaration(name, rawNode = ctx)
             } else {
-                newRecordTemplateDeclaration(name, frontend.codeOf(ctx))
+                newRecordTemplateDeclaration(name, rawNode = ctx)
             }
 
         templateDeclaration.location = frontend.locationOf(ctx)
@@ -626,12 +626,7 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
         val (nameDecl: IASTDeclarator, _) = declarator.realName()
 
         val declaration =
-            frontend.typeManager.createTypeAlias(
-                frontend,
-                frontend.codeOf(ctx),
-                type,
-                frontend.typeOf(nameDecl.name)
-            )
+            frontend.typeManager.createTypeAlias(frontend, type, frontend.typeOf(nameDecl.name))
 
         // Add the declaration to the current scope
         frontend.scopeManager.addDeclaration(declaration)

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
@@ -644,19 +644,14 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
         declSpecifier: IASTEnumerationSpecifier
     ): EnumDeclaration {
         val entries = mutableListOf<EnumConstantDeclaration>()
-        val enum =
-            newEnumDeclaration(
-                name = declSpecifier.name.toString(),
-                location = frontend.locationOf(ctx),
-            )
+        val enum = newEnumDeclaration(name = declSpecifier.name.toString(), rawNode = ctx)
 
         // Loop through its members
         for (enumerator in declSpecifier.enumerators) {
             val enumConst =
                 newEnumConstantDeclaration(
                     enumerator.name.toString(),
-                    frontend.codeOf(enumerator),
-                    frontend.locationOf(enumerator),
+                    rawNode = enumerator,
                 )
 
             // In C/C++, default enums are of type int

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
@@ -206,7 +206,7 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
 
                 // add an implicit return statement, if there is none
                 if (lastStatement !is ReturnStatement) {
-                    val returnStatement = newReturnStatement("return;")
+                    val returnStatement = newReturnStatement()
                     returnStatement.isImplicit = true
                     bodyStatement.addStatement(returnStatement)
                 }

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclaratorHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclaratorHandler.kt
@@ -333,7 +333,7 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
         // is appended to the original ones. For coherent graph behaviour, we introduce an implicit
         // declaration that wraps this list
         if (ctx.takesVarArgs()) {
-            val varargs = newParameterDeclaration("va_args", unknownType(), true, "")
+            val varargs = newParameterDeclaration("va_args", unknownType(), true)
             varargs.isImplicit = true
             varargs.argumentIndex = i
             frontend.scopeManager.addDeclaration(varargs)
@@ -457,10 +457,10 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
             // create an implicit constructor declaration with the same name as the record
             val constructorDeclaration =
                 newConstructorDeclaration(
-                    recordDeclaration.name.localName,
-                    recordDeclaration,
-                    rawNode = implicit(code = recordDeclaration.name.localName)
-                )
+                        recordDeclaration.name.localName,
+                        recordDeclaration,
+                    )
+                    .implicit(code = recordDeclaration.name.localName)
 
             createMethodReceiver(constructorDeclaration)
 

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/ExpressionHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/ExpressionHandler.kt
@@ -417,7 +417,7 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
             }
             reference is UnaryOperator && reference.operatorCode == "*" -> {
                 // Classic C-style function pointer call -> let's extract the target
-                callExpression = newCallExpression(reference, "", reference.code, false)
+                callExpression = newCallExpression(reference, "", false, rawNode = ctx)
             }
             ctx.functionNameExpression is IASTIdExpression &&
                 (ctx.functionNameExpression as IASTIdExpression).name is CPPASTTemplateId -> {

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/ExpressionHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/ExpressionHandler.kt
@@ -567,43 +567,7 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
         val des = ctx.designators.firstOrNull()
         if (des == null) {
             Util.errorWithFileLocation(frontend, ctx, log, "no designator found")
-<<<<<<< HEAD
             return newProblemExpression("no designator found")
-=======
-        } else {
-            for (des in ctx.designators) {
-                var oneLhs: Expression? = null
-                when (des) {
-                    is CPPASTArrayDesignator -> {
-                        oneLhs = handle(des.subscriptExpression)
-                    }
-                    is CPPASTFieldDesignator -> {
-                        oneLhs = newReference(des.name.toString(), unknownType(), rawNode = des)
-                    }
-                    is CPPASTArrayRangeDesignator -> {
-                        oneLhs =
-                            newRangeExpression(
-                                handle(des.rangeFloor),
-                                handle(des.rangeCeiling),
-                                rawNode = des
-                            )
-                        oneLhs.operatorCode = "..."
-                    }
-                    else -> {
-                        Util.errorWithFileLocation(
-                            frontend,
-                            ctx,
-                            log,
-                            "Unknown designated lhs {}",
-                            des.javaClass.toGenericString()
-                        )
-                    }
-                }
-                if (oneLhs != null) {
-                    lhs.add(oneLhs)
-                }
-            }
->>>>>>> dc8011663 (Trying to type-safe rawNode)
         }
 
         // We need to start with our target (which we need to find in a hacky way) as
@@ -659,43 +623,7 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
         val des = ctx.designators.firstOrNull()
         if (des == null) {
             Util.errorWithFileLocation(frontend, ctx, log, "no designator found")
-<<<<<<< HEAD
             return newProblemExpression("no designator found")
-=======
-        } else {
-            for (des in ctx.designators) {
-                var oneLhs: Expression? = null
-                when (des) {
-                    is CPPASTArrayDesignator -> {
-                        oneLhs = handle(des.subscriptExpression)
-                    }
-                    is CPPASTFieldDesignator -> {
-                        oneLhs = newReference(des.name.toString(), unknownType(), rawNode = des)
-                    }
-                    is CPPASTArrayRangeDesignator -> {
-                        oneLhs =
-                            newRangeExpression(
-                                handle(des.rangeFloor),
-                                handle(des.rangeCeiling),
-                                rawNode = des
-                            )
-                        oneLhs.operatorCode = "..."
-                    }
-                    else -> {
-                        Util.errorWithFileLocation(
-                            frontend,
-                            ctx,
-                            log,
-                            "Unknown designated lhs {}",
-                            des.javaClass.toGenericString()
-                        )
-                    }
-                }
-                if (oneLhs != null) {
-                    lhs.add(oneLhs)
-                }
-            }
->>>>>>> dc8011663 (Trying to type-safe rawNode)
         }
 
         // We need to start with our target (which we need to find in a hacky way) as

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/StatementHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/StatementHandler.kt
@@ -239,7 +239,8 @@ class StatementHandler(lang: CXXLanguageFrontend) :
         // Adds true expression node where default empty condition evaluates to true, remove here
         // and in java StatementAnalyzer
         if (statement.conditionDeclaration == null && statement.condition == null) {
-            val literal: Literal<*> = newLiteral(true, primitiveType("bool"), "true")
+            val literal: Literal<*> =
+                newLiteral(true, primitiveType("bool")).implicit(code = "true")
             statement.condition = literal
         }
 

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/StatementHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/StatementHandler.kt
@@ -92,7 +92,7 @@ class StatementHandler(lang: CXXLanguageFrontend) :
     }
 
     private fun handleTryBlockStatement(tryBlockStatement: CPPASTTryBlockStatement): TryStatement {
-        val tryStatement = newTryStatement(tryBlockStatement.toString())
+        val tryStatement = newTryStatement()
         frontend.scopeManager.enterScope(tryStatement)
         val statement = handle(tryBlockStatement.tryBody) as Block?
         val catchClauses =
@@ -260,7 +260,7 @@ class StatementHandler(lang: CXXLanguageFrontend) :
         val statement = newForEachStatement(rawNode = ctx)
         frontend.scopeManager.enterScope(statement)
         val decl = frontend.declarationHandler.handle(ctx.declaration)
-        val `var` = newDeclarationStatement(decl?.code)
+        val `var` = newDeclarationStatement()
         `var`.singleDeclaration = decl
         val iterable: Statement? = frontend.expressionHandler.handle(ctx.initializerClause)
         statement.variable = `var`

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CXXExtraPass.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CXXExtraPass.kt
@@ -30,6 +30,7 @@ import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
+import de.fraunhofer.aisec.cpg.graph.implicit
 import de.fraunhofer.aisec.cpg.graph.newConstructExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.ConstructExpression
@@ -64,9 +65,10 @@ class CXXExtraPass(ctx: TranslationContext) : ComponentPass(ctx) {
             if (record != null) {
                 val currInitializer = node.initializer
                 if (currInitializer == null && node.isImplicitInitializerAllowed) {
-                    val initializer = node.newConstructExpression(typeString, "$typeString()")
+                    val initializer =
+                        newConstructExpression(typeString).implicit(code = "$typeString()")
+                    initializer.language = node.language
                     initializer.type = node.type
-                    initializer.isImplicit = true
                     node.initializer = initializer
                     node.templateParameters?.let {
                         SymbolResolver.addImplicitTemplateParametersToCall(it, initializer)
@@ -80,10 +82,11 @@ class CXXExtraPass(ctx: TranslationContext) : ComponentPass(ctx) {
                     val arguments = currInitializer.arguments
                     val signature = arguments.map(Node::code).joinToString(", ")
                     val initializer =
-                        node.newConstructExpression(typeString, "$typeString($signature)")
+                        newConstructExpression(typeString)
+                            .implicit(code = "$typeString($signature)")
+                    initializer.language = node.language
                     initializer.type = node.type
                     initializer.arguments = mutableListOf(*arguments.toTypedArray())
-                    initializer.isImplicit = true
                     node.initializer = initializer
                     currInitializer.disconnectFromGraph()
                 }

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/DeclarationHandler.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/DeclarationHandler.kt
@@ -100,7 +100,7 @@ class DeclarationHandler(frontend: GoLanguageFrontend) :
                     localNameOnly = true
                 }
 
-                newFunctionDeclaration(funcDecl.name.name, null, funcDecl, localNameOnly)
+                newFunctionDeclaration(funcDecl.name.name, localNameOnly, rawNode = funcDecl)
             }
 
         frontend.scopeManager.enterScope(func)

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/DeclarationHandler.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/DeclarationHandler.kt
@@ -65,10 +65,10 @@ class DeclarationHandler(frontend: GoLanguageFrontend) :
                 if (recvField?.names?.isNotEmpty() == true) {
                     method.receiver =
                         newVariableDeclaration(
-                            recvField.names[0].name,
-                            recordType,
-                            rawNode = recvField
-                        )
+                                recvField.names[0].name,
+                                recordType,
+                            )
+                            .locationAndCodeFrom(frontend, recvField)
                 }
 
                 if (recordType !is UnknownType) {
@@ -122,10 +122,10 @@ class DeclarationHandler(frontend: GoLanguageFrontend) :
                 if (returnVar.names.isNotEmpty()) {
                     val param =
                         newVariableDeclaration(
-                            returnVar.names[0].name,
-                            frontend.typeOf(returnVar.type),
-                            rawNode = returnVar
-                        )
+                                returnVar.names[0].name,
+                                frontend.typeOf(returnVar.type),
+                            )
+                            .locationAndCodeFrom(frontend, returnVar)
 
                     // Add parameter to scope
                     frontend.scopeManager.addDeclaration(param)
@@ -202,7 +202,9 @@ class DeclarationHandler(frontend: GoLanguageFrontend) :
                 // (and make it an array afterwards)
                 val (type, variadic) = frontend.fieldTypeOf(param.type)
 
-                val p = newParameterDeclaration(name, type, variadic, rawNode = param)
+                val p =
+                    newParameterDeclaration(name, type, variadic)
+                        .locationAndCodeFrom(frontend, param)
 
                 frontend.scopeManager.addDeclaration(p)
                 frontend.setComment(p, param)

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/DeclarationHandler.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/DeclarationHandler.kt
@@ -68,7 +68,7 @@ class DeclarationHandler(frontend: GoLanguageFrontend) :
                                 recvField.names[0].name,
                                 recordType,
                             )
-                            .locationAndCodeFrom(frontend, recvField)
+                            .codeAndLocationFrom(frontend, recvField)
                 }
 
                 if (recordType !is UnknownType) {
@@ -125,7 +125,7 @@ class DeclarationHandler(frontend: GoLanguageFrontend) :
                                 returnVar.names[0].name,
                                 frontend.typeOf(returnVar.type),
                             )
-                            .locationAndCodeFrom(frontend, returnVar)
+                            .codeAndLocationFrom(frontend, returnVar)
 
                     // Add parameter to scope
                     frontend.scopeManager.addDeclaration(param)
@@ -204,7 +204,7 @@ class DeclarationHandler(frontend: GoLanguageFrontend) :
 
                 val p =
                     newParameterDeclaration(name, type, variadic)
-                        .locationAndCodeFrom(frontend, param)
+                        .codeAndLocationFrom(frontend, param)
 
                 frontend.scopeManager.addDeclaration(p)
                 frontend.setComment(p, param)

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/SpecificationHandler.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/SpecificationHandler.kt
@@ -55,9 +55,9 @@ class SpecificationHandler(frontend: GoLanguageFrontend) :
         val include = newIncludeDeclaration(filename, rawNode = importSpec)
         include.name = parseName(name)
 
-        var alias = importSpec.name?.name
+        val alias = importSpec.name?.name
         if (alias != null && alias != name) {
-            var location = frontend.locationOf(importSpec)
+            val location = frontend.locationOf(importSpec)
 
             // If the name differs from the import name, we have an alias
             // Add an alias for the package on the current file
@@ -125,7 +125,8 @@ class SpecificationHandler(frontend: GoLanguageFrontend) :
                         Pair(field.names[0].name, listOf())
                     }
 
-                val decl = newFieldDeclaration(fieldName, type, modifiers, rawNode = field)
+                val decl = newFieldDeclaration(fieldName, type, modifiers)
+                frontend.setCodeAndLocation(decl, field)
                 frontend.scopeManager.addDeclaration(decl)
             }
         }
@@ -155,7 +156,8 @@ class SpecificationHandler(frontend: GoLanguageFrontend) :
                 // "method" actually has a name, we declare a new method
                 // declaration.
                 if (field.names.isNotEmpty()) {
-                    val method = newMethodDeclaration(field.names[0].name, rawNode = field)
+                    val method = newMethodDeclaration(field.names[0].name)
+                    frontend.setCodeAndLocation(method, field)
                     method.type = type
 
                     frontend.scopeManager.enterScope(method)

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/StatementHandler.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/StatementHandler.kt
@@ -327,7 +327,7 @@ class StatementHandler(frontend: GoLanguageFrontend) :
             rangeStmt.key?.let {
                 val ref = frontend.expressionHandler.handle(it)
                 if (ref is Reference) {
-                    val key = newVariableDeclaration(ref.name).locationAndCodeFrom(frontend, it)
+                    val key = newVariableDeclaration(ref.name).codeAndLocationFrom(frontend, it)
                     frontend.scopeManager.addDeclaration(key)
                     stmt.addToPropertyEdgeDeclaration(key)
                 }
@@ -337,7 +337,7 @@ class StatementHandler(frontend: GoLanguageFrontend) :
             rangeStmt.value?.let {
                 val ref = frontend.expressionHandler.handle(it)
                 if (ref is Reference) {
-                    val key = newVariableDeclaration(ref.name).locationAndCodeFrom(frontend, it)
+                    val key = newVariableDeclaration(ref.name).codeAndLocationFrom(frontend, it)
                     frontend.scopeManager.addDeclaration(key)
                     stmt.addToPropertyEdgeDeclaration(key)
                 }

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/StatementHandler.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/StatementHandler.kt
@@ -35,28 +35,28 @@ import de.fraunhofer.aisec.cpg.graph.types.Type
 class StatementHandler(frontend: GoLanguageFrontend) :
     GoHandler<Statement, GoStandardLibrary.Ast.Stmt>(::ProblemExpression, frontend) {
 
-    override fun handleNode(stmt: GoStandardLibrary.Ast.Stmt): Statement {
-        return when (stmt) {
-            is GoStandardLibrary.Ast.AssignStmt -> handleAssignStmt(stmt)
-            is GoStandardLibrary.Ast.BranchStmt -> handleBranchStmt(stmt)
-            is GoStandardLibrary.Ast.BlockStmt -> handleBlockStmt(stmt)
-            is GoStandardLibrary.Ast.CaseClause -> handleCaseClause(stmt)
-            is GoStandardLibrary.Ast.DeclStmt -> handleDeclStmt(stmt)
-            is GoStandardLibrary.Ast.DeferStmt -> handleDeferStmt(stmt)
+    override fun handleNode(node: GoStandardLibrary.Ast.Stmt): Statement {
+        return when (node) {
+            is GoStandardLibrary.Ast.AssignStmt -> handleAssignStmt(node)
+            is GoStandardLibrary.Ast.BranchStmt -> handleBranchStmt(node)
+            is GoStandardLibrary.Ast.BlockStmt -> handleBlockStmt(node)
+            is GoStandardLibrary.Ast.CaseClause -> handleCaseClause(node)
+            is GoStandardLibrary.Ast.DeclStmt -> handleDeclStmt(node)
+            is GoStandardLibrary.Ast.DeferStmt -> handleDeferStmt(node)
             is GoStandardLibrary.Ast.ExprStmt -> {
-                return frontend.expressionHandler.handle(stmt.x)
+                return frontend.expressionHandler.handle(node.x)
             }
-            is GoStandardLibrary.Ast.ForStmt -> handleForStmt(stmt)
-            is GoStandardLibrary.Ast.GoStmt -> handleGoStmt(stmt)
-            is GoStandardLibrary.Ast.IncDecStmt -> handleIncDecStmt(stmt)
-            is GoStandardLibrary.Ast.IfStmt -> handleIfStmt(stmt)
-            is GoStandardLibrary.Ast.LabeledStmt -> handleLabeledStmt(stmt)
-            is GoStandardLibrary.Ast.RangeStmt -> handleRangeStmt(stmt)
-            is GoStandardLibrary.Ast.ReturnStmt -> handleReturnStmt(stmt)
-            is GoStandardLibrary.Ast.SendStmt -> handleSendStmt(stmt)
-            is GoStandardLibrary.Ast.SwitchStmt -> handleSwitchStmt(stmt)
-            is GoStandardLibrary.Ast.TypeSwitchStmt -> handleTypeSwitchStmt(stmt)
-            else -> handleNotSupported(stmt, stmt.goType)
+            is GoStandardLibrary.Ast.ForStmt -> handleForStmt(node)
+            is GoStandardLibrary.Ast.GoStmt -> handleGoStmt(node)
+            is GoStandardLibrary.Ast.IncDecStmt -> handleIncDecStmt(node)
+            is GoStandardLibrary.Ast.IfStmt -> handleIfStmt(node)
+            is GoStandardLibrary.Ast.LabeledStmt -> handleLabeledStmt(node)
+            is GoStandardLibrary.Ast.RangeStmt -> handleRangeStmt(node)
+            is GoStandardLibrary.Ast.ReturnStmt -> handleReturnStmt(node)
+            is GoStandardLibrary.Ast.SendStmt -> handleSendStmt(node)
+            is GoStandardLibrary.Ast.SwitchStmt -> handleSwitchStmt(node)
+            is GoStandardLibrary.Ast.TypeSwitchStmt -> handleTypeSwitchStmt(node)
+            else -> handleNotSupported(node, node.goType)
         }
     }
 
@@ -324,19 +324,23 @@ class StatementHandler(frontend: GoLanguageFrontend) :
 
             // TODO: not really the best way to deal with this
             // TODO: key type is always int. we could set this
-            var ref = rangeStmt.key?.let { frontend.expressionHandler.handle(it) }
-            if (ref is Reference) {
-                val key = newVariableDeclaration(ref.name, rawNode = rangeStmt.key)
-                frontend.scopeManager.addDeclaration(key)
-                stmt.addToPropertyEdgeDeclaration(key)
+            rangeStmt.key?.let {
+                val ref = frontend.expressionHandler.handle(it)
+                if (ref is Reference) {
+                    val key = newVariableDeclaration(ref.name).locationAndCodeFrom(frontend, it)
+                    frontend.scopeManager.addDeclaration(key)
+                    stmt.addToPropertyEdgeDeclaration(key)
+                }
             }
 
             // TODO: not really the best way to deal with this
-            ref = rangeStmt.value?.let { frontend.expressionHandler.handle(it) }
-            if (ref is Reference) {
-                val key = newVariableDeclaration(ref.name, rawNode = rangeStmt.key)
-                frontend.scopeManager.addDeclaration(key)
-                stmt.addToPropertyEdgeDeclaration(key)
+            rangeStmt.value?.let {
+                val ref = frontend.expressionHandler.handle(it)
+                if (ref is Reference) {
+                    val key = newVariableDeclaration(ref.name).locationAndCodeFrom(frontend, it)
+                    frontend.scopeManager.addDeclaration(key)
+                    stmt.addToPropertyEdgeDeclaration(key)
+                }
             }
 
             forEach.variable = stmt

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
@@ -440,7 +440,9 @@ class GoExtraPass(ctx: TranslationContext) : ComponentPass(ctx) {
         call: CallExpression,
         pointer: Boolean,
     ) {
-        val cast = parent.newCastExpression(call.code)
+        val cast = newCastExpression()
+        cast.code = call.code
+        cast.language = call.language
         cast.location = call.location
         cast.castType =
             if (pointer) {

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
@@ -346,6 +346,7 @@ class GoExtraPass(ctx: TranslationContext) : ComponentPass(ctx) {
                 if (ref == null) {
                     // We need to implicitly declare it, if it's not declared before.
                     val decl = newVariableDeclaration(expr.name, expr.autoType())
+                    decl.language = expr.language
                     decl.location = expr.location
                     decl.isImplicit = true
 

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
@@ -135,7 +135,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
      */
     private fun handleArrayCreationExpr(expr: Expression): Statement {
         val arrayCreationExpr = expr as ArrayCreationExpr
-        val creationExpression = this.newNewArrayExpression(expr.toString())
+        val creationExpression = this.newNewArrayExpression(rawNode = expr)
 
         // in Java, an array creation expression either specifies an initializer or dimensions
 
@@ -464,39 +464,39 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
                 newLiteral(
                     literalExpr.asIntegerLiteralExpr().asNumber(),
                     this.primitiveType("int"),
-                    value
+                    rawNode = expr
                 )
             is StringLiteralExpr ->
                 newLiteral(
                     literalExpr.asStringLiteralExpr().asString(),
                     this.primitiveType("java.lang.String"),
-                    value
+                    rawNode = expr
                 )
             is BooleanLiteralExpr ->
                 newLiteral(
                     literalExpr.asBooleanLiteralExpr().value,
                     this.primitiveType("boolean"),
-                    value
+                    rawNode = expr
                 )
             is CharLiteralExpr ->
                 newLiteral(
                     literalExpr.asCharLiteralExpr().asChar(),
                     this.primitiveType("char"),
-                    value
+                    rawNode = expr
                 )
             is DoubleLiteralExpr ->
                 newLiteral(
                     literalExpr.asDoubleLiteralExpr().asDouble(),
                     this.primitiveType("double"),
-                    value
+                    rawNode = expr
                 )
             is LongLiteralExpr ->
                 newLiteral(
                     literalExpr.asLongLiteralExpr().asNumber(),
                     this.primitiveType("long"),
-                    value
+                    rawNode = expr
                 )
-            is NullLiteralExpr -> newLiteral<Any?>(null, this.objectType("null"), value)
+            is NullLiteralExpr -> newLiteral<Any?>(null, this.objectType("null"), rawNode = expr)
             else -> null
         }
     }

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
@@ -75,17 +75,13 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
 
     private fun handleLambdaExpr(expr: Expression): Statement {
         val lambdaExpr = expr.asLambdaExpr()
-        val lambda = newLambdaExpression(frontend.codeOf(lambdaExpr))
+        val lambda = newLambdaExpression(rawNode = lambdaExpr)
         val anonymousFunction = newFunctionDeclaration("", rawNode = lambdaExpr)
         frontend.scopeManager.enterScope(anonymousFunction)
         for (parameter in lambdaExpr.parameters) {
             val resolvedType = frontend.getTypeAsGoodAsPossible(parameter.type)
             val param =
-                this.newParameterDeclaration(
-                    parameter.nameAsString,
-                    resolvedType,
-                    parameter.isVarArgs
-                )
+                newParameterDeclaration(parameter.nameAsString, resolvedType, parameter.isVarArgs)
             anonymousFunction.addParameter(param)
             frontend.setCodeAndLocation(param, parameter)
             frontend.processAnnotations(param, parameter)
@@ -106,7 +102,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
 
     private fun handleCastExpr(expr: Expression): Statement {
         val castExpr = expr.asCastExpr()
-        val castExpression = this.newCastExpression(expr.toString())
+        val castExpression = newCastExpression(rawNode = expr)
         val expression =
             handle(castExpr.expression)
                 as? de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
@@ -135,7 +131,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
      */
     private fun handleArrayCreationExpr(expr: Expression): Statement {
         val arrayCreationExpr = expr as ArrayCreationExpr
-        val creationExpression = this.newNewArrayExpression(rawNode = expr)
+        val creationExpression = newNewArrayExpression(rawNode = expr)
 
         // in Java, an array creation expression either specifies an initializer or dimensions
 
@@ -167,7 +163,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
 
         // ArrayInitializerExpressions are converted into InitializerListExpressions to reduce the
         // syntactic distance a CPP and JAVA CPG
-        val initList = this.newInitializerListExpression(arrayType, expr.toString())
+        val initList = newInitializerListExpression(arrayType, rawNode = expr)
         val initializers =
             arrayInitializerExpr.values
                 .map { handle(it) }
@@ -182,7 +178,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
 
     private fun handleArrayAccessExpr(expr: Expression): SubscriptExpression {
         val arrayAccessExpr = expr as ArrayAccessExpr
-        val arraySubsExpression = this.newSubscriptExpression(expr.toString())
+        val arraySubsExpression = newSubscriptExpression(rawNode = expr)
         (handle(arrayAccessExpr.name)
                 as de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression?)
             ?.let { arraySubsExpression.arrayExpression = it }
@@ -228,7 +224,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
         val elseExpr =
             handle(conditionalExpr.elseExpr)
                 as de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression?
-        return this.newConditionalExpression(condition, thenExpr, elseExpr, superType)
+        return newConditionalExpression(condition, thenExpr, elseExpr, superType)
     }
 
     private fun handleAssignmentExpression(expr: Expression): AssignExpression {
@@ -246,7 +242,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
                 as? de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
                 ?: newProblemExpression("could not parse lhs")
         val assign =
-            this.newAssignExpression(
+            newAssignExpression(
                 assignExpr.operator.asString(),
                 listOf(lhs),
                 listOf(rhs),
@@ -259,30 +255,9 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
     // Not sure how to handle this exactly yet
     private fun handleVariableDeclarationExpr(expr: Expression): DeclarationStatement {
         val variableDeclarationExpr = expr.asVariableDeclarationExpr()
-        val declarationStatement = this.newDeclarationStatement(variableDeclarationExpr.toString())
+        val declarationStatement = newDeclarationStatement(variableDeclarationExpr.toString())
         for (variable in variableDeclarationExpr.variables) {
-            val resolved = variable.resolve()
-            val declarationType = frontend.getTypeAsGoodAsPossible(variable, resolved)
-            val declaration =
-                this.newVariableDeclaration(
-                    resolved.name,
-                    declarationType,
-                    false,
-                    rawNode = variable
-                )
-            if (declarationType is PointerType && declarationType.isArray) {
-                declaration.isArray = true
-            }
-            val oInitializer = variable.initializer
-            if (oInitializer.isPresent) {
-                val initializer =
-                    handle(oInitializer.get())
-                        as de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression?
-                if (initializer is NewArrayExpression) {
-                    declaration.isArray = true
-                }
-                declaration.initializer = initializer
-            }
+            val declaration = frontend.declarationHandler.handleVariableDeclarator(variable)
             frontend.setCodeAndLocation(declaration, variable)
             declarationStatement.addToPropertyEdgeDeclaration(declaration)
             frontend.processAnnotations(declaration, variableDeclarationExpr)
@@ -357,7 +332,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
                         }
                 }
             }
-            base = this.newReference(scope.asNameExpr().nameAsString, baseType, scope.toString())
+            base = newReference(scope.asNameExpr().nameAsString, baseType, rawNode = scope)
             base.isStaticAccess = isStaticAccess
             frontend.setCodeAndLocation(base, fieldAccessExpr.scope)
         } else if (scope.isFieldAccessExpr) {
@@ -390,11 +365,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
                         unknownType()
                     }
                 base =
-                    this.newReference(
-                        scope.asFieldAccessExpr().nameAsString,
-                        baseType,
-                        scope.toString()
-                    )
+                    newReference(scope.asFieldAccessExpr().nameAsString, baseType, rawNode = scope)
                 base.isStaticAccess = true
             }
             frontend.setCodeAndLocation(base, fieldAccessExpr.scope)
@@ -426,7 +397,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
                     unknownType()
                 }
             val memberExpression =
-                this.newMemberExpression(
+                newMemberExpression(
                     fieldAccessExpr.name.identifier,
                     base,
                     fieldType,
@@ -446,14 +417,14 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
                     unknownType()
                 }
             val memberExpression =
-                this.newMemberExpression(fieldAccessExpr.name.identifier, base, fieldType, ".")
+                newMemberExpression(fieldAccessExpr.name.identifier, base, fieldType, ".")
             memberExpression.isStaticAccess = true
             return memberExpression
         }
         if (base.location == null) {
             base.location = frontend.locationOf(fieldAccessExpr)
         }
-        return this.newMemberExpression(fieldAccessExpr.name.identifier, base, fieldType, ".")
+        return newMemberExpression(fieldAccessExpr.name.identifier, base, fieldType, ".")
     }
 
     private fun handleLiteralExpression(expr: Expression): Literal<*>? {
@@ -496,7 +467,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
                     this.primitiveType("long"),
                     rawNode = expr
                 )
-            is NullLiteralExpr -> newLiteral<Any?>(null, this.objectType("null"), rawNode = expr)
+            is NullLiteralExpr -> newLiteral(null, this.objectType("null"), rawNode = expr)
             else -> null
         }
     }
@@ -505,10 +476,10 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
         val classExpr = expr.asClassExpr()
         val type = frontend.typeOf(classExpr.type)
         val thisExpression =
-            this.newReference(
+            newReference(
                 classExpr.toString().substring(classExpr.toString().lastIndexOf('.') + 1),
                 type,
-                classExpr.toString()
+                rawNode = expr
             )
         thisExpression.isStaticAccess = true
         frontend.setCodeAndLocation(thisExpression, classExpr)
@@ -530,7 +501,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
         if (typeName.isPresent) {
             name = "this$" + typeName.get().identifier
         }
-        val thisExpression = this.newReference(name, type, thisExpr.toString())
+        val thisExpression = newReference(name, type, rawNode = expr)
         frontend.setCodeAndLocation(thisExpression, thisExpr)
         return thisExpression
     }
@@ -539,7 +510,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
         // The actual type is hard to determine at this point, as we may not have full information
         // about the inheritance structure. Thus, we delay the resolving to the variable resolving
         // process
-        val superExpression = this.newReference(expr.toString(), unknownType(), expr.toString())
+        val superExpression = newReference(expr.toString(), unknownType(), rawNode = expr)
         frontend.setCodeAndLocation(superExpression, expr)
         return superExpression
     }
@@ -620,7 +591,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
                 if (type == null) {
                     type = frontend.typeOf(symbol.type)
                 }
-                this.newReference(symbol.name, type, nameExpr.toString())
+                newReference(symbol.name, type, rawNode = nameExpr)
             }
         } catch (ex: UnsolvedSymbolException) {
             val typeString: String? =
@@ -640,7 +611,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
                 t = this.objectType(typeString)
                 t.typeOrigin = Type.Origin.GUESSED
             }
-            val declaredReferenceExpression = this.newReference(name, t, nameExpr.toString())
+            val declaredReferenceExpression = newReference(name, t, rawNode = nameExpr)
             val recordDeclaration = frontend.scopeManager.currentRecord
             if (recordDeclaration != null && recordDeclaration.name.lastPartsMatch(name)) {
                 declaredReferenceExpression.refersTo = recordDeclaration
@@ -649,11 +620,11 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
         } catch (ex: RuntimeException) {
             val t = unknownType()
             log.info("Unresolved symbol: {}", nameExpr.nameAsString)
-            this.newReference(nameExpr.nameAsString, t, nameExpr.toString())
+            newReference(nameExpr.nameAsString, t, rawNode = nameExpr)
         } catch (ex: NoClassDefFoundError) {
             val t = unknownType()
             log.info("Unresolved symbol: {}", nameExpr.nameAsString)
-            this.newReference(nameExpr.nameAsString, t, nameExpr.toString())
+            newReference(nameExpr.nameAsString, t, rawNode = nameExpr)
         }
     }
 
@@ -670,12 +641,12 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
 
         // second, handle the value. this is the second argument of the operator call
         val rhs: de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression =
-            this.newLiteral(
+            newLiteral(
                 typeAsGoodAsPossible.typeName,
                 this.objectType("class"),
-                binaryExpr.typeAsString
+                rawNode = binaryExpr
             )
-        val binaryOperator = this.newBinaryOperator("instanceof", binaryExpr.toString())
+        val binaryOperator = newBinaryOperator("instanceof", rawNode = binaryExpr)
         binaryOperator.lhs = lhs
         binaryOperator.rhs = rhs
         return binaryOperator
@@ -690,11 +661,11 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
                 as? de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
                 ?: newProblemExpression("could not parse input")
         val unaryOperator =
-            this.newUnaryOperator(
+            newUnaryOperator(
                 unaryExpr.operator.asString(),
                 unaryExpr.isPostfix,
                 unaryExpr.isPrefix,
-                unaryExpr.toString()
+                rawNode = unaryExpr
             )
         unaryOperator.input = expression
         return unaryOperator
@@ -714,8 +685,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
             handle(binaryExpr.right)
                 as? de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
                 ?: newProblemExpression("could not parse rhs")
-        val binaryOperator =
-            this.newBinaryOperator(binaryExpr.operator.asString(), binaryExpr.toString())
+        val binaryOperator = newBinaryOperator(binaryExpr.operator.asString(), rawNode = binaryExpr)
         binaryOperator.lhs = lhs
         binaryOperator.rhs = rhs
         return binaryOperator
@@ -783,7 +753,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
                         this.parseName(qualifiedName).parent
                     }
                 baseType = this.objectType(baseName ?: Type.UNKNOWN_TYPE_STRING)
-                base = this.newReference(baseName, baseType)
+                base = newReference(baseName, baseType)
             } else {
                 // Since it is possible to omit the "this" keyword, some methods in java do not have
                 // a base.
@@ -793,12 +763,12 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
                 base = createImplicitThis()
             }
         }
-        val member = this.newMemberExpression(name, base, unknownType(), ".")
+        val member = newMemberExpression(name, base, unknownType(), ".")
         frontend.setCodeAndLocation(
             member,
             methodCallExpr.name
         ) // This will also overwrite the code set to the empty string set above
-        callExpression = this.newMemberCallExpression(member, isStatic, rawNode = expr)
+        callExpression = newMemberCallExpression(member, isStatic, rawNode = expr)
         callExpression.type = typeString?.let { this.objectType(it) } ?: unknownType()
         val arguments = methodCallExpr.arguments
 
@@ -826,8 +796,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
         val thisType =
             (frontend.scopeManager.currentFunction as MethodDeclaration?)?.receiver?.type
                 ?: unknownType()
-        base = this.newReference("this", thisType, "this")
-        base.isImplicit = true
+        base = newReference("this", thisType).implicit("this")
         return base
     }
 
@@ -846,10 +815,10 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
 
         // To be consistent with other languages, we need to create a NewExpression (for the "new X"
         // part) as well as a ConstructExpression (for the constructor call)
-        val newExpression = this.newNewExpression(t, rawNode = expr)
+        val newExpression = newNewExpression(t, rawNode = expr)
         val arguments = objectCreationExpr.arguments
 
-        val ctor = this.newConstructExpression()
+        val ctor = newConstructExpression()
         ctor.type = t
         frontend.setCodeAndLocation(ctor, expr)
 
@@ -888,11 +857,11 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
 
             if (anonymousRecord.constructors.isEmpty()) {
                 val constructorDeclaration =
-                    this.newConstructorDeclaration(
-                        anonymousRecord.name.localName,
-                        anonymousRecord,
-                        rawNode = implicit(anonymousRecord.name.localName)
-                    )
+                    newConstructorDeclaration(
+                            anonymousRecord.name.localName,
+                            anonymousRecord,
+                        )
+                        .implicit(anonymousRecord.name.localName)
 
                 ctor.arguments.forEachIndexed { i, arg ->
                     constructorDeclaration.addParameter(

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
@@ -76,7 +76,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
     private fun handleLambdaExpr(expr: Expression): Statement {
         val lambdaExpr = expr.asLambdaExpr()
         val lambda = newLambdaExpression(frontend.codeOf(lambdaExpr))
-        val anonymousFunction = newFunctionDeclaration("", frontend.codeOf(lambdaExpr))
+        val anonymousFunction = newFunctionDeclaration("", rawNode = lambdaExpr)
         frontend.scopeManager.enterScope(anonymousFunction)
         for (parameter in lambdaExpr.parameters) {
             val resolvedType = frontend.getTypeAsGoodAsPossible(parameter.type)
@@ -267,9 +267,8 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
                 this.newVariableDeclaration(
                     resolved.name,
                     declarationType,
-                    variable.toString(),
                     false,
-                    variable
+                    rawNode = variable
                 )
             if (declarationType is PointerType && declarationType.isArray) {
                 declaration.isArray = true
@@ -799,8 +798,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
             member,
             methodCallExpr.name
         ) // This will also overwrite the code set to the empty string set above
-        callExpression =
-            this.newMemberCallExpression(member, isStatic, methodCallExpr.toString(), expr)
+        callExpression = this.newMemberCallExpression(member, isStatic, rawNode = expr)
         callExpression.type = typeString?.let { this.objectType(it) } ?: unknownType()
         val arguments = methodCallExpr.arguments
 
@@ -848,7 +846,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
 
         // To be consistent with other languages, we need to create a NewExpression (for the "new X"
         // part) as well as a ConstructExpression (for the constructor call)
-        val newExpression = this.newNewExpression(expr.toString(), t)
+        val newExpression = this.newNewExpression(t, rawNode = expr)
         val arguments = objectCreationExpr.arguments
 
         val ctor = this.newConstructExpression()
@@ -892,8 +890,8 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
                 val constructorDeclaration =
                     this.newConstructorDeclaration(
                         anonymousRecord.name.localName,
-                        anonymousRecord.name.localName,
-                        anonymousRecord
+                        anonymousRecord,
+                        rawNode = implicit(anonymousRecord.name.localName)
                     )
 
                 ctor.arguments.forEachIndexed { i, arg ->

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
@@ -255,7 +255,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
     // Not sure how to handle this exactly yet
     private fun handleVariableDeclarationExpr(expr: Expression): DeclarationStatement {
         val variableDeclarationExpr = expr.asVariableDeclarationExpr()
-        val declarationStatement = newDeclarationStatement(variableDeclarationExpr.toString())
+        val declarationStatement = newDeclarationStatement()
         for (variable in variableDeclarationExpr.variables) {
             val declaration = frontend.declarationHandler.handleVariableDeclarator(variable)
             frontend.setCodeAndLocation(declaration, variable)

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
@@ -446,7 +446,7 @@ open class JavaLanguageFrontend(language: Language<JavaLanguageFrontend>, ctx: T
     private fun handleAnnotations(owner: NodeWithAnnotations<*>): List<Annotation> {
         val list = ArrayList<Annotation>()
         for (expr in owner.annotations) {
-            val annotation = newAnnotation(expr.nameAsString)
+            val annotation = newAnnotation(expr.nameAsString, rawNode = expr)
             val members = ArrayList<AnnotationMember>()
 
             // annotations can be specified as member / value pairs
@@ -455,7 +455,8 @@ open class JavaLanguageFrontend(language: Language<JavaLanguageFrontend>, ctx: T
                     val member =
                         newAnnotationMember(
                             pair.nameAsString,
-                            expressionHandler.handle(pair.value) as Expression
+                            expressionHandler.handle(pair.value) as Expression,
+                            rawNode = pair.value
                         )
                     members.add(member)
                 }
@@ -466,7 +467,8 @@ open class JavaLanguageFrontend(language: Language<JavaLanguageFrontend>, ctx: T
                     val member =
                         newAnnotationMember(
                             ANNOTATION_MEMBER_VALUE,
-                            expressionHandler.handle(value.asLiteralExpr()) as Expression
+                            expressionHandler.handle(value.asLiteralExpr()) as Expression,
+                            rawNode = value
                         )
                     members.add(member)
                 }

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
@@ -114,14 +114,14 @@ open class JavaLanguageFrontend(language: Language<JavaLanguageFrontend>, ctx: T
             context?.setData(Node.SYMBOL_RESOLVER_KEY, javaSymbolResolver)
 
             // starting point is always a translation declaration
-            val fileDeclaration = newTranslationUnitDeclaration(file.toString(), context.toString())
+            val fileDeclaration = newTranslationUnitDeclaration(file.toString(), rawNode = context)
             currentTU = fileDeclaration
             scopeManager.resetToGlobal(fileDeclaration)
             val packDecl = context?.packageDeclaration?.orElse(null)
             var namespaceDeclaration: NamespaceDeclaration? = null
             if (packDecl != null) {
                 namespaceDeclaration =
-                    newNamespaceDeclaration(packDecl.name.asString(), codeOf(packDecl))
+                    newNamespaceDeclaration(packDecl.name.asString(), rawNode = packDecl)
                 setCodeAndLocation(namespaceDeclaration, packDecl)
                 scopeManager.addDeclaration(namespaceDeclaration)
                 scopeManager.enterScope(namespaceDeclaration)

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
@@ -446,7 +446,7 @@ open class JavaLanguageFrontend(language: Language<JavaLanguageFrontend>, ctx: T
     private fun handleAnnotations(owner: NodeWithAnnotations<*>): List<Annotation> {
         val list = ArrayList<Annotation>()
         for (expr in owner.annotations) {
-            val annotation = newAnnotation(expr.nameAsString, codeOf(expr))
+            val annotation = newAnnotation(expr.nameAsString)
             val members = ArrayList<AnnotationMember>()
 
             // annotations can be specified as member / value pairs
@@ -455,8 +455,7 @@ open class JavaLanguageFrontend(language: Language<JavaLanguageFrontend>, ctx: T
                     val member =
                         newAnnotationMember(
                             pair.nameAsString,
-                            expressionHandler.handle(pair.value) as Expression,
-                            codeOf(pair)
+                            expressionHandler.handle(pair.value) as Expression
                         )
                     members.add(member)
                 }
@@ -467,8 +466,7 @@ open class JavaLanguageFrontend(language: Language<JavaLanguageFrontend>, ctx: T
                     val member =
                         newAnnotationMember(
                             ANNOTATION_MEMBER_VALUE,
-                            expressionHandler.handle(value.asLiteralExpr()) as Expression,
-                            codeOf(value)
+                            expressionHandler.handle(value.asLiteralExpr()) as Expression
                         )
                     members.add(member)
                 }

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
@@ -83,12 +83,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
     ): de.fraunhofer.aisec.cpg.graph.statements.Statement {
         val throwStmt = stmt as ThrowStmt
         val throwOperation =
-            this.newUnaryOperator(
-                "throw",
-                postfix = false,
-                prefix = true,
-                code = throwStmt.toString()
-            )
+            this.newUnaryOperator("throw", postfix = false, prefix = true, rawNode = stmt)
         throwOperation.input =
             frontend.expressionHandler.handle(throwStmt.expression)
                 as de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
@@ -605,8 +600,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
             this.newVariableDeclaration(
                 catchCls.parameter.name.toString(),
                 concreteType,
-                catchCls.parameter.toString(),
-                false
+                rawNode = catchCls.parameter
             )
         parameter.addAssignedTypes(possibleTypes)
         val body = handleBlockStatement(catchCls.body)

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
@@ -102,7 +102,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
                 frontend.expressionHandler.handle(expr)
                     as? de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
         }
-        val returnStatement = this.newReturnStatement(returnStmt.toString())
+        val returnStatement = this.newReturnStatement()
         // JavaParser seems to add implicit return statements, that are not part of the original
         // source code. We mark it as such
         returnStatement.isImplicit = !returnStmt.tokenRange.isPresent
@@ -119,7 +119,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
         val conditionExpression = ifStmt.condition
         val thenStatement = ifStmt.thenStmt
         val optionalElseStatement = ifStmt.elseStmt
-        val ifStatement = this.newIfStatement(ifStmt.toString())
+        val ifStatement = this.newIfStatement()
         frontend.scopeManager.enterScope(ifStatement)
         ifStatement.thenStatement = handle(thenStatement)
         ifStatement.condition =
@@ -134,7 +134,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
         val assertStmt = stmt.asAssertStmt()
         val conditionExpression = assertStmt.check
         val thenStatement = assertStmt.message
-        val assertStatement = this.newAssertStatement(stmt.toString())
+        val assertStatement = this.newAssertStatement()
         assertStatement.condition =
             frontend.expressionHandler.handle(conditionExpression)
                 as de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
@@ -148,7 +148,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
         val whileStmt = stmt.asWhileStmt()
         val conditionExpression = whileStmt.condition
         val statement = whileStmt.body
-        val whileStatement = this.newWhileStatement(whileStmt.toString())
+        val whileStatement = this.newWhileStatement()
         frontend.scopeManager.enterScope(whileStatement)
         whileStatement.statement = handle(statement)
         whileStatement.condition =
@@ -159,7 +159,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
     }
 
     private fun handleForEachStatement(stmt: Statement): ForEachStatement {
-        val statement = this.newForEachStatement(stmt.toString())
+        val statement = this.newForEachStatement()
         frontend.scopeManager.enterScope(statement)
         val forEachStmt = stmt.asForEachStmt()
         val variable = frontend.expressionHandler.handle(forEachStmt.variable)
@@ -185,7 +185,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
             } else {
                 stmt.toString()
             }
-        val statement = this.newForStatement(code)
+        val statement = this.newForStatement()
         frontend.setCodeAndLocation(statement, stmt)
         frontend.scopeManager.enterScope(statement)
         if (forStmt.initialization.size > 1) {
@@ -291,7 +291,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
         val doStmt = stmt.asDoStmt()
         val conditionExpression = doStmt.condition
         val statement = doStmt.body
-        val doStatement = this.newDoStatement(doStmt.toString())
+        val doStatement = this.newDoStatement()
         frontend.scopeManager.enterScope(doStatement)
         doStatement.statement = handle(statement)
         doStatement.condition =
@@ -303,12 +303,12 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
 
     private fun handleEmptyStatement(stmt: Statement): EmptyStatement {
         val emptyStmt = stmt.asEmptyStmt()
-        return this.newEmptyStatement(emptyStmt.toString())
+        return this.newEmptyStatement()
     }
 
     private fun handleSynchronizedStatement(stmt: Statement): SynchronizedStatement {
         val synchronizedJava = stmt.asSynchronizedStmt()
-        val synchronizedCPG = this.newSynchronizedStatement(stmt.toString())
+        val synchronizedCPG = this.newSynchronizedStatement()
         synchronizedCPG.expression =
             frontend.expressionHandler.handle(synchronizedJava.expression)
                 as de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
@@ -320,7 +320,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
         val labelStmt = stmt.asLabeledStmt()
         val label = labelStmt.label.identifier
         val statement = labelStmt.statement
-        val labelStatement = this.newLabelStatement(labelStmt.toString())
+        val labelStatement = this.newLabelStatement()
         labelStatement.subStatement = handle(statement)
         labelStatement.label = label
         return labelStatement
@@ -383,7 +383,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
                     )
             }
             val defaultStatement =
-                this.newDefaultStatement(getCodeBetweenTokens(caseTokens.a, caseTokens.b))
+                this.newDefaultStatement()
             defaultStatement.location =
                 getLocationsFromTokens(parentLocation, caseTokens.a, caseTokens.b)
             return defaultStatement
@@ -397,7 +397,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
                     getNextTokenWith(":", caseExprTokenRange.get().end)
                 )
         }
-        val caseStatement = this.newCaseStatement(getCodeBetweenTokens(caseTokens.a, caseTokens.b))
+        val caseStatement = this.newCaseStatement()
         caseStatement.caseExpression =
             frontend.expressionHandler.handle(caseExpression)
                 as de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
@@ -471,7 +471,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
 
     fun handleSwitchStatement(stmt: Statement): SwitchStatement {
         val switchStmt = stmt.asSwitchStmt()
-        val switchStatement = this.newSwitchStatement(stmt.toString())
+        val switchStatement = this.newSwitchStatement()
 
         // make sure location is set
         frontend.setCodeAndLocation(switchStatement, switchStmt)
@@ -555,7 +555,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
 
     private fun handleTryStatement(stmt: Statement): TryStatement {
         val tryStmt = stmt.asTryStmt()
-        val tryStatement = this.newTryStatement(stmt.toString())
+        val tryStatement = this.newTryStatement()
         frontend.scopeManager.enterScope(tryStatement)
         val resources =
             tryStmt.resources.mapNotNull { ctx: Expression ->
@@ -589,7 +589,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
     private fun handleCatchClause(
         catchCls: CatchClause
     ): de.fraunhofer.aisec.cpg.graph.statements.CatchClause {
-        val cClause = this.newCatchClause(catchCls.toString())
+        val cClause = this.newCatchClause()
         frontend.scopeManager.enterScope(cClause)
         val possibleTypes = mutableSetOf<Type>()
         val concreteType: Type

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
@@ -236,10 +236,10 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
         }
 
         // Adds true expression node where default empty condition evaluates to true, remove here
-        // and in
-        // cpp StatementHandler
+        // and in cpp StatementHandler
         if (statement.condition == null) {
-            val literal: Literal<*> = this.newLiteral(true, this.primitiveType("boolean"), "true")
+            val literal: Literal<*> =
+                this.newLiteral(true, this.primitiveType("boolean")).implicit("true")
             statement.condition = literal
         }
         if (forStmt.update.size > 1) {
@@ -489,7 +489,8 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
             start = getNextTokenWith("{", tokenRangeSelector.get().end)
             end = getPreviousTokenWith("}", tokenRange.get().end)
         }
-        val compoundStatement = this.newBlock(getCodeBetweenTokens(start, end))
+        val compoundStatement = this.newBlock()
+        compoundStatement.code = getCodeBetweenTokens(start, end)
         compoundStatement.location = getLocationsFromTokens(switchStatement.location, start, end)
         for (sentry in switchStmt.entries) {
             if (sentry.labels.isEmpty()) {
@@ -520,6 +521,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
         } else {
             containingClass = currentRecord.name.toString()
         }
+<<<<<<< HEAD
 
         val name = containingClass
         val node = this.newConstructExpression(name, rawNode = null)
@@ -536,6 +538,13 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
                 node.callee = this.newReference(it.name)
             }
         }
+=======
+        val node =
+            this.newConstructorCallExpression(
+                containingClass,
+                rawNode = explicitConstructorInvocationStmt
+            )
+>>>>>>> dc8011663 (Trying to type-safe rawNode)
         val arguments =
             explicitConstructorInvocationStmt.arguments
                 .map(frontend.expressionHandler::handle)
@@ -598,10 +607,10 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
         }
         val parameter =
             this.newVariableDeclaration(
-                catchCls.parameter.name.toString(),
-                concreteType,
-                rawNode = catchCls.parameter
-            )
+                    catchCls.parameter.name.toString(),
+                    concreteType,
+                )
+                .locationAndCodeFrom(frontend, catchCls.parameter)
         parameter.addAssignedTypes(possibleTypes)
         val body = handleBlockStatement(catchCls.body)
         cClause.body = body

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
@@ -177,14 +177,6 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
 
     private fun handleForStatement(stmt: Statement): ForStatement {
         val forStmt = stmt.asForStmt()
-        val code: String
-        val tokenRange = forStmt.tokenRange
-        code =
-            if (tokenRange.isPresent) {
-                tokenRange.get().toString()
-            } else {
-                stmt.toString()
-            }
         val statement = this.newForStatement()
         frontend.setCodeAndLocation(statement, stmt)
         frontend.scopeManager.enterScope(statement)
@@ -302,7 +294,6 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
     }
 
     private fun handleEmptyStatement(stmt: Statement): EmptyStatement {
-        val emptyStmt = stmt.asEmptyStmt()
         return this.newEmptyStatement()
     }
 
@@ -382,8 +373,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
                         getNextTokenWith(":", optionalTokenRange.get().begin)
                     )
             }
-            val defaultStatement =
-                this.newDefaultStatement()
+            val defaultStatement = this.newDefaultStatement()
             defaultStatement.location =
                 getLocationsFromTokens(parentLocation, caseTokens.a, caseTokens.b)
             return defaultStatement
@@ -610,7 +600,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
                     catchCls.parameter.name.toString(),
                     concreteType,
                 )
-                .locationAndCodeFrom(frontend, catchCls.parameter)
+                .codeAndLocationFrom(frontend, catchCls.parameter)
         parameter.addAssignedTypes(possibleTypes)
         val body = handleBlockStatement(catchCls.body)
         cClause.body = body

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
@@ -511,7 +511,6 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
         } else {
             containingClass = currentRecord.name.toString()
         }
-<<<<<<< HEAD
 
         val name = containingClass
         val node = this.newConstructExpression(name, rawNode = null)
@@ -528,18 +527,13 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
                 node.callee = this.newReference(it.name)
             }
         }
-=======
-        val node =
-            this.newConstructorCallExpression(
-                containingClass,
-                rawNode = explicitConstructorInvocationStmt
-            )
->>>>>>> dc8011663 (Trying to type-safe rawNode)
+
         val arguments =
             explicitConstructorInvocationStmt.arguments
                 .map(frontend.expressionHandler::handle)
                 .filterIsInstance<de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression>()
         node.arguments = arguments
+
         return node
     }
 

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
@@ -346,7 +346,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
         val blockStmt = stmt.asBlockStmt()
 
         // first of, all we need a compound statement
-        val compoundStatement = this.newBlock(stmt.toString())
+        val compoundStatement = this.newBlock(rawNode = stmt)
         frontend.scopeManager.enterScope(compoundStatement)
         for (child in blockStmt.statements) {
             val statement = handle(child)

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/DeclarationHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/DeclarationHandler.kt
@@ -74,8 +74,7 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
         // the pointer type
         val type = frontend.typeOf(valueRef)
 
-        val variableDeclaration =
-            newVariableDeclaration(name, type, frontend.codeOf(valueRef), false)
+        val variableDeclaration = newVariableDeclaration(name, type, false, rawNode = valueRef)
 
         // cache binding
         frontend.bindingsCache[valueRef.symbolName] = variableDeclaration
@@ -98,7 +97,7 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
      */
     private fun handleFunction(func: LLVMValueRef): FunctionDeclaration {
         val name = LLVMGetValueName(func)
-        val functionDeclaration = newFunctionDeclaration(name.string, frontend.codeOf(func))
+        val functionDeclaration = newFunctionDeclaration(name.string, rawNode = func)
 
         // return types are a bit tricky, because the type of the function is a pointer to the
         // function type, which then has the return type in it
@@ -220,7 +219,7 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
             // there are no names, so we need to invent some dummy ones for easier reading
             val fieldName = "field_$i"
 
-            val field = newFieldDeclaration(fieldName, fieldType, listOf(), "", null, null, false)
+            val field = newFieldDeclaration(fieldName, fieldType, listOf(), null, false)
 
             frontend.scopeManager.addDeclaration(field)
         }

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/DeclarationHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/DeclarationHandler.kt
@@ -58,7 +58,7 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
                 newProblemDeclaration(
                     "Not handling declaration kind $kind yet.",
                     ProblemNode.ProblemType.TRANSLATION,
-                    frontend.codeOf(value)
+                    rawNode = value
                 )
             }
         }
@@ -118,7 +118,7 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
             val type = frontend.typeOf(param)
 
             // TODO: support variardic
-            val decl = newParameterDeclaration(paramName, type, false, frontend.codeOf(param))
+            val decl = newParameterDeclaration(paramName, type, false, rawNode = param)
 
             frontend.scopeManager.addDeclaration(decl)
             frontend.bindingsCache[paramSymbolName] = decl
@@ -206,7 +206,7 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
             return record
         }
 
-        record = newRecordDeclaration(name, "struct", "")
+        record = newRecordDeclaration(name, "struct")
 
         frontend.scopeManager.enterScope(record)
 

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/ExpressionHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/ExpressionHandler.kt
@@ -526,7 +526,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
         // since getelementpr returns the *address*, whereas extractvalue returns a *value*, we need
         // to do a final unary & operation
         if (isGetElementPtr) {
-            val ref = newUnaryOperator("&", postfix = false, prefix = true, code = "")
+            val ref = newUnaryOperator("&", postfix = false, prefix = true)
             ref.input = expr
             expr = ref
         }

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/ExpressionHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/ExpressionHandler.kt
@@ -61,14 +61,11 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
             LLVMConstantFPValueKind -> handleConstantFP(value)
             LLVMConstantPointerNullValueKind -> handleNullPointer(value)
             LLVMPoisonValueValueKind -> {
-                newReference("poison", frontend.typeOf(value), "poison")
+                newReference("poison", frontend.typeOf(value), rawNode = value)
             }
-            LLVMConstantTokenNoneValueKind ->
-                newLiteral(null, unknownType(), frontend.codeOf(value))
-            LLVMUndefValueValueKind ->
-                initializeAsUndef(frontend.typeOf(value), frontend.codeOf(value))
-            LLVMConstantAggregateZeroValueKind ->
-                initializeAsZero(frontend.typeOf(value), frontend.codeOf(value))
+            LLVMConstantTokenNoneValueKind -> newLiteral(null, unknownType(), rawNode = value)
+            LLVMUndefValueValueKind -> initializeAsUndef(frontend.typeOf(value), value)
+            LLVMConstantAggregateZeroValueKind -> initializeAsZero(frontend.typeOf(value), value)
             LLVMArgumentValueKind,
             LLVMGlobalVariableValueKind,
             // this is a little tricky. It seems weird, that an instruction value kind turns
@@ -80,7 +77,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
             LLVMFunctionValueKind -> handleFunction(value)
             LLVMGlobalAliasValueKind -> {
                 val name = frontend.getNameOf(value).first
-                newReference(name, frontend.typeOf(value), frontend.codeOf(value))
+                newReference(name, frontend.typeOf(value), rawNode = value)
             }
             LLVMMetadataAsValueValueKind,
             LLVMInlineAsmValueKind -> {
@@ -88,7 +85,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
                 return newProblemExpression(
                     "Metadata or ASM value kind not supported yet",
                     ProblemNode.ProblemType.TRANSLATION,
-                    frontend.codeOf(value)
+                    rawNode = value
                 )
             }
             else -> {
@@ -111,17 +108,17 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
                             // representation
                             LLVMPrintValueToString(value).string
                         }
-                    newLiteral(operandName, cpgType, operandName)
+                    newLiteral(operandName, cpgType, rawNode = value)
                 } else if (LLVMIsUndef(value) == 1) {
-                    newReference("undef", cpgType, "undef")
+                    newReference("undef", cpgType, rawNode = value)
                 } else if (LLVMIsPoison(value) == 1) {
-                    newReference("poison", cpgType, "poison")
+                    newReference("poison", cpgType, rawNode = value)
                 } else {
                     log.error("Unknown expression {}", kind)
                     newProblemExpression(
                         "Unknown expression $kind",
                         ProblemNode.ProblemType.TRANSLATION,
-                        frontend.codeOf(value)
+                        rawNode = value
                     )
                 }
             }
@@ -130,7 +127,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
 
     /** Returns a [Reference] for a function (pointer). */
     private fun handleFunction(valueRef: LLVMValueRef): Expression {
-        return newReference(valueRef.name, frontend.typeOf(valueRef), frontend.codeOf(valueRef))
+        return newReference(valueRef.name, frontend.typeOf(valueRef), rawNode = valueRef)
     }
 
     /**
@@ -148,7 +145,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
 
         val type = frontend.typeOf(valueRef)
 
-        val ref = newReference(name, type, "${type.typeName} $name")
+        val ref = newReference(name, type, rawNode = valueRef)
 
         // try to resolve the reference. actually the valueRef is already referring to the resolved
         // variable because we obtain it using LLVMGetOperand, so we just need to look it up in the
@@ -180,7 +177,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
                 LLVMConstIntGetSExtValue(valueRef)
             }
 
-        val literal = newLiteral(value, type, value.toString())
+        val literal = newLiteral(value, type, rawNode = valueRef)
         literal.name = Name(value.toString())
         return literal
     }
@@ -194,7 +191,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
         val losesInfo = IntArray(1)
         val value = LLVMConstRealGetDouble(valueRef, losesInfo)
 
-        val literal = newLiteral(value, frontend.typeOf(valueRef), value.toString())
+        val literal = newLiteral(value, frontend.typeOf(valueRef), rawNode = valueRef)
         literal.name = Name(value.toString())
         return literal
     }
@@ -229,7 +226,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
                         ?: newProblemExpression(
                             "Wrong type of constant binary operation +",
                             ProblemNode.ProblemType.TRANSLATION,
-                            frontend.codeOf(value)
+                            rawNode = value
                         )
                 LLVMSub,
                 LLVMFSub ->
@@ -237,7 +234,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
                         ?: newProblemExpression(
                             "Wrong type of constant binary operation -",
                             ProblemNode.ProblemType.TRANSLATION,
-                            frontend.codeOf(value)
+                            rawNode = value
                         )
                 LLVMAShr ->
                     frontend.statementHandler.handleBinaryOperator(value, ">>", false)
@@ -245,20 +242,20 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
                         ?: newProblemExpression(
                             "Wrong type of constant binary operation >>",
                             ProblemNode.ProblemType.TRANSLATION,
-                            frontend.codeOf(value)
+                            rawNode = value
                         )
                 LLVMICmp -> frontend.statementHandler.handleIntegerComparison(value) as? Expression
                         ?: newProblemExpression(
                             "Wrong type of constant comparison",
                             ProblemNode.ProblemType.TRANSLATION,
-                            frontend.codeOf(value)
+                            rawNode = value
                         )
                 else -> {
                     log.error("Not handling constant expression of opcode {} yet", kind)
                     newProblemExpression(
                         "Not handling constant expression of opcode $kind yet",
                         ProblemNode.ProblemType.TRANSLATION,
-                        frontend.codeOf(value)
+                        rawNode = value
                     )
                 }
             }
@@ -305,12 +302,11 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
         if (LLVMIsConstantString(valueRef) == 1) {
             val string = LLVMGetAsString(valueRef, SizeTPointer(0)).string
 
-            return newLiteral(string, frontend.typeOf(valueRef), frontend.codeOf(valueRef))
+            return newLiteral(string, frontend.typeOf(valueRef), rawNode = valueRef)
         }
 
         val arrayType = LLVMTypeOf(valueRef)
-        val list =
-            newInitializerListExpression(frontend.typeOf(valueRef), frontend.codeOf(valueRef))
+        val list = newInitializerListExpression(frontend.typeOf(valueRef), rawNode = valueRef)
         val length =
             if (LLVMIsAConstantDataArray(valueRef) != null) {
                 LLVMGetArrayLength(arrayType)
@@ -337,13 +333,14 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
      *
      * Returns a [ConstructExpression].
      */
-    private fun initializeAsUndef(type: Type, code: String?): Expression {
+    private fun initializeAsUndef(type: Type, value: LLVMValueRef): Expression {
         return if (
             !frontend.isKnownStructTypeName(type.name.toString()) && !type.name.contains("{")
         ) {
-            newLiteral(null, type, code)
+            newLiteral(null, type, rawNode = value)
         } else {
-            val expr: ConstructExpression = newConstructExpression(code)
+            val expr: ConstructExpression =
+                newConstructExpression(frontend.codeOf(value), rawNode = value)
             // map the construct expression to the record declaration of the type
             expr.instantiates = (type as? ObjectType)?.recordDeclaration
             if (expr.instantiates == null) return expr
@@ -351,7 +348,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
             // loop through the operands
             for (field in (expr.instantiates as RecordDeclaration).fields) {
                 // and handle them as expressions themselves
-                val arg = initializeAsUndef(field.type, code)
+                val arg = initializeAsUndef(field.type, value)
                 expr.addArgument(arg)
             }
 
@@ -364,13 +361,14 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
      *
      * Returns a [ConstructExpression].
      */
-    private fun initializeAsZero(type: Type, code: String?): Expression {
+    private fun initializeAsZero(type: Type, value: LLVMValueRef): Expression {
         return if (
             !frontend.isKnownStructTypeName(type.name.toString()) && !type.name.contains("{")
         ) {
-            newLiteral(0, type, code)
+            newLiteral(0, type, rawNode = value)
         } else {
-            val expr: ConstructExpression = newConstructExpression(code)
+            val expr: ConstructExpression =
+                newConstructExpression(frontend.codeOf(value), rawNode = value)
             // map the construct expression to the record declaration of the type
             expr.instantiates = (type as? ObjectType)?.recordDeclaration
             if (expr.instantiates == null) return expr
@@ -378,7 +376,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
             // loop through the operands
             for (field in (expr.instantiates as RecordDeclaration).fields) {
                 // and handle them as expressions themselves
-                val arg = initializeAsZero(field.type, code)
+                val arg = initializeAsZero(field.type, value)
                 expr.addArgument(arg)
             }
 
@@ -389,7 +387,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
     /** Returns a literal with the type of [value] and value `null`. */
     private fun handleNullPointer(value: LLVMValueRef): Expression {
         val type = frontend.typeOf(value)
-        return newLiteral(null, type, frontend.codeOf(value))
+        return newLiteral(null, type, rawNode = value)
     }
 
     /**
@@ -433,7 +431,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
             newProblemExpression(
                 "Default node for getelementptr",
                 ProblemNode.ProblemType.TRANSLATION,
-                frontend.codeOf(instr)
+                rawNode = instr
             )
 
         // loop through all operands / indices
@@ -457,7 +455,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
             // check, if the current base type is a pointer -> then we need to handle this as an
             // array access
             if (baseType is PointerType) {
-                val arrayExpr = newSubscriptExpression("")
+                val arrayExpr = newSubscriptExpression()
                 arrayExpr.arrayExpression = base
                 arrayExpr.name = Name(index.toString())
                 arrayExpr.subscriptExpression = operand
@@ -515,7 +513,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
                 baseType = field?.type ?: unknownType()
 
                 // construct our member expression
-                expr = newMemberExpression(fieldName, base, field?.type ?: unknownType(), ".", "")
+                expr = newMemberExpression(fieldName, base, field?.type ?: unknownType(), ".")
                 log.info("{}", expr)
 
                 // the current expression is the new base
@@ -551,7 +549,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
      * [cast instruction](https://llvm.org/docs/LangRef.html#conversion-operations).
      */
     fun handleCastInstruction(instr: LLVMValueRef): Expression {
-        val castExpr = newCastExpression(frontend.codeOf(instr))
+        val castExpr = newCastExpression(rawNode = instr)
         castExpr.castType = frontend.typeOf(instr)
         castExpr.expression = frontend.getOperandValueAtIndex(instr, 0)
         return castExpr

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/StatementHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/StatementHandler.kt
@@ -74,7 +74,7 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
 
         when (opcode) {
             LLVMRet -> {
-                val ret = newReturnStatement(frontend.codeOf(instr))
+                val ret = newReturnStatement()
 
                 val numOps = LLVMGetNumOperands(instr)
                 if (numOps != 0) {
@@ -98,7 +98,7 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
             }
             LLVMUnreachable -> {
                 // Does nothing
-                return newEmptyStatement(frontend.codeOf(instr))
+                return newEmptyStatement()
             }
             LLVMCallBr -> {
                 // Maps to a call but also to a goto statement? Barely used => not relevant
@@ -133,7 +133,7 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
             }
             LLVMPHI -> {
                 frontend.phiList.add(instr)
-                return newEmptyStatement(frontend.codeOf(instr))
+                return newEmptyStatement()
             }
             LLVMSelect -> {
                 return declarationOrNot(frontend.expressionHandler.handleSelect(instr), instr)
@@ -143,7 +143,7 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
                 log.info(
                     "userop instruction is not a real instruction. Replacing it with empty statement"
                 )
-                return newEmptyStatement(frontend.codeOf(instr))
+                return newEmptyStatement()
             }
             LLVMVAArg -> {
                 return handleVaArg(instr)
@@ -244,7 +244,7 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
             gotoStatement.name = name
             gotoStatement
         } else {
-            val emptyStatement = newEmptyStatement(frontend.codeOf(instr))
+            val emptyStatement = newEmptyStatement()
             emptyStatement.name = name
             emptyStatement
         }
@@ -1036,7 +1036,7 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
     private fun handleBrStatement(instr: LLVMValueRef): Statement {
         if (LLVMGetNumOperands(instr) == 3) {
             // if(op) then {goto label1} else {goto label2}
-            val ifStatement = newIfStatement(frontend.codeOf(instr))
+            val ifStatement = newIfStatement()
             val condition = frontend.getOperandValueAtIndex(instr, 0)
             ifStatement.condition = condition
 
@@ -1182,7 +1182,7 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
      * [CompressLLVMPass] will move this instruction to the correct location
      */
     private fun handleLandingpad(instr: LLVMValueRef): Statement {
-        val catchInstr = newCatchClause(frontend.codeOf(instr))
+        val catchInstr = newCatchClause()
         /* Get the number of clauses on the landingpad instruction and iterate through the clauses to get all types for the catch clauses */
         val numClauses = LLVMGetNumClauses(instr)
         var catchType = ""
@@ -1501,7 +1501,7 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
         val labelName = getBasicBlockName(bb)
 
         if (labelName != "") {
-            val labelStatement = newLabelStatement(labelName)
+            val labelStatement = newLabelStatement()
             labelStatement.name = Name(labelName)
             labelStatement.label = labelName
             labelStatement.subStatement = compound
@@ -1630,7 +1630,7 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
         val bb: LLVMBasicBlockRef = LLVMValueAsBasicBlock(bbTarget)
         val labelName = LLVMGetBasicBlockName(bb).string
         goto.labelName = labelName
-        val label = newLabelStatement(labelName)
+        val label = newLabelStatement()
         label.name = Name(labelName)
         // If the bound AST node is/or was transformed into a CPG node the cpg node is bound
         // to the CPG goto statement

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CompressLLVMPass.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CompressLLVMPass.kt
@@ -190,7 +190,6 @@ class CompressLLVMPass(ctx: TranslationContext) : ComponentPass(ctx) {
                     catch.newVariableDeclaration(
                         "e_${catch.name}",
                         UnknownType.getUnknownType(catch.language),
-                        "",
                         true,
                     )
                 catch.parameter = error

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CompressLLVMPass.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CompressLLVMPass.kt
@@ -187,19 +187,20 @@ class CompressLLVMPass(ctx: TranslationContext) : ComponentPass(ctx) {
         if (reachableThrowNodes.isNotEmpty()) {
             if (catch.parameter == null) {
                 val error =
-                    catch.newVariableDeclaration(
+                    newVariableDeclaration(
                         "e_${catch.name}",
                         UnknownType.getUnknownType(catch.language),
                         true,
                     )
+                error.language = catch.language
                 catch.parameter = error
             }
             val exceptionReference =
-                catch.newReference(
+                newReference(
                     catch.parameter?.name,
                     catch.parameter?.type ?: UnknownType.getUnknownType(catch.language),
-                    ""
                 )
+            exceptionReference.language = catch.language
             exceptionReference.refersTo = catch.parameter
             reachableThrowNodes.forEach { n -> (n as UnaryOperator).input = exceptionReference }
         }

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
@@ -385,12 +385,8 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
         return annotations
     }
 
-    private fun makeBlock(
-        stmts: List<Python.ASTBASEstmt>,
-        code: String? = null,
-        rawNode: Python.AST? = null
-    ): Block {
-        val result = newBlock(code, rawNode)
+    private fun makeBlock(stmts: List<Python.ASTBASEstmt>, rawNode: Python.AST? = null): Block {
+        val result = newBlock(rawNode = rawNode)
         for (stmt in stmts) {
             result.addStatement(handle(stmt))
         }
@@ -411,7 +407,7 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
      * @return The wrapped [decl]
      */
     private fun wrapDeclarationToStatement(decl: Declaration): DeclarationStatement {
-        val declStmt = newDeclarationStatement(code = decl.code, rawNode = null) // TODO: rawNode
+        val declStmt = newDeclarationStatement().codeAndLocationFrom(decl)
         declStmt.addDeclaration(decl)
         return declStmt
     }

--- a/cpg-language-ruby/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/ruby/DeclarationHandler.kt
+++ b/cpg-language-ruby/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/ruby/DeclarationHandler.kt
@@ -68,7 +68,7 @@ class DeclarationHandler(lang: RubyLanguageFrontend) :
 
             // add an implicit return statement, if there is no return statement
             if (lastStatement !is ReturnStatement) {
-                val returnStatement = newReturnStatement("return")
+                val returnStatement = newReturnStatement()
                 returnStatement.isImplicit = true
                 body += returnStatement
 

--- a/cpg-language-ruby/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/ruby/ExpressionHandler.kt
+++ b/cpg-language-ruby/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/ruby/ExpressionHandler.kt
@@ -71,7 +71,7 @@ class ExpressionHandler(lang: RubyLanguageFrontend) :
     private fun handleIterNode(node: IterNode): LambdaExpression {
         // a complete hack, to handle iter nodes, which is sort of a lambda expression
         // so we create an anonymous function declaration out of the bodyNode and varNode
-        val func = newFunctionDeclaration("", frontend.codeOf(node))
+        val func = newFunctionDeclaration("", rawNode = node)
 
         frontend.scopeManager.enterScope(func)
 

--- a/cpg-language-ruby/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/ruby/RubyLanguageFrontend.kt
+++ b/cpg-language-ruby/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/ruby/RubyLanguageFrontend.kt
@@ -62,7 +62,7 @@ class RubyLanguageFrontend(language: RubyLanguage, ctx: @NonNull TranslationCont
     }
 
     private fun handleRootNode(node: RootNode): TranslationUnitDeclaration {
-        val tu = newTranslationUnitDeclaration(node.file, codeOf(node))
+        val tu = newTranslationUnitDeclaration(node.file, rawNode = node)
 
         scopeManager.resetToGlobal(tu)
 

--- a/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/DeclarationHandler.kt
+++ b/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/DeclarationHandler.kt
@@ -58,16 +58,7 @@ class DeclarationHandler(lang: TypeScriptLanguageFrontend) :
         val name = this.frontend.getIdentifierName(node)
         val type = node.typeChildNode?.let { this.frontend.typeOf(it) } ?: unknownType()
 
-        val field =
-            newFieldDeclaration(
-                name,
-                type,
-                listOf(),
-                this.frontend.codeOf(node),
-                this.frontend.locationOf(node),
-                null,
-                false,
-            )
+        val field = newFieldDeclaration(name, type, listOf(), null, false, rawNode = node)
 
         this.frontend.processAnnotations(field, node)
 
@@ -85,7 +76,7 @@ class DeclarationHandler(lang: TypeScriptLanguageFrontend) :
                 } else {
                     "class"
                 },
-                this.frontend.codeOf(node)
+                rawNode = node
             )
 
         this.frontend.scopeManager.enterScope(record)
@@ -144,18 +135,18 @@ class DeclarationHandler(lang: TypeScriptLanguageFrontend) :
                 "MethodDeclaration" -> {
                     val record = this.frontend.scopeManager.currentRecord
 
-                    newMethodDeclaration(name, this.frontend.codeOf(node), false, record)
+                    newMethodDeclaration(name, false, record, rawNode = node)
                 }
                 "Constructor" -> {
                     val record = this.frontend.scopeManager.currentRecord
 
                     newConstructorDeclaration(
                         record?.name?.toString() ?: "",
-                        this.frontend.codeOf(node),
-                        record
+                        record,
+                        rawNode = node
                     )
                 }
-                else -> newFunctionDeclaration(name, this.frontend.codeOf(node))
+                else -> newFunctionDeclaration(name, rawNode = node)
             }
 
         node.typeChildNode?.let { func.type = this.frontend.typeOf(it) }
@@ -197,8 +188,7 @@ class DeclarationHandler(lang: TypeScriptLanguageFrontend) :
 
         // TODO: support ObjectBindingPattern (whatever it is). seems to be multiple assignment
 
-        val declaration =
-            newVariableDeclaration(name, unknownType(), this.frontend.codeOf(node), false)
+        val declaration = newVariableDeclaration(name, unknownType(), false, rawNode = node)
         declaration.location = this.frontend.locationOf(node)
 
         // the last node that is not an identifier or an object binding pattern is an initializer

--- a/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/DeclarationHandler.kt
+++ b/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/DeclarationHandler.kt
@@ -102,11 +102,11 @@ class DeclarationHandler(lang: TypeScriptLanguageFrontend) :
         val name = this.frontend.getIdentifierName(node)
         val type = node.typeChildNode?.let { this.frontend.typeOf(it) } ?: unknownType()
 
-        return newParameterDeclaration(name, type, false, this.frontend.codeOf(node))
+        return newParameterDeclaration(name, type, false, rawNode = node)
     }
 
     fun handleSourceFile(node: TypeScriptNode): TranslationUnitDeclaration {
-        val tu = newTranslationUnitDeclaration(node.location.file, this.frontend.codeOf(node))
+        val tu = newTranslationUnitDeclaration(node.location.file, rawNode = node)
 
         this.frontend.scopeManager.resetToGlobal(tu)
 

--- a/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/ExpressionHandler.kt
+++ b/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/ExpressionHandler.kt
@@ -194,10 +194,7 @@ class ExpressionHandler(lang: TypeScriptLanguageFrontend) :
                     this.handle(propertyAccess) as? MemberExpression
                         ?: return ProblemExpression("node is not a member expression")
 
-                newMemberCallExpression(
-                    memberExpressionExpression,
-                    code = this.frontend.codeOf(node)
-                )
+                newMemberCallExpression(memberExpressionExpression, rawNode = node)
             } else {
                 // TODO: fqn - how?
                 val fqn = this.frontend.getIdentifierName(node)
@@ -205,7 +202,7 @@ class ExpressionHandler(lang: TypeScriptLanguageFrontend) :
 
                 val ref = newReference(fqn)
 
-                newCallExpression(ref, fqn, this.frontend.codeOf(node), false)
+                newCallExpression(ref, fqn, false, rawNode = node)
             }
 
         // parse the arguments. the first node is the identifier, so we skip that

--- a/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/ExpressionHandler.kt
+++ b/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/ExpressionHandler.kt
@@ -65,12 +65,12 @@ class ExpressionHandler(lang: TypeScriptLanguageFrontend) :
         val key = node.children?.first()?.let { this.handle(it) }
         val value = node.children?.last()?.let { this.handle(it) }
 
-        return newKeyValueExpression(key, value, this.frontend.codeOf(node))
+        return newKeyValueExpression(key, value, rawNode = node)
     }
 
     private fun handleJsxClosingElement(node: TypeScriptNode): Expression {
         // this basically represents an HTML tag with attributes
-        val tag = newExpressionList(this.frontend.codeOf(node))
+        val tag = newExpressionList(rawNode = node)
 
         // it contains an Identifier node, we map this into the name
         this.frontend.getIdentifierName(node).let { tag.name = Name("</$it>") }
@@ -86,7 +86,7 @@ class ExpressionHandler(lang: TypeScriptLanguageFrontend) :
 
     private fun handleJsxOpeningElement(node: TypeScriptNode): ExpressionList {
         // this basically represents an HTML tag with attributes
-        val tag = newExpressionList(this.frontend.codeOf(node))
+        val tag = newExpressionList(rawNode = node)
 
         // it contains an Identifier node, we map this into the name
         this.frontend.getIdentifierName(node).let { tag.name = Name("<$it>") }
@@ -100,7 +100,7 @@ class ExpressionHandler(lang: TypeScriptLanguageFrontend) :
     }
 
     private fun handeJsxElement(node: TypeScriptNode): ExpressionList {
-        val jsx = newExpressionList(this.frontend.codeOf(node))
+        val jsx = newExpressionList(rawNode = node)
 
         jsx.expressions = node.children?.mapNotNull { this.handle(it) } ?: emptyList()
 
@@ -129,7 +129,7 @@ class ExpressionHandler(lang: TypeScriptLanguageFrontend) :
 
         // we cannot directly return a function declaration as an expression, so we
         // wrap it into a lambda expression
-        val lambda = newLambdaExpression(frontend.codeOf(node))
+        val lambda = newLambdaExpression(rawNode = node)
         lambda.function = func
 
         return lambda
@@ -139,11 +139,11 @@ class ExpressionHandler(lang: TypeScriptLanguageFrontend) :
         val key = node.children?.first()?.let { this.handle(it) }
         val value = node.children?.last()?.let { this.handle(it) }
 
-        return newKeyValueExpression(key, value, this.frontend.codeOf(node))
+        return newKeyValueExpression(key, value, rawNode = node)
     }
 
     private fun handleObjectLiteralExpression(node: TypeScriptNode): InitializerListExpression {
-        val ile = newInitializerListExpression(unknownType(), this.frontend.codeOf(node))
+        val ile = newInitializerListExpression(unknownType(), rawNode = node)
 
         ile.initializers = node.children?.mapNotNull { this.handle(it) } ?: emptyList()
 
@@ -163,13 +163,13 @@ class ExpressionHandler(lang: TypeScriptLanguageFrontend) :
                 ?.replace("'", "")
                 ?: ""
 
-        return newLiteral(value, primitiveType("string"), frontend.codeOf(node))
+        return newLiteral(value, primitiveType("string"), rawNode = node)
     }
 
     private fun handleIdentifier(node: TypeScriptNode): Expression {
         val name = this.frontend.codeOf(node)?.trim() ?: ""
 
-        return newReference(name, unknownType(), this.frontend.codeOf(node))
+        return newReference(name, unknownType(), rawNode = node)
     }
 
     private fun handlePropertyAccessExpression(node: TypeScriptNode): Expression {
@@ -179,7 +179,7 @@ class ExpressionHandler(lang: TypeScriptLanguageFrontend) :
 
         val name = node.children?.last()?.let { this.frontend.codeOf(it) } ?: ""
 
-        return newMemberExpression(name, base, unknownType(), ".", this.frontend.codeOf(node))
+        return newMemberExpression(name, base, unknownType(), ".", rawNode = node)
     }
 
     private fun handleCallExpression(node: TypeScriptNode): Expression {

--- a/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/StatementHandler.kt
+++ b/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/StatementHandler.kt
@@ -82,7 +82,7 @@ class StatementHandler(lang: TypeScriptLanguageFrontend) :
     }
 
     private fun handleBlock(node: TypeScriptNode): Block {
-        val block = newBlock(this.frontend.codeOf(node))
+        val block = newBlock(rawNode = node)
 
         node.children?.forEach { this.handle(it)?.let { it1 -> block.addStatement(it1) } }
 

--- a/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/StatementHandler.kt
+++ b/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/StatementHandler.kt
@@ -58,7 +58,7 @@ class StatementHandler(lang: TypeScriptLanguageFrontend) :
     private fun handleFunctionDeclaration(node: TypeScriptNode): Statement {
         // typescript allows to declare function on a statement level, e.g. within a compound
         // statement. We can wrap it into a declaration statement
-        val statement = newDeclarationStatement(this.frontend.codeOf(node))
+        val statement = newDeclarationStatement()
 
         val decl = this.frontend.declarationHandler.handle(node)
 
@@ -72,7 +72,7 @@ class StatementHandler(lang: TypeScriptLanguageFrontend) :
     }
 
     private fun handleReturnStatement(node: TypeScriptNode): ReturnStatement {
-        val returnStmt = newReturnStatement(this.frontend.codeOf(node))
+        val returnStmt = newReturnStatement()
 
         node.children?.first()?.let {
             returnStmt.returnValue = this.frontend.expressionHandler.handle(it)
@@ -98,7 +98,7 @@ class StatementHandler(lang: TypeScriptLanguageFrontend) :
     }
 
     private fun handleVariableStatement(node: TypeScriptNode): DeclarationStatement {
-        val statement = newDeclarationStatement(this.frontend.codeOf(node))
+        val statement = newDeclarationStatement()
 
         // the declarations are contained in a VariableDeclarationList
         val nodes = node.firstChild("VariableDeclarationList")?.children

--- a/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/TypeScriptLanguageFrontend.kt
+++ b/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/TypeScriptLanguageFrontend.kt
@@ -218,10 +218,9 @@ class TypeScriptLanguageFrontend(
         return if (callExpr != null) {
             val call = this.expressionHandler.handle(callExpr) as CallExpression
 
-            val annotation = newAnnotation(call.name.localName, this.codeOf(node) ?: "")
+            val annotation = newAnnotation(call.name.localName)
 
-            annotation.members =
-                call.arguments.map { newAnnotationMember("", it, it.code ?: "") }.toMutableList()
+            annotation.members = call.arguments.map { newAnnotationMember("", it) }.toMutableList()
 
             call.disconnectFromGraph()
 
@@ -230,7 +229,7 @@ class TypeScriptLanguageFrontend(
             // or a decorator just has a simple identifier
             val name = this.getIdentifierName(node)
 
-            newAnnotation(name, this.codeOf(node) ?: "")
+            newAnnotation(name)
         }
     }
 }

--- a/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/TypeScriptLanguageFrontend.kt
+++ b/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/TypeScriptLanguageFrontend.kt
@@ -221,7 +221,9 @@ class TypeScriptLanguageFrontend(
             val annotation = newAnnotation(call.name.localName, rawNode = node)
 
             annotation.members =
-                call.arguments.map { newAnnotationMember("", it, rawNode = it) }.toMutableList()
+                call.arguments
+                    .map { newAnnotationMember("", it).codeAndLocationFrom(it) }
+                    .toMutableList()
 
             call.disconnectFromGraph()
 

--- a/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/TypeScriptLanguageFrontend.kt
+++ b/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/TypeScriptLanguageFrontend.kt
@@ -218,9 +218,10 @@ class TypeScriptLanguageFrontend(
         return if (callExpr != null) {
             val call = this.expressionHandler.handle(callExpr) as CallExpression
 
-            val annotation = newAnnotation(call.name.localName)
+            val annotation = newAnnotation(call.name.localName, rawNode = node)
 
-            annotation.members = call.arguments.map { newAnnotationMember("", it) }.toMutableList()
+            annotation.members =
+                call.arguments.map { newAnnotationMember("", it, rawNode = it) }.toMutableList()
 
             call.disconnectFromGraph()
 
@@ -229,7 +230,7 @@ class TypeScriptLanguageFrontend(
             // or a decorator just has a simple identifier
             val name = this.getIdentifierName(node)
 
-            newAnnotation(name)
+            newAnnotation(name, rawNode = node)
         }
     }
 }


### PR DESCRIPTION
NodeBuilder uses `rawNode` to apply metadata. Optional parameters `location` and `code` are not in the rest of the codebase used and removed to cleanup the NodeBuilder code.