### PR TITLE
Fixed class cast exception in `createImplicitThis`

### DIFF
--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
@@ -792,7 +792,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
         de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression {
         val base: de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
         val thisType =
-            (frontend.scopeManager.currentFunction as MethodDeclaration?)?.receiver?.type
+            (frontend.scopeManager.currentFunction as? MethodDeclaration?)?.receiver?.type
                 ?: unknownType()
         base = newReference("this", thisType).implicit("this")
         return base


### PR DESCRIPTION
The culprit was a hard `as` cast, which should have been a smart `as?` cast.

Fixes #1377
