### PR TITLE
Remove slow `toString` implementation

### DIFF
--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/NumberSet.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/NumberSet.kt
@@ -25,9 +25,6 @@
  */
 package de.fraunhofer.aisec.cpg.analysis
 
-import de.fraunhofer.aisec.cpg.graph.Node
-import org.apache.commons.lang3.builder.ToStringBuilder
-
 interface NumberSet {
     fun min(): Long
 
@@ -71,7 +68,7 @@ class Interval : NumberSet {
     }
 }
 
-class ConcreteNumberSet(var values: MutableSet<Long> = mutableSetOf()) : NumberSet {
+data class ConcreteNumberSet(var values: MutableSet<Long> = mutableSetOf()) : NumberSet {
     override fun addValue(value: Long) {
         values.add(value)
     }
@@ -90,22 +87,5 @@ class ConcreteNumberSet(var values: MutableSet<Long> = mutableSetOf()) : NumberS
 
     override fun clear() {
         values.clear()
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as ConcreteNumberSet
-
-        return values == other.values
-    }
-
-    override fun hashCode(): Int {
-        return values.hashCode()
-    }
-
-    override fun toString(): String {
-        return ToStringBuilder(this, Node.TO_STRING_STYLE).append(values).toString()
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/InferenceConfiguration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/InferenceConfiguration.kt
@@ -25,9 +25,6 @@
  */
 package de.fraunhofer.aisec.cpg
 
-import org.apache.commons.lang3.builder.ToStringBuilder
-import org.apache.commons.lang3.builder.ToStringStyle
-
 /**
  * This class holds configuration options for the inference of certain constructs and auto-guessing
  * when executing language frontends.
@@ -93,13 +90,5 @@ private constructor(
         fun builder(): Builder {
             return Builder()
         }
-    }
-
-    override fun toString(): String {
-        return ToStringBuilder(this, ToStringStyle.JSON_STYLE)
-            .append("guessCastExpressions", guessCastExpressions)
-            .append("inferRecords", inferRecords)
-            .append("inferDfgForUnresolvedCalls", inferDfgForUnresolvedSymbols)
-            .toString()
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -44,7 +44,6 @@ import de.fraunhofer.aisec.cpg.passes.*
 import de.fraunhofer.aisec.cpg.processing.IVisitable
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 import java.util.*
-import org.apache.commons.lang3.builder.ToStringBuilder
 import org.apache.commons.lang3.builder.ToStringStyle
 import org.neo4j.ogm.annotation.*
 import org.neo4j.ogm.annotation.typeconversion.Convert
@@ -412,13 +411,7 @@ open class Node : IVisitable<Node>, Persistable, LanguageProvider, ScopeProvider
     }
 
     override fun toString(): String {
-        val builder = ToStringBuilder(this, TO_STRING_STYLE)
-
-        if (name.isNotEmpty()) {
-            builder.append("name", name)
-        }
-
-        return builder.append("location", location).toString()
+        return "${this::class.simpleName}(name=$name,location=$location)"
     }
 
     override fun equals(other: Any?): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/EnumDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/EnumDeclaration.kt
@@ -28,7 +28,6 @@ package de.fraunhofer.aisec.cpg.graph.declarations
 import de.fraunhofer.aisec.cpg.graph.AST
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
-import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.Relationship
 
 class EnumDeclaration : RecordDeclaration() {
@@ -37,11 +36,4 @@ class EnumDeclaration : RecordDeclaration() {
     var entryEdges: MutableList<PropertyEdge<EnumConstantDeclaration>> = ArrayList()
 
     var entries by PropertyEdgeDelegate(EnumDeclaration::entryEdges)
-
-    override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE)
-            .appendSuper(super.toString())
-            .append("entries", entries)
-            .toString()
-    }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/FieldDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/FieldDeclaration.kt
@@ -27,7 +27,6 @@ package de.fraunhofer.aisec.cpg.graph.declarations
 
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import java.util.*
-import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.Relationship
 
 /**
@@ -52,11 +51,7 @@ class FieldDeclaration : VariableDeclaration() {
     var modifiers: List<String> = mutableListOf()
 
     override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE)
-            .appendSuper(super.toString())
-            .append("initializer", initializer)
-            .append("modifiers", modifiers)
-            .toString()
+        return "${this::class.simpleName}(name=$name,type=$type,initializer=$initializer,modifiers=$modifiers,location=$location)"
     }
 
     override fun equals(other: Any?): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/FunctionDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/FunctionDeclaration.kt
@@ -35,7 +35,6 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.Block
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import java.util.*
-import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.Relationship
 
 /** Represents the declaration or definition of a function. */
@@ -176,10 +175,7 @@ open class FunctionDeclaration : ValueDeclaration(), DeclarationHolder, EOGStart
     }
 
     override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE)
-            .appendSuper(super.toString())
-            .append("parameters", parameters)
-            .toString()
+        return "${this::class.simpleName}(name=$name,parameters=$parameters],isDefinition=$isDefinition,location=$location)"
     }
 
     override val eogStarters: List<Node>

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/IncludeDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/IncludeDeclaration.kt
@@ -31,7 +31,6 @@ import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
 import java.util.Objects
