### PR TITLE
Only propagate type updates in a `Reference` from FULL previous DFG nodes

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Reference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Reference.kt
@@ -143,8 +143,11 @@ open class Reference : Expression(), HasType.TypeObserver, HasAliases {
             this.addAssignedTypes(assignedTypes)
         }
 
-        // We also allow updates from our previous DFG nodes
-        if (prevDFG.contains(src as Node)) {
+        // We also allow updates from our previous DFG nodes; but only for FULL data-flows. This is
+        // important especially for MemberExpression nodes (which are also Reference nodes).
+        // Otherwise, an update in the base's type could propagate to a member (since we have a
+        // PARTIAL DFG from the base to the member) and this is BAD.
+        if (prevFullDFG.contains(src as Node)) {
             this.addAssignedTypes(assignedTypes)
         }
     }


### PR DESCRIPTION
Otherwise, an update in the base's type could propagate to a member and this is BAD. This is due to the fact that

- a `MemberExpression` is also a `Reference`
- we have a PARTIAL DFG from the base of the member expression to the member expression
