### PR TITLE
Cleanup of depdendencies and CDT update

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ In order to get familiar with the graph itself, you can use the subproject [cpg-
 ### As Library
 
 The most recent version is being published to Maven central and can be used as a simple dependency, either using Maven or Gradle. Since Eclipse CDT is not published on maven central, it is necessary to add a repository with a custom layout to find the released CDT files. For example, using Gradle's Kotlin syntax:
+
 ```kotlin
 repositories {
     ivy {
-        setUrl("https://download.eclipse.org/tools/cdt/releases/11.0/cdt-11.0.0/plugins")
+        setUrl("https://download.eclipse.org/tools/cdt/releases/11.3/cdt-11.3.1/plugins")
         metadataSources {
             artifact()
         }
@@ -48,11 +49,11 @@ repositories {
 }
 
 dependencies {
-    var cpgVersion = "5.1.0" 
-    
+    val cpgVersion = "8.0.0"
+
     // if you want to include all published cpg modules
     implementation("de.fraunhofer.aisec", "cpg", cpgVersion)
-    
+
     // if you only want to use some of the cpg modules
     // use the 'cpg-core' module
     // and then add the needed extra modules, such as Go and Python

--- a/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts
@@ -23,7 +23,7 @@ repositories {
     mavenCentral()
 
     ivy {
-        setUrl("https://download.eclipse.org/tools/cdt/releases/11.0/cdt-11.0.0/plugins")
+        setUrl("https://download.eclipse.org/tools/cdt/releases/11.3/cdt-11.3.1/plugins")
         metadataSources {
             artifact()
         }

--- a/cpg-console/build.gradle.kts
+++ b/cpg-console/build.gradle.kts
@@ -59,6 +59,5 @@ dependencies {
 
     implementation(libs.kotlin.script.runtime)
     implementation(libs.kotlin.coroutines.core)
-    implementation(libs.jline)
     implementation(libs.kotlin.ki.shell)
 }

--- a/cpg-core/build.gradle.kts
+++ b/cpg-core/build.gradle.kts
@@ -59,32 +59,14 @@ tasks.test {
 
 dependencies {
     api(libs.apache.commons.lang3)
-
     api(libs.neo4j.ogm.core)
-
-    implementation(libs.bundles.log4j)
-
-    api(libs.javaparser)
     api(libs.jackson)
 
-    // Eclipse dependencies
-    api(libs.eclipse.runtime) {
-        // For some reason, this group name is wrong
-        exclude("org.osgi.service", "org.osgi.service.prefs")
-    }
-    api(libs.osgi.service)
-    api(libs.icu4j)
-
-    // CDT
-    api(libs.eclipse.cdt.core)
-
-    api(libs.commons.io)
-
+    implementation(libs.bundles.log4j)
     implementation(libs.kotlin.reflect)
 
     testImplementation(libs.junit.params)
 
-    // JUnit
     testFixturesApi(libs.kotlin.test.junit5)  // somehow just using testFixturesApi(kotlin("test")) does not work for testFixtures
     testFixturesApi(libs.mockito)
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/helpers/LocationConverterTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/helpers/LocationConverterTest.kt
@@ -25,12 +25,13 @@
  */
 package de.fraunhofer.aisec.cpg.helpers
 
-import com.google.common.base.Objects
 import de.fraunhofer.aisec.cpg.BaseTest
 import de.fraunhofer.aisec.cpg.helpers.neo4j.LocationConverter
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 import de.fraunhofer.aisec.cpg.sarif.Region
 import java.net.URI
+import java.util.*
+import kotlin.collections.HashMap
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -335,7 +336,7 @@ internal class LocationConverterTest : BaseTest() {
         }
 
         override fun hashCode(): Int {
-            return Objects.hashCode(value)
+            return Objects.hash(value)
         }
 
         override fun toByte(): Byte {

--- a/cpg-language-cxx/build.gradle.kts
+++ b/cpg-language-cxx/build.gradle.kts
@@ -40,7 +40,16 @@ publishing {
 }
 
 dependencies {
-    api(libs.javaparser)
+    // Eclipse dependencies
+    api(libs.eclipse.runtime) {
+        // For some reason, this group name is wrong
+        exclude("org.osgi.service", "org.osgi.service.prefs")
+    }
+    api(libs.osgi.service)
+    api(libs.icu4j)
+
+    // CDT
+    api(libs.eclipse.cdt.core)
 
     testImplementation(libs.junit.params)
 }

--- a/cpg-language-ruby/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/ruby/RubyLanguageFrontend.kt
+++ b/cpg-language-ruby/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/ruby/RubyLanguageFrontend.kt
@@ -32,7 +32,6 @@ import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 import java.io.File
-import org.checkerframework.checker.nullness.qual.NonNull
 import org.jruby.Ruby
 import org.jruby.ast.BlockNode
 import org.jruby.ast.MethodDefNode
@@ -40,7 +39,7 @@ import org.jruby.ast.RootNode
 import org.jruby.parser.Parser
 import org.jruby.parser.ParserConfiguration
 
-class RubyLanguageFrontend(language: RubyLanguage, ctx: @NonNull TranslationContext) :
+class RubyLanguageFrontend(language: RubyLanguage, ctx: TranslationContext) :
     LanguageFrontend<org.jruby.ast.Node, org.jruby.ast.Node>(language, ctx) {
     val declarationHandler: DeclarationHandler = DeclarationHandler(this)
     val expressionHandler: ExpressionHandler = ExpressionHandler(this)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ jackson = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", versi
 eclipse-runtime = { module = "org.eclipse.platform:org.eclipse.core.runtime", version = "3.29.0"}
 osgi-service = { module = "org.osgi:org.osgi.service.prefs", version = "1.1.2"}
 icu4j = { module = "com.ibm.icu:icu4j", version = "74.1"}
-eclipse-cdt-core = { module = "org.eclipse.cdt:core", version = "8.0.0.202211292120"}
+eclipse-cdt-core = { module = "org.eclipse.cdt:core", version = "8.3.1.202309150117"}
 commons-io = { module = "commons-io:commons-io", version = "2.15.0"}
 picocli = { module = "info.picocli:picocli", version = "4.7.0"}
 picocli-codegen = { module = "info.picocli:picocli-codegen", version = "4.7.0"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,6 @@ kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", versi
 log4j-impl = { module = "org.apache.logging.log4j:log4j-slf4j2-impl", version.ref = "log4j" }
 log4j-core = { module= "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
 
-jline = { module = "org.jline:jline", version = "3.24.0" }
 apache-commons-lang3 = { module = "org.apache.commons:commons-lang3", version = "3.14.0"}
 neo4j-ogm-core = { module = "org.neo4j:neo4j-ogm-core", version.ref = "neo4j"}
 neo4j-ogm-bolt-driver = { module = "org.neo4j:neo4j-ogm-bolt-driver", version.ref = "neo4j"}
@@ -27,7 +26,6 @@ eclipse-runtime = { module = "org.eclipse.platform:org.eclipse.core.runtime", ve
 osgi-service = { module = "org.osgi:org.osgi.service.prefs", version = "1.1.2"}
 icu4j = { module = "com.ibm.icu:icu4j", version = "74.1"}
 eclipse-cdt-core = { module = "org.eclipse.cdt:core", version = "8.3.1.202309150117"}
-commons-io = { module = "commons-io:commons-io", version = "2.15.0"}
 picocli = { module = "info.picocli:picocli", version = "4.7.0"}
 picocli-codegen = { module = "info.picocli:picocli-codegen", version = "4.7.0"}
 jep = { module = "black.ninia:jep", version = "4.1.1" }  # build.yml uses grep to extract the jep verison number for CI/CD purposes


### PR DESCRIPTION
This PR cleans some weird dependencies that were misused in the language frontends and also updates CDT to 11.3.1. This means, that the ivy repository needs to be updated for all users. The README.md was adjusted accordingly.
