### PR TITLE
Take operator into account when evaluating conditional expressions

### DIFF
--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/ValueEvaluator.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/ValueEvaluator.kt
@@ -361,12 +361,17 @@ open class ValueEvaluator(
     }
 
     protected open fun handleConditionalExpression(expr: ConditionalExpression, depth: Int): Any? {
-        // Assume that condition is a binary operator
-        if (expr.condition is BinaryOperator) {
-            val lhs = evaluateInternal((expr.condition as? BinaryOperator)?.lhs, depth)
-            val rhs = evaluateInternal((expr.condition as? BinaryOperator)?.rhs, depth)
+        var condition = expr.condition
 
-            return if (lhs == rhs) {
+        // Assume that condition is a binary operator
+        if (condition is BinaryOperator) {
+            val lhs = evaluateInternal(condition.lhs, depth)
+            val rhs = evaluateInternal(condition.rhs, depth)
+
+            // Compute the effect of the comparison
+            val comparison = computeBinaryOpEffect(lhs, rhs, condition)
+
+            return if (comparison == true) {
                 evaluateInternal(expr.thenExpression, depth + 1)
             } else {
                 evaluateInternal(expr.elseExpression, depth + 1)

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/ValueEvaluator.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/ValueEvaluator.kt
@@ -179,6 +179,7 @@ open class ValueEvaluator(
             "<" -> handleLess(lhsValue, rhsValue, expr)
             "<=" -> handleLEq(lhsValue, rhsValue, expr)
             "==" -> handleEq(lhsValue, rhsValue, expr)
+            "!=" -> handleNEq(lhsValue, rhsValue, expr)
             else -> cannotEvaluate(expr as Node, this)
         }
     }
@@ -293,6 +294,14 @@ open class ValueEvaluator(
     private fun handleEq(lhsValue: Any?, rhsValue: Any?, expr: Expression?): Any? {
         return if (lhsValue is Number && rhsValue is Number) {
             lhsValue.compareTo(rhsValue) == 0
+        } else {
+            cannotEvaluate(expr, this)
+        }
+    }
+
+    private fun handleNEq(lhsValue: Any?, rhsValue: Any?, expr: Expression?): Any? {
+        return if (lhsValue is Number && rhsValue is Number) {
+            lhsValue.compareTo(rhsValue) != 0
         } else {
             cannotEvaluate(expr, this)
         }

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/ValueEvaluatorTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/analysis/ValueEvaluatorTest.kt
@@ -772,7 +772,7 @@ class ValueEvaluatorTest {
     }
 
     @Test
-    fun handleConditionalExpression() {
+    fun testHandleConditionalExpression() {
         with(TestLanguageFrontend()) {
             val a = newVariableDeclaration("a")
             a.initializer = newLiteral(1)
@@ -781,12 +781,25 @@ class ValueEvaluatorTest {
             aRef.refersTo = a
             aRef.prevDFG = mutableSetOf(a)
 
-            val comparison = newBinaryOperator("!=")
+            // handle not equals
+            var comparison = newBinaryOperator("!=")
             comparison.lhs = aRef
             comparison.rhs = newLiteral(1)
 
-            val cond = newConditionalExpression(comparison, newLiteral(2), aRef)
+            var cond = newConditionalExpression(comparison, newLiteral(2), aRef)
             assertEquals(1, cond.evaluate())
+
+            // handle equals
+            comparison = newBinaryOperator("==")
+            comparison.lhs = aRef
+            comparison.rhs = newLiteral(1)
+
+            cond = newConditionalExpression(comparison, newLiteral(2), aRef)
+            assertEquals(2, cond.evaluate())
+
+            // handle invalid
+            cond = newConditionalExpression(newProblemExpression(), newLiteral(2), aRef)
+            assertEquals("{}", cond.evaluate())
         }
     }
 }


### PR DESCRIPTION
Previously, the `ValueEvaluator` was assuming that a conditional expression was only using the `==` operator.

Fixes #1527 
