### PR TITLE
Added `registerReplacement` to `ScopedWalker`

### DIFF
--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
@@ -110,13 +110,15 @@ import de.fraunhofer.aisec.cpg.passes.order.ExecuteBefore
 @ExecuteBefore(DFGPass::class)
 class GoExtraPass(ctx: TranslationContext) : ComponentPass(ctx) {
 
+    private lateinit var walker: SubgraphWalker.ScopedWalker
+
     override fun accept(component: Component) {
         // Add built-int functions, but only if one of the components contains a GoLanguage
         if (component.translationUnits.any { it.language is GoLanguage }) {
             component.translationUnits += addBuiltIn()
         }
 
-        val walker = SubgraphWalker.ScopedWalker(scopeManager)
+        walker = SubgraphWalker.ScopedWalker(scopeManager)
         walker.registerHandler { _, parent, node ->
             when (node) {
                 is CallExpression -> handleCall(node, parent)
@@ -467,6 +469,9 @@ class GoExtraPass(ctx: TranslationContext) : ComponentPass(ctx) {
             )
         } else {
             call.disconnectFromGraph()
+
+            // Make sure to inform the walker about our change
+            walker.registerReplacement(call, cast)
         }
     }
 

--- a/cpg-language-go/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
+++ b/cpg-language-go/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
@@ -1090,6 +1090,28 @@ class GoLanguageFrontendTest : BaseTest() {
     }
 
     @Test
+    fun testChainedCast() {
+        val topLevel = Path.of("src", "test", "resources", "golang")
+        val tu =
+            analyze(
+                listOf(
+                    topLevel.resolve("cast.go").toFile(),
+                ),
+                topLevel,
+                true
+            ) {
+                it.registerLanguage<GoLanguage>()
+            }
+        assertNotNull(tu)
+
+        assertEquals(0, tu.calls.size)
+        assertEquals(
+            listOf("string", "error", "p.myError"),
+            tu.casts.map { it.castType.name.toString() }
+        )
+    }
+
+    @Test
     fun testComplexResolution() {
         val topLevel = Path.of("src", "test", "resources", "golang", "complex_resolution")
         val result =

--- a/cpg-language-go/src/test/resources/golang/cast.go
+++ b/cpg-language-go/src/test/resources/golang/cast.go
@@ -1,0 +1,9 @@
+package p
+
+type myError string
+
+func (err myError) Error() string {
+	return string(err)
+}
+
+var s = error(myError("abc"))


### PR DESCRIPTION
In some frontends (e.g., the Go frontend) we are replacing certain nodes in an extra pass, while iterating with the `ScopedWalker`. One such usecase is to replace calls with casts. Previously, when doing so, chained replacement of calls were a problem, since the original replaced value was stil registered in the walker and was used to determine further AST children to "walk" on, instead of the new node.

This adds a function to register such replacements with the walker.
