### PR TITLE
Fix output of pass ordering and dependencies

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
@@ -395,7 +395,7 @@ private constructor(
         }
 
     class Builder {
-        private var config: TranslationConfiguration = TranslationConfiguration.builder().build()
+        private var config: TranslationConfiguration? = null
 
         fun config(config: TranslationConfiguration): Builder {
             this.config = config
@@ -403,7 +403,7 @@ private constructor(
         }
 
         fun build(): TranslationManager {
-            return TranslationManager(config)
+            return TranslationManager(config ?: TranslationConfiguration.builder().build())
         }
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/PassWithDependencies.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/order/PassWithDependencies.kt
@@ -53,10 +53,15 @@ data class PassWithDependencies(
         }
 
     override fun toString(): String {
-        return ToStringBuilder(this, Node.TO_STRING_STYLE)
-            .append("pass", pass.simpleName)
-            .append("softDependencies", softDependencies.map { it.simpleName })
-            .append("hardDependencies", hardDependencies.map { it.simpleName })
-            .toString()
+        val builder = ToStringBuilder(this, Node.TO_STRING_STYLE).append("pass", pass.simpleName)
+
+        if (softDependencies.isNotEmpty()) {
+            builder.append("softDependencies", softDependencies.map { it.simpleName })
+        }
+
+        if (hardDependencies.isNotEmpty()) {
+            builder.append("hardDependencies", hardDependencies.map { it.simpleName })
+        }
+        return builder.toString()
     }
 }


### PR DESCRIPTION
Fixes #1480 

- Things are printed twice (once empty) because a default `config` of the `TranslationManager` is built (which is empty) and one actual config set by `TranslationManager.Builder.config()`. Fix: No default config if it is not required.