### PR TITLE
Java frontend: Handle multi-field-declaration statements

### DIFF
--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.kt
@@ -235,8 +235,8 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
 
     fun handleFieldDeclaration(
         fieldDecl: com.github.javaparser.ast.body.FieldDeclaration
-    ): FieldDeclaration? {
-        var fieldDeclaration: FieldDeclaration? = null
+    ): DeclarationSequence {
+        val declarationSequence = DeclarationSequence()
 
         val modifiers = fieldDecl.modifiers.map { modifier -> modifier.keyword.asString() }
 
@@ -282,7 +282,7 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
                     type.typeOrigin = Type.Origin.GUESSED
                 }
             }
-            fieldDeclaration =
+            val fieldDeclaration =
                 this.newFieldDeclaration(
                     variable.name.asString(),
                     type,
@@ -292,8 +292,9 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
                 )
             frontend.scopeManager.addDeclaration(fieldDeclaration)
             frontend.processAnnotations(fieldDeclaration, fieldDecl)
+            declarationSequence.addDeclaration(fieldDeclaration)
         }
-        return fieldDeclaration
+        return declarationSequence
     }
 
     fun handleEnumDeclaration(

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.kt
@@ -236,61 +236,64 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
 
     fun handleFieldDeclaration(
         fieldDecl: com.github.javaparser.ast.body.FieldDeclaration
-    ): FieldDeclaration {
+    ): FieldDeclaration? {
+        var fieldDeclaration: FieldDeclaration? = null
 
-        // TODO: can  field have more than one variable?
-        val variable = fieldDecl.getVariable(0)
         val modifiers = fieldDecl.modifiers.map { modifier -> modifier.keyword.asString() }
-        val initializer =
-            variable.initializer
-                .map { ctx: Expression -> frontend.expressionHandler.handle(ctx) }
-                .orElse(null) as? de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
-        var type: Type
-        try {
-            // Resolve type first with ParameterizedType
-            type =
-                frontend.typeManager.getTypeParameter(
-                    frontend.scopeManager.currentRecord,
-                    variable.resolve().type.describe()
-                ) ?: frontend.typeOf(variable.resolve().type)
-        } catch (e: UnsolvedSymbolException) {
-            val t = frontend.recoverTypeFromUnsolvedException(e)
-            if (t == null) {
-                log.warn("Could not resolve type for {}", variable)
-                type = frontend.typeOf(variable.type)
-            } else {
-                type = this.objectType(t)
-                type.typeOrigin = Type.Origin.GUESSED
+
+        for (variable in fieldDecl.variables) {
+            val initializer =
+                variable.initializer
+                    .map { ctx: Expression -> frontend.expressionHandler.handle(ctx) }
+                    .orElse(null)
+                    as? de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
+            var type: Type
+            try {
+                // Resolve type first with ParameterizedType
+                type =
+                    frontend.typeManager.getTypeParameter(
+                        frontend.scopeManager.currentRecord,
+                        variable.resolve().type.describe()
+                    ) ?: frontend.typeOf(variable.resolve().type)
+            } catch (e: UnsolvedSymbolException) {
+                val t = frontend.recoverTypeFromUnsolvedException(e)
+                if (t == null) {
+                    log.warn("Could not resolve type for {}", variable)
+                    type = frontend.typeOf(variable.type)
+                } else {
+                    type = this.objectType(t)
+                    type.typeOrigin = Type.Origin.GUESSED
+                }
+            } catch (e: UnsupportedOperationException) {
+                val t = frontend.recoverTypeFromUnsolvedException(e)
+                if (t == null) {
+                    log.warn("Could not resolve type for {}", variable)
+                    type = frontend.typeOf(variable.type)
+                } else {
+                    type = this.objectType(t)
+                    type.typeOrigin = Type.Origin.GUESSED
+                }
+            } catch (e: IllegalArgumentException) {
+                val t = frontend.recoverTypeFromUnsolvedException(e)
+                if (t == null) {
+                    log.warn("Could not resolve type for {}", variable)
+                    type = frontend.typeOf(variable.type)
+                } else {
+                    type = this.objectType(t)
+                    type.typeOrigin = Type.Origin.GUESSED
+                }
             }
-        } catch (e: UnsupportedOperationException) {
-            val t = frontend.recoverTypeFromUnsolvedException(e)
-            if (t == null) {
-                log.warn("Could not resolve type for {}", variable)
-                type = frontend.typeOf(variable.type)
-            } else {
-                type = this.objectType(t)
-                type.typeOrigin = Type.Origin.GUESSED
-            }
-        } catch (e: IllegalArgumentException) {
-            val t = frontend.recoverTypeFromUnsolvedException(e)
-            if (t == null) {
-                log.warn("Could not resolve type for {}", variable)
-                type = frontend.typeOf(variable.type)
-            } else {
-                type = this.objectType(t)
-                type.typeOrigin = Type.Origin.GUESSED
-            }
+            fieldDeclaration =
+                this.newFieldDeclaration(
+                    variable.name.asString(),
+                    type,
+                    modifiers,
+                    initializer,
+                    rawNode = fieldDecl
+                )
+            frontend.scopeManager.addDeclaration(fieldDeclaration)
+            frontend.processAnnotations(fieldDeclaration, fieldDecl)
         }
-        val fieldDeclaration =
-            this.newFieldDeclaration(
-                variable.name.asString(),
-                type,
-                modifiers,
-                initializer,
-                rawNode = fieldDecl
-            )
-        frontend.scopeManager.addDeclaration(fieldDeclaration)
-        frontend.processAnnotations(fieldDeclaration, fieldDecl)
         return fieldDeclaration
     }
 

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.kt
@@ -332,7 +332,6 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
         typeDecl: T,
         recordDeclaration: RecordDeclaration,
     ) {
-        // TODO: 'this' identifier for multiple instances?
         for (decl in typeDecl.members) {
             (decl as? com.github.javaparser.ast.body.FieldDeclaration)?.let {
                 handle(it) // will be added via the scopemanager

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.kt
@@ -288,7 +288,6 @@ internal class JavaLanguageFrontendTest : BaseTest() {
             analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
                 it.registerLanguage(JavaLanguage())
             }
-        // TODO: Use GraphExamples here as well.
         assertNotNull(tu)
 
         val namespaceDeclaration = tu.getDeclarationAs(0, NamespaceDeclaration::class.java)
@@ -297,8 +296,11 @@ internal class JavaLanguageFrontendTest : BaseTest() {
             namespaceDeclaration?.getDeclarationAs(0, RecordDeclaration::class.java)
         assertNotNull(recordDeclaration)
 
-        val fields = recordDeclaration.fields.map { it.name.localName }
-        assertTrue(fields.contains("field"))
+        val fields = recordDeclaration.fields.map { it.name.localName }.toSet()
+        assertTrue(fields.containsAll(setOf("field", "field1", "field2")))
+
+        assertEquals(1, (recordDeclaration.fields["field1"]?.initializer as? Literal<*>)?.value)
+        assertEquals(2, (recordDeclaration.fields["field2"]?.initializer as? Literal<*>)?.value)
 
         val method = recordDeclaration.methods[0]
         assertNotNull(method)

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.kt
@@ -299,8 +299,8 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val fields = recordDeclaration.fields.map { it.name.localName }.toSet()
         assertTrue(fields.containsAll(setOf("field", "field1", "field2")))
 
-        assertEquals(1, (recordDeclaration.fields["field1"]?.initializer as? Literal<*>)?.value)
-        assertEquals(2, (recordDeclaration.fields["field2"]?.initializer as? Literal<*>)?.value)
+        assertLiteralValue(1, recordDeclaration.fields["field1"]?.initializer)
+        assertLiteralValue(2, recordDeclaration.fields["field2"]?.initializer)
 
         val method = recordDeclaration.methods[0]
         assertNotNull(method)

--- a/cpg-language-java/src/test/resources/compiling/RecordDeclaration.java
+++ b/cpg-language-java/src/test/resources/compiling/RecordDeclaration.java
@@ -4,6 +4,8 @@ class SimpleClass {
 
   private int field;
 
+  private int field1 = 1, field2 = 2;
+
   SimpleClass() {
     // constructor
   }


### PR DESCRIPTION
Fixes #1548 by implementing the proposed measures. However, `handleFieldDeclaration` now only returns the last field/variable which is declared in a multi-field-declaration statement but since we never use the return value in this case, it should be fine.