### PR TITLE
Use qualified names for types and record declarations

### DIFF
--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.kt
@@ -178,7 +178,7 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
         classInterDecl: ClassOrInterfaceDeclaration
     ): RecordDeclaration {
         // TODO: support other kinds, such as interfaces
-        val fqn = classInterDecl.nameAsString
+        val fqn = classInterDecl.fullyQualifiedName.orElse(classInterDecl.nameAsString)
 
         // Todo adapt name using a new type of scope "Namespace/Package scope"
 

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
@@ -487,7 +487,7 @@ open class JavaLanguageFrontend(language: Language<JavaLanguageFrontend>, ctx: T
             is PrimitiveType -> primitiveType(type.asString())
             is ClassOrInterfaceType ->
                 objectType(
-                    type.nameAsString,
+                    type.nameWithScope,
                     type.typeArguments.getOrNull()?.map { this.typeOf(it) } ?: listOf()
                 )
             is ReferenceType -> objectType(type.asString())


### PR DESCRIPTION
Fixes #1472 .

The StackOverflow occurs because the class implements an interface with the same localName but in another package. Thus, we should consider the FQN when generating a type (if available). Same probably holds for the RecordDeclaration where we have somehow only used a local name so far? The change in `typeOf` itself is sufficient to prevent the StackOverflow but I'm not sure if these changes could have an impact on something else (i.e. the `TypeResolver`)?