### PR TITLE
Fixing javaparser resultion error

### DIFF
--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
@@ -470,8 +470,13 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
 
     private fun handleThisExpression(expr: Expression): Reference {
         val thisExpr = expr.asThisExpr()
-        val resolvedValueDeclaration = thisExpr.resolve()
-        val type = this.objectType(resolvedValueDeclaration.qualifiedName)
+        var qualifiedName: String
+        try {
+            qualifiedName = thisExpr.resolve().qualifiedName
+        } catch (use: UnsolvedSymbolException) {
+            qualifiedName = frontend.scopeManager.currentRecord?.name.toString()
+        }
+        val type = this.objectType(qualifiedName)
         var name = thisExpr.toString()
 
         // If the typeName is specified, then this a "qualified this" and we need to handle it

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
@@ -470,12 +470,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
 
     private fun handleThisExpression(expr: Expression): Reference {
         val thisExpr = expr.asThisExpr()
-        var qualifiedName: String
-        try {
-            qualifiedName = thisExpr.resolve().qualifiedName
-        } catch (use: UnsolvedSymbolException) {
-            qualifiedName = frontend.scopeManager.currentRecord?.name.toString()
-        }
+        val qualifiedName = frontend.scopeManager.currentRecord?.name.toString()
         val type = this.objectType(qualifiedName)
         var name = thisExpr.toString()
 


### PR DESCRIPTION
When javaparser tries to resolve the type of `this` it failed in a case where it was used in an anomymouse inner class. In this case we now take the name of the current record from the scope manager.