### PR TITLE
Cleanup of `SubgraphWalker`

### DIFF
--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGPass.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGPass.kt
@@ -58,7 +58,7 @@ class UnreachableEOGPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {
      *
      * @param node every node in the TranslationResult
      */
-    protected fun handle(node: Node) {
+    protected fun handle(node: Node, parent: Node?) {
         if (node is FunctionDeclaration) {
             val startState = UnreachabilityState()
             for (firstEdge in node.nextEOGEdges) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
@@ -45,7 +45,7 @@ class DFGPass(ctx: TranslationContext) : ComponentPass(ctx) {
     override fun accept(component: Component) {
         val inferDfgForUnresolvedCalls = config.inferenceConfiguration.inferDfgForUnresolvedSymbols
         val walker = IterativeGraphWalker()
-        walker.registerOnNodeVisit2 { node, parent ->
+        walker.registerOnNodeVisit { node, parent ->
             handle(node, parent, inferDfgForUnresolvedCalls, config.functionSummaries)
         }
         for (tu in component.translationUnits) {

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
@@ -1692,4 +1692,18 @@ internal class CXXLanguageFrontendTest : BaseTest() {
         lookup = scope.lookupSymbol("string").singleOrNull()
         assertEquals(string, lookup)
     }
+
+    @Test
+    fun testSymbolResolverFail() {
+        val file = File("src/test/resources/c/symbol_resolver_fail.c")
+        val result =
+            analyze(listOf(file), file.parentFile.toPath(), true) {
+                it.registerLanguage<CLanguage>()
+            }
+        assertNotNull(result)
+
+        val doCall = result.calls["do_call"]
+        assertNotNull(doCall)
+        assertTrue(doCall.invokes.isNotEmpty())
+    }
 }

--- a/cpg-language-cxx/src/test/resources/c/symbol_resolver_fail.c
+++ b/cpg-language-cxx/src/test/resources/c/symbol_resolver_fail.c
@@ -1,0 +1,12 @@
+// this macro contains two literals. Because this is a macro, both
+// literals will contain the same location and thus, the same hash-code.
+// this confuses the EOG walker
+#define SOME_MACRO (1u<<1)
+
+int symbol_resolver_fail()
+{
+  char *address;
+  if (SOME_MACRO) {
+    do_call(address);
+  }
+}


### PR DESCRIPTION
This PR fixes a rather intricate bug in the subgraph walker that made the symbol resolver not resolve / "reach" all the necessary nodes. I took this opportunity to remove some legacy code from the class and also clean it up a lot.

In theory this should also make it a little bit faster because we do a little less stack pushing / peeking than before, but this is probably not noticeable.
