### PR TITLE
Better design of the `CodeAndLocationProvider`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.kt
@@ -120,23 +120,6 @@ abstract class LanguageFrontend<AstNode, TypeNode>(
      */
     abstract override fun locationOf(astNode: AstNode): PhysicalLocation?
 
-    @Deprecated(
-        message =
-            "This function should not be called directly, instead the node builders should be supplied with a raw node"
-    )
-    fun setCodeAndLocation(cpgNode: Node, astNode: AstNode) {
-        if (config.codeInNodes) {
-            // only set code, if it's not already set or empty
-            val code = codeOf(astNode)
-            if (code != null) {
-                cpgNode.code = code
-            } else {
-                log.warn("Unexpected: No code for node {}", astNode)
-            }
-        }
-        cpgNode.location = locationOf(astNode)
-    }
-
     open fun cleanup() {
         clearProcessed()
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -38,6 +38,7 @@ import de.fraunhofer.aisec.cpg.passes.inference.IsImplicitProvider
 import de.fraunhofer.aisec.cpg.passes.inference.IsInferredProvider
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 import de.fraunhofer.aisec.cpg.sarif.Region
+import java.net.URI
 import org.slf4j.LoggerFactory
 
 object NodeBuilder {
@@ -308,7 +309,7 @@ fun <T : Node, AstNode> T.codeAndLocationFromChildren(parentNode: AstNode): T {
     val worklist: MutableList<Node> = this.astChildren.toMutableList()
     while (worklist.isNotEmpty()) {
         val current = worklist.removeFirst()
-        if (current.location?.region == null || current.location?.region == Region()) {
+        if (current.location == null || current.location?.region == Region()) {
             // If the node has no location we use the same search on his children again
             worklist.addAll(current.astChildren)
         } else {
@@ -348,7 +349,8 @@ fun <T : Node, AstNode> T.codeAndLocationFromChildren(parentNode: AstNode): T {
                 endLine = last.location?.region?.endLine ?: -1,
                 endColumn = last.location?.region?.endColumn ?: -1,
             )
-        this.location?.region = newRegion
+        this.location =
+            PhysicalLocation(first.location?.artifactLocation?.uri ?: URI(""), newRegion)
 
         val parentCode = this@CodeAndLocationProvider.codeOf(parentNode)
         val parentRegion = this@CodeAndLocationProvider.locationOf(parentNode)?.region

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/RegionUtils.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/RegionUtils.kt
@@ -26,20 +26,8 @@
 package de.fraunhofer.aisec.cpg.helpers
 
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
-import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.sarif.Region
 import org.apache.commons.lang3.StringUtils
-
-/**
- * To prevent issues with different newline types and formatting.
- *
- * @param node The newline type is extracted from this node's code.
- * @return the string of the newline
- */
-fun getNewLineType(node: Node): String {
-    val region = node.location?.region
-    return getNewLineType(node.code ?: "", region)
-}
 
 /**
  * To prevent issues with different newline types and formatting.
@@ -65,19 +53,6 @@ fun getNewLineType(multilineCode: String, region: Region? = null): String {
     return "\n"
 }
 
-/**
- * Returns the code represented by the subregion extracted from the parent node and its region.
- *
- * @param node The parent node of the subregion
- * @param nodeRegion region needs to be precomputed.
- * @param subRegion precomputed subregion
- * @return the code of the subregion.
- */
-fun getCodeOfSubregion(node: Node, nodeRegion: Region, subRegion: Region): String {
-    val code = node.code ?: return ""
-    return getCodeOfSubregion(code, nodeRegion, subRegion)
-}
-
 fun getCodeOfSubregion(code: String, nodeRegion: Region, subRegion: Region): String {
     val nlType = getNewLineType(code, nodeRegion)
     val start =
@@ -95,37 +70,4 @@ fun getCodeOfSubregion(code: String, nodeRegion: Region, subRegion: Region): Str
                 subRegion.endColumn)
         }
     return code.substring(start, end)
-}
-
-/**
- * Merges two regions. The new region contains both and is the minimal region to do so.
- *
- * @param regionOne the first region
- * @param regionTwo the second region
- * @return the merged region
- */
-fun mergeRegions(regionOne: Region, regionTwo: Region): Region {
-    val ret = Region()
-    if (
-        regionOne.startLine < regionTwo.startLine ||
-            regionOne.startLine == regionTwo.startLine &&
-                regionOne.startColumn < regionTwo.startColumn
-    ) {
-        ret.startLine = regionOne.startLine
-        ret.startColumn = regionOne.startColumn
-    } else {
-        ret.startLine = regionTwo.startLine
-        ret.startColumn = regionTwo.startColumn
-    }
-    if (
-        regionOne.endLine > regionTwo.endLine ||
-            regionOne.endLine == regionTwo.endLine && regionOne.endColumn > regionTwo.endColumn
-    ) {
-        ret.endLine = regionOne.endLine
-        ret.endColumn = regionOne.startColumn
-    } else {
-        ret.endLine = regionTwo.endLine
-        ret.endColumn = regionTwo.endColumn
-    }
-    return ret
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/RegionUtils.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/RegionUtils.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2024, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.helpers
+
+import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.sarif.Region
+import org.apache.commons.lang3.StringUtils
+
+/**
+ * To prevent issues with different newline types and formatting.
+ *
+ * @param node The newline type is extracted from this node's code.
+ * @return the string of the newline
+ */
+fun getNewLineType(node: Node): String {
+    val region = node.location?.region
+    return getNewLineType(node.code ?: "", region)
+}
+
+/**
+ * To prevent issues with different newline types and formatting.
+ *
+ * @param multilineCode The newline type is extracted from the code assuming it contains newlines
+ * @return the String of the newline or \n as default
+ */
+fun getNewLineType(multilineCode: String, region: Region? = null): String {
+    var code = multilineCode
+    region?.let {
+        if (it.startLine != it.endLine) {
+            code = code.substring(0, code.length - it.endColumn + 1)
+        }
+    }
+
+    val nls = listOf("\n\r", "\r\n", "\n")
+    for (nl in nls) {
+        if (code.endsWith(nl)) {
+            return nl
+        }
+    }
+    LanguageFrontend.log.debug("Could not determine newline type. Assuming \\n.")
+    return "\n"
+}
+
+/**
+ * Returns the code represented by the subregion extracted from the parent node and its region.
+ *
+ * @param node The parent node of the subregion
+ * @param nodeRegion region needs to be precomputed.
+ * @param subRegion precomputed subregion
+ * @return the code of the subregion.
+ */
+fun getCodeOfSubregion(node: Node, nodeRegion: Region, subRegion: Region): String {
+    val code = node.code ?: return ""
+    return getCodeOfSubregion(code, nodeRegion, subRegion)
+}
+
+fun getCodeOfSubregion(code: String, nodeRegion: Region, subRegion: Region): String {
+    val nlType = getNewLineType(code, nodeRegion)
+    val start =
+        if (subRegion.startLine == nodeRegion.startLine) {
+            subRegion.startColumn - nodeRegion.startColumn
+        } else {
+            (StringUtils.ordinalIndexOf(code, nlType, subRegion.startLine - nodeRegion.startLine) +
+                subRegion.startColumn)
+        }
+    val end =
+        if (subRegion.endLine == nodeRegion.startLine) {
+            subRegion.endColumn - nodeRegion.startColumn
+        } else {
+            (StringUtils.ordinalIndexOf(code, nlType, subRegion.endLine - nodeRegion.startLine) +
+                subRegion.endColumn)
+        }
+    return code.substring(start, end)
+}
+
+/**
+ * Merges two regions. The new region contains both and is the minimal region to do so.
+ *
+ * @param regionOne the first region
+ * @param regionTwo the second region
+ * @return the merged region
+ */
+fun mergeRegions(regionOne: Region, regionTwo: Region): Region {
+    val ret = Region()
+    if (
+        regionOne.startLine < regionTwo.startLine ||
+            regionOne.startLine == regionTwo.startLine &&
+                regionOne.startColumn < regionTwo.startColumn
+    ) {
+        ret.startLine = regionOne.startLine
+        ret.startColumn = regionOne.startColumn
+    } else {
+        ret.startLine = regionTwo.startLine
+        ret.startColumn = regionTwo.startColumn
+    }
+    if (
+        regionOne.endLine > regionTwo.endLine ||
+            regionOne.endLine == regionTwo.endLine && regionOne.endColumn > regionTwo.endColumn
+    ) {
+        ret.endLine = regionOne.endLine
+        ret.endColumn = regionOne.startColumn
+    } else {
+        ret.endLine = regionTwo.endLine
+        ret.endColumn = regionTwo.endColumn
+    }
+    return ret
+}

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXHandler.kt
@@ -57,12 +57,6 @@ abstract class CXXHandler<S : Node, T : IASTNode>(
 
         val node = handleNode(ctx)
 
-        // The language frontend might set a location, which we should respect. Otherwise, we will
-        // set the location here.
-        if (node.location == null) {
-            frontend.setCodeAndLocation(node, ctx)
-        }
-
         frontend.process(ctx, node)
 
         this.lastNode = node

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/StatementHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/StatementHandler.kt
@@ -282,11 +282,8 @@ class StatementHandler(lang: CXXLanguageFrontend) :
 
     private fun handleExpressionStatement(ctx: IASTExpressionStatement): Expression {
         val expression =
-            frontend.expressionHandler.handle(ctx.expression)
+            frontend.expressionHandler.handle(ctx.expression)?.codeAndLocationFromOtherRawNode(ctx)
                 ?: ProblemExpression("could not parse expression in statement")
-
-        // update the code and region to include the whole statement
-        frontend.setCodeAndLocation(expression, ctx)
 
         return expression
     }

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/DeclarationHandler.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/DeclarationHandler.kt
@@ -65,10 +65,10 @@ class DeclarationHandler(frontend: GoLanguageFrontend) :
                 if (recvField?.names?.isNotEmpty() == true) {
                     method.receiver =
                         newVariableDeclaration(
-                                recvField.names[0].name,
-                                recordType,
-                            )
-                            .codeAndLocationFrom(frontend, recvField)
+                            recvField.names[0].name,
+                            recordType,
+                            rawNode = recvField
+                        )
                 }
 
                 if (recordType !is UnknownType) {
@@ -122,10 +122,10 @@ class DeclarationHandler(frontend: GoLanguageFrontend) :
                 if (returnVar.names.isNotEmpty()) {
                     val param =
                         newVariableDeclaration(
-                                returnVar.names[0].name,
-                                frontend.typeOf(returnVar.type),
-                            )
-                            .codeAndLocationFrom(frontend, returnVar)
+                            returnVar.names[0].name,
+                            frontend.typeOf(returnVar.type),
+                            rawNode = returnVar
+                        )
 
                     // Add parameter to scope
                     frontend.scopeManager.addDeclaration(param)
@@ -202,9 +202,7 @@ class DeclarationHandler(frontend: GoLanguageFrontend) :
                 // (and make it an array afterwards)
                 val (type, variadic) = frontend.fieldTypeOf(param.type)
 
-                val p =
-                    newParameterDeclaration(name, type, variadic)
-                        .codeAndLocationFrom(frontend, param)
+                val p = newParameterDeclaration(name, type, variadic, rawNode = param)
 
                 frontend.scopeManager.addDeclaration(p)
                 frontend.setComment(p, param)

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoHandler.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoHandler.kt
@@ -49,12 +49,6 @@ abstract class GoHandler<ResultNode : Node?, HandlerNode : GoStandardLibrary.Ast
             return node
         }
 
-        // The language frontend might set a location, which we should respect. Otherwise, we will
-        // set the location here.
-        if (node.location == null) {
-            frontend.setCodeAndLocation(node, ctx)
-        }
-
         frontend.setComment(node, ctx)
         frontend.process(ctx, node)
 

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/SpecificationHandler.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/SpecificationHandler.kt
@@ -124,8 +124,7 @@ class SpecificationHandler(frontend: GoLanguageFrontend) :
                         Pair(field.names[0].name, listOf())
                     }
 
-                val decl = newFieldDeclaration(fieldName, type, modifiers)
-                frontend.setCodeAndLocation(decl, field)
+                val decl = newFieldDeclaration(fieldName, type, modifiers, rawNode = field)
                 frontend.scopeManager.addDeclaration(decl)
             }
         }
@@ -155,8 +154,7 @@ class SpecificationHandler(frontend: GoLanguageFrontend) :
                 // "method" actually has a name, we declare a new method
                 // declaration.
                 if (field.names.isNotEmpty()) {
-                    val method = newMethodDeclaration(field.names[0].name)
-                    frontend.setCodeAndLocation(method, field)
+                    val method = newMethodDeclaration(field.names[0].name, rawNode = field)
                     method.type = type
 
                     frontend.scopeManager.enterScope(method)

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/StatementHandler.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/StatementHandler.kt
@@ -327,7 +327,7 @@ class StatementHandler(frontend: GoLanguageFrontend) :
             rangeStmt.key?.let {
                 val ref = frontend.expressionHandler.handle(it)
                 if (ref is Reference) {
-                    val key = newVariableDeclaration(ref.name).codeAndLocationFrom(frontend, it)
+                    val key = newVariableDeclaration(ref.name, rawNode = it)
                     frontend.scopeManager.addDeclaration(key)
                     stmt.addToPropertyEdgeDeclaration(key)
                 }
@@ -337,7 +337,7 @@ class StatementHandler(frontend: GoLanguageFrontend) :
             rangeStmt.value?.let {
                 val ref = frontend.expressionHandler.handle(it)
                 if (ref is Reference) {
-                    val key = newVariableDeclaration(ref.name).codeAndLocationFrom(frontend, it)
+                    val key = newVariableDeclaration(ref.name, rawNode = it)
                     frontend.scopeManager.addDeclaration(key)
                     stmt.addToPropertyEdgeDeclaration(key)
                 }

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.kt
@@ -78,10 +78,10 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
                 this.newParameterDeclaration(
                     parameter.nameAsString,
                     frontend.getTypeAsGoodAsPossible(parameter, parameter.resolve()),
-                    parameter.isVarArgs
+                    parameter.isVarArgs,
+                    rawNode = parameter
                 )
             declaration.addParameter(param)
-            frontend.setCodeAndLocation(param, parameter)
             frontend.scopeManager.addDeclaration(param)
         }
 
@@ -132,10 +132,10 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
                 this.newParameterDeclaration(
                     parameter.nameAsString,
                     resolvedType,
-                    parameter.isVarArgs
+                    parameter.isVarArgs,
+                    rawNode = parameter
                 )
             functionDeclaration.addParameter(param)
-            frontend.setCodeAndLocation(param, parameter)
             frontend.processAnnotations(param, parameter)
             frontend.scopeManager.addDeclaration(param)
         }

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
@@ -122,7 +122,6 @@ open class JavaLanguageFrontend(language: Language<JavaLanguageFrontend>, ctx: T
             if (packDecl != null) {
                 namespaceDeclaration =
                     newNamespaceDeclaration(packDecl.name.asString(), rawNode = packDecl)
-                setCodeAndLocation(namespaceDeclaration, packDecl)
                 scopeManager.addDeclaration(namespaceDeclaration)
                 scopeManager.enterScope(namespaceDeclaration)
             }

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
@@ -52,6 +52,8 @@ import de.fraunhofer.aisec.cpg.graph.statements.TryStatement
 import de.fraunhofer.aisec.cpg.graph.statements.WhileStatement
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.Type
+import de.fraunhofer.aisec.cpg.helpers.getCodeOfSubregion
+import de.fraunhofer.aisec.cpg.helpers.mergeRegions
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 import de.fraunhofer.aisec.cpg.sarif.Region
 import java.util.function.Supplier
@@ -199,17 +201,14 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
                     ofExprList = s.location
                 }
                 ofExprList?.region?.let { ofRegion ->
-                    s.location?.region?.let {
-                        ofExprList?.region = frontend.mergeRegions(ofRegion, it)
-                    }
+                    s.location?.region?.let { ofExprList?.region = mergeRegions(ofRegion, it) }
                 }
             }
 
             // set code and location of init list
             statement.location?.let { location ->
                 ofExprList?.let {
-                    val initCode =
-                        frontend.getCodeOfSubregion(statement, location.region, it.region)
+                    val initCode = getCodeOfSubregion(statement, location.region, it.region)
                     initExprList.location = ofExprList
                     initExprList.code = initCode
                 }
@@ -253,17 +252,14 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
                     ofExprList = s.location
                 }
                 ofExprList?.region?.let { ofRegion ->
-                    s.location?.region?.let {
-                        ofExprList.region = frontend.mergeRegions(ofRegion, it)
-                    }
+                    s.location?.region?.let { ofExprList.region = mergeRegions(ofRegion, it) }
                 }
             }
 
             // set code and location of init list
             statement.location?.let { location ->
                 ofExprList?.let {
-                    val updateCode =
-                        frontend.getCodeOfSubregion(statement, location.region, it.region)
+                    val updateCode = getCodeOfSubregion(statement, location.region, it.region)
                     iterationExprList.location = ofExprList
                     iterationExprList.code = updateCode
                 }

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonHandler.kt
@@ -42,12 +42,6 @@ abstract class PythonHandler<ResultNode : Node, HandlerNode : Python.AST>(
     override fun handle(ctx: HandlerNode): ResultNode {
         val node = handleNode(ctx)
 
-        // The language frontend might set a location, which we should respect. Otherwise, we will
-        // set the location here.
-        if (node.location == null) {
-            frontend.setCodeAndLocation(node, ctx)
-        }
-
         frontend.setComment(node, ctx)
         frontend.process(ctx, node)
 

--- a/cpg-language-ruby/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/ruby/RubyHandler.kt
+++ b/cpg-language-ruby/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/ruby/RubyHandler.kt
@@ -41,12 +41,6 @@ abstract class RubyHandler<ResultNode : Node, HandlerNode : org.jruby.ast.Node>(
     override fun handle(ctx: HandlerNode): ResultNode {
         val node = handleNode(ctx)
 
-        // The language frontend might set a location, which we should respect. Otherwise, we will
-        // set the location here.
-        if (node.location == null) {
-            frontend.setCodeAndLocation(node, ctx)
-        }
-
         frontend.setComment(node, ctx)
         frontend.process(ctx, node)
 


### PR DESCRIPTION
Instead of directly setting the code and location provider in the implementation of the `CodeAndLocationProvider` we rather now have an implementor of this interface implement the methods `codeOf` and `locationOf` and set the code/location in the node builder. This is more in line with the other providers, since they should *provide* a value, but not *set* it.