### PR TITLE
Code and location from children

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.kt
@@ -143,13 +143,33 @@ abstract class LanguageFrontend<AstNode, TypeNode>(
      * @return the String of the newline
      */
     fun getNewLineType(node: Node): String {
+        var region = node.location?.region
+        return getNewLineType(node.code?:"", region)
+    }
+
+    /**
+     * To prevent issues with different newline types and formatting.
+     *
+     * @param multilineCode
+     * - The newline type is extracted from the code assuming it contains newlines
+     *
+     * @return the String of the newline or \n as default
+     */
+    fun getNewLineType(multilineCode: String, region:Region? = null): String {
+        var code = multilineCode
+        region?.let {
+            if (it.startLine != it.endLine) {
+                code = code.substring(0, code.length - it.endColumn + 1)
+            }
+        }
+
         val nls = listOf("\n\r", "\r\n", "\n")
         for (nl in nls) {
-            if (node.toString().endsWith(nl)) {
+            if (code.endsWith(nl)) {
                 return nl
             }
         }
-        log.debug("Could not determine newline type. Assuming \\n. {}", node)
+        log.debug("Could not determine newline type. Assuming \\n.")
         return "\n"
     }
 
@@ -169,7 +189,11 @@ abstract class LanguageFrontend<AstNode, TypeNode>(
      */
     fun getCodeOfSubregion(node: Node, nodeRegion: Region, subRegion: Region): String {
         val code = node.code ?: return ""
-        val nlType = getNewLineType(node)
+        return getCodeOfSubregion(code,nodeRegion,subRegion)
+    }
+
+    fun getCodeOfSubregion(code: String, nodeRegion: Region, subRegion: Region): String {
+        val nlType = getNewLineType(code, nodeRegion)
         val start =
             if (subRegion.startLine == nodeRegion.startLine) {
                 subRegion.startColumn - nodeRegion.startColumn

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.kt
@@ -144,7 +144,7 @@ abstract class LanguageFrontend<AstNode, TypeNode>(
      */
     fun getNewLineType(node: Node): String {
         var region = node.location?.region
-        return getNewLineType(node.code?:"", region)
+        return getNewLineType(node.code ?: "", region)
     }
 
     /**
@@ -155,7 +155,7 @@ abstract class LanguageFrontend<AstNode, TypeNode>(
      *
      * @return the String of the newline or \n as default
      */
-    fun getNewLineType(multilineCode: String, region:Region? = null): String {
+    fun getNewLineType(multilineCode: String, region: Region? = null): String {
         var code = multilineCode
         region?.let {
             if (it.startLine != it.endLine) {
@@ -189,7 +189,7 @@ abstract class LanguageFrontend<AstNode, TypeNode>(
      */
     fun getCodeOfSubregion(node: Node, nodeRegion: Region, subRegion: Region): String {
         val code = node.code ?: return ""
-        return getCodeOfSubregion(code,nodeRegion,subRegion)
+        return getCodeOfSubregion(code, nodeRegion, subRegion)
     }
 
     fun getCodeOfSubregion(code: String, nodeRegion: Region, subRegion: Region): String {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -272,6 +272,18 @@ fun <T : Node, S> T.codeAndLocationFrom(frontend: LanguageFrontend<S, *>, rawNod
     return this
 }
 
+/**
+ * This function allows the setting of a node's code and location region as the code and location of its children.
+ * Sometimes, when we translate a parent node in the language-specific AST with its children into the CPG AST,
+ * we have to set a specific intermediate Node between, that has no language-specific AST that can give it a proper
+ * code and location.
+ *
+ * While the location of the node is determined by the start and end of the child locations, the code is extracted from
+ * the parent node to catch separators and auxiliary syntactic elements that are between the child nodes.
+ *
+ * @param frontend Used to invoke language specific code and location generation
+ * @param parentNode Used to extract the code for this node
+ */
 fun <T : Node, S> T.codeAndLocationFromChildren(
     frontend: LanguageFrontend<S, *>,
     parentNode: S

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -303,7 +303,8 @@ fun <T : Node, S> T.codeAndLocationFromChildren(
         // All regions are present and not default at this point
         val startLine = sortedNodes.first().location?.region?.startLine ?: -1
         val endLine = sortedNodes.last().location?.region?.endLine ?: -1
-        val newRegion = Region(
+        val newRegion =
+            Region(
                 startLine = startLine,
                 startColumn = sortedNodes.first().location?.region?.startColumn ?: -1,
                 endLine = endLine,
@@ -313,12 +314,10 @@ fun <T : Node, S> T.codeAndLocationFromChildren(
 
         val parentCode = frontend.codeOf(parentNode)
         val parentRegion = frontend.locationOf(parentNode)?.region
-        if(parentCode != null && parentRegion != null){
+        if (parentCode != null && parentRegion != null) {
             this.code = frontend.getCodeOfSubregion(parentCode, parentRegion, newRegion)
         }
-
     }
-
 
     return this
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -294,16 +294,16 @@ fun <T : Node, S> T.codeAndLocationFromChildren(
 
     // Search through all children to find the first and last node based on region startLine and
     // startColumn
-    var worklist: MutableList<Node> = this.astChildren.toMutableList()
+    val worklist: MutableList<Node> = this.astChildren.toMutableList()
     while (worklist.isNotEmpty()) {
-        var current = worklist.removeFirst()
+        val current = worklist.removeFirst()
         if (current.location?.region == null || current.location?.region == Region()) {
             // If the node has no location we use the same search on his children again
             worklist.addAll(current.astChildren)
         } else {
             // Compare nodes by line and column in lexicographic order, i.e. column is compared if
             // lines are equal
-            if (first == null || last == null) {
+            if (first == null) {
                 first = current
                 last = current
             }
@@ -312,8 +312,8 @@ fun <T : Node, S> T.codeAndLocationFromChildren(
                     first,
                     current,
                     compareBy(
-                        { it?.location?.region?.startLine },
-                        { it?.location?.region?.startColumn }
+                        { it.location?.region?.startLine },
+                        { it.location?.region?.startColumn }
                     )
                 )
             last =

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -273,13 +273,14 @@ fun <T : Node, S> T.codeAndLocationFrom(frontend: LanguageFrontend<S, *>, rawNod
 }
 
 /**
- * This function allows the setting of a node's code and location region as the code and location of its children.
- * Sometimes, when we translate a parent node in the language-specific AST with its children into the CPG AST,
- * we have to set a specific intermediate Node between, that has no language-specific AST that can give it a proper
- * code and location.
+ * This function allows the setting of a node's code and location region as the code and location of
+ * its children. Sometimes, when we translate a parent node in the language-specific AST with its
+ * children into the CPG AST, we have to set a specific intermediate Node between, that has no
+ * language-specific AST that can give it a proper code and location.
  *
- * While the location of the node is determined by the start and end of the child locations, the code is extracted from
- * the parent node to catch separators and auxiliary syntactic elements that are between the child nodes.
+ * While the location of the node is determined by the start and end of the child locations, the
+ * code is extracted from the parent node to catch separators and auxiliary syntactic elements that
+ * are between the child nodes.
  *
  * @param frontend Used to invoke language specific code and location generation
  * @param parentNode Used to extract the code for this node

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
@@ -341,7 +341,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
         }
         frontend.setCodeAndLocation(compoundStatement, stmt)
         frontend.scopeManager.leaveScope(compoundStatement)
-        return compoundStatement
+        return compoundStatement.codeAndLocationFromChildren(frontend, stmt)
     }
 
     fun handleCaseDefaultStatement(

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
@@ -341,7 +341,7 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
         }
         frontend.setCodeAndLocation(compoundStatement, stmt)
         frontend.scopeManager.leaveScope(compoundStatement)
-        return compoundStatement.codeAndLocationFromChildren(frontend, stmt)
+        return compoundStatement
     }
 
     fun handleCaseDefaultStatement(


### PR DESCRIPTION
This PR allows the setting of a node's code and location region as the code and location of its children.
Sometimes, when we translate a parent node in the language-specific  AST with its children into the CPG AST, we have to set a specific intermediate Node between that has no language-specific AST that can give it a proper code and location.

This PR provides the function `codeAndLocationFromChildren(frontend: LanguageFrontend<S, *>, parentNode: S)` that is purely optional and can be used in language frontends to cover the use-case mentioned above and set the region of the node to the start and end region of its children. The code is then extracted from the language-specific AST parent using the newly determined location region.

The function modifies the base node, meaning it should be used after construction:
`newBlock(...).codecodeAndLocationFromChildren()`
or before returning the node if the children are processed and returned after construction:
`return block..codecodeAndLocationFromChildren()` 