### PR TITLE
Parsing `CPPASTLinkageSpecification`

### DIFF
--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
@@ -1721,4 +1721,17 @@ internal class CXXLanguageFrontendTest : BaseTest() {
         assertTrue(printf.prevEOG.isNotEmpty())
         assertTrue(printf.invokes.isNotEmpty())
     }
+
+    @Test
+    fun testExternC() {
+        val file = File("src/test/resources/cxx/extern_c.cpp")
+        val result =
+            analyze(listOf(file), file.parentFile.toPath(), true) {
+                it.registerLanguage<CPPLanguage>()
+            }
+        assertNotNull(result)
+
+        val test = result.functions["test"]
+        assertNotNull(test)
+    }
 }

--- a/cpg-language-cxx/src/test/resources/cxx/extern_c.cpp
+++ b/cpg-language-cxx/src/test/resources/cxx/extern_c.cpp
@@ -1,0 +1,3 @@
+extern "C" {
+void test();
+}


### PR DESCRIPTION
It seems we previously ignored it, which meant that all code that was behind `extern "C"` was ignored.

Fixes #1578
