### PR TITLE
Resolve cast ambiguity in C++ frontend

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/InferenceConfiguration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/InferenceConfiguration.kt
@@ -37,9 +37,6 @@ private constructor(
     /** Enables or disables the inference system as a whole. */
     val enabled: Boolean,
 
-    /** Enables smart guessing of cast vs. call expressions in the C/C++ language frontend. */
-    val guessCastExpressions: Boolean,
-
     /** Enables the inference of record declarations. */
     val inferRecords: Boolean,
 
@@ -57,14 +54,11 @@ private constructor(
 ) {
     class Builder(
         private var enabled: Boolean = true,
-        private var guessCastExpressions: Boolean = true,
         private var inferRecords: Boolean = true,
         private var inferFunctions: Boolean = true,
         private var inferVariables: Boolean = true,
         private var inferDfgForUnresolvedCalls: Boolean = true
     ) {
-        fun guessCastExpressions(guess: Boolean) = apply { this.guessCastExpressions = guess }
-
         fun enabled(infer: Boolean) = apply { this.enabled = infer }
 
         fun inferRecords(infer: Boolean) = apply { this.inferRecords = infer }
@@ -80,7 +74,6 @@ private constructor(
         fun build() =
             InferenceConfiguration(
                 enabled,
-                guessCastExpressions,
                 inferRecords,
                 inferFunctions,
                 inferVariables,
@@ -97,7 +90,6 @@ private constructor(
 
     override fun toString(): String {
         return ToStringBuilder(this, ToStringStyle.JSON_STYLE)
-            .append("guessCastExpressions", guessCastExpressions)
             .append("inferRecords", inferRecords)
             .append("inferDfgForUnresolvedCalls", inferDfgForUnresolvedSymbols)
             .toString()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TypeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TypeManager.kt
@@ -225,7 +225,11 @@ class TypeManager {
     }
 
     fun typeExists(name: String): Boolean {
-        return firstOrderTypes.stream().anyMatch { type: Type -> type.root.name.toString() == name }
+        return firstOrderTypes.any { type: Type -> type.root.name.toString() == name }
+    }
+
+    fun typeOf(name: Name): Type? {
+        return firstOrderTypes.firstOrNull { type: Type -> type.root.name == name }
     }
 
     fun resolvePossibleTypedef(alias: Type, scopeManager: ScopeManager): Type {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TypeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TypeManager.kt
@@ -228,10 +228,6 @@ class TypeManager {
         return firstOrderTypes.any { type: Type -> type.root.name.toString() == name }
     }
 
-    fun typeOf(name: Name): Type? {
-        return firstOrderTypes.firstOrNull { type: Type -> type.root.name == name }
-    }
-
     fun resolvePossibleTypedef(alias: Type, scopeManager: ScopeManager): Type {
         val finalToCheck = alias.root
         val applicable = scopeManager.typedefFor(finalToCheck)

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/ExpressionHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/ExpressionHandler.kt
@@ -385,21 +385,13 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
             IASTUnaryExpression.op_bracketedPrimary -> {
                 // If this expression is NOT part of a call expression and contains a "name" or
                 // something similar, we want to keep the information that this is an expression
-                // wrapped in parentheses. The easiest way to do this is to create a cast
-                // expression.
+                // wrapped in parentheses. The best way to do this is to create a unary expression
                 if (ctx.operand is IASTIdExpression && ctx.parent !is IASTFunctionCallExpression) {
-                    val cast = newCastExpression(rawNode = ctx)
-                    cast.setCastOperator(0)
-                    // We only set the name of the cast expression here. It is important to not
-                    // create a new type here, because we do not know if this is really a type or
-                    // not. We need to find this out in the CXXExtraPass.
-                    cast.name = parseName((ctx.operand as IASTIdExpression).name.toString())
-                    // The expression member can only be filled by the parent call
+                    val op = newUnaryOperator("()", postfix = true, prefix = true, rawNode = ctx)
                     if (input != null) {
-                        cast.expression = input
+                        op.input = input
                     }
-                    cast.location = frontend.locationOf(ctx)
-                    return cast
+                    return op
                 }
 
                 // In all other cases, e.g., if the parenthesis is nested or part of a function

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/ExpressionHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/ExpressionHandler.kt
@@ -383,24 +383,28 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
             IASTUnaryExpression.op_not -> operatorCode = "!"
             IASTUnaryExpression.op_sizeof -> operatorCode = "sizeof"
             IASTUnaryExpression.op_bracketedPrimary -> {
-                if (
-                    frontend.config.inferenceConfiguration.guessCastExpressions &&
-                        ctx.operand is IASTIdExpression
-                ) {
-                    // this can either be just a meaningless bracket or it can be a cast expression
-                    val typeName = (ctx.operand as IASTIdExpression).name.toString()
-                    if (frontend.typeManager.typeExists(typeName)) {
-                        val cast = newCastExpression(rawNode = ctx)
-                        cast.setCastOperator(0)
-                        cast.castType = frontend.typeOf((ctx.operand as IASTIdExpression).name)
-                        // The expression member can only be filled by the parent call
-                        // (handleFunctionCallExpression and handleBinaryExpression)
-                        cast.location = frontend.locationOf(ctx)
-                        return cast
+                // If this expression is NOT part of a call expression and contains a "name" or
+                // something similar, we want to keep the information that this is an expression
+                // wrapped in parentheses. The easiest way to do this is to create a cast
+                // expression.
+                if (ctx.operand is IASTIdExpression && ctx.parent !is IASTFunctionCallExpression) {
+                    val cast = newCastExpression(rawNode = ctx)
+                    cast.setCastOperator(0)
+                    // We only set the name of the cast expression here. It is important to not
+                    // create a new type here, because we do not know if this is really a type or
+                    // not. We need to find this out in the CXXExtraPass.
+                    cast.name = parseName((ctx.operand as IASTIdExpression).name.toString())
+                    // The expression member can only be filled by the parent call
+                    if (input != null) {
+                        cast.expression = input
                     }
+                    cast.location = frontend.locationOf(ctx)
+                    return cast
                 }
 
-                // otherwise, ignore this kind of expression and return the input directly
+                // In all other cases, e.g., if the parenthesis is nested or part of a function
+                // call, we just return the unwrapped expression, because in this case we do not
+                // need to information about the parenthesis.
                 return input as Expression
             }
             IASTUnaryExpression.op_throw -> operatorCode = "throw"
@@ -475,14 +479,6 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
                         (ctx.functionNameExpression as IASTIdExpression).name as CPPASTTemplateId
                     )
                     .forEach { callExpression.addTemplateParameter(it) }
-            }
-            reference is CastExpression &&
-                frontend.config.inferenceConfiguration.guessCastExpressions -> {
-                // this really is a cast expression in disguise
-                reference.expression =
-                    ctx.arguments.firstOrNull()?.let { handle(it) }
-                        ?: newProblemExpression("could not parse argument for cast")
-                return reference
             }
             else -> {
                 callExpression =
@@ -576,21 +572,6 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
             } else {
                 handle(ctx.initOperand2)
             } ?: newProblemExpression("could not parse rhs")
-
-        if (
-            lhs is CastExpression &&
-                (language as? CLanguage)
-                    ?.unaryOperators
-                    ?.contains((binaryOperator.operatorCode ?: "")) == true &&
-                frontend.config.inferenceConfiguration.guessCastExpressions
-        ) {
-            // this really is a combination of a cast and a unary operator
-            val op = newUnaryOperator(operatorCode, postfix = true, prefix = false, rawNode = ctx)
-            op.input = rhs
-            op.location = frontend.locationOf(ctx.operand2)
-            lhs.expression = op
-            return lhs
-        }
 
         binaryOperator.lhs = lhs
         binaryOperator.rhs = rhs

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CXXExtraPass.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CXXExtraPass.kt
@@ -26,15 +26,14 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationContext
-import de.fraunhofer.aisec.cpg.graph.Component
-import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
-import de.fraunhofer.aisec.cpg.graph.implicit
-import de.fraunhofer.aisec.cpg.graph.newConstructExpression
 import de.fraunhofer.aisec.cpg.graph.scopes.GlobalScope
 import de.fraunhofer.aisec.cpg.graph.scopes.ValueDeclarationScope
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.BinaryOperator
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.CastExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.ConstructExpression
 import de.fraunhofer.aisec.cpg.graph.types.recordDeclaration
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
@@ -52,14 +51,68 @@ import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
 @DependsOn(TypeResolver::class)
 class CXXExtraPass(ctx: TranslationContext) : ComponentPass(ctx) {
 
+    private lateinit var walker: SubgraphWalker.ScopedWalker
+
     override fun accept(component: Component) {
-        val walker = SubgraphWalker.ScopedWalker(ctx.scopeManager)
+        walker = SubgraphWalker.ScopedWalker(ctx.scopeManager)
 
         walker.registerHandler(::fixInitializers)
+        walker.registerHandler { _, parent, node ->
+            when (node) {
+                is BinaryOperator -> convertOperators(node, parent)
+            }
+        }
         walker.registerHandler(::connectDefinitions)
 
         for (tu in component.translationUnits) {
             walker.iterate(tu)
+        }
+    }
+
+    /**
+     * In C++ there is an ambiguity between the combination of a cast + unary operator or a binary
+     * operator where some arguments are wrapped in parenthesis. This function tries to resolve
+     * this. Note: This is done especially for the C++ frontend. [ReplaceCallCastPass.handleCall]
+     * handles the more general case (which also applies to C++), in which a cast and a call are
+     * indistinguishable and need to be resolved once all types are known.
+     */
+    private fun convertOperators(binOp: BinaryOperator, parent: Node?) {
+        val cast = binOp.lhs
+        if (cast is CastExpression) {
+            // We need to check, if the supposed cast expression is really referring to a type or
+            // not
+            val type = typeManager.typeOf(cast.name)
+            if (type != null) {
+                // If the name of the cast expression is really a type, then this is really a unary
+                // expression instead of a binary operator. We need to perform the following steps:
+                // * create a unary operator with the rhs of the binary operator (and the same
+                //   operator code)
+                // * set this unary operator as the "expression" of the cast
+                // * actually set the type of cast, since before we only set the name (so we do not
+                //   accidentally create the type)
+                // * replace the binary operator with the cast expression in the parent argument
+                //   holder
+                val unaryOp =
+                    newUnaryOperator(binOp.operatorCode ?: "", postfix = false, prefix = true)
+                        .codeAndLocationFrom(binOp.rhs)
+                unaryOp.input = binOp.rhs
+
+                // disconnect the old expression
+                cast.expression.disconnectFromGraph()
+                // set the unary operator as the new expression
+                cast.expression = unaryOp
+                cast.type = type
+                cast.castType = type
+
+                // replace the node in the parent of the bin/unary op
+                walker.replaceArgument(parent, binOp, cast)
+            } else {
+                // Otherwise, the supposed cast expression was really just parenthesis around an
+                // identifier, but we can only make this distinction now. In this case we can just
+                // unwrap the reference and exchange the cast expression in the arguments of the
+                // binary op
+                walker.replaceArgument(binOp, cast, cast.expression)
+            }
         }
     }
 

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
@@ -1673,5 +1673,4 @@ internal class CXXLanguageFrontendTest : BaseTest() {
         val functions = result.functions { it.name.localName == "foo" && it.isDefinition }
         assertEquals(2, functions.size)
     }
-
 }

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
@@ -1266,7 +1266,6 @@ internal class CXXLanguageFrontendTest : BaseTest() {
         val file = File("src/test/resources/cxx/parenthesis.cpp")
         val tu =
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
-                it.inferenceConfiguration(builder().guessCastExpressions(true).build())
                 it.registerLanguage<CPPLanguage>()
             }
         val main = tu.functions["main"]
@@ -1674,4 +1673,5 @@ internal class CXXLanguageFrontendTest : BaseTest() {
         val functions = result.functions { it.name.localName == "foo" && it.isDefinition }
         assertEquals(2, functions.size)
     }
+
 }

--- a/cpg-language-cxx/src/test/resources/cxx/parenthesis.cpp
+++ b/cpg-language-cxx/src/test/resources/cxx/parenthesis.cpp
@@ -10,6 +10,14 @@ int main() {
 	// this cast could be mistaken for a binary operation
 	int64_t addr = (int64_t) &count;
 
+	// this is a binary operation, even though it has parenthesis.
+	// The added parenthesis are just for more confusion
+	addr = ((addr)) & count;
+	addr = (long) & count;
+
+    // this is a complex combination of cast and binary operation
+	addr = (long)&addr + 1;
+
 	// finally, a more complex example of unary operators and casts
 	char* outptr, key;
 	*(int64_t *)outptr = *(int64_t *)&key;

--- a/cpg-language-cxx/src/test/resources/cxx/parenthesis.cpp
+++ b/cpg-language-cxx/src/test/resources/cxx/parenthesis.cpp
@@ -12,11 +12,13 @@ int main() {
 
 	// this is a binary operation, even though it has parenthesis.
 	// The added parenthesis are just for more confusion
-	addr = ((addr)) & count;
-	addr = (long) & count;
+	addr = ((addr)) &count;
+
+	// this is the same as in line 11, just with a different type
+	addr = (long) &count;
 
     // this is a complex combination of cast and binary operation
-	addr = (long)&addr + 1;
+	addr = (long) &addr + 1;
 
 	// finally, a more complex example of unary operators and casts
 	char* outptr, key;


### PR DESCRIPTION
Follow up to #1406. This PR now resolves cast ambiguities in the `CXXExtraPass` instead of the frontend.
