### PR TITLE
Using ki-shell from JitPack

### DIFF
--- a/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts
@@ -97,9 +97,7 @@ signing {
 //
 // specify Java & Kotlin JVM version
 kotlin {
-    jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
+    jvmToolchain(17)
 }
 
 tasks.withType<KotlinCompile> {

--- a/cpg-console/build.gradle.kts
+++ b/cpg-console/build.gradle.kts
@@ -52,12 +52,25 @@ tasks.withType<Test> {
     }
 }
 
+
+repositories {
+    maven {
+        setUrl("https://jitpack.io")
+    }
+}
+
 dependencies {
     // CPG
     api(projects.cpgAnalysis)
     api(projects.cpgNeo4j)
 
-    implementation(libs.kotlin.script.runtime)
-    implementation(libs.kotlin.coroutines.core)
     implementation(libs.kotlin.ki.shell)
+
+    // ki-shell dependencies, that we need to specify manually because we are using the JitPack "release"
+    implementation(libs.kotlin.script.runtime)
+    implementation(libs.bundles.kotlin.scripting)
+    implementation(libs.antlr.runtime)
+    implementation(libs.kotlin.coroutines.core)
+    implementation(libs.jline)
+
 }

--- a/cpg-console/src/main/kotlin/de/fraunhofer/aisec/cpg/console/CpgConsole.kt
+++ b/cpg-console/src/main/kotlin/de/fraunhofer/aisec/cpg/console/CpgConsole.kt
@@ -29,11 +29,11 @@ import de.fraunhofer.aisec.cpg.analysis.MultiLineToStringStyle
 import de.fraunhofer.aisec.cpg.graph.Node
 import kotlin.script.experimental.api.ScriptCompilationConfiguration
 import kotlin.script.experimental.api.ScriptEvaluationConfiguration
+import kotlin.script.experimental.api.compilerOptions
 import kotlin.script.experimental.jvm.baseClassLoader
 import kotlin.script.experimental.jvm.defaultJvmScriptingHostConfiguration
 import kotlin.script.experimental.jvm.dependenciesFromClassloader
 import kotlin.script.experimental.jvm.jvm
-import org.jetbrains.kotlinx.ki.shell.KotlinShell
 import org.jetbrains.kotlinx.ki.shell.Plugin
 import org.jetbrains.kotlinx.ki.shell.Shell
 import org.jetbrains.kotlinx.ki.shell.configuration.CachedInstance
@@ -52,13 +52,14 @@ object CpgConsole {
                 ScriptCompilationConfiguration {
                     jvm {
                         dependenciesFromClassloader(
-                            classLoader = KotlinShell::class.java.classLoader,
+                            classLoader = CpgConsole::class.java.classLoader,
                             wholeClasspath = true
                         )
                     }
+                    compilerOptions("-jvm-target=17") // this needs to match the JVM toolchain target in the CPG
                 },
                 ScriptEvaluationConfiguration {
-                    jvm { baseClassLoader(Shell::class.java.classLoader) }
+                    jvm { baseClassLoader(CpgConsole::class.java.classLoader) }
                 }
             )
 

--- a/cpg-console/src/main/kotlin/de/fraunhofer/aisec/cpg/console/CpgConsole.kt
+++ b/cpg-console/src/main/kotlin/de/fraunhofer/aisec/cpg/console/CpgConsole.kt
@@ -56,7 +56,9 @@ object CpgConsole {
                             wholeClasspath = true
                         )
                     }
