### PR TITLE
Fixing record inference and making `SymbolResolver` deterministic again

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -727,7 +727,7 @@ class ScopeManager : ScopeProvider {
             val scopes = filterScopes { (it is NameScope && it.name == scopeName) }
             s =
                 if (scopes.isEmpty()) {
-                    Util.errorWithFileLocation(
+                    Util.warnWithFileLocation(
                         node,
                         LOGGER,
                         "Could not find the scope $scopeName needed to resolve the call ${node.name}"

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -35,7 +35,6 @@ import de.fraunhofer.aisec.cpg.graph.statements.SwitchStatement
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Block
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
-import de.fraunhofer.aisec.cpg.helpers.toIdentitySet
 import de.fraunhofer.aisec.cpg.passes.EvaluationOrderGraphPass
 import de.fraunhofer.aisec.cpg.passes.astParent
 
@@ -66,9 +65,9 @@ inline fun <reified T> Node?.allChildren(noinline predicate: ((T) -> Boolean)? =
  * include retrieving it from either an individual [TranslationUnitDeclaration] or the complete
  * [TranslationResult].
  */
-val Node.allEOGStarters: Set<Node>
+val Node.allEOGStarters: List<Node>
     get() {
-        return this.allChildren<EOGStarterHolder>().flatMap { it.eogStarters }.toIdentitySet()
+        return this.allChildren<EOGStarterHolder>().flatMap { it.eogStarters }.distinct()
     }
 
 @JvmName("astNodes")

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -700,7 +700,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
                 if (root != null && record == null) {
                     record =
                         it.startInference(ctx)
-                            ?.inferRecordDeclaration(it, currentTU, locationHint = call)
+                            ?.inferRecordDeclaration(root, currentTU, locationHint = call)
                     // update the record declaration
                     root.recordDeclaration = record
                 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -100,7 +100,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         for (tu in component.translationUnits) {
             currentTU = tu
             // gather all resolution start holders and their start nodes
-            val nodes = tu.allEOGStarters.toSet()
+            val nodes = tu.allEOGStarters
 
             for (node in nodes) {
                 walker.iterate(node)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
@@ -375,17 +375,18 @@ class Inference internal constructor(val start: Node, override val ctx: Translat
             )
             return null
         }
-        debugWithFileLocation(
-            locationHint,
-            log,
-            "Encountered an unknown record type ${type.typeName} during a call. We are going to infer that record"
-        )
 
         return inferInScopeOf(currentTU) {
             // This could be a class or a struct. We start with a class and may have to fine-tune
             // this later.
             val declaration = newRecordDeclaration(type.typeName, kind)
             declaration.isInferred = true
+
+            debugWithFileLocation(
+                locationHint,
+                log,
+                "Inferred a new record declaration ${declaration.name} (${declaration.kind})"
+            )
 
             // Update the type
             type.recordDeclaration = declaration

--- a/cpg-language-go/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
+++ b/cpg-language-go/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
@@ -511,6 +511,30 @@ class GoLanguageFrontendTest : BaseTest() {
     }
 
     @Test
+    fun testPointerTypeInference() {
+        val topLevel = Path.of("src", "test", "resources", "golang")
+        val result =
+            analyze(
+                listOf(
+                    topLevel.resolve("inference.go").toFile(),
+                ),
+                topLevel,
+                true
+            ) {
+                it.registerLanguage<GoLanguage>()
+            }
+        assertNotNull(result)
+
+        // There should be only a single one inferred method with that name
+        val queryDecl = result.methods("Query").singleOrNull()
+        assertNotNull(queryDecl)
+        assertTrue(queryDecl.isInferred)
+
+        val query = result.mcalls["Query"]
+        assertInvokes(query, queryDecl)
+    }
+
+    @Test
     fun testQualifiedCallInMethod() {
         val stdLib = Path.of("src", "test", "resources", "golang-std")
         val topLevel = Path.of("src", "test", "resources", "golang")

--- a/cpg-language-go/src/test/resources/golang/inference.go
+++ b/cpg-language-go/src/test/resources/golang/inference.go
@@ -1,0 +1,8 @@
+package p
+
+import "database/sql"
+
+func doDB() {
+	var db *sql.DB
+	db.Query("SELECT * FROM table")
+}

--- a/cpg-neo4j/src/test/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/ApplicationTest.kt
+++ b/cpg-neo4j/src/test/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/ApplicationTest.kt
@@ -62,7 +62,6 @@ class ApplicationTest {
     @Test
     fun testSerializeCpgViaOGM() {
         val (application, translationResult) = createTranslationResult()
-
         assertEquals(32, translationResult.functions.size)
 
         val (nodes, edges) = application.translateCPGToOGMBuilders(translationResult)

--- a/cpg-neo4j/src/test/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Neo4JTest.kt
+++ b/cpg-neo4j/src/test/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Neo4JTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg_vis_neo4j
+
+import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
+import de.fraunhofer.aisec.cpg.graph.functions
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class Neo4JTest {
+    @Test
+    @Throws(InterruptedException::class)
+    fun testPush() {
+        val (application, translationResult) = createTranslationResult()
+
+        assertEquals(32, translationResult.functions.size)
+
+        application.pushToNeo4j(translationResult)
+
+        val sessionAndSessionFactoryPair = application.connect()
+
+        val session = sessionAndSessionFactoryPair.first
+        session.beginTransaction().use { transaction ->
+            val functions = session.loadAll(FunctionDeclaration::class.java)
+            assertNotNull(functions)
+
+            assertEquals(32, functions.size)
+
+            transaction.commit()
+        }
+
+        session.clear()
+        sessionAndSessionFactoryPair.second.close()
+    }
+}

--- a/cpg-neo4j/src/test/resources/log4j2.xml
+++ b/cpg-neo4j/src/test/resources/log4j2.xml
@@ -1,0 +1,15 @@
+<Configuration status="WARN">
+	<Appenders>
+		<Console name="STDOUT" target="SYSTEM_OUT">
+			<PatternLayout pattern="%d{HH:mm:ss,SSS} %-5p %C{1} %m%n"/>
+			<ThresholdFilter level="DEBUG"/>
+		</Console>
+	</Appenders>
+	<Loggers>
+		<Logger level="DEBUG" name="de.fraunhofer.aisec"/>
+		<Logger level="ERROR" name="org.neo4j.ogm.drivers.bolt.response.BoltResponse" />
+		<Root level="INFO">
+			<AppenderRef ref="STDOUT"/>
+		</Root>
+	</Loggers>
+</Configuration>


### PR DESCRIPTION
This PR changes the type that is forwarded to the inference type. Previously any type (including a pointer type) was forwarded to `inferRecordDeclaration`. This was not working for pointer types. Now instead, the `root` type is used, which points to the element type in case of (chained) pointer types. Also changed an error message in the scope manager to a warning and improved logging in the inference system slightly.

This also makes the behaviour of the `SymbolResolver` deterministic again, this was caused by a unfortunate combination of `toSet` calls.

Fixes #1475