-import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.Relationship
 
 /** This declaration represents either an include or an import, depending on the language. */
@@ -71,16 +70,6 @@ class IncludeDeclaration : Declaration() {
         val propertyEdge = PropertyEdge(this, problemDeclaration)
         propertyEdge.addProperty(Properties.INDEX, problemEdges.size)
         problemEdges.add(propertyEdge)
-    }
-
-    override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE)
-            .appendSuper(super.toString())
-            .append("name", name)
-            .append("filename", filename)
-            .append("includes", includes)
-            .append("problems", problems)
-            .toString()
     }
 
     override fun equals(other: Any?): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ProblemDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ProblemDeclaration.kt
@@ -27,7 +27,6 @@ package de.fraunhofer.aisec.cpg.graph.declarations
 
 import de.fraunhofer.aisec.cpg.graph.ProblemNode
 import java.util.Objects
-import org.apache.commons.lang3.builder.ToStringBuilder
 
 /**
  * A node where the statement could not be translated by the graph. We use ProblemExpressions
@@ -39,10 +38,7 @@ class ProblemDeclaration(
 ) : ValueDeclaration(), ProblemNode {
 
     override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE)
-            .appendSuper(super.toString())
-            .append("problem", problem)
-            .toString()
+        return "${this::class.simpleName}(problem=$problem,type=$type,location=$location)"
     }
 
     override fun equals(other: Any?): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/RecordDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/RecordDeclaration.kt
@@ -32,7 +32,6 @@ import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
 import de.fraunhofer.aisec.cpg.graph.statements.Statement
 import de.fraunhofer.aisec.cpg.graph.types.ObjectType
 import de.fraunhofer.aisec.cpg.graph.types.Type
-import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.Relationship
 import org.neo4j.ogm.annotation.Transient
 
@@ -160,16 +159,7 @@ open class RecordDeclaration : Declaration(), DeclarationHolder, StatementHolder
     }
 
     override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE)
-            .appendSuper(super.toString())
-            .append("name", name)
-            .append("kind", kind)
-            .append("superTypeDeclarations", superTypeDeclarations)
-            .append("fields", fields)
-            .append("methods", methods)
-            .append("constructors", constructors)
-            .append("records", records)
-            .toString()
+        return "${this::class.simpleName}(name=$name,kind=$kind,location=$location)"
     }
 
     override val eogStarters: List<Node>

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TranslationUnitDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TranslationUnitDeclaration.kt
@@ -32,7 +32,6 @@ import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.unwrap
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
 import de.fraunhofer.aisec.cpg.graph.statements.Statement
 import java.util.*
-import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.Relationship
 
 /** The top most declaration, representing a translation unit, for example a file. */
@@ -115,14 +114,6 @@ class TranslationUnitDeclaration :
             addIfNotContains(namespaceEdges, declaration)
         }
         addIfNotContains(declarationEdges, declaration)
-    }
-
-    override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE)
-            .append("declarations", declarationEdges)
-            .append("includes", includeEdges)
-            .append("namespaces", namespaceEdges)
-            .toString()
     }
 
     override val eogStarters: List<Node>

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TypedefDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TypedefDeclaration.kt
@@ -28,7 +28,6 @@ package de.fraunhofer.aisec.cpg.graph.declarations
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.graph.types.UnknownType
 import java.util.*
-import org.apache.commons.lang3.builder.ToStringBuilder
 
 /** Represents a type alias definition as found in C/C++: `typedef unsigned long ulong;` */
 class TypedefDeclaration : Declaration() {
@@ -47,9 +46,6 @@ class TypedefDeclaration : Declaration() {
     override fun hashCode() = Objects.hash(super.hashCode(), type, alias)
 
     override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE)
-            .append("type", type)
-            .append("alias", alias)
-            .toString()
+        return "${this::class.simpleName}(type=$type,alias=$alias,location=$location)"
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ValueDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ValueDeclaration.kt
@@ -35,7 +35,6 @@ import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.helpers.identitySetOf
 import de.fraunhofer.aisec.cpg.passes.SymbolResolver
 import java.util.stream.Collectors
-import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.NodeEntity
 import org.neo4j.ogm.annotation.Relationship
 
@@ -109,7 +108,7 @@ abstract class ValueDeclaration : Declaration(), HasType, HasAliases {
     }
 
     override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE).appendSuper(super.toString()).toString()
+        return "${this::class.simpleName}(name=$name,type=$type,location=$location)"
     }
 
     override fun equals(other: Any?): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/VariableDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/VariableDeclaration.kt
@@ -34,7 +34,6 @@ import de.fraunhofer.aisec.cpg.graph.types.AutoType
 import de.fraunhofer.aisec.cpg.graph.types.HasType
 import de.fraunhofer.aisec.cpg.graph.types.TupleType
 import de.fraunhofer.aisec.cpg.graph.types.Type
-import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.Relationship
 
 /** Represents the declaration of a local variable. */
@@ -83,11 +82,7 @@ open class VariableDeclaration : ValueDeclaration(), HasInitializer, HasType.Typ
     }
 
     override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE)
-            .append("name", name)
-            .append("location", location)
-            .append("initializer", initializer)
-            .toString()
+        return "${this::class.simpleName}(name=$name,type=$type,initializer=$initializer,location=$location)"
     }
 
     override fun typeChanged(newType: Type, src: HasType) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
@@ -28,10 +28,8 @@ package de.fraunhofer.aisec.cpg.graph.scopes
 import com.fasterxml.jackson.annotation.JsonBackReference
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.Node.Companion.TO_STRING_STYLE
 import de.fraunhofer.aisec.cpg.graph.statements.LabelStatement
 import de.fraunhofer.aisec.cpg.helpers.neo4j.NameConverter
-import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.GeneratedValue
 import org.neo4j.ogm.annotation.Id
 import org.neo4j.ogm.annotation.NodeEntity
@@ -100,6 +98,10 @@ abstract class Scope(
         return result
     }
 
+    override fun toString(): String {
+        return "${this::class.simpleName}(name=$name)"
+    }
+
     /** Returns the [GlobalScope] of this scope by traversing its parents upwards. */
     val globalScope: Scope?
         get() {
@@ -114,14 +116,4 @@ abstract class Scope(
 
             return scope
         }
-
-    override fun toString(): String {
-        val builder = ToStringBuilder(this, TO_STRING_STYLE)
-
-        if (name?.isNotEmpty() == true) {
-            builder.append("name", name)
-        }
-
-        return builder.toString()
-    }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/DeclarationStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/DeclarationStatement.kt
@@ -32,7 +32,6 @@ import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
 import java.util.Objects
-import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.Relationship
 
 /**
@@ -77,10 +76,7 @@ open class DeclarationStatement : Statement() {
     }
 
     override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE)
-            .appendSuper(super.toString())
-            .append("declarations", declarations)
-            .toString()
+        return "${this::class.simpleName}(label=$declarations,location=$location)"
     }
 
     override fun equals(other: Any?): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/DoStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/DoStatement.kt
@@ -29,7 +29,6 @@ import de.fraunhofer.aisec.cpg.graph.AST
 import de.fraunhofer.aisec.cpg.graph.ArgumentHolder
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import java.util.*
-import org.apache.commons.lang3.builder.ToStringBuilder
 
 /** Represents a conditional loop statement of the form: `do{...}while(...)`. */
 class DoStatement : Statement(), ArgumentHolder {
@@ -43,13 +42,6 @@ class DoStatement : Statement(), ArgumentHolder {
      * false for the first time. Usually a [Block].
      */
     @AST var statement: Statement? = null
-
-    override fun toString() =
-        ToStringBuilder(this, TO_STRING_STYLE)
-            .appendSuper(super.toString())
-            .append("condition", condition)
-            .append("statement", statement)
-            .toString()
 
     override fun addArgument(expression: Expression) {
         this.condition = expression

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/IfStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/IfStatement.kt
@@ -32,7 +32,6 @@ import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import java.util.*
-import org.apache.commons.lang3.builder.ToStringBuilder
 
 /** Represents a condition control flow statement, usually indicating by `If`. */
 class IfStatement : Statement(), BranchingNode, ArgumentHolder {
@@ -58,15 +57,6 @@ class IfStatement : Statement(), BranchingNode, ArgumentHolder {
      * The statement that is executed, if the condition is evaluated as false. Usually a [Block].
      */
     @AST var elseStatement: Statement? = null
-
-    override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE)
-            .appendSuper(super.toString())
-            .append("condition", condition)
-            .append("thenStatement", thenStatement)
-            .append("elseStatement", elseStatement)
-            .toString()
-    }
 
     override fun addArgument(expression: Expression) {
         this.condition = expression

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/LabelStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/LabelStatement.kt
@@ -29,7 +29,6 @@ import de.fraunhofer.aisec.cpg.graph.AST
 import de.fraunhofer.aisec.cpg.graph.StatementHolder
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import java.util.Objects
-import org.apache.commons.lang3.builder.ToStringBuilder
 
 /**
  * A label attached to a statement that is used to change control flow by labeled continue and
@@ -41,14 +40,6 @@ class LabelStatement : Statement(), StatementHolder {
 
     /** Label in the form of a String */
     var label: String? = null
-
-    override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE)
-            .appendSuper(super.toString())
-            .append("subStatement", subStatement)
-            .append("label", label)
-            .toString()
-    }
 
     override var statementEdges: MutableList<PropertyEdge<Statement>>
         get() = subStatement?.let { PropertyEdge.wrap(listOf(it), this) } ?: mutableListOf()
@@ -63,4 +54,8 @@ class LabelStatement : Statement(), StatementHolder {
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), label)
+
+    override fun toString(): String {
+        return "${this::class.simpleName}(label=$label,location=$location)"
+    }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/ReturnStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/ReturnStatement.kt
@@ -29,7 +29,6 @@ import de.fraunhofer.aisec.cpg.graph.AST
 import de.fraunhofer.aisec.cpg.graph.ArgumentHolder
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import java.util.Objects
-import org.apache.commons.lang3.builder.ToStringBuilder
 
 /** Represents a statement that returns out of the current function. */
 class ReturnStatement : Statement(), ArgumentHolder {
@@ -50,10 +49,7 @@ class ReturnStatement : Statement(), ArgumentHolder {
         }
 
     override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE)
-            .appendSuper(super.toString())
-            .append("returnValues", returnValues)
-            .toString()
+        return "${this::class.simpleName}(returnValues=$returnValues,location=$location)"
     }
 
     override fun addArgument(expression: Expression) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/WhileStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/WhileStatement.kt
@@ -32,7 +32,6 @@ import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import java.util.*
-import org.apache.commons.lang3.builder.ToStringBuilder
 
 /** Represents a conditional loop statement of the form: `while(...){...}`. */
 class WhileStatement : Statement(), BranchingNode, ArgumentHolder {
@@ -50,14 +49,6 @@ class WhileStatement : Statement(), BranchingNode, ArgumentHolder {
 
     override val branchedBy: Node?
         get() = condition ?: conditionDeclaration
-
-    override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE)
-            .appendSuper(super.toString())
-            .append("condition", condition)
-            .append("statement", statement)
-            .toString()
-    }
 
     override fun addArgument(expression: Expression) {
         this.condition = expression

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/BinaryOperator.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/BinaryOperator.kt
@@ -106,11 +106,7 @@ open class BinaryOperator :
     }
 
     override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE)
-            .append("lhs", lhs.name)
-            .append("rhs", rhs.name)
-            .append("operatorCode", operatorCode)
-            .toString()
+        return "${this::class.simpleName}(lhs=$lhs,operatorCode=$operatorCode,rhs=$rhs,type=$type,location=$location)"
     }
 
     override fun typeChanged(newType: Type, src: HasType) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Block.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Block.kt
@@ -54,7 +54,7 @@ open class Block : Expression(), StatementHolder {
     var isStaticBlock = false
 
     override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE).appendSuper(super.toString()).toString()
+        return "${this::class.simpleName}(location=$location)"
     }
 
     override fun equals(other: Any?): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
@@ -38,7 +38,6 @@ import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.wrap
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.passes.SymbolResolver
 import java.util.*
-import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.Relationship
 
 /**
@@ -266,7 +265,7 @@ open class CallExpression : Expression(), HasType.TypeObserver, ArgumentHolder {
     }
 
     override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE).appendSuper(super.toString()).toString()
+        return "${this::class.simpleName}(name=$name,argument=$arguments,type=$type,location=$location)"
     }
 
     override fun equals(other: Any?): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/ConstructExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/ConstructExpression.kt
@@ -31,7 +31,6 @@ import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.types.UnknownType
 import de.fraunhofer.aisec.cpg.passes.SymbolResolver
 import java.util.*
-import org.apache.commons.lang3.builder.ToStringBuilder
 
 /**
  * Represents a call to a constructor, usually as an initializer.
@@ -79,15 +78,6 @@ class ConstructExpression : CallExpression() {
                 type = objectType(value.name)
             }
         }
-
-    override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE)
-            .appendSuper(super.toString())
-            .append("constructor", constructor)
-            .append("instantiates", instantiates)
-            .append("arguments", arguments)
-            .toString()
-    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Expression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Expression.kt
@@ -29,7 +29,6 @@ import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.statements.Statement
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.helpers.identitySetOf
-import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.NodeEntity
 import org.neo4j.ogm.annotation.Transient
 
@@ -77,10 +76,7 @@ abstract class Expression : Statement(), HasType {
         }
 
     override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE)
-            .appendSuper(super.toString())
-            .append("type", type)
-            .toString()
+        return "${this::class.simpleName}(name=$name,type=$type,location=$location)"
     }
 
     override fun equals(other: Any?): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Literal.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Literal.kt
@@ -41,10 +41,7 @@ class Literal<T> : Expression() {
     @Convert(ValueConverter::class) var value: T? = null
 
     override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE)
-            .appendSuper(super.toString())
-            .append("value", value)
-            .toString()
+        return "${this::class.simpleName}(value=$name,type=$type,location=$location)"
     }
 
     override fun equals(other: Any?): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/MemberExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/MemberExpression.kt
@@ -33,7 +33,6 @@ import de.fraunhofer.aisec.cpg.graph.fqn
 import de.fraunhofer.aisec.cpg.graph.types.HasType
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import java.util.Objects
-import org.apache.commons.lang3.builder.ToStringBuilder
 
 /**
  * Represents access to a member of a [RecordDeclaration], such as `obj.property`. Another common
@@ -51,13 +50,6 @@ class MemberExpression : Reference(), ArgumentHolder, HasBase {
         }
 
     override var operatorCode: String? = null
-
-    override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE)
-            .appendSuper(super.toString())
-            .append("base", base)
-            .toString()
-    }
 
     override fun addArgument(expression: Expression) {
         this.base = expression

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Reference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Reference.kt
@@ -39,7 +39,6 @@ import de.fraunhofer.aisec.cpg.graph.types.HasType
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.passes.SymbolResolver
 import java.util.*
-import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.Relationship
 
 /**
@@ -119,13 +118,6 @@ open class Reference : Expression(), HasType.TypeObserver, HasAliases {
         return if (refersTo?.javaClass?.let { clazz.isAssignableFrom(it) } == true)
             clazz.cast(refersTo)
         else null
-    }
-
-    override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE)
-            .appendSuper(super.toString())
-            .append("refersTo", refersTo)
-            .toString()
     }
 
     override fun typeChanged(newType: Type, src: HasType) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/Type.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/Type.kt
@@ -189,7 +189,7 @@ abstract class Type : Node {
     override fun hashCode() = Objects.hash(name, language)
 
     override fun toString(): String {
-        return ToStringBuilder(this, TO_STRING_STYLE).append("name", name).toString()
+        return "${this::class.simpleName}(name=$name)"
     }
 
     companion object {


### PR DESCRIPTION
This PR limits ourselves to a very limited implementation of `toString`. The old approach using a to-string-builder and including a lot of fields was actually costing some performance, for example in the (debug) output of the inference system.

I would argue that toString should only include the very basic things to quickly identify a node, which is in most cases its name and location and then sparsley adding additional information. In one particular case the execution time of the symbol resolver was reduced from 3000ms to 500ms.
