### PR TITLE
Initial implementation for symbols and imports

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -78,17 +78,6 @@ class ScopeManager : ScopeProvider {
      */
     private val symbolTable = mutableMapOf<ReferenceTag, Pair<Reference, ValueDeclaration>>()
 
-    /**
-     * In some languages, we can define aliases for names. An example is renaming package imports in
-     * Go, e.g., to avoid name conflicts.
-     *
-     * In reality, they can probably be defined at different scopes for other languages, but for now
-     * we only allow it for the current file.
-     *
-     * This can potentially be merged with [addTypedef] at some point.
-     */
-    private val aliases = mutableMapOf<PhysicalLocation.ArtifactLocation, MutableSet<Alias>>()
-
     /** True, if the scope manager is currently in a [BlockScope]. */
     val isInBlock: Boolean
         get() = this.firstScopeOrNull { it is BlockScope } != null
@@ -159,13 +148,8 @@ class ScopeManager : ScopeProvider {
             for (entry in manager.fqnScopeMap.entries) {
                 val existing = fqnScopeMap[entry.key]
                 if (existing != null) {
-                    // a name scope with an identical FQN already exist. we transfer all
-                    // declarations over to it. We are NOT using [addValueDeclaration] because this
-                    // will add it to the underlying AST node as well. This was already done by the
-                    // respective sub-scope manager. We add it directly to the declarations array
-                    // instead.
-                    existing.valueDeclarations.addAll(entry.value.valueDeclarations)
-                    existing.structureDeclarations.addAll(entry.value.structureDeclarations)
+                    // merge symbols
+                    existing.symbols.mergeFrom(entry.value.symbols)
 
                     // copy over the typedefs as well just to be sure
                     existing.typedefs.putAll(entry.value.typedefs)
@@ -197,9 +181,6 @@ class ScopeManager : ScopeProvider {
             // individual scope manager into our map, otherwise we would overwrite our merged global
             // scope.
             scopeMap.putAll(manager.scopeMap.filter { it.key != null })
-
-            // Merge aliases
-            aliases.putAll(manager.aliases)
 
             // free the maps, just to clear up some things. this scope manager will not be used
             // anymore
@@ -265,6 +246,7 @@ class ScopeManager : ScopeProvider {
                     is RecordDeclaration -> RecordScope(nodeToScope)
                     is TemplateDeclaration -> TemplateScope(nodeToScope)
                     is TryStatement -> TryScope(nodeToScope)
+                    is TranslationUnitDeclaration -> FileScope(nodeToScope)
                     is NamespaceDeclaration -> newNameScopeIfNecessary(nodeToScope)
                     else -> {
                         LOGGER.error(
@@ -302,7 +284,7 @@ class ScopeManager : ScopeProvider {
      */
     private fun newNameScopeIfNecessary(nodeToScope: NamespaceDeclaration): NameScope? {
         val existingScope =
-            currentScope?.children?.firstOrNull { it is NameScope && it.name == nodeToScope.name }
+            filterScopes { it is NameScope && it.name == nodeToScope.name }.firstOrNull()
 
         return if (existingScope != null) {
             // update the AST node to this namespace declaration
@@ -398,6 +380,12 @@ class ScopeManager : ScopeProvider {
      */
     @JvmOverloads
     fun addDeclaration(declaration: Declaration?, addToAST: Boolean = true) {
+        if (declaration != null) {
+            // New stuff here
+            currentScope?.addSymbol(declaration.symbol, declaration)
+        }
+
+        // Legacy stuff here
         when (declaration) {
             is ProblemDeclaration,
             is IncludeDeclaration -> {
@@ -406,8 +394,9 @@ class ScopeManager : ScopeProvider {
             }
             is ValueDeclaration -> {
                 val scope = this.firstScopeIsInstanceOrNull<ValueDeclarationScope>()
-                scope?.addValueDeclaration(declaration, addToAST)
+                scope?.addDeclaration(declaration, addToAST)
             }
+            is ImportDeclaration,
             is EnumDeclaration,
             is RecordDeclaration,
             is NamespaceDeclaration,
@@ -725,7 +714,7 @@ class ScopeManager : ScopeProvider {
 
         // Retrieve a list of possible functions with a matching name
         result.candidateFunctions =
-            callee.candidates.filterIsInstance<FunctionDeclaration>()?.toSet() ?: setOf()
+            callee.candidates.filterIsInstance<FunctionDeclaration>().toSet()
 
         if (call.language !is HasFunctionOverloading) {
             // If the function does not allow function overloading, and we have multiple candidate
@@ -774,10 +763,10 @@ class ScopeManager : ScopeProvider {
     /**
      * This function extracts a scope for the [Name] in node, e.g. if the name is fully qualified.
      *
-     * The pair returns the extracted scope and a name that is adjusted by [aliases]. The extracted
-     * scope is "responsible" for the name (e.g. declares the parent namespace) and the returned
-     * name only differs from the provided name if aliasing was involved at the node location (e.g.
-     * because of imports).
+     * The pair returns the extracted scope and a name that is adjusted by possible import aliases.
+     * The extracted scope is "responsible" for the name (e.g. declares the parent namespace) and
+     * the returned name only differs from the provided name if aliasing was involved at the node
+     * location (e.g. because of imports).
      *
      * Note: Currently only *fully* qualified names are properly resolved. This function will
      * probably return imprecise results for partially qualified names, e.g. if a name `A` inside
@@ -794,10 +783,10 @@ class ScopeManager : ScopeProvider {
     /**
      * This function extracts a scope for the [Name], e.g. if the name is fully qualified.
      *
-     * The pair returns the extracted scope and a name that is adjusted by [aliases]. The extracted
-     * scope is "responsible" for the name (e.g. declares the parent namespace) and the returned
-     * name only differs from the provided name if aliasing was involved at the node location (e.g.
-     * because of imports).
+     * The pair returns the extracted scope and a name that is adjusted by possible import aliases.
+     * The extracted scope is "responsible" for the name (e.g. declares the parent namespace) and
+     * the returned name only differs from the provided name if aliasing was involved at the node
+     * location (e.g. because of imports).
      *
      * Note: Currently only *fully* qualified names are properly resolved. This function will
      * probably return imprecise results for partially qualified names, e.g. if a name `A` inside
@@ -809,20 +798,20 @@ class ScopeManager : ScopeProvider {
      */
     fun extractScope(
         name: Name,
-        location: PhysicalLocation?,
-        scope: Scope? = currentScope
+        location: PhysicalLocation? = null,
+        scope: Scope? = currentScope,
     ): Pair<Scope?, Name> {
-        var name = name
+        var n = name
         var s = scope
 
         // First, we need to check, whether we have some kind of scoping.
-        if (name.isQualified()) {
+        if (n.isQualified()) {
             // We need to check, whether we have an alias for the name's parent in this file
-            name = resolveParentAlias(name, location)
+            n = resolveParentAlias(n, scope)
 
             // extract the scope name, it is usually a name space, but could probably be something
             // else as well in other languages
-            val scopeName = name.parent
+            val scopeName = n.parent
 
             // this is a scoped call. we need to explicitly jump to that particular scope
             val scopes = filterScopes { (it is NameScope && it.name == scopeName) }
@@ -831,7 +820,7 @@ class ScopeManager : ScopeProvider {
                     Util.warnWithFileLocation(
                         location,
                         LOGGER,
-                        "Could not find the scope $scopeName needed to resolve $name"
+                        "Could not find the scope $scopeName needed to resolve $n"
                     )
                     scope
                 } else {
@@ -839,24 +828,39 @@ class ScopeManager : ScopeProvider {
                 }
         }
 
-        return Pair(s, name)
+        return Pair(s, n)
     }
 
     /**
-     * This function resolves a name alias (contained in [aliases]) for the [Name.parent] of the
-     * given [Name].
+     * This function resolves a name alias (contained in an import alias) for the [Name.parent] of
+     * the given [Name].
      */
-    fun resolveParentAlias(
-        name: Name,
-        location: PhysicalLocation?,
-    ): Name {
+    fun resolveParentAlias(name: Name, scope: Scope?): Name {
+        val parentName = name.parent ?: return name
+
+        // This is not 100 % ideal, but at least somewhat compatible to the previous approach
         var newName = name
-        val list = aliases[location?.artifactLocation]
-        val alias = list?.firstOrNull { it.to == name.parent }?.from
-        if (alias != null) {
-            // Reconstruct the original name with the alias, so we can resolve declarations with
-            // the namespace
-            newName = Name(newName.localName, alias, delimiter = newName.delimiter)
+        var decl =
+            scope?.lookupSymbol(parentName.localName)?.singleOrNull {
+                it is NamespaceDeclaration || it is RecordDeclaration
+            }
+        if (decl != null && parentName != decl.name) {
+            // This is probably an already resolved alias so, we take this one
+            return Name(newName.localName, decl.name, delimiter = newName.delimiter)
+        }
+
+        // If we do not have a match yet, it could be that we are trying to resolve an FQN type
+        // during frontend translation. This is deprecated and will be replaced in the future
+        // by a system that also resolves type during symbol resolving. However, to support aliases
+        // from imports in this intermediate stage, we have to look for unresolved import
+        // declarations and also take their aliases into account
+        decl =
+            scope
+                ?.lookupSymbol(parentName.localName)
+                ?.filterIsInstance<ImportDeclaration>()
+                ?.singleOrNull()
+        if (decl != null && decl.importedSymbols.isEmpty() && parentName != decl.import) {
+            newName = Name(newName.localName, decl.import, delimiter = newName.delimiter)
         }
 
         return newName
@@ -985,15 +989,8 @@ class ScopeManager : ScopeProvider {
      *
      * @return the declaration, or null if it does not exist
      */
-    fun getRecordForName(name: Name, scope: Scope? = currentScope): RecordDeclaration? {
-        return resolve<RecordDeclaration>(scope, true) { it.name.lastPartsMatch(name) }
-            .firstOrNull()
-    }
-
-    fun addAlias(file: PhysicalLocation.ArtifactLocation, from: Name, to: Name) {
-        val list = aliases.computeIfAbsent(file) { mutableSetOf() }
-
-        list += Alias(from, to)
+    fun getRecordForName(name: Name): RecordDeclaration? {
+        return findSymbols(name).filterIsInstance<RecordDeclaration>().singleOrNull()
     }
 
     fun typedefFor(alias: Type): Type? {
@@ -1004,7 +1001,7 @@ class ScopeManager : ScopeProvider {
         while (current != null) {
             if (current is ValueDeclarationScope) {
                 // This is a little bit of a hack to support partial FQN resolution at least with
-                // typedefs, but its not really ideal.
+                // typedefs, but it's not really ideal.
                 // And this also should be merged with the scope manager logic when resolving names.
                 //
                 // The better approach would be to harmonize the FQN of all types in one pass before
@@ -1014,7 +1011,7 @@ class ScopeManager : ScopeProvider {
                 // First, do a quick local lookup, to see if we have a typedef our current scope
                 // (only do this if the name is not qualified)
                 if (!alias.name.isQualified() && current == currentScope) {
-                    var decl = current.typedefs[alias]
+                    val decl = current.typedefs[alias]
                     if (decl != null) {
                         return decl.type
                     }
@@ -1052,6 +1049,40 @@ class ScopeManager : ScopeProvider {
     /** Returns the current scope for the [ScopeProvider] interface. */
     override val scope: Scope?
         get() = currentScope
+
+    /**
+     * This function tries to resolve a [Node.name] to a list of symbols (a symbol represented by a
+     * [Declaration]) starting with [startScope]. This function can return a list of multiple
+     * symbols in order to check for things like function overloading. but it will only return list
+     * of symbols within the same scope; the list cannot be spread across different scopes.
+     *
+     * This means that as soon one or more symbols are found in a "local" scope, these shadow all
+     * other occurrences of the same / symbol in a "higher" scope and only the ones from the lower
+     * ones will be returned.
+     */
+    fun findSymbols(
+        name: Name,
+        location: PhysicalLocation? = null,
+        startScope: Scope? = currentScope,
+    ): List<Declaration> {
+        val (scope, n) = extractScope(name, location, startScope)
+        val list = scope?.lookupSymbol(n.localName)?.toMutableList() ?: mutableListOf()
+
+        // If we have both the definition and the declaration of a function declaration in our list,
+        // we chose only the definition
+        val it = list.iterator()
+        while (it.hasNext()) {
+            val decl = it.next()
+            if (decl is FunctionDeclaration) {
+                val definition = decl.definition
+                if (!decl.isDefinition && definition != null && definition in list) {
+                    it.remove()
+                }
+            }
+        }
+
+        return list
+    }
 }
 
 /**
@@ -1157,7 +1188,7 @@ data class CallResolutionResult(
 
     /**
      * A set of candidate symbols we discovered based on the [CallExpression.callee] (using
-     * [SymbolResolver.findSymbols]), more specifically a list of [FunctionDeclaration] nodes.
+     * [ScopeManager.findSymbols]), more specifically a list of [FunctionDeclaration] nodes.
      */
     var candidateFunctions: Set<FunctionDeclaration>,
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
@@ -487,7 +487,7 @@ private constructor(
          *
          * This will register
          * - [TypeHierarchyResolver]
-         * - [ImportResolver]
+         * - [JavaImportResolver]
          * - [SymbolResolver]
          * - [DFGPass]
          * - [EvaluationOrderGraphPass]
@@ -499,8 +499,8 @@ private constructor(
          */
         fun defaultPasses(): Builder {
             registerPass<TypeHierarchyResolver>()
-            registerPass<ImportResolver>()
             registerPass<SymbolResolver>()
+            registerPass<ImportResolver>()
             registerPass<DFGPass>()
             registerPass<DynamicInvokeResolver>()
             registerPass<EvaluationOrderGraphPass>() // creates EOG

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
@@ -416,20 +416,28 @@ fun MetadataProvider.newNamespaceDeclaration(
 }
 
 /**
- * Creates a new [UsingDeclaration]. The [MetadataProvider] receiver will be used to fill different
+ * Creates a new [ImportDeclaration]. The [MetadataProvider] receiver will be used to fill different
  * meta-data using [Node.applyMetadata]. Calling this extension function outside of Kotlin requires
  * an appropriate [MetadataProvider], such as a [LanguageFrontend] as an additional prepended
  * argument.
  */
 @JvmOverloads
-fun MetadataProvider.newUsingDeclaration(
-    qualifiedName: CharSequence?,
+fun MetadataProvider.newImportDeclaration(
+    import: Name,
+    wildcardImport: Boolean = false,
+    alias: Name? = null,
     rawNode: Any? = null
-): UsingDeclaration {
-    val node = UsingDeclaration()
-    node.applyMetadata(this, qualifiedName, rawNode)
-
-    node.qualifiedName = qualifiedName.toString()
+): ImportDeclaration {
+    val node = ImportDeclaration()
+    node.applyMetadata(this, "", rawNode)
+    node.import = import
+    node.alias = alias
+    node.wildcardImport = wildcardImport
+    if (alias != null) {
+        node.name = alias
+    } else {
+        node.name = import
+    }
 
     log(node)
     return node

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -566,6 +566,10 @@ val Node?.records: List<RecordDeclaration>
 val Node?.namespaces: List<NamespaceDeclaration>
     get() = this.allChildren()
 
+/** Returns all [ImportDeclaration] children in this graph, starting with this [Node]. */
+val Node?.imports: List<ImportDeclaration>
+    get() = this.allChildren()
+
 /** Returns all [VariableDeclaration] children in this graph, starting with this [Node]. */
 val Node?.variables: List<VariableDeclaration>
     get() = this.allChildren()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Declaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Declaration.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.graph.declarations
 
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.scopes.Symbol
 import org.neo4j.ogm.annotation.NodeEntity
 
 /**
@@ -37,4 +38,10 @@ import org.neo4j.ogm.annotation.NodeEntity
  * currently have two [FunctionDeclaration] nodes. This is very similar to the behaviour of clang,
  * however clang does establish a connection between those nodes, we currently do not.
  */
-@NodeEntity abstract class Declaration : Node()
+@NodeEntity
+abstract class Declaration : Node() {
+    val symbol: Symbol
+        get() {
+            return this.name.localName
+        }
+}

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ImportDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ImportDeclaration.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2024, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.graph.declarations
+
+import de.fraunhofer.aisec.cpg.PopulatedByPass
+import de.fraunhofer.aisec.cpg.graph.Name
+import de.fraunhofer.aisec.cpg.graph.scopes.FileScope
+import de.fraunhofer.aisec.cpg.graph.scopes.NameScope
+import de.fraunhofer.aisec.cpg.graph.scopes.Scope
+import de.fraunhofer.aisec.cpg.graph.scopes.SymbolMap
+import de.fraunhofer.aisec.cpg.passes.ImportResolver
+
+/**
+ * This class represents a real *import* of one or more symbols of a specified [NameScope] (e.g.,
+ * defined by a [NamespaceDeclaration]) into the current scope. Depending on the language, this can
+ * be only used at the global or package scope (e.g. in Go and Java with the `import` keyword) or in
+ * any scope (e.g. in C++ with the `using` keyword).
+ *
+ * ### Examples (Go)
+ *
+ * In Go, we usually import the package itself as a symbol.
+ *
+ * ```Go
+ * package p
+ *
+ * import(
+ *   // standard library imports have only relative import
+ *   // paths
+ *   "os"
+ *
+ *   // packages from external sources have a hostname and
+ *   // path
+ *   "golang.org/x/oauth2"
+ *
+ *   // we can also define an alias, to avoid conflicts
+ *   // (in this case with the config variable)
+ *   configpkg "example.com/library/config"
+ * )
+ *
+ * func main() {
+ *   // We can then use symbols of the particular
+ *   // package by prefixing the symbol with the
+ *   // imported name
+ *   file, err := os.Open("myfile")
+ *
+ *   var config oauth2.Config
+ *
+ *   configpkg.DoAwesome(&config)
+ * }
+ * ```
+ *
+ * In this example we set [import] and [name] to the names `os` and `oauth2` respectively. For the
+ * first import, the [importURL] is empty, for the second import [importURL] is
+ * `golang.org/x/oauth2`.
+ *
+ * In the last import, the property [alias] is used to import the symbol using an alias. In this
+ * case the [import] is still `config`, but the [name] is the same as the alias (`configpkg`), so
+ * that the symbol resolver can find it.
+ *
+ * The import is valid for the whole file, where it is imported, i.e., its [FileScope].
+ *
+ * ### Examples (C++)
+ *
+ * In C++, we can import a single symbol using its fully qualified name.
+ *
+ * ```cpp
+ * namespace std {
+ *   class string {};
+ * }
+ *
+ * int main() {
+ *   using std::string;
+ *   string s;
+ *   return 1;
+ * }
+ * ```
+ *
+ * The imported symbol is then visible within the current [Scope] of the [ImportDeclaration]. In the
+ * example [name] and [import] is set to `std::string`, [wildcardImport] is `false`.
+ *
+ * Another possibility is to import a complete namespace, or to be more precise import all symbols
+ * of the specified namespace into the current scope.
+ *
+ * ```cpp
+ * namespace std {
+ *   class string {};
+ * }
+ *
+ * int main() {
+ *   using namespace std;
+ *   string s;
+ *   return 1;
+ * }
+ * ```
+ *
+ * In this example, the [name] and [import] is set to `std` and [wildcardImport] is `true`.
+ */
+class ImportDeclaration : Declaration() {
+
+    /**
+     * The imported symbol: This usually refers to a [NamespaceDeclaration] / its [NameScope] or a
+     * [Declaration] within this namespace. This will always refer to the original name of the
+     * imported symbol, even though an alias is used.
+     * * If no alias is used, the [name] of this declaration is also set to the same name as the
+     *   imported symbol.
+     * * If an alias is used, the [name] of this declaration is set to the value of [alias].
+     */
+    var import: Name = Name(EMPTY_NAME)
+
+    /**
+     * Some languages support the use of aliases in importing symbols, for example to avoid
+     * conflicts with already named symbols.
+     *
+     * In case this is used, the [name] is also set to the value of [alias], so in theory this
+     * property would be not needed, instead we could check whether [name] and [import] point to
+     * different names. However, in practice, it is easier to have this as an extra property to
+     * quickly identify imports with aliases.
+     */
+    var alias: Name? = null
+
+    /**
+     * In some languages (such as Go), we can specify packages to fetch from external sources. In
+     * this case, this property can be used to hold the import url.
+     */
+    var importURL: String? = null
+
+    /**
+     * Specifies that [name] is pointing to a [NameScope] and that all [Scope.symbols] of that name
+     * scope need to be imported into the scope this declaration lives in.
+     */
+    var wildcardImport: Boolean = false
+
+    /**
+     * A list of symbols that this declaration imports. This will be populated by
+     * [ImportResolver.handleImportDeclaration].
+     */
+    @PopulatedByPass(ImportResolver::class) var importedSymbols: SymbolMap = mutableMapOf()
+}

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/FileScope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/FileScope.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Fraunhofer AISEC. All rights reserved.
+ * Copyright (c) 2024, Fraunhofer AISEC. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,19 +23,14 @@
  *                    \______/ \__|       \______/
  *
  */
-package de.fraunhofer.aisec.cpg.graph.declarations
+package de.fraunhofer.aisec.cpg.graph.scopes
 
-import java.util.Objects
+import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 
-/** Represents a using directive used to extend the currently valid name scope. */
-class UsingDeclaration : Declaration() {
-    var qualifiedName: String? = null
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is UsingDeclaration) return false
-        return super.equals(other) && qualifiedName == other.qualifiedName
-    }
-
-    override fun hashCode() = Objects.hash(super.hashCode(), qualifiedName)
-}
+/**
+ * Represents a scope that is only visible in the current file. This is usually used in programming
+ * languages for file-level imports.
+ *
+ * The only supported AST node is a [TranslationUnitDeclaration].
+ */
+class FileScope(astNode: TranslationUnitDeclaration?) : Scope(astNode)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/GlobalScope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/GlobalScope.kt
@@ -48,12 +48,24 @@ class GlobalScope : StructureDeclarationScope(null) {
      */
     fun mergeFrom(others: Collection<GlobalScope>) {
         for (other in others) {
-            structureDeclarations.addAll(other.structureDeclarations)
-            valueDeclarations.addAll(other.valueDeclarations)
             typedefs.putAll(other.typedefs)
+
+            // Make sure, the child scopes of the global scope point to the new global scope parent
+            // (this)
             for (child in other.children) {
                 child.parent = this
                 children.add(child)
+            }
+
+            // Merge symbols lists
+            symbols.mergeFrom(other.symbols)
+
+            for (symbolList in other.symbols) {
+                // Update the scope property of all nodes that live on the global scope to our new
+                // global scope (this)
+                for (symbol in symbolList.value) {
+                    symbol.scope = this
+                }
             }
         }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/StructureDeclarationScope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/StructureDeclarationScope.kt
@@ -27,15 +27,23 @@ package de.fraunhofer.aisec.cpg.graph.scopes
 
 import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
-import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.*
 
 open class StructureDeclarationScope(final override var astNode: Node?) :
     ValueDeclarationScope(astNode) {
-    @Transient var structureDeclarations = mutableListOf<Declaration>()
+    val structureDeclarations: List<Declaration>
+        get() {
+            return symbols
+                .flatMap { it.value }
+                .filter {
+                    it is EnumDeclaration ||
+                        it is RecordDeclaration ||
+                        it is NamespaceDeclaration ||
+                        it is TemplateDeclaration
+                }
+        }
 
     private fun addStructureDeclaration(declaration: Declaration) {
-        structureDeclarations.add(declaration)
         if (astNode is DeclarationHolder) {
             val holder = astNode as DeclarationHolder
             holder.addDeclaration(declaration)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/ValueDeclarationScope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/ValueDeclarationScope.kt
@@ -40,7 +40,10 @@ import org.slf4j.LoggerFactory
  * Works for if, for, and extends to the block scope
  */
 open class ValueDeclarationScope(override var astNode: Node?) : Scope(astNode) {
-    @Transient var valueDeclarations = mutableListOf<ValueDeclaration>()
+    val valueDeclarations: List<ValueDeclaration>
+        get() {
+            return symbols.flatMap { it.value }.filterIsInstance<ValueDeclaration>()
+        }
 
     /** A map of typedefs keyed by their alias. */
     @Transient val typedefs = mutableMapOf<Type, TypedefDeclaration>()
@@ -68,8 +71,7 @@ open class ValueDeclarationScope(override var astNode: Node?) : Scope(astNode) {
      * @param valueDeclaration the [ValueDeclaration]
      * @param addToAST whether to also add the declaration to the AST of its holder.
      */
-    fun addValueDeclaration(valueDeclaration: ValueDeclaration, addToAST: Boolean) {
-        valueDeclarations.add(valueDeclaration)
+    protected fun addValueDeclaration(valueDeclaration: ValueDeclaration, addToAST: Boolean) {
         if (addToAST) {
             if (astNode is DeclarationHolder) {
                 val holder = astNode as DeclarationHolder

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Fraunhofer AISEC. All rights reserved.
+ * Copyright (c) 2024, Fraunhofer AISEC. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,146 +26,57 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationContext
-import de.fraunhofer.aisec.cpg.graph.*
-import de.fraunhofer.aisec.cpg.graph.declarations.*
-import de.fraunhofer.aisec.cpg.graph.types.UnknownType
+import de.fraunhofer.aisec.cpg.graph.Component
+import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.declarations.ImportDeclaration
+import de.fraunhofer.aisec.cpg.graph.scopes.NameScope
+import de.fraunhofer.aisec.cpg.graph.scopes.Scope
+import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
-import de.fraunhofer.aisec.cpg.processing.IVisitor
-import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
-import java.util.*
-import java.util.regex.Pattern
 
+/**
+ * This pass looks for [ImportDeclaration] nodes and imports symbols into their respective [Scope]
+ */
 @DependsOn(TypeHierarchyResolver::class)
-open class ImportResolver(ctx: TranslationContext) : ComponentPass(ctx) {
-    protected val records: MutableList<RecordDeclaration> = ArrayList()
-    protected val importables: MutableMap<String, Declaration> = HashMap()
+class ImportResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
-    override fun cleanup() {
-        records.clear()
-        importables.clear()
+    lateinit var walker: SubgraphWalker.ScopedWalker
+
+    override fun accept(t: Component) {
+        walker = SubgraphWalker.ScopedWalker(scopeManager)
+
+        walker.registerHandler(::handleImportDeclaration)
+        walker.iterate(t)
     }
 
-    override fun accept(component: Component) {
-        for (tu in component.translationUnits) {
-            findImportables(tu)
-        }
-        for (recordDecl in records) {
-            val imports = getDeclarationsForTypeNames(recordDecl.importStatements)
-            recordDecl.imports = imports
-            val staticImports = getStaticImports(recordDecl)
-            recordDecl.staticImports = staticImports
-        }
-    }
-
-    protected fun getStaticImports(
-        recordDeclaration: RecordDeclaration
-    ): MutableSet<ValueDeclaration> {
-        val partitioned =
-            recordDeclaration.staticImportStatements.groupBy { it.endsWith("*") }.toMutableMap()
-
-        val staticImports = mutableSetOf<ValueDeclaration>()
-        val importPattern = Pattern.compile("(?<base>.*)\\.(?<member>.*)")
-
-        for (specificStaticImport in partitioned[false] ?: listOf()) {
-            val matcher = importPattern.matcher(specificStaticImport)
-            if (!matcher.matches()) {
-                continue
-            }
-            val base = importables[matcher.group("base")]
-            var members = setOf<ValueDeclaration>()
-            if (base is RecordDeclaration) {
-                members = getOrCreateMembers(base, matcher.group("member"))
-            }
-            staticImports.addAll(members)
+    private fun handleImportDeclaration(node: Node?) {
+        if (node !is ImportDeclaration) {
+            return
         }
 
-        for (asteriskImport in partitioned[true] ?: listOf()) {
-            val base = importables[asteriskImport.replace(".*", "")]
-            if (base is EnumDeclaration) {
-                staticImports.addAll(base.entries)
-            } else if (base is RecordDeclaration) {
-                val classes = listOf(base, *base.superTypeDeclarations.toTypedArray())
-                // Add all the static methods implemented in the class "base" and its superclasses
-                staticImports.addAll(
-                    classes.flatMap { it.methods }.filter(MethodDeclaration::isStatic)
-                )
-                // Add all the static fields implemented in the class "base" and its superclasses
-                staticImports.addAll(
-                    classes.flatMap { it.fields }.filter { "static" in it.modifiers }
-                )
-            }
-        }
-        return staticImports
-    }
+        // We always need to search at the global scope because we are "importing" something, so by
+        // definition, this is not in the scope of the current file.
+        val scope = scopeManager.globalScope ?: return
 
-    protected fun getDeclarationsForTypeNames(targetTypes: List<String>): MutableSet<Declaration> {
-        return targetTypes.mapNotNull { importables[it] }.toMutableSet()
-    }
-
-    protected fun getOrCreateMembers(base: RecordDeclaration, name: String): Set<ValueDeclaration> {
-        val memberMethods = base.methods.filter { it.name.localName.endsWith(name) }.toMutableSet()
-
-        // add methods from superclasses
-        memberMethods.addAll(
-            base.superTypeDeclarations
-                .flatMap { it.methods }
-                .filter { it.name.localName.endsWith(name) }
-        )
-        val memberFields = base.fields.filter { it.name.localName == name }.toMutableSet()
-        // add fields from superclasses
-        memberFields.addAll(
-            base.superTypeDeclarations.flatMap { it.fields }.filter { it.name.localName == name }
-        )
-
-        val memberEntries = mutableSetOf<EnumConstantDeclaration>()
-        if (base is EnumDeclaration) {
-            base.entries[name]?.let { memberEntries.add(it) }
-        }
-
-        // now it gets weird: you can import a field and a number of methods that have the same
-        // name, all with a *single* static import...
-        // TODO(oxisto): Move all of the following code to the [Inference] class
-        val result = mutableSetOf<ValueDeclaration>()
-        result.addAll(memberMethods)
-        result.addAll(memberFields)
-        result.addAll(memberEntries)
-        if (result.isEmpty()) {
-            // the target might be a field or a method, we don't know. Thus, we need to create both
-            val targetField =
-                newFieldDeclaration(
-                    name,
-                    UnknownType.getUnknownType(base.language),
-                    ArrayList(),
-                    null,
-                    false,
-                )
-            targetField.language = base.language
-            targetField.isInferred = true
-
-            val targetMethod = newMethodDeclaration(name, true, base)
-            targetMethod.language = base.language
-            targetMethod.isInferred = true
-
-            base.addField(targetField)
-            base.addMethod(targetMethod)
-            result.add(targetField)
-            result.add(targetMethod)
-        }
-        return result
-    }
-
-    protected fun findImportables(node: Node) {
-        // Using a visitor to avoid loops in the AST
-        node.accept(
-            Strategy::AST_FORWARD,
-            object : IVisitor<Node>() {
-                override fun visit(t: Node) {
-                    if (t is RecordDeclaration) {
-                        records.add(t)
-                        importables.putIfAbsent(t.name.toString(), t)
-                    }
+        // Let's do some importing. We need to import either a wildcard
+        if (node.wildcardImport) {
+            val list = scopeManager.findSymbols(node.import, node.location, scope)
+            val symbol = list.singleOrNull()
+            if (symbol != null) {
+                // In this case, the symbol must point to a name scope
+                val symbolScope = scopeManager.lookupScope(symbol)
+                if (symbolScope is NameScope) {
+                    node.importedSymbols = symbolScope.symbols
                 }
             }
-        )
+        } else {
+            // or a symbol directly
+            val list = scopeManager.findSymbols(node.import, node.location, scope).toMutableList()
+            node.importedSymbols = mutableMapOf(node.symbol to list)
+        }
+    }
+
+    override fun cleanup() {
+        // Nothing to do
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -32,7 +32,6 @@ import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.scopes.NameScope
 import de.fraunhofer.aisec.cpg.graph.scopes.RecordScope
-import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.graph.scopes.StructureDeclarationScope
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.*
@@ -80,6 +79,7 @@ import org.slf4j.LoggerFactory
 @DependsOn(TypeResolver::class)
 @DependsOn(TypeHierarchyResolver::class)
 @DependsOn(EvaluationOrderGraphPass::class)
+@DependsOn(ImportResolver::class)
 open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
     protected lateinit var walker: ScopedWalker
@@ -176,7 +176,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
         // Find a list of candidate symbols. Currently, this is only used the in the "next-gen" call
         // resolution, but in future this will also be used in resolving regular references.
-        current.candidates = findSymbols(current)
+        current.candidates = scopeManager.findSymbols(current.name, current.location).toSet()
 
         // For now, we need to ignore reference expressions that are directly embedded into call
         // expressions, because they are the "callee" property. In the future, we will use this
@@ -254,41 +254,6 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
                 "Did not find a declaration for ${current.name}"
             )
         }
-    }
-
-    /**
-     * This function tries to resolve a [Node.name] to a list of symbols (a symbol represented by a
-     * [Declaration]) starting with [startScope]. This function can return a list of multiple
-     * symbols in order to check for things like function overloading. but it will only return list
-     * of symbols within the same scope; the list cannot be spread across different scopes.
-     *
-     * This means that as soon one or more symbols are found in a "local" scope, these shadow all
-     * other occurrences of the same / symbol in a "higher" scope and only the ones from the lower
-     * ones will be returned.
-     */
-    private fun findSymbols(
-        nodeWithName: Node,
-        startScope: Scope? = scopeManager.currentScope
-    ): Set<Declaration> {
-        val (scope, name) = scopeManager.extractScope(nodeWithName, startScope)
-        val list =
-            scopeManager
-                .resolve<Declaration>(scope, true) { it.name.lastPartsMatch(name) }
-                .toMutableSet()
-        // If we have both the definition and the declaration of a function declaration in our list,
-        // we chose only the definition
-        val it = list.iterator()
-        while (it.hasNext()) {
-            val decl = it.next()
-            if (decl is FunctionDeclaration) {
-                val definition = decl.definition
-                if (!decl.isDefinition && definition != null && definition in list) {
-                    it.remove()
-                }
-            }
-        }
-
-        return list
     }
 
     /**
@@ -947,9 +912,8 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
         val candidateFunctions =
             scope
-                ?.valueDeclarations
+                ?.lookupSymbol(name)
                 ?.filterIsInstance<MethodDeclaration>()
-                ?.filter { it.name.lastPartsMatch(name) }
                 ?.toSet<FunctionDeclaration>() ?: setOf()
 
         // The following code is unfortunately largely a copy/paste from the new resolveCall

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
@@ -454,7 +454,7 @@ class Inference internal constructor(val start: Node, override val ctx: Translat
             debugWithFileLocation(
                 origin,
                 log,
-                "Inferring a new namespace declaration {} {}",
+                "Inferring a new namespace declaration {} {} in $it",
                 name,
                 if (path != null) {
                     "with path '$path'"

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/DFGFunctionSummariesTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/DFGFunctionSummariesTest.kt
@@ -301,7 +301,6 @@ class DFGFunctionSummariesTest {
         // DFGPass.connectInferredCallArguments
         val dfgTest = getDfgInferredCall {
             this.registerPass<TypeHierarchyResolver>()
-            registerPass<ImportResolver>()
             registerPass<SymbolResolver>()
             registerPass<DFGPass>()
             registerPass<DynamicInvokeResolver>()

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManagerTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManagerTest.kt
@@ -84,8 +84,8 @@ internal class ScopeManagerTest : BaseTest() {
             assertEquals(scopeA, final.lookupScope("A"))
 
             // and it should contain both functions from the different file in the same namespace
-            assertTrue(scopeA.valueDeclarations.contains(func1))
-            assertTrue(scopeA.valueDeclarations.contains(func2))
+            assertContains(scopeA.symbols["func1"] ?: listOf(), func1)
+            assertContains(scopeA.symbols["func2"] ?: listOf(), func2)
 
             // finally, test whether our two namespace declarations are pointing to the same
             // NameScope

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontend.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontend.kt
@@ -697,7 +697,7 @@ open class CXXLanguageFrontend(language: Language<CXXLanguageFrontend>, ctx: Tra
         val location = currentTU?.location
 
         // We need to take name(space) aliases into account.
-        typeName = scopeManager.resolveParentAlias(typeName, location)
+        typeName = scopeManager.resolveParentAlias(typeName, scopeManager.currentScope)
 
         return objectType(typeName)
     }

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
@@ -25,7 +25,6 @@
  */
 package de.fraunhofer.aisec.cpg.frontends.cxx
 
-import de.fraunhofer.aisec.cpg.ScopeManager
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.scopes.NameScope
@@ -71,6 +70,7 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
             is CPPASTTemplateDeclaration -> handleTemplateDeclaration(node)
             is CPPASTNamespaceDefinition -> handleNamespace(node)
             is CPPASTUsingDirective -> handleUsingDirective(node)
+            is CPPASTUsingDeclaration -> handleUsingDeclaration(node)
             is CPPASTAliasDeclaration -> handleAliasDeclaration(node)
             is CPPASTNamespaceAlias -> handleNamespaceAlias(node)
             else -> {
@@ -82,31 +82,46 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
     /**
      * Translates a C++ (namespace
      * alias)[https://en.cppreference.com/w/cpp/language/namespace_alias] into an alias handled by
-     * the scope manager using [ScopeManager.addAlias] done yet. Since we do not have any node
-     * itself for this concept, we just return an empty [DeclarationSequence], which will then be
-     * ignored in the final graph.
+     * an [ImportDeclaration].
      */
-    private fun handleNamespaceAlias(ctx: CPPASTNamespaceAlias): DeclarationSequence {
-        val location = locationOf(ctx)
-
+    private fun handleNamespaceAlias(ctx: CPPASTNamespaceAlias): ImportDeclaration {
         val from = parseName(ctx.mappingName.toString())
         val to = parseName(ctx.alias.toString())
 
-        // Currently, we can only scope the alias to the file location, this is a shortcoming of the
-        // scope manager. In reality, the namespace alias is valid in the current scope block
-        location?.artifactLocation?.let { frontend.scopeManager.addAlias(it, from, to) }
+        val import = newImportDeclaration(from, false, to, rawNode = ctx)
 
-        return DeclarationSequence()
+        frontend.scopeManager.addDeclaration(import)
+
+        return import
     }
 
     /**
      * Translates a C++ (using
      * directive)[https://en.cppreference.com/w/cpp/language/namespace#Using-directives] into a
-     * [UsingDeclaration]. However, currently, no actual adjustment of available names / scopes is
-     * done yet.
+     * [ImportDeclaration].
      */
-    private fun handleUsingDirective(using: CPPASTUsingDirective): Declaration {
-        return newUsingDeclaration(qualifiedName = using.qualifiedName.toString(), rawNode = using)
+    private fun handleUsingDirective(ctx: CPPASTUsingDirective): Declaration {
+        val import = parseName(ctx.qualifiedName.toString())
+        val declaration = newImportDeclaration(import, rawNode = ctx)
+        declaration.wildcardImport = true
+
+        frontend.scopeManager.addDeclaration(declaration)
+
+        return declaration
+    }
+
+    /**
+     * Translates a C++ (using
+     * declaration)[https://en.cppreference.com/w/cpp/language/using_declaration] into a
+     * [ImportDeclaration].
+     */
+    private fun handleUsingDeclaration(ctx: CPPASTUsingDeclaration): Declaration {
+        val import = parseName(ctx.name.toString())
+        val declaration = newImportDeclaration(import, rawNode = ctx)
+
+        frontend.scopeManager.addDeclaration(declaration)
+
+        return declaration
     }
 
     /**

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclaratorHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclaratorHandler.kt
@@ -270,8 +270,11 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
                 scopeParent.addDeclaration(declaration)
             }
 
-            // Enter the record scope
-            parentScope.astNode?.let { frontend.scopeManager.enterScope(it) }
+            // Enter the name scope
+            parentScope.astNode?.let {
+                frontend.scopeManager.enterScope(it)
+                frontend.scopeManager.addDeclaration(declaration, addToAST = false)
+            }
 
             // We also need to by-pass the scope manager for this, because it will
             // otherwise add the declaration to the AST element of the named scope (the record
@@ -280,7 +283,7 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
             // AST field, (for now) we only want those methods in there, that were actual AST
             // parents. This is also something that we need to figure out how we want to handle
             // this.
-            parentScope.valueDeclarations.add(declaration)
+            parentScope.addSymbol(declaration.symbol, declaration)
         } else {
             // Add the declaration via the scope manager
             frontend.scopeManager.addDeclaration(declaration)

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CXXExtraPass.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CXXExtraPass.kt
@@ -210,14 +210,13 @@ class CXXExtraPass(ctx: TranslationContext) : ComponentPass(ctx) {
         if (scope is ValueDeclarationScope) {
             // Update the definition
             val candidates =
-                scope.valueDeclarations.filterIsInstance<FunctionDeclaration>().filter {
+                scope.symbols[declaration.symbol]?.filterIsInstance<FunctionDeclaration>()?.filter {
                     // We should only connect methods to methods, functions to functions and
                     // constructors to constructors.
                     it::class == declaration::class &&
                         !it.isDefinition &&
-                        it.name == declaration.name &&
                         it.signature == declaration.signature
-                }
+                } ?: emptyList()
             for (candidate in candidates) {
                 candidate.definition = declaration
 

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXDeclarationTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXDeclarationTest.kt
@@ -207,8 +207,11 @@ class CXXDeclarationTest {
             }
         assertNotNull(result)
 
+        val manipulateString = result.functions["manipulateString"]
+        assertNotNull(manipulateString)
+
         // We should be able to resolve all calls to manipulateString
         val calls = result.calls("manipulateString")
-        calls.forEach { it.invokes.isNotEmpty() && it.invokes.all { decl -> !decl.isInferred } }
+        calls.forEach { assertContains(it.invokes, manipulateString) }
     }
 }

--- a/cpg-language-cxx/src/test/resources/cxx/using.cpp
+++ b/cpg-language-cxx/src/test/resources/cxx/using.cpp
@@ -1,0 +1,26 @@
+namespace std
+ {
+   class string
+   {
+   public:
+     const char *c_str() const
+     {
+       return "mock";
+     }
+   };
+ }
+
+void function1()
+{
+   using namespace std;
+   string s;
+   s.c_str();
+}
+
+void function2()
+  {
+    using std::string;
+    string s;
+    s.c_str();
+  }
+

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/DeclarationHandler.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/DeclarationHandler.kt
@@ -222,6 +222,11 @@ class DeclarationHandler(frontend: GoLanguageFrontend) :
         val sequence = DeclarationSequence()
 
         for (spec in genDecl.specs) {
+            // We parse imports specifications directly in the frontend
+            if (spec is GoStandardLibrary.Ast.ImportSpec) {
+                continue
+            }
+
             val declaration = frontend.specificationHandler.handle(spec)
             if (declaration != null) {
                 sequence += declaration

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontend.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontend.kt
@@ -34,6 +34,7 @@ import de.fraunhofer.aisec.cpg.frontends.golang.GoStandardLibrary.Modfile
 import de.fraunhofer.aisec.cpg.frontends.golang.GoStandardLibrary.Parser
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.DeclarationSequence
+import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.graph.newNamespaceDeclaration
@@ -170,6 +171,11 @@ class GoLanguageFrontend(language: Language<GoLanguageFrontend>, ctx: Translatio
         scopeManager.resetToGlobal(tu)
         currentTU = tu
 
+        // We need to keep imports on a special file scope. We can simulate this by "entering" the
+        // translation unit
+        scopeManager.enterScope(tu)
+
+        // We parse the imports specifically and not as part of the handler later
         for (spec in f.imports) {
             val import = specificationHandler.handle(spec)
             scopeManager.addDeclaration(import)
@@ -205,11 +211,28 @@ class GoLanguageFrontend(language: Language<GoLanguageFrontend>, ctx: Translatio
             if (declaration is DeclarationSequence) {
                 declaration.declarations.forEach { scopeManager.addDeclaration(it) }
             } else {
-                scopeManager.addDeclaration(declaration)
+                // We need to be careful with method declarations. We need to put them in the
+                // respective name scope of the record and NOT on the global scope / namespace scope
+                // TODO: this is broken if we see the declaration of the method before the class :(
+                if (declaration is MethodDeclaration) {
+                    declaration.recordDeclaration?.let {
+                        scopeManager.enterScope(it)
+                        scopeManager.addDeclaration(declaration)
+                        scopeManager.leaveScope(it)
+                        // But still add it to the AST of the namespace so our AST walker can find
+                        // it
+                        p.declarations += declaration
+                    }
+                } else {
+                    scopeManager.addDeclaration(declaration)
+                }
             }
         }
 
         scopeManager.leaveScope(p)
+        scopeManager.leaveScope(tu)
+
+        scopeManager.resetToGlobal(tu)
 
         scopeManager.addDeclaration(p)
 

--- a/cpg-language-go/src/test/resources/golang/field.go
+++ b/cpg-language-go/src/test/resources/golang/field.go
@@ -2,10 +2,11 @@ package p
 
 import "otherPackage"
 
-func (r Receiver) myFunc() {
-   r.Field = otherPackage.OtherField
+type Receiver struct {
+	Field int
 }
 
-type Receiver struct {
-    Field int
+// For now this must be specified AFTER our type declaration, because otherwise we wont find it
+func (r Receiver) myFunc() {
+	r.Field = otherPackage.OtherField
 }

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.kt
@@ -179,7 +179,7 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
         classInterDecl: ClassOrInterfaceDeclaration
     ): RecordDeclaration {
         // TODO: support other kinds, such as interfaces
-        val fqn = classInterDecl.nameAsString
+        val fqn = classInterDecl.fullyQualifiedName.orElse(classInterDecl.nameAsString)
 
         // Todo adapt name using a new type of scope "Namespace/Package scope"
 

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
@@ -63,6 +63,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import de.fraunhofer.aisec.cpg.helpers.Benchmark
 import de.fraunhofer.aisec.cpg.helpers.CommonPath
 import de.fraunhofer.aisec.cpg.passes.JavaExternalTypeHierarchyResolver
+import de.fraunhofer.aisec.cpg.passes.JavaImportResolver
 import de.fraunhofer.aisec.cpg.passes.configuration.RegisterExtraPass
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 import de.fraunhofer.aisec.cpg.sarif.Region
@@ -76,6 +77,7 @@ import kotlin.jvm.optionals.getOrNull
 @RegisterExtraPass(
     JavaExternalTypeHierarchyResolver::class
 ) // this pass is always required for Java
+@RegisterExtraPass(JavaImportResolver::class)
 open class JavaLanguageFrontend(language: Language<JavaLanguageFrontend>, ctx: TranslationContext) :
     LanguageFrontend<Node, Type>(language, ctx) {
 

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
@@ -487,7 +487,7 @@ open class JavaLanguageFrontend(language: Language<JavaLanguageFrontend>, ctx: T
             is PrimitiveType -> primitiveType(type.asString())
             is ClassOrInterfaceType ->
                 objectType(
-                    type.nameAsString,
+                    type.nameWithScope,
                     type.typeArguments.getOrNull()?.map { this.typeOf(it) } ?: listOf()
                 )
             is ReferenceType -> objectType(type.asString())

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaExternalTypeHierarchyResolver.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaExternalTypeHierarchyResolver.kt
@@ -41,7 +41,7 @@ import de.fraunhofer.aisec.cpg.passes.configuration.RequiredFrontend
 import org.slf4j.LoggerFactory
 
 @DependsOn(TypeHierarchyResolver::class)
-@ExecuteBefore(ImportResolver::class)
+@ExecuteBefore(JavaImportResolver::class)
 @RequiredFrontend(JavaLanguageFrontend::class)
 class JavaExternalTypeHierarchyResolver(ctx: TranslationContext) : ComponentPass(ctx) {
     override fun accept(component: Component) {

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaImportResolver.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaImportResolver.kt
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2019, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.passes
+
+import de.fraunhofer.aisec.cpg.TranslationContext
+import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.declarations.*
+import de.fraunhofer.aisec.cpg.graph.types.UnknownType
+import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
+import de.fraunhofer.aisec.cpg.passes.configuration.RequiredFrontend
+import de.fraunhofer.aisec.cpg.processing.IVisitor
+import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
+import java.util.*
+import java.util.regex.Pattern
+
+/**
+ * Some piece of legacy code that deals with Java imports. We need to convert this to the new import
+ * system.
+ *
+ * We need to remove this class and use [ImportResolver] and [ImportDeclaration] instead.
+ */
+@DependsOn(TypeHierarchyResolver::class)
+@RequiredFrontend(JavaLanguageFrontend::class)
+open class JavaImportResolver(ctx: TranslationContext) : ComponentPass(ctx) {
+    protected val records: MutableList<RecordDeclaration> = ArrayList()
+    protected val importables: MutableMap<String, Declaration> = HashMap()
+
+    override fun cleanup() {
+        records.clear()
+        importables.clear()
+    }
+
+    override fun accept(component: Component) {
+        for (tu in component.translationUnits) {
+            findImportables(tu)
+        }
+        for (recordDecl in records) {
+            val imports = getDeclarationsForTypeNames(recordDecl.importStatements)
+            recordDecl.imports = imports
+            val staticImports = getStaticImports(recordDecl)
+            recordDecl.staticImports = staticImports
+        }
+    }
+
+    protected fun getStaticImports(
+        recordDeclaration: RecordDeclaration
+    ): MutableSet<ValueDeclaration> {
+        val partitioned =
+            recordDeclaration.staticImportStatements.groupBy { it.endsWith("*") }.toMutableMap()
+
+        val staticImports = mutableSetOf<ValueDeclaration>()
+        val importPattern = Pattern.compile("(?<base>.*)\\.(?<member>.*)")
+
+        for (specificStaticImport in partitioned[false] ?: listOf()) {
+            val matcher = importPattern.matcher(specificStaticImport)
+            if (!matcher.matches()) {
+                continue
+            }
+            val base = importables[matcher.group("base")]
+            var members = setOf<ValueDeclaration>()
+            if (base is RecordDeclaration) {
+                members = getOrCreateMembers(base, matcher.group("member"))
+            }
+            staticImports.addAll(members)
+        }
+
+        for (asteriskImport in partitioned[true] ?: listOf()) {
+            val base = importables[asteriskImport.replace(".*", "")]
+            if (base is EnumDeclaration) {
+                staticImports.addAll(base.entries)
+            } else if (base is RecordDeclaration) {
+                val classes = listOf(base, *base.superTypeDeclarations.toTypedArray())
+                // Add all the static methods implemented in the class "base" and its superclasses
+                staticImports.addAll(
+                    classes.flatMap { it.methods }.filter(MethodDeclaration::isStatic)
+                )
+                // Add all the static fields implemented in the class "base" and its superclasses
+                staticImports.addAll(
+                    classes.flatMap { it.fields }.filter { "static" in it.modifiers }
+                )
+            }
+        }
+        return staticImports
+    }
+
+    protected fun getDeclarationsForTypeNames(targetTypes: List<String>): MutableSet<Declaration> {
+        return targetTypes.mapNotNull { importables[it] }.toMutableSet()
+    }
+
+    protected fun getOrCreateMembers(base: RecordDeclaration, name: String): Set<ValueDeclaration> {
+        val memberMethods = base.methods.filter { it.name.localName.endsWith(name) }.toMutableSet()
+
+        // add methods from superclasses
+        memberMethods.addAll(
+            base.superTypeDeclarations
+                .flatMap { it.methods }
+                .filter { it.name.localName.endsWith(name) }
+        )
+        val memberFields = base.fields.filter { it.name.localName == name }.toMutableSet()
+        // add fields from superclasses
+        memberFields.addAll(
+            base.superTypeDeclarations.flatMap { it.fields }.filter { it.name.localName == name }
+        )
+
+        val memberEntries = mutableSetOf<EnumConstantDeclaration>()
+        if (base is EnumDeclaration) {
+            base.entries[name]?.let { memberEntries.add(it) }
+        }
+
+        // now it gets weird: you can import a field and a number of methods that have the same
+        // name, all with a *single* static import...
+        // TODO(oxisto): Move all of the following code to the [Inference] class
+        val result = mutableSetOf<ValueDeclaration>()
+        result.addAll(memberMethods)
+        result.addAll(memberFields)
+        result.addAll(memberEntries)
+        if (result.isEmpty()) {
+            // the target might be a field or a method, we don't know. Thus, we need to create both
+            val targetField =
+                newFieldDeclaration(
+                    name,
+                    UnknownType.getUnknownType(base.language),
+                    ArrayList(),
+                    null,
+                    false,
+                )
+            targetField.language = base.language
+            targetField.isInferred = true
+
+            val targetMethod = newMethodDeclaration(name, true, base)
+            targetMethod.language = base.language
+            targetMethod.isInferred = true
+
+            base.addField(targetField)
+            base.addMethod(targetMethod)
+            result.add(targetField)
+            result.add(targetMethod)
+        }
+        return result
+    }
+
+    protected fun findImportables(node: Node) {
+        // Using a visitor to avoid loops in the AST
+        node.accept(
+            Strategy::AST_FORWARD,
+            object : IVisitor<Node>() {
+                override fun visit(t: Node) {
+                    if (t is RecordDeclaration) {
+                        records.add(t)
+                        importables.putIfAbsent(t.name.toString(), t)
+                    }
+                }
+            }
+        )
+    }
+}

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/DeclarationHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/DeclarationHandler.kt
@@ -208,8 +208,6 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
 
         record = newRecordDeclaration(name, "struct")
 
-        frontend.scopeManager.enterScope(record)
-
         val size = LLVMCountStructElementTypes(typeRef)
 
         for (i in 0 until size) {
@@ -219,15 +217,17 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
             // there are no names, so we need to invent some dummy ones for easier reading
             val fieldName = "field_$i"
 
+            frontend.scopeManager.enterScope(record)
+
             val field = newFieldDeclaration(fieldName, fieldType, listOf(), null, false)
 
             frontend.scopeManager.addDeclaration(field)
+
+            frontend.scopeManager.leaveScope(record)
         }
 
-        frontend.scopeManager.leaveScope(record)
-
         // add it to the global scope
-        frontend.scopeManager.globalScope?.addDeclaration(record, true)
+        frontend.scopeManager.addDeclaration(record)
 
         return record
     }

--- a/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
+++ b/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
@@ -263,7 +263,7 @@ class Application : Callable<Int> {
     private var passClassList =
         listOf(
             TypeHierarchyResolver::class,
-            ImportResolver::class,
+            JavaImportResolver::class,
             SymbolResolver::class,
             DFGPass::class,
             EvaluationOrderGraphPass::class,


### PR DESCRIPTION
Tries to implement the concepts in #1533. This is not yet implemented for all language frontends. I am using the new concepts in the C/C++ and Go frontend as a show case.

- [x] Fixes #1539
- [x] Fixes #1540
- [x] Removing `aliases` and replacing them with imports