-                    compilerOptions("-jvm-target=17") // this needs to match the JVM toolchain target in the CPG
+                    compilerOptions(
+                        "-jvm-target=17"
+                    ) // this needs to match the JVM toolchain target in the CPG
                 },
                 ScriptEvaluationConfiguration {
                     jvm { baseClassLoader(CpgConsole::class.java.classLoader) }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -527,6 +527,10 @@ fun Node.followPrevDFG(predicate: (Node) -> Boolean): MutableList<Node>? {
     return null
 }
 
+/** Returns all [Node] children in this graph, starting with this [Node]. */
+val Node?.nodes: List<Node>
+    get() = this.allChildren()
+
 /** Returns all [CallExpression] children in this graph, starting with this [Node]. */
 val Node?.calls: List<CallExpression>
     get() = this.allChildren()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,12 +9,17 @@ nexus-publish = "1.3.0"
 [libraries]
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin"}
 kotlin-script-runtime = { module = "org.jetbrains.kotlin:kotlin-script-runtime", version.ref = "kotlin"}
+kotlin-scripting-common = { module = "org.jetbrains.kotlin:kotlin-scripting-common", version.ref = "kotlin"}
+kotlin-scripting-jvm = { module = "org.jetbrains.kotlin:kotlin-scripting-jvm", version.ref = "kotlin"}
+kotlin-scripting-dependencies = { module = "org.jetbrains.kotlin:kotlin-scripting-dependencies", version.ref = "kotlin"}
+kotlin-scripting-dependencies-maven-all = { module = "org.jetbrains.kotlin:kotlin-scripting-dependencies-maven-all", version.ref = "kotlin"}
+kotlin-scripting-ide-services = { module = "org.jetbrains.kotlin:kotlin-scripting-ide-services", version.ref = "kotlin"}
 kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.8.0"}
-kotlin-ki-shell = { module = "org.jetbrains.kotlinx:ki-shell", version = "0.5.2"}
+kotlin-ki-shell = { module = "com.github.Kotlin:kotlin-interactive-shell", version = "5b1ff4d821"}
 kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlin"}  # this is only needed for the testFixtures in cpg-core, everywhere else kotlin("test") is used
 
 log4j-impl = { module = "org.apache.logging.log4j:log4j-slf4j2-impl", version.ref = "log4j" }
-log4j-core = { module= "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
+log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
 
 apache-commons-lang3 = { module = "org.apache.commons:commons-lang3", version = "3.14.0"}
 neo4j-ogm-core = { module = "org.neo4j:neo4j-ogm-core", version.ref = "neo4j"}
@@ -30,7 +35,9 @@ picocli = { module = "info.picocli:picocli", version = "4.7.0"}
 picocli-codegen = { module = "info.picocli:picocli-codegen", version = "4.7.0"}
 jep = { module = "black.ninia:jep", version = "4.2.0" }  # build.yml uses grep to extract the jep verison number for CI/CD purposes
 llvm = { module = "org.bytedeco:llvm-platform", version = "16.0.4-1.5.9"}
-jruby = {module = "org.jruby:jruby-core", version = "9.4.3.0" }
+jruby = { module = "org.jruby:jruby-core", version = "9.4.3.0" }
+jline = { module = "org.jline:jline", version = "3.25.1" }
+antlr-runtime = { module = "org.antlr:antlr4-runtime", version = "4.8-1" } # we cannot upgrade until ki-shell upgrades this!
 
 # test
 junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version = "5.10.0"}
@@ -47,6 +54,13 @@ nexus-publish-gradle = { module = "io.github.gradle-nexus:publish-plugin", versi
 [bundles]
 log4j = ["log4j-impl", "log4j-core"]
 neo4j = ["neo4j-ogm-core", "neo4j-ogm-bolt-driver"]
+kotlin-scripting = [
+    "kotlin-scripting-common",
+    "kotlin-scripting-jvm",
+    "kotlin-scripting-ide-services",
+    "kotlin-scripting-dependencies",
+    "kotlin-scripting-dependencies-maven-all",
+]
 
 [plugins]
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin"}


### PR DESCRIPTION
Instead of reyling on maven central, we are using a JitPack release for the console. This is ok, since the console is a standalone binary and is not to be used as a dependency.

Fixes #1426
Fixes #1439
Fixes #1272
