### PR TITLE
Synchronize adding TUs

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
@@ -351,7 +351,7 @@ private constructor(
                 }
                 return null
             }
-            component.translationUnits.add(frontend.parse(sourceLocation))
+            component.addTranslationUnit(frontend.parse(sourceLocation))
         } catch (ex: TranslationException) {
             log.error("An error occurred during parsing of ${sourceLocation.name}: ${ex.message}")
             if (config.failOnError) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
@@ -132,7 +132,7 @@ class TranslationResult(
                 components.add(swc)
             }
         }
-        tu?.let { swc.translationUnits.add(it) }
+        tu?.let { swc.addTranslationUnit(it) }
     }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
@@ -38,6 +38,11 @@ open class Component : Node() {
     /** All translation units belonging to this application. */
     @AST val translationUnits: MutableList<TranslationUnitDeclaration> = mutableListOf()
 
+    @Synchronized
+    fun addTranslationUnit(tu: TranslationUnitDeclaration) {
+        translationUnits.add(tu)
+    }
+
     /**
      * All points where unknown data may enter this application, e.g., the main method, or other
      * targets such as listeners to external events such as HTTP requests. This also includes the

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXCompilationDatabaseTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXCompilationDatabaseTest.kt
@@ -130,8 +130,7 @@ class CXXCompilationDatabaseTest {
         assertEquals(2, tus.size)
         val ref = mapOf("main_tu_1.c" to 1, "main_tu_2.c" to 2)
 
-        for (i in tus.indices) {
-            val tu = tus[i]
+        for (tu in tus) {
             val value = ref[File(tu.name.toString()).name]
             val mainFunc = tu.byNameOrNull<FunctionDeclaration>("main")
             assertNotNull(mainFunc)


### PR DESCRIPTION
Adding TUs to a component has not been synchronized. This is obviously a bad idea when parsing multiple files in parallel. It seems to cause at least some of the randomly occurring test failures.