### PR TITLE
Fixes incorrect field resolution in base classes

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -399,8 +399,8 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         if (member == null) {
             member =
                 containingClass.superTypes
-                    .flatMap { it.fields }
-                    .filter { it.name.lastPartsMatch(reference.name) }
+                    .flatMap { it.recordDeclaration?.fields ?: listOf() }
+                    .filter { it.name.localName == reference.name.localName }
                     .map { it.definition }
                     .firstOrNull()
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeHierarchyResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeHierarchyResolver.kt
@@ -109,6 +109,11 @@ open class TypeHierarchyResolver(ctx: TranslationContext) : ComponentPass(ctx) {
                 .mapNotNull { (it as? ObjectType)?.recordDeclaration }
                 .toSet()
         recordDeclaration.superTypeDeclarations = superTypeDeclarations
+
+        // This will make sure that the type is correctly registered with the type system and that
+        // all the super types are set correctly
+        recordDeclaration.toType()
+
         return superTypeDeclarations
     }
 


### PR DESCRIPTION
Due to a bug in the symbol resolver, we did not resolve fields that are in base classes of classes correctly.
