### PR TITLE
Using `io.joern:eclipse-cdt-core` release of CDT

### DIFF
--- a/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts
@@ -21,16 +21,6 @@ java {
 //
 repositories {
     mavenCentral()
-
-    ivy {
-        setUrl("https://download.eclipse.org/tools/cdt/releases/11.3/cdt-11.3.1/plugins")
-        metadataSources {
-            artifact()
-        }
-        patternLayout {
-            artifact("/[organisation].[module]_[revision].[ext]")
-        }
-    }
 }
 
 //

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ jacksonyml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yam
 eclipse-runtime = { module = "org.eclipse.platform:org.eclipse.core.runtime", version = "3.31.0"}
 osgi-service = { module = "org.osgi:org.osgi.service.prefs", version = "1.1.2"}
 icu4j = { module = "com.ibm.icu:icu4j", version = "74.2"}
-eclipse-cdt-core = { module = "org.eclipse.cdt:core", version = "8.3.1.202309150117"}
+eclipse-cdt-core = { module = "io.joern:eclipse-cdt-core", version = "8.4.0.202401242025_1"}
 picocli = { module = "info.picocli:picocli", version = "4.7.0"}
 picocli-codegen = { module = "info.picocli:picocli-codegen", version = "4.7.0"}
 jep = { module = "black.ninia:jep", version = "4.2.0" }  # build.yml uses grep to extract the jep verison number for CI/CD purposes


### PR DESCRIPTION
It seems that joern provides releases of CDT on maven central. We could use this instead of having this rather ugly workaround with the ivy repository, which we need to change with every CDT release.

I am not sure how often they will update it. Any opinions on this?
