### PR TITLE
Filter eogstarters which do not start the eog

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TranslationUnitDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TranslationUnitDeclaration.kt
@@ -130,8 +130,8 @@ class TranslationUnitDeclaration :
             val list = mutableListOf<Node>()
             // Add all top-level declarations
             list += declarations
-            // Add all top-level statements
-            list += statements
+            // Add the TU itself, so that we can catch any static statements in the TU
+            list += this
 
             return list
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -101,17 +101,9 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
         for (tu in component.translationUnits) {
             currentTU = tu
-            // gather all resolution start holders and their start nodes
-            val nodes =
-                tu.allEOGStarters.filter {
-                    it.prevEOG.isEmpty() ||
-                        // TODO: This ugly check should ideally not be necessary but it happens when
-                        // an eog-starter depends on some child. Not sure why this is required
-                        // though...
-                        it.allChildren<Node>().let { astChildren ->
-                            it.prevEOG.all { eog -> eog in astChildren }
-                        }
-                }
+            // Gather all resolution EOG starters; and make sure they really do not have a
+            // predecessor, otherwise we might analyze a node multiple times
+            val nodes = tu.allEOGStarters.filter { it.prevEOG.isEmpty() }
 
             for (node in nodes) {
                 walker.iterate(node)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -102,7 +102,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         for (tu in component.translationUnits) {
             currentTU = tu
             // gather all resolution start holders and their start nodes
-            val nodes = tu.allEOGStarters
+            val nodes = tu.allEOGStarters.filter { it.prevEOG.isEmpty() }
 
             for (node in nodes) {
                 walker.iterate(node)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -102,7 +102,13 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         for (tu in component.translationUnits) {
             currentTU = tu
             // gather all resolution start holders and their start nodes
-            val nodes = tu.allEOGStarters.filter { it.prevEOG.isEmpty() }
+            val nodes =
+                tu.allEOGStarters.filter {
+                    it.prevEOG.isEmpty() ||
+                        it.allChildren<Node>().let { astChildren ->
+                            it.prevEOG.all { eog -> eog in astChildren }
+                        }
+                }
 
             for (node in nodes) {
                 walker.iterate(node)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -105,6 +105,9 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
             val nodes =
                 tu.allEOGStarters.filter {
                     it.prevEOG.isEmpty() ||
+                        // TODO: This ugly check should ideally not be necessary but it happens when
+                        // an eog-starter depends on some child. Not sure why this is required
+                        // though...
                         it.allChildren<Node>().let { astChildren ->
                             it.prevEOG.all { eog -> eog in astChildren }
                         }

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/WalkerTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/WalkerTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.passes
+
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationManager
+import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguage
+import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
+import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class WalkerTest {
+    @Test
+    fun testSingleVisitor() {
+        val file = File("src/test/resources/Issue1459.java")
+
+        val config =
+            TranslationConfiguration.builder()
+                .sourceLocations(listOf(file))
+                .defaultPasses()
+                .debugParser(true)
+                .registerLanguage<JavaLanguage>()
+                .failOnError(true)
+                .build()
+
+        val analyzer = TranslationManager.builder().config(config).build()
+        val result = analyzer.analyze().get()
+        assertNotNull(result)
+        val scopeManager = result.finalCtx.scopeManager
+        val walker = SubgraphWalker.ScopedWalker(scopeManager)
+
+        val visitedNodes = mutableSetOf<Node>()
+
+        walker.strategy = Strategy::EOG_FORWARD
+        walker.registerHandler { _, _, node ->
+            if (node != null) {
+                assertTrue(visitedNodes.add(node), "Visited node $node multiple times")
+            }
+        }
+
+        for (tu in result.components.flatMap { it.translationUnits }) {
+            // gather all resolution start holders and their start nodes
+            val nodes = tu.allEOGStarters.filter { it.prevEOG.isEmpty() }
+
+            for (node in nodes) {
+                walker.iterate(node)
+            }
+        }
+
+        val i2 = result.fields["i2"]
+        assertNotNull(i2)
+        assertContains(visitedNodes, i2)
+    }
+}

--- a/cpg-language-java/src/test/resources/Issue1459.java
+++ b/cpg-language-java/src/test/resources/Issue1459.java
@@ -1,0 +1,16 @@
+public class Issue1459 {
+    public static final int i1 = 1;
+    public static final int i2 = i1;
+
+    public static void main(String[] args) {
+        System.out.println(i2);
+    }
+
+    class Inner { // EOG predecessor: MemberExpression "i2"
+        static final int i3 = i2;
+    }
+
+    class Inner2 {// EOG predecessor: FieldDeclaration "Inner$this"
+        static final int i4 = FieldRecord.Inner.i3;
+    }
+}


### PR DESCRIPTION
We use `EOGStarterHolder`s to identify possible start nodes of the EOG. However, they might also be located in the middle of an existing EOG which means that some visitors would visit them multiple times and potentially even out-of-order. One example is the `SymbolResolver` which also led to #1459. We check that we only start the EOG-iteration/walking for nodes which are not in another EOG (i.e., we only visit nodes which actually serve as an entry-point).

Fixes #1459 