### PR TITLE
Adjusting `HasType` type once a language changes

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -716,6 +716,13 @@ class ScopeManager : ScopeProvider {
                 CallResolutionResult.SuccessKind.UNRESOLVED,
                 startScope,
             )
+        val language = call.language
+
+        if (language == null) {
+            result.success = CallResolutionResult.SuccessKind.PROBLEMATIC
+            return result
+        }
+
         // We can only resolve non-dynamic function calls here that have a reference node to our
         // function
         val callee = call.callee as? Reference ?: return result
@@ -725,7 +732,7 @@ class ScopeManager : ScopeProvider {
 
         // Retrieve a list of possible functions with a matching name
         result.candidateFunctions =
-            callee.candidates?.filterIsInstance<FunctionDeclaration>()?.toSet() ?: setOf()
+            callee.candidates.filterIsInstance<FunctionDeclaration>()?.toSet() ?: setOf()
 
         if (call.language !is HasFunctionOverloading) {
             // If the function does not allow function overloading, and we have multiple candidate
@@ -764,11 +771,9 @@ class ScopeManager : ScopeProvider {
 
         // Otherwise, give the language a chance to narrow down the result (ideally to one) and set
         // the success kind.
-        val pair = call.language?.bestViableResolution(result)
-        if (pair != null) {
-            result.bestViable = pair.first
-            result.success = pair.second
-        }
+        val pair = language.bestViableResolution(result)
+        result.bestViable = pair.first
+        result.success = pair.second
 
         return result
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ValueDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ValueDeclaration.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.graph.declarations
 
 import de.fraunhofer.aisec.cpg.PopulatedByPass
+import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.edge.Properties
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
@@ -44,6 +45,16 @@ import org.neo4j.ogm.annotation.Relationship
 abstract class ValueDeclaration : Declaration(), HasType, HasAliases {
 
     override val typeObservers: MutableSet<HasType.TypeObserver> = identitySetOf()
+
+    override var language: Language<*>? = null
+        get() = super.language
+        set(value) {
+            // We need to adjust an eventual unknown type, once we know the language
+            field = value
+            if (value != null && type is UnknownType) {
+                type = UnknownType.getUnknownType(value)
+            }
+        }
 
     /** The type of this declaration. */
     override var type: Type = unknownType()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ValueDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ValueDeclaration.kt
@@ -47,7 +47,6 @@ abstract class ValueDeclaration : Declaration(), HasType, HasAliases {
     override val typeObservers: MutableSet<HasType.TypeObserver> = identitySetOf()
 
     override var language: Language<*>? = null
-        get() = super.language
         set(value) {
             // We need to adjust an eventual unknown type, once we know the language
             field = value

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Expression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Expression.kt
@@ -50,7 +50,6 @@ abstract class Expression : Statement(), HasType {
     @Transient override val typeObservers: MutableSet<HasType.TypeObserver> = identitySetOf()
 
     override var language: Language<*>? = null
-        get() = super.language
         set(value) {
             // We need to adjust an eventual unknown type, once we know the language
             field = value

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Expression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Expression.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.graph.statements.expressions
 
+import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.statements.Statement
 import de.fraunhofer.aisec.cpg.graph.types.*
@@ -47,6 +48,16 @@ import org.neo4j.ogm.annotation.Transient
 @NodeEntity
 abstract class Expression : Statement(), HasType {
     @Transient override val typeObservers: MutableSet<HasType.TypeObserver> = identitySetOf()
+
+    override var language: Language<*>? = null
+        get() = super.language
+        set(value) {
+            // We need to adjust an eventual unknown type, once we know the language
+            field = value
+            if (value != null && type is UnknownType) {
+                type = UnknownType.getUnknownType(value)
+            }
+        }
 
     override var type: Type = unknownType()
         set(value) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -515,7 +515,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
                 newFieldDeclaration(
                     name.localName,
                     // we will set the type later through the type inference observer
-                    unknownType(),
+                    record.unknownType(),
                     listOf(),
                     null,
                     false,

--- a/cpg-neo4j/src/test/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/ApplicationTest.kt
+++ b/cpg-neo4j/src/test/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/ApplicationTest.kt
@@ -63,7 +63,7 @@ class ApplicationTest {
     fun testSerializeCpgViaOGM() {
         val (application, translationResult) = createTranslationResult()
         // TODO: this was originally 32 nodes, it seems we can now resolve less :(
-        assertEquals(35, translationResult.functions.size)
+        assertEquals(34, translationResult.functions.size)
 
         val (nodes, edges) = application.translateCPGToOGMBuilders(translationResult)
         val graph = application.buildJsonGraph(nodes, edges)
@@ -96,7 +96,7 @@ class ApplicationTest {
     fun testExportToJson() {
         val (application, translationResult) = createTranslationResult()
         // TODO: this was originally 32 nodes, it seems we can now resolve less :(
-        assertEquals(35, translationResult.functions.size)
+        assertEquals(34, translationResult.functions.size)
         val path = createTempFile().toFile()
         application.exportToJson(translationResult, path)
         assert(path.length() > 0)

--- a/cpg-neo4j/src/test/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Neo4JTest.kt
+++ b/cpg-neo4j/src/test/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Neo4JTest.kt
@@ -40,7 +40,7 @@ class Neo4JTest {
         val (application, translationResult) = createTranslationResult()
 
         // TODO: this was originally 32 nodes, it seems we can now resolve less :(
-        assertEquals(35, translationResult.functions.size)
+        assertEquals(34, translationResult.functions.size)
 
         application.pushToNeo4j(translationResult)
 
@@ -51,7 +51,7 @@ class Neo4JTest {
             val functions = session.loadAll(FunctionDeclaration::class.java)
             assertNotNull(functions)
 
-            assertEquals(35, functions.size)
+            assertEquals(34, functions.size)
 
             transaction.commit()
         }


### PR DESCRIPTION
We need to adjust the `UnknownType` once we know the language, otherwise there is a problem when comparing types. This stems from the fact that we initialise the type property with an unknown type that has a `null` language.
