### PR TITLE
Add members, methods and imports to EnumDeclarations

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -386,7 +386,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
             // this in the call resolver instead
             return null
         }
-        var member: FieldDeclaration? = null
+        var member: ValueDeclaration? = null
         val record = containingClass.recordDeclaration
         if (record != null) {
             member =
@@ -402,6 +402,9 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
                     .filter { it.name.lastPartsMatch(reference.name) }
                     .map { it.definition }
                     .firstOrNull()
+        }
+        if (member == null && record is EnumDeclaration) {
+            member = record.entries[reference.name.localName]
         }
         return member ?: handleUnknownField(containingClass, reference)
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.passes
 
+import de.fraunhofer.aisec.cpg.InferenceConfiguration
 import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.*
 import de.fraunhofer.aisec.cpg.graph.*

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
@@ -36,10 +36,14 @@ import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration
 import de.fraunhofer.aisec.cpg.frontends.Handler
 import de.fraunhofer.aisec.cpg.frontends.HandlerInterface
 import de.fraunhofer.aisec.cpg.graph.*
-import de.fraunhofer.aisec.cpg.graph.declarations.*
-import de.fraunhofer.aisec.cpg.graph.statements.*
+import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
+import de.fraunhofer.aisec.cpg.graph.statements.DeclarationStatement
+import de.fraunhofer.aisec.cpg.graph.statements.Statement
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
-import de.fraunhofer.aisec.cpg.graph.types.*
+import de.fraunhofer.aisec.cpg.graph.types.FunctionType
+import de.fraunhofer.aisec.cpg.graph.types.Type
 import org.slf4j.LoggerFactory
 import java.util.function.Supplier
 import kotlin.collections.set

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
@@ -44,10 +44,10 @@ import de.fraunhofer.aisec.cpg.graph.statements.Statement
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.FunctionType
 import de.fraunhofer.aisec.cpg.graph.types.Type
-import org.slf4j.LoggerFactory
 import java.util.function.Supplier
 import kotlin.collections.set
 import kotlin.jvm.optionals.getOrNull
+import org.slf4j.LoggerFactory
 
 class ExpressionHandler(lang: JavaLanguageFrontend) :
     Handler<Statement, Expression, JavaLanguageFrontend>(Supplier { ProblemExpression() }, lang) {

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.kt
@@ -616,7 +616,7 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val file1 = File("src/test/resources/fix-328/Cat.java")
         val file2 = File("src/test/resources/fix-328/Animal.java")
         val result =
-            TestUtils.analyze(listOf(file1, file2), file1.parentFile.toPath(), true) {
+            analyze(listOf(file1, file2), file1.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
             }
         val tu =
@@ -741,7 +741,7 @@ internal class JavaLanguageFrontendTest : BaseTest() {
     fun testQualifiedThis() {
         val file = File("src/test/resources/compiling/OuterClass.java")
         val result =
-            TestUtils.analyze(listOf(file), file.parentFile.toPath(), true) {
+            analyze(listOf(file), file.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
             }
         val tu = result.components.flatMap { it.translationUnits }.firstOrNull()

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.frontends.java
 
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration
 import de.fraunhofer.aisec.cpg.*
+import de.fraunhofer.aisec.cpg.TestUtils.analyze
 import de.fraunhofer.aisec.cpg.TestUtils.analyzeAndGetFirstTU
 import de.fraunhofer.aisec.cpg.TestUtils.analyzeWithBuilder
 import de.fraunhofer.aisec.cpg.TestUtils.findByUniqueName
@@ -619,10 +620,7 @@ internal class JavaLanguageFrontendTest : BaseTest() {
                 it.registerLanguage(JavaLanguage())
             }
         val tu =
-            findByUniqueName(
-                result.components.flatMap { it.translationUnits },
-                "src/test/resources/fix-328/Cat.java"
-            )
+            findByUniqueName(result.components.flatMap { it.translationUnits }, file1.toString())
         val namespace = tu.getDeclarationAs(0, NamespaceDeclaration::class.java)
         assertNotNull(namespace)
 
@@ -799,5 +797,38 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val jArg = forIterator.calls["println"]?.arguments?.firstOrNull()
         assertNotNull(jArg)
         assertContains(jArg.prevDFG, loopVariable)
+    }
+
+    @Test
+    fun testEnums() {
+        val parentFile = File("src/test/resources/compiling/enums/")
+        val result =
+            analyze(".java", parentFile.toPath(), true) { it.registerLanguage(JavaLanguage()) }
+
+        val enum = result.records["Enums"] as EnumDeclaration
+        assertNotNull(enum)
+
+        assertNotNull(enum.imports["EnumsImport"])
+        assertNotNull(enum.staticImports["CONSTANT"])
+        assertNotNull(enum.staticImports["getConstant"])
+
+        assertEquals(2, enum.entries.size)
+
+        val valueField = enum.fields["value"]
+        assertTrue { valueField?.modifiers?.contains("private") ?: false }
+
+        val nameField = enum.fields["NAME"]
+        assertTrue { nameField?.modifiers?.containsAll(listOf("public", "static")) ?: false }
+
+        assertEquals(1, enum.constructors.size)
+        val constructor = enum.constructors.first()
+        assertNotNull(constructor.parameters["value"])
+        assertNotNull(constructor.bodyOrNull<AssignExpression>(0))
+
+        val mainMethod = enum.methods["main"]
+        assertNotNull(mainMethod)
+        assertNotNull(mainMethod.parameters["args"])
+        assertNotNull(mainMethod.bodyOrNull<DeclarationStatement>(0))
+        assertNotNull(mainMethod.bodyOrNull<DeclarationStatement>(1))
     }
 }

--- a/cpg-language-java/src/test/resources/compiling/enums/Enums.java
+++ b/cpg-language-java/src/test/resources/compiling/enums/Enums.java
@@ -1,0 +1,34 @@
+package compiling.enums;
+
+import compiling.enums.EnumsImport;
+import static compiling.enums.EnumsImport.CONSTANT;
+import static compiling.enums.EnumsImport.getConstant;
+
+public enum Enums {
+
+    VALUE_ONE(1),
+    VALUE_TWO(2);
+
+    private int value;
+    public static final String NAME = "Enums";
+
+    Enums(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public static void main(String[] args) {
+        Enums e1 = Enums.VALUE_ONE;
+        Enums e2 = Enums.VALUE_TWO;
+
+        System.out.println(e1.value + e2.value);
+
+        int c1 = getConstant();
+        int c2 = CONSTANT;
+
+        System.out.println(c1 + c2);
+    }
+}

--- a/cpg-language-java/src/test/resources/compiling/enums/EnumsImport.java
+++ b/cpg-language-java/src/test/resources/compiling/enums/EnumsImport.java
@@ -1,0 +1,11 @@
+package compiling.enums;
+
+public class EnumsImport {
+
+    public static final int CONSTANT = 39;
+
+    public static int getConstant() {
+        return CONSTANT;
+    }
+
+}


### PR DESCRIPTION
Concerning #1445:

- `EnumDeclaration`s now get assigned their class members, just like `RecordDeclaration`s.
- The `ImportResolver` correctly identifies entries and other members of `EnumDeclaration`s that are imported.
- combined the processing of static and non-static `ImportDeclaration`s, separating them afterwards by `isStatic` (a comment indicated that something similar was done earlier and then undone)
- in some cases re-merged the processing of `EnumDeclaration`s and `RecordDeclaration`s and refactored out common parts into separate methods
- added a test and test files for the above changes