### PR TITLE
Adds pass dependencies for `EdgeCachePass`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EdgeCachePass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EdgeCachePass.kt
@@ -29,6 +29,7 @@ import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
+import de.fraunhofer.aisec.cpg.passes.order.DependsOn
 import de.fraunhofer.aisec.cpg.processing.IVisitor
 import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 
@@ -82,6 +83,13 @@ object Edges {
  *
  * The cache itself is stored in the [Edges] object.
  */
+@DependsOn(TypeResolver::class)
+@DependsOn(TypeHierarchyResolver::class)
+@DependsOn(EvaluationOrderGraphPass::class)
+@DependsOn(SymbolResolver::class)
+@DependsOn(DFGPass::class)
+@DependsOn(DynamicInvokeResolver::class)
+@DependsOn(ControlFlowSensitiveDFGPass::class)
 class EdgeCachePass(ctx: TranslationContext) : ComponentPass(ctx) {
     override fun accept(component: Component) {
         Edges.clear()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EdgeCachePass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EdgeCachePass.kt
@@ -83,8 +83,6 @@ object Edges {
  *
  * The cache itself is stored in the [Edges] object.
  */
-@DependsOn(TypeResolver::class)
-@DependsOn(TypeHierarchyResolver::class)
 @DependsOn(EvaluationOrderGraphPass::class)
 @DependsOn(SymbolResolver::class)
 @DependsOn(DFGPass::class)


### PR DESCRIPTION
The `EdgeCachePass` acts as a cache for AST, DFG and EOG edges.

Currently, the `EdgeCachePass` does not depend on any other passes. This can cause incomplete edge caches, if passes, excecuted later, add new edges.

This change adds pass dependencies for all current passes that add AST, DFG or EOG edges.