### PR TITLE
Resolving types based on type name normalisation

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -834,14 +834,19 @@ class ScopeManager : ScopeProvider {
 
     /**
      * This function resolves a name alias (contained in an import alias) for the [Name.parent] of
-     * the given [Name]. This has also the major problem of only resolving one layer of aliases :(
+     * the given [Name]. It also does this recursively.
      */
     fun resolveParentAlias(name: Name, scope: Scope?): Name {
         var parentName = name.parent ?: return name
         parentName = resolveParentAlias(parentName, scope)
 
-        // This is not 100 % ideal, but at least somewhat compatible to the previous approach
-        var newName = Name(name.localName, parentName, delimiter = name.delimiter)
+        // Build a new name based on the eventual resolved parent alias
+        var newName =
+            if (parentName != name.parent) {
+                Name(name.localName, parentName, delimiter = name.delimiter)
+            } else {
+                name
+            }
         var decl =
             scope?.lookupSymbol(parentName.localName)?.singleOrNull {
                 it is NamespaceDeclaration || it is RecordDeclaration

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -568,7 +568,7 @@ class ScopeManager : ScopeProvider {
     }
 
     private fun getCurrentTypedefs(searchScope: Scope?): Collection<TypedefDeclaration> {
-        val typedefs = mutableMapOf<Type, TypedefDeclaration>()
+        val typedefs = mutableMapOf<Name, TypedefDeclaration>()
 
         val path = mutableListOf<ValueDeclarationScope>()
         var current = searchScope
@@ -781,7 +781,8 @@ class ScopeManager : ScopeProvider {
     }
 
     /**
-     * This function extracts a scope for the [Name], e.g. if the name is fully qualified.
+     * This function extracts a scope for the [Name], e.g. if the name is fully qualified. `null` is
+     * returned, if no scope can be extracted.
      *
      * The pair returns the extracted scope and a name that is adjusted by possible import aliases.
      * The extracted scope is "responsible" for the name (e.g. declares the parent namespace) and
@@ -822,7 +823,7 @@ class ScopeManager : ScopeProvider {
                         LOGGER,
                         "Could not find the scope $scopeName needed to resolve $n"
                     )
-                    scope
+                    null
                 } else {
                     scopes[0]
                 }
@@ -833,13 +834,14 @@ class ScopeManager : ScopeProvider {
 
     /**
      * This function resolves a name alias (contained in an import alias) for the [Name.parent] of
-     * the given [Name].
+     * the given [Name]. This has also the major problem of only resolving one layer of aliases :(
      */
     fun resolveParentAlias(name: Name, scope: Scope?): Name {
-        val parentName = name.parent ?: return name
+        var parentName = name.parent ?: return name
+        parentName = resolveParentAlias(parentName, scope)
 
         // This is not 100 % ideal, but at least somewhat compatible to the previous approach
-        var newName = name
+        var newName = Name(name.localName, parentName, delimiter = name.delimiter)
         var decl =
             scope?.lookupSymbol(parentName.localName)?.singleOrNull {
                 it is NamespaceDeclaration || it is RecordDeclaration
@@ -847,6 +849,16 @@ class ScopeManager : ScopeProvider {
         if (decl != null && parentName != decl.name) {
             // This is probably an already resolved alias so, we take this one
             return Name(newName.localName, decl.name, delimiter = newName.delimiter)
+        }
+
+        // Some special handling of typedefs; this should somehow be merged with the above but not
+        // exactly sure how. The issue is that we cannot take the "name" of the typedef declaration,
+        // but we rather want its original type name.
+        // TODO: This really needs to be handled better somehow, maybe a common interface for
+        //  typedefs, namespaces and records that return the correct name?
+        decl = scope?.lookupSymbol(parentName.localName)?.singleOrNull { it is TypedefDeclaration }
+        if ((decl as? TypedefDeclaration) != null) {
+            return Name(newName.localName, decl.type.name, delimiter = newName.delimiter)
         }
 
         // If we do not have a match yet, it could be that we are trying to resolve an FQN type
@@ -993,8 +1005,8 @@ class ScopeManager : ScopeProvider {
         return findSymbols(name).filterIsInstance<RecordDeclaration>().singleOrNull()
     }
 
-    fun typedefFor(alias: Type): Type? {
-        var current = currentScope
+    fun typedefFor(alias: Name, scope: Scope? = currentScope): Type? {
+        var current = scope
 
         // We need to build a path from the current scope to the top most one. This ensures us that
         // a local definition overwrites / shadows one that was there on a higher scope.
@@ -1010,7 +1022,7 @@ class ScopeManager : ScopeProvider {
                 // This process has several steps:
                 // First, do a quick local lookup, to see if we have a typedef our current scope
                 // (only do this if the name is not qualified)
-                if (!alias.name.isQualified() && current == currentScope) {
+                if (!alias.isQualified() && current == currentScope) {
                     val decl = current.typedefs[alias]
                     if (decl != null) {
                         return decl.type
@@ -1021,7 +1033,7 @@ class ScopeManager : ScopeProvider {
                 // qualified based on the current namespace
                 val key =
                     current.typedefs.keys.firstOrNull {
-                        var lookupName = alias.name
+                        var lookupName = alias
 
                         // If the lookup name is already a FQN, we can use the name directly
                         lookupName =
@@ -1033,7 +1045,7 @@ class ScopeManager : ScopeProvider {
                                 currentNamespace?.fqn(lookupName.localName) ?: lookupName
                             }
 
-                        it.name.lastPartsMatch(lookupName)
+                        it.lastPartsMatch(lookupName)
                     }
                 if (key != null) {
                     return current.typedefs[key]?.type
@@ -1064,9 +1076,12 @@ class ScopeManager : ScopeProvider {
         name: Name,
         location: PhysicalLocation? = null,
         startScope: Scope? = currentScope,
+        predicate: ((Declaration) -> Boolean)? = null,
     ): List<Declaration> {
         val (scope, n) = extractScope(name, location, startScope)
-        val list = scope?.lookupSymbol(n.localName)?.toMutableList() ?: mutableListOf()
+        val list =
+            scope?.lookupSymbol(n.localName, predicate = predicate)?.toMutableList()
+                ?: mutableListOf()
 
         // If we have both the definition and the declaration of a function declaration in our list,
         // we chose only the definition

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
@@ -77,6 +77,11 @@ class TranslationResult(
     val isCancelled: Boolean
         get() = translationManager.isCancelled()
 
+    override var ctx: TranslationContext? = null
+        get() {
+            return finalCtx
+        }
+
     /**
      * Checks if only a single software component has been analyzed and returns its translation
      * units. For multiple software components, it aggregates the results.

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
@@ -204,10 +204,12 @@ fun MetadataProvider.newTypedefDeclaration(
     rawNode: Any? = null
 ): TypedefDeclaration {
     val node = TypedefDeclaration()
-    node.applyMetadata(this, alias.typeName, rawNode, true)
+    node.applyMetadata(this, alias.typeName, rawNode)
 
     node.type = targetType
     node.alias = alias
+    // litle bit of a hack to make the type FQN
+    node.alias.name = node.name
 
     log(node)
     return node

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/TypeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/TypeBuilder.kt
@@ -89,11 +89,16 @@ fun Type.ref(): Type {
 
 /**
  * This function returns an [ObjectType] with the given [name]. If a respective [Type] does not yet
- * exist, it will be created In order to avoid unnecessary allocation of simple types, we do a
- * pre-check within this function, whether a built-in type exist with the particular name.
+ * exist (in the current scope), it will be created. In order to avoid unnecessary allocation of
+ * simple types, we do a pre-check within this function, whether a built-in type exist with the
+ * particular name.
  */
 @JvmOverloads
-fun LanguageProvider.objectType(name: CharSequence, generics: List<Type> = listOf()): Type {
+fun LanguageProvider.objectType(
+    name: CharSequence,
+    generics: List<Type> = listOf(),
+    rawNode: Any? = null
+): Type {
     // First, we check, whether this is a built-in type, to avoid necessary allocations of simple
     // types
     val builtIn = language?.getSimpleTypeOf(name.toString())
@@ -108,12 +113,15 @@ fun LanguageProvider.objectType(name: CharSequence, generics: List<Type> = listO
                 "Could not create type: translation context not available"
             )
 
+    val scope = c.scopeManager.currentScope
+
     synchronized(c.typeManager.firstOrderTypes) {
         // We can try to look up the type by its name and return it, if it already exists.
         var type =
             c.typeManager.firstOrderTypes.firstOrNull {
                 it is ObjectType &&
                     it.name == name &&
+                    it.scope == scope &&
                     it.generics == generics &&
                     it.language == language
             }
@@ -124,9 +132,13 @@ fun LanguageProvider.objectType(name: CharSequence, generics: List<Type> = listO
         // Otherwise, we either need to create the type because of the generics or because we do not
         // know the type yet.
         type = ObjectType(name, generics, false, language)
+        // Apply our usual metadata, such as scope, code, location, if we have any. Make sure only
+        // to refer by the local name because we will treat types as sort of references when
+        // creating them and resolve them later.
+        type.applyMetadata(this, name, rawNode = rawNode, localNameOnly = true)
 
         // Piping it through register type will ensure that in any case we return the one unique
-        // type object for it.
+        // type object (per scope) for it.
         return c.typeManager.registerType(type)
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ConstructorDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ConstructorDeclaration.kt
@@ -25,6 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.graph.declarations
 
+import de.fraunhofer.aisec.cpg.graph.fqn
+
 /**
  * The declaration of a constructor within a [RecordDeclaration]. Is it essentially a special case
  * of a [MethodDeclaration].
@@ -38,6 +40,9 @@ class ConstructorDeclaration : MethodDeclaration() {
             if (recordDeclaration != null) {
                 // constructors always have implicitly the return type of their class
                 returnTypes = listOf(recordDeclaration.toType())
+
+                // also make sure, our name is updated to the FQN of the record
+                name = recordDeclaration.name.fqn(this.name.localName)
             }
         }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/RecordDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/RecordDeclaration.kt
@@ -30,6 +30,7 @@ import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edge.PropertyEdgeDelegate
 import de.fraunhofer.aisec.cpg.graph.statements.Statement
+import de.fraunhofer.aisec.cpg.graph.types.DeclaresType
 import de.fraunhofer.aisec.cpg.graph.types.ObjectType
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import org.apache.commons.lang3.builder.ToStringBuilder
@@ -37,7 +38,8 @@ import org.neo4j.ogm.annotation.Relationship
 import org.neo4j.ogm.annotation.Transient
 
 /** Represents a C++ union/struct/class or Java class */
-open class RecordDeclaration : Declaration(), DeclarationHolder, StatementHolder, EOGStarterHolder {
+open class RecordDeclaration :
+    Declaration(), DeclarationHolder, StatementHolder, EOGStarterHolder, DeclaresType {
     /** The kind, i.e. struct, class, union or enum. */
     var kind: String? = null
 
@@ -229,4 +231,7 @@ open class RecordDeclaration : Declaration(), DeclarationHolder, StatementHolder
         type.superTypes.addAll(this.superTypes)
         return type
     }
+
+    override val declaredType: Type
+        get() = toType()
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TypedefDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TypedefDeclaration.kt
@@ -31,7 +31,7 @@ import java.util.*
 import org.apache.commons.lang3.builder.ToStringBuilder
 
 /** Represents a type alias definition as found in C/C++: `typedef unsigned long ulong;` */
-class TypedefDeclaration : Declaration() {
+class TypedefDeclaration : Declaration() /*, DeclaresType*/ {
     /** The already existing type that is to be aliased */
     var type: Type = UnknownType.getUnknownType(null)
 
@@ -52,4 +52,7 @@ class TypedefDeclaration : Declaration() {
             .append("alias", alias)
             .toString()
     }
+
+    /*override val declaredType: Type
+    get() = alias*/
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/GlobalScope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/GlobalScope.kt
@@ -59,6 +59,7 @@ class GlobalScope : StructureDeclarationScope(null) {
 
             // Merge symbols lists
             symbols.mergeFrom(other.symbols)
+            wildcardImports.addAll(other.wildcardImports)
 
             for (symbolList in other.symbols) {
                 // Update the scope property of all nodes that live on the global scope to our new

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
@@ -102,8 +102,15 @@ abstract class Scope(
         }
     }
 
-    /** Looks up a list of [Declaration] nodes for the specified [symbol]. */
-    fun lookupSymbol(symbol: Symbol): List<Declaration> {
+    /**
+     * Looks up a list of [Declaration] nodes for the specified [symbol]. Optionally, [predicate]
+     * can be used for additional filtering.
+     */
+    fun lookupSymbol(
+        symbol: Symbol,
+        replaceImports: Boolean = true,
+        predicate: ((Declaration) -> Boolean)? = null
+    ): List<Declaration> {
         // First, try to look for the symbol in the current scope
         var scope: Scope? = this
         var list: MutableList<Declaration>? = null
@@ -120,7 +127,14 @@ abstract class Scope(
             }
 
             // We need to resolve any imported symbols
-            list.replaceImports(symbol)
+            if (replaceImports) {
+                list.replaceImports(symbol)
+            }
+
+            // Filter the list according to the predicate, if we have any
+            if (predicate != null) {
+                list = list.filter(predicate).toMutableList()
+            }
 
             // If we have a hit, we can break the loop
             if (list.isNotEmpty()) {
@@ -206,8 +220,9 @@ private fun MutableList<Declaration>.replaceImports(symbol: Symbol) {
         val set = import.importedSymbols[symbol]
         if (set != null) {
             this.addAll(set)
-            this.remove(import)
         }
+
+        this.remove(import)
     }
 }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/ValueDeclarationScope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/ValueDeclarationScope.kt
@@ -26,11 +26,11 @@
 package de.fraunhofer.aisec.cpg.graph.scopes
 
 import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
+import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.TypedefDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
-import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.helpers.Util
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -45,11 +45,14 @@ open class ValueDeclarationScope(override var astNode: Node?) : Scope(astNode) {
             return symbols.flatMap { it.value }.filterIsInstance<ValueDeclaration>()
         }
 
-    /** A map of typedefs keyed by their alias. */
-    @Transient val typedefs = mutableMapOf<Type, TypedefDeclaration>()
+    /**
+     * A map of typedefs keyed by their alias name. This is still needed as a bridge until we
+     * completely redesign the alias / typedef system.
+     */
+    @Transient val typedefs = mutableMapOf<Name, TypedefDeclaration>()
 
     fun addTypedef(typedef: TypedefDeclaration) {
-        typedefs[typedef.alias] = typedef
+        typedefs[typedef.alias.name] = typedef
     }
 
     open fun addDeclaration(declaration: Declaration, addToAST: Boolean) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionPointerType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionPointerType.kt
@@ -81,12 +81,6 @@ class FunctionPointerType : Type {
         return this
     }
 
-    override fun isSimilar(t: Type?): Boolean {
-        return if (t is FunctionPointerType) {
-            parametersPropertyEdge == t.parametersPropertyEdge && returnType == t.returnType
-        } else false
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is FunctionPointerType) return false

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/IncompleteType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/IncompleteType.kt
@@ -25,21 +25,19 @@
  */
 package de.fraunhofer.aisec.cpg.graph.types
 
+import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.types.PointerType.PointerOrigin
-import java.util.*
 
 /**
  * IncompleteTypes are defined as object with unknown size. For instance: void, arrays of unknown
- * length, forward declarated classes in C++
+ * length, forward declared classes in C++
  *
  * Right now we are only dealing with void for objects with unknown size, therefore the name is
  * fixed to void. However, this can be changed in the future, in order to support other objects with
  * unknown size apart from void. Therefore, this Type is not called VoidType
  */
 class IncompleteType : Type {
-    constructor() : super("void", null)
-
-    constructor(type: Type?) : super(type)
+    @JvmOverloads constructor(language: Language<*>? = null) : super("void", language)
 
     /** @return PointerType to a IncompleteType, e.g. void* */
     override fun reference(pointer: PointerOrigin?): Type {
@@ -55,5 +53,5 @@ class IncompleteType : Type {
         return other is IncompleteType
     }
 
-    override fun hashCode() = Objects.hash(super.hashCode())
+    override fun hashCode() = super.hashCode()
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/NumericType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/NumericType.kt
@@ -35,6 +35,12 @@ open class NumericType(
     language: Language<*>? = null,
     val modifier: Modifier = Modifier.SIGNED
 ) : ObjectType(typeName, listOf(), true, language) {
+
+    init {
+        // Built-in types are always resolved
+        this.typeOrigin = Origin.RESOLVED
+    }
+
     /**
      * NumericTypes can have a modifier. The default is signed. Some types (e.g. char in C) may be
      * neither of the signed/unsigned option.

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ObjectType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ObjectType.kt
@@ -46,8 +46,15 @@ open class ObjectType : Type {
     /**
      * Reference from the [ObjectType] to its class ([RecordDeclaration]), only if the class is
      * available. This is set by the [TypeResolver].
+     *
+     * This also sets this type's [scope] to the [RecordDeclaration.scope].
      */
-    @PopulatedByPass(TypeResolver::class) var recordDeclaration: RecordDeclaration? = null
+    @PopulatedByPass(TypeResolver::class)
+    var recordDeclaration: RecordDeclaration? = null
+        set(value) {
+            field = value
+            this.scope = value?.scope
+        }
 
     @Relationship(value = "GENERICS", direction = Relationship.Direction.OUTGOING)
     var genericsPropertyEdges: MutableList<PropertyEdge<Type>> = mutableListOf()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/PointerType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/PointerType.kt
@@ -106,15 +106,6 @@ class PointerType : Type, SecondOrderType {
     val isArray: Boolean
         get() = pointerOrigin == PointerOrigin.ARRAY
 
-    override fun isSimilar(t: Type?): Boolean {
-        if (t !is PointerType) {
-            return false
-        }
-        return (referenceDepth == t.referenceDepth &&
-            elementType.isSimilar(t.root) &&
-            super.isSimilar(t))
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is PointerType) return false

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ReferenceType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ReferenceType.kt
@@ -68,10 +68,6 @@ class ReferenceType : Type, SecondOrderType {
         return elementType.dereference()
     }
 
-    override fun isSimilar(t: Type?): Boolean {
-        return t is ReferenceType && t.elementType == this && super.isSimilar(t)
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is ReferenceType) return false

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/StringType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/StringType.kt
@@ -31,4 +31,10 @@ class StringType(
     typeName: CharSequence = "",
     language: Language<*>? = null,
     generics: List<Type> = listOf()
-) : ObjectType(typeName, generics, false, language)
+) : ObjectType(typeName, generics, false, language) {
+
+    init {
+        // Built-in types are always resolved
+        this.typeOrigin = Origin.RESOLVED
+    }
+}

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/Type.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/Type.kt
@@ -29,10 +29,12 @@ import de.fraunhofer.aisec.cpg.PopulatedByPass
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.parseName
 import de.fraunhofer.aisec.cpg.graph.types.PointerType.PointerOrigin
 import de.fraunhofer.aisec.cpg.passes.TypeHierarchyResolver
+import de.fraunhofer.aisec.cpg.passes.TypeResolver
 import java.util.*
 import org.apache.commons.lang3.builder.ToStringBuilder
 import org.neo4j.ogm.annotation.NodeEntity
@@ -71,6 +73,12 @@ abstract class Type : Node {
         protected set
 
     open var typeOrigin: Origin? = null
+
+    /**
+     * This points to the [DeclaresType] node (most likely a [Declaration]), that declares this
+     * type. At some point this should replace [ObjectType.recordDeclaration].
+     */
+    @PopulatedByPass(TypeResolver::class) var declaredFrom: DeclaresType? = null
 
     constructor() {
         name = Name(EMPTY_NAME, null, language)
@@ -177,24 +185,19 @@ abstract class Type : Node {
                 this is IncompleteType ||
                 this is ParameterizedType)
 
-    /**
-     * Required for possibleSubTypes to check if the new Type should be considered a subtype or not
-     *
-     * @param t other type the similarity is checked with
-     * @return True if the parameter t is equal to the current type (this)
-     */
-    open fun isSimilar(t: Type?): Boolean {
-        return if (this == t) {
-            true
-        } else this.root.name == t?.root?.name
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        return other is Type && name == other.name && language == other.language
+        return other is Type &&
+            name == other.name &&
+            scope === other.scope &&
+            language == other.language
     }
 
-    override fun hashCode() = Objects.hash(name, language)
+    /**
+     * We need a constant hashcode implementation because we need to change [name] and [scope]
+     * during the [TypeResolver], so we cannot use them for hashcode.
+     */
+    override fun hashCode() = 1
 
     override fun toString(): String {
         return ToStringBuilder(this, TO_STRING_STYLE).append("name", name).toString()
@@ -218,7 +221,7 @@ abstract class Type : Node {
             // array
             val operations = mutableListOf<TypeOperation>()
 
-            var type: Type = this as Type
+            var type = this
             while (type is SecondOrderType) {
                 var op =
                     if (type is ReferenceType) {
@@ -276,13 +279,12 @@ fun TypeOperations.apply(root: Type): Type {
     if (this.isNotEmpty()) {
         for (i in this.size - 1 downTo 0) {
             var wrap = this[i]
-            if (wrap == TypeOperation.REFERENCE) {
-                type = ReferenceType(type)
-            } else if (wrap == TypeOperation.ARRAY) {
-                type = type.reference(PointerType.PointerOrigin.ARRAY)
-            } else if (wrap == TypeOperation.POINTER) {
-                type = type.reference(PointerType.PointerOrigin.POINTER)
-            }
+            type =
+                when (wrap) {
+                    TypeOperation.REFERENCE -> ReferenceType(type)
+                    TypeOperation.ARRAY -> type.reference(PointerOrigin.ARRAY)
+                    TypeOperation.POINTER -> type.reference(PointerOrigin.POINTER)
+                }
         }
     }
 
@@ -299,3 +301,8 @@ var Type.recordDeclaration: RecordDeclaration?
             this.recordDeclaration = value
         }
     }
+
+interface DeclaresType {
+
+    val declaredType: Type
+}

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
@@ -43,6 +43,11 @@ class DFGPass(ctx: TranslationContext) : ComponentPass(ctx) {
     private val callsInferredFunctions = mutableListOf<CallExpression>()
 
     override fun accept(component: Component) {
+        log.info(
+            "Function summaries database has {} entries",
+            config.functionSummaries.functionToDFGEntryMap.size
+        )
+
         val inferDfgForUnresolvedCalls = config.inferenceConfiguration.inferDfgForUnresolvedSymbols
         val walker = IterativeGraphWalker()
         walker.registerOnNodeVisit { node, parent ->

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
@@ -32,12 +32,10 @@ import de.fraunhofer.aisec.cpg.graph.declarations.ImportDeclaration
 import de.fraunhofer.aisec.cpg.graph.scopes.NameScope
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
-import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
 
 /**
  * This pass looks for [ImportDeclaration] nodes and imports symbols into their respective [Scope]
  */
-@DependsOn(TypeHierarchyResolver::class)
 class ImportResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
     lateinit var walker: SubgraphWalker.ScopedWalker

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
@@ -26,40 +26,120 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationContext
-import de.fraunhofer.aisec.cpg.graph.Component
-import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
+import de.fraunhofer.aisec.cpg.graph.types.DeclaresType
 import de.fraunhofer.aisec.cpg.graph.types.ObjectType
 import de.fraunhofer.aisec.cpg.graph.types.Type
-import de.fraunhofer.aisec.cpg.processing.IVisitor
-import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
+import de.fraunhofer.aisec.cpg.graph.types.recordDeclaration
+import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
+import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
 
 /**
  * The purpose of this [Pass] is to establish a relationship between [Type] nodes (more specifically
  * [ObjectType]s) and their [RecordDeclaration].
  */
+@DependsOn(ImportResolver::class)
 open class TypeResolver(ctx: TranslationContext) : ComponentPass(ctx) {
+
+    lateinit var walker: SubgraphWalker.ScopedWalker
+
     override fun accept(component: Component) {
-        component.accept(
-            Strategy::AST_FORWARD,
-            object : IVisitor<Node>() {
-                /**
-                 * Creates the [ObjectType.recordDeclaration] relationship between [ObjectType]s and
-                 * [RecordDeclaration] with the same [Node.name].
-                 */
-                fun visit(record: RecordDeclaration) {
-                    for (t in typeManager.firstOrderTypes) {
-                        if (t.name == record.name && t is ObjectType) {
-                            // The node is the class of the type t
-                            t.recordDeclaration = record
-                        }
-                    }
+        resolveFirstOrderTypes()
+        refreshNames()
+
+        walker = SubgraphWalker.ScopedWalker(scopeManager)
+        walker.registerHandler(::handleNode)
+        walker.iterate(component)
+    }
+
+    private fun refreshNames() {
+        for (type in typeManager.secondOrderTypes) {
+            type.refreshNames()
+        }
+    }
+
+    companion object {
+        context(ContextProvider)
+        fun resolveType(type: Type): Boolean {
+            // Let's start by looking up the type according to their name and scope. We exclusively
+            // filter for nodes that implement DeclaresType, because otherwise we will get a lot of
+            // constructor declarations and such with the same name. It seems this is ok since most
+            // languages will prefer structs/classes over functions when resolving types.
+            var symbols =
+                ctx?.scopeManager?.findSymbols(type.name, startScope = type.scope) {
+                    it is DeclaresType
+                } ?: listOf()
+
+            // We need to have a single match, otherwise we have an ambiguous type and we cannot
+            // normalize it.
+            // TODO: Maybe we should have a warning in this case?
+            var declares = symbols.filterIsInstance<DeclaresType>().singleOrNull()
+
+            // Check for a possible typedef
+            var target = ctx?.scopeManager?.typedefFor(type.name, type.scope)
+            if (target != null) {
+                if (target.typeOrigin == Type.Origin.UNRESOLVED && type != target) {
+                    // Make sure our typedef target is resolved
+                    resolveType(target)
+                }
+
+                var originDeclares = target.recordDeclaration
+                var name = target.name
+                log.debug("Aliasing type {} in {} scope to {}", type.name, type.scope, name)
+                type.declaredFrom = originDeclares
+                type.recordDeclaration = originDeclares
+                type.typeOrigin = Type.Origin.RESOLVED
+                return true
+            }
+
+            if (declares == null) {
+                declares = ctx?.tryRecordInference(type, locationHint = type)
+            }
+
+            // If we found the "real" declared type, we can normalize the name of our scoped type
+            // and
+            // set the name to the declared type.
+            if (declares != null) {
+                var declaredType = declares.declaredType
+                log.debug(
+                    "Resolving type {} in {} scope to {}",
+                    type.name,
+                    type.scope,
+                    declaredType.name
+                )
+                type.name = declaredType.name
+                type.declaredFrom = declares
+                type.recordDeclaration = declares as? RecordDeclaration
+                type.typeOrigin = Type.Origin.RESOLVED
+                type.superTypes.addAll(declaredType.superTypes)
+                return true
+            }
+
+            return false
+        }
+    }
+
+    private fun handleNode(node: Node?) {
+        if (node is RecordDeclaration) {
+            for (t in typeManager.firstOrderTypes) {
+                if (t.name == node.name && t is ObjectType) {
+                    // The node is the class of the type t
+                    t.recordDeclaration = node
                 }
             }
-        )
+        }
     }
 
     override fun cleanup() {
         // Nothing to do
+    }
+
+    fun resolveFirstOrderTypes() {
+        for (type in typeManager.firstOrderTypes.sortedBy { it.name }) {
+            if (type is ObjectType && type.typeOrigin == Type.Origin.UNRESOLVED) {
+                resolveType(type)
+            }
+        }
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/DFGFunctionSummaries.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/DFGFunctionSummaries.kt
@@ -31,17 +31,21 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import de.fraunhofer.aisec.cpg.IncompatibleSignature
-import de.fraunhofer.aisec.cpg.TranslationConfiguration.Builder
 import de.fraunhofer.aisec.cpg.ancestors
 import de.fraunhofer.aisec.cpg.frontends.CastNotPossible
+import de.fraunhofer.aisec.cpg.graph.ContextProvider
+import de.fraunhofer.aisec.cpg.graph.LanguageProvider
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.objectType
 import de.fraunhofer.aisec.cpg.graph.parseName
 import de.fraunhofer.aisec.cpg.graph.types.Type
+import de.fraunhofer.aisec.cpg.graph.unknownType
 import de.fraunhofer.aisec.cpg.matchesSignature
 import de.fraunhofer.aisec.cpg.tryCast
 import java.io.File
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /**
  * If the user of the library registers one or multiple DFG-function summary files (via
@@ -113,9 +117,11 @@ class DFGFunctionSummaries {
     private fun findFunctionDeclarationEntry(functionDecl: FunctionDeclaration): List<DFGEntry>? {
         if (functionToDFGEntryMap.isEmpty()) return null
 
+        val provider = functionDecl
         val language = functionDecl.language
         val languageName = language?.javaClass?.name
         val methodName = functionDecl.name
+
         // The language and the method name have to match. If a signature is specified, it also has
         // to match to the one of the FunctionDeclaration, null indicates that we accept everything.
         val matchingEntries =
@@ -125,9 +131,7 @@ class DFGFunctionSummaries {
                     // Split the name if we have a FQN
                     val entryMethodName = language.parseName(it.methodName)
                     val entryRecord =
-                        entryMethodName.parent?.let {
-                            functionDecl.objectType(entryMethodName.parent)
-                        }
+                        entryMethodName.parent?.let { provider.lookupType(entryMethodName.parent) }
                     methodName.lastPartsMatch(
                         entryMethodName.localName
                     ) && // The local name has to match
@@ -144,13 +148,22 @@ class DFGFunctionSummaries {
                         (it.signature == null ||
                             functionDecl.matchesSignature(
                                 it.signature.map { signatureType ->
-                                    functionDecl.objectType(signatureType)
+                                    provider.lookupType(signatureType)
                                 }
                             ) != IncompatibleSignature)
                 } else {
                     false
                 }
             }
+
+        log.debug(
+            "Found {} matching entries for function declaration {} with parameter types {} in {}",
+            matchingEntries.size,
+            functionDecl.name,
+            functionDecl.signatureTypes.map(Node::name),
+            functionDecl.scope
+        )
+
         return if (matchingEntries.size == 1) {
             // Only one entry => We take this one.
             functionToDFGEntryMap[matchingEntries.single()]
@@ -339,6 +352,23 @@ class DFGFunctionSummaries {
             val dfgFunctionSummaries = DFGFunctionSummaries()
             files.forEach { dfgFunctionSummaries.addEntriesFromFile(it) }
             return dfgFunctionSummaries
+        }
+
+        val log: Logger = LoggerFactory.getLogger(DFGFunctionSummaries::class.java)
+    }
+
+    fun ContextProvider.lookupType(fqn: CharSequence): Type {
+        // Try to look up the type from the specified FQN string
+        var type =
+            ctx?.typeManager?.lookupResolvedType(
+                fqn.toString(),
+                language = (this as? LanguageProvider)?.language
+            )
+        return if (type == null) {
+            log.warn("Could not find specified type $fqn. Using UnknownType")
+            this.unknownType()
+        } else {
+            type
         }
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
@@ -446,7 +446,7 @@ class Inference internal constructor(val start: Node, override val ctx: Translat
         }
     }
 
-    fun inferNamespaceDeclaration(name: Name, path: String?, origin: Node): NamespaceDeclaration? {
+    fun inferNamespaceDeclaration(name: Name, path: String?, origin: Node?): NamespaceDeclaration? {
         if (!ctx.config.inferenceConfiguration.inferNamespaces) {
             return null
         }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypePropagationTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypePropagationTest.kt
@@ -219,11 +219,11 @@ class TypePropagationTest {
 
             val b = main.variables["b"]
             assertNotNull(b)
-            assertEquals(objectType("BaseClass").pointer(), b.type)
+            assertEquals(assertResolvedType("BaseClass").pointer(), b.type)
             assertEquals(
                 setOf(
-                    objectType("BaseClass").pointer(),
-                    objectType("DerivedClass").pointer(),
+                    assertResolvedType("BaseClass").pointer(),
+                    assertResolvedType("DerivedClass").pointer(),
                 ),
                 b.assignedTypes
             )

--- a/cpg-core/src/testFixtures/kotlin/de/fraunhofer/aisec/cpg/test/TestUtils.kt
+++ b/cpg-core/src/testFixtures/kotlin/de/fraunhofer/aisec/cpg/test/TestUtils.kt
@@ -34,6 +34,7 @@ import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
+import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.test.TestUtils.ENFORCE_MEMBER_EXPRESSION
 import de.fraunhofer.aisec.cpg.test.TestUtils.ENFORCE_REFERENCES
 import java.io.File
@@ -315,4 +316,9 @@ fun assertLocalName(localName: String, node: Node?, message: String? = null) {
  */
 fun <T : Any?> assertLiteralValue(expected: T, expr: Expression?, message: String? = null) {
     assertEquals(expected, assertIs<Literal<T>>(expr).value, message)
+}
+
+fun ContextProvider.assertResolvedType(fqn: String, generics: List<Type>? = null): Type {
+    var type = ctx?.typeManager?.lookupResolvedType(fqn, generics)
+    return assertNotNull(type)
 }

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontend.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontend.kt
@@ -65,7 +65,6 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTLiteralExpression
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTQualifiedName
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTTemplateId
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTTypeId
-import org.eclipse.cdt.internal.core.model.ASTStringUtil
 import org.eclipse.cdt.internal.core.parser.IMacroDictionary
 import org.eclipse.cdt.internal.core.parser.scanner.InternalFileContent
 import org.eclipse.cdt.internal.core.parser.scanner.InternalFileContentProvider
@@ -496,9 +495,6 @@ open class CXXLanguageFrontend(language: Language<CXXLanguageFrontend>, ctx: Tra
     }
 
     fun typeOf(specifier: IASTDeclSpecifier, hint: Declaration? = null): Type {
-        // Retrieve the "name" of this type, including qualifiers.
-        val name = ASTStringUtil.getSignatureString(specifier, null)
-
         var resolveTypeDef = false
 
         var type =
@@ -519,24 +515,20 @@ open class CXXLanguageFrontend(language: Language<CXXLanguageFrontend>, ctx: Tra
                         resolveTypeDef = true
                         typeOf(specifier.name)
                     } else {
-                        // Case b: Peek into our symbols. This is most likely limited to our current
-                        // translation unit
                         resolveTypeDef = true
 
-                        val decl = scopeManager.getRecordForName(Name(name))
-
-                        // We found a symbol, so we can use its name
-                        if (decl != null) {
-                            objectType(decl.name)
+                        // It could be, that this is a parameterized type
+                        val paramType =
+                            typeManager.searchTemplateScopeForDefinedParameterizedTypes(
+                                scopeManager.currentScope,
+                                specifier.name.toString()
+                            )
+                        if (paramType != null) {
+                            paramType
                         } else {
-                            // It could be, that this is a parameterized type
-                            val paramType =
-                                typeManager.searchTemplateScopeForDefinedParameterizedTypes(
-                                    scopeManager.currentScope,
-                                    specifier.name.toString()
-                                )
-                            // Otherwise, we keep it as a local name and hope for the best
-                            paramType ?: typeOf(specifier.name)
+                            // Otherwise, we keep it as a local name and the type normalizer will
+                            // take care of it
+                            typeOf(specifier.name)
                         }
                     }
                 }
@@ -545,13 +537,13 @@ open class CXXLanguageFrontend(language: Language<CXXLanguageFrontend>, ctx: Tra
                     // in handleSimpleDeclaration, but we might want to move it here
                     resolveTypeDef = true
 
-                    objectType(specifier.name.toString())
+                    objectType(specifier.name.toString(), rawNode = specifier)
                 }
                 is IASTElaboratedTypeSpecifier -> {
                     resolveTypeDef = true
 
                     // A class or struct
-                    objectType(specifier.name.toString())
+                    objectType(specifier.name.toString(), rawNode = specifier)
                 }
                 else -> {
                     unknownType()
@@ -584,28 +576,35 @@ open class CXXLanguageFrontend(language: Language<CXXLanguageFrontend>, ctx: Tra
             }
             // __typeof__ type
             specifier.type == IASTSimpleDeclSpecifier.t_typeof -> {
-                objectType("typeof(${specifier.declTypeExpression.rawSignature})")
+                objectType(
+                    "typeof(${specifier.declTypeExpression.rawSignature})",
+                    rawNode = specifier
+                )
             }
             // A decl type
             specifier.type == IASTSimpleDeclSpecifier.t_decltype -> {
-                objectType("decltype(${specifier.declTypeExpression.rawSignature})")
+                objectType(
+                    "decltype(${specifier.declTypeExpression.rawSignature})",
+                    rawNode = specifier
+                )
             }
             // The type of constructor declaration is always the declaration itself
             specifier.type == IASTSimpleDeclSpecifier.t_unspecified &&
                 hint is ConstructorDeclaration -> {
-                hint.name.parent?.let { objectType(it) } ?: unknownType()
+                hint.name.parent?.let { objectType(it, rawNode = specifier) } ?: unknownType()
             }
             // The type of conversion operator is also always the declaration itself
             specifier.type == IASTSimpleDeclSpecifier.t_unspecified &&
                 hint is MethodDeclaration &&
                 hint.name.localName == "operator#0" -> {
-                hint.name.parent?.let { objectType(it) } ?: unknownType()
+                hint.name.parent?.let { objectType(it, rawNode = specifier) } ?: unknownType()
             }
             // The type of conversion operator is also always the declaration itself
             specifier.type == IASTSimpleDeclSpecifier.t_unspecified &&
                 hint is MethodDeclaration &&
                 hint.name.localName == "operator#0*" -> {
-                hint.name.parent?.let { objectType(it).pointer() } ?: unknownType()
+                hint.name.parent?.let { objectType(it, rawNode = specifier).pointer() }
+                    ?: unknownType()
             }
             // The type of destructor is unspecified, but we model it as a void type to make it
             // compatible with other methods.
@@ -682,7 +681,7 @@ open class CXXLanguageFrontend(language: Language<CXXLanguageFrontend>, ctx: Tra
                 }
             }
 
-            return objectType(fqn, generics)
+            return objectType(fqn, generics, rawNode = name)
         }
 
         var typeName =
@@ -692,14 +691,10 @@ open class CXXLanguageFrontend(language: Language<CXXLanguageFrontend>, ctx: Tra
                 parseName(name.toString())
             }
 
-        // Rather hacky, but currently the only way to do this, until we redesign the aliases in the
-        // scope manager to be valid for a scope and not for a location
-        val location = currentTU?.location
-
         // We need to take name(space) aliases into account.
         typeName = scopeManager.resolveParentAlias(typeName, scopeManager.currentScope)
 
-        return objectType(typeName)
+        return objectType(typeName, rawNode = name)
     }
 
     /**

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
@@ -541,10 +541,8 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
                         // typedef'd name is called S. However, to make things a little bit easier
                         // we also transfer the name to the record declaration.
                         ctx.declarators.firstOrNull()?.name?.toString()?.let {
-                            primaryDeclaration?.name = parseName(it)
-                            // We need to inform the later steps that we want to take the name
-                            // of this declaration as the basis for the result type of the typedef
-                            useNameOfDeclarator = true
+                            primaryDeclaration.name = parseName(it)
+                            useNameOfDeclarator = false
                         }
                     }
                     frontend.processAttributes(primaryDeclaration, ctx)
@@ -647,21 +645,25 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
 
         // Loop through its members
         for (enumerator in declSpecifier.enumerators) {
+            // Enums are a bit complicated. Their fully qualified name (in C++) includes the enum
+            // class, so e.g. `MyEnum::THIS'. In order to do that, we need to be in the `MyEnum`
+            // scope when we create it. But, the symbol of the enum can both be resolved using just
+            // the enum constant `THIS` as well as `MyEnum::THIS` (at least in C++11). So we need to
+            // put the symbol both in the outer scope as well as the enum's scope.
+            frontend.scopeManager.enterScope(enum)
             val enumConst =
                 newEnumConstantDeclaration(
                     enumerator.name.toString(),
                     rawNode = enumerator,
                 )
+            frontend.scopeManager.addDeclaration(enumConst)
+            frontend.scopeManager.leaveScope(enum)
 
             // In C/C++, default enums are of type int
             enumConst.type = primitiveType("int")
 
-            // We need to make them visible to the enclosing scope. However, we do NOT
-            // want to add it to the AST of the enclosing scope, but to the AST of the
-            // EnumDeclaration
+            // Also put the symbol in the outer scope (but do not add AST nodes)
             frontend.scopeManager.addDeclaration(enumConst, false)
-
-            entries += enumConst
         }
 
         enum.entries = entries

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclaratorHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclaratorHandler.kt
@@ -451,7 +451,9 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
         // Handle C++ classes
         if (ctx is CPPASTCompositeTypeSpecifier) {
             recordDeclaration.superClasses =
-                ctx.baseSpecifiers.map { objectType(it.nameSpecifier.toString()) }.toMutableList()
+                ctx.baseSpecifiers
+                    .map { objectType(it.nameSpecifier.toString(), rawNode = it) }
+                    .toMutableList()
         }
 
         frontend.scopeManager.addDeclaration(recordDeclaration)

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/types/TypedefTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/types/TypedefTest.kt
@@ -28,7 +28,6 @@ package de.fraunhofer.aisec.cpg.enhancements.types
 import de.fraunhofer.aisec.cpg.frontends.cxx.CPPLanguage
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
-import de.fraunhofer.aisec.cpg.graph.objectType
 import de.fraunhofer.aisec.cpg.graph.types.FunctionPointerType
 import de.fraunhofer.aisec.cpg.graph.types.IntegerType
 import de.fraunhofer.aisec.cpg.graph.types.NumericType
@@ -80,7 +79,7 @@ internal class TypedefTest : BaseTest() {
             assertEquals(NumericType.Modifier.UNSIGNED, returnType.modifier)
             assertEquals(uintfp1.type, uintfp2?.type)
 
-            val type = tu.ctx?.scopeManager?.typedefFor(objectType("test"))
+            val type = tu.ctx?.scopeManager?.typedefFor(Name("test"))
             assertIs<IntegerType>(type)
             assertLocalName("uint8_t", type)
         }
@@ -159,7 +158,7 @@ internal class TypedefTest : BaseTest() {
             val fPtr2 = tu.variables["intFptr2"]
             assertEquals(fPtr1?.type, fPtr2?.type)
 
-            val type = tu.ctx?.scopeManager?.typedefFor(objectType("type_B"))
+            val type = tu.ctx?.scopeManager?.typedefFor(Name("type_B"))
             assertLocalName("template_class_A", type)
             assertIs<ObjectType>(type)
             assertEquals(listOf(primitiveType("int"), primitiveType("int")), type.generics)

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/variable_resolution/VariableResolverCppTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/variable_resolution/VariableResolverCppTest.kt
@@ -74,7 +74,10 @@ internal class VariableResolverCppTest : BaseTest() {
             listOf("scope_variables.cpp", "external_class.cpp").map {
                 topLevel.resolve(it).toFile()
             }
-        val result = analyze(files, topLevel, true) { it.registerLanguage<CPPLanguage>() }
+        val result =
+            analyze(files, topLevel, true) {
+                it.registerLanguage<CPPLanguage>().useUnityBuild(true)
+            }
         val calls = result.calls { it.name.localName == "printLog" }
         val records = result.records
         val functions = result.functions

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXDeclarationTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXDeclarationTest.kt
@@ -203,9 +203,33 @@ class CXXDeclarationTest {
 
         val manipulateString = result.functions["manipulateString"]
         assertNotNull(manipulateString)
+        assertFalse(manipulateString.isInferred)
+
+        val size = result.functions["size"]
+        assertNotNull(size)
+        assertFalse(size.isInferred)
 
         // We should be able to resolve all calls to manipulateString
-        val calls = result.calls("manipulateString")
+        var calls = result.calls("manipulateString")
         calls.forEach { assertContains(it.invokes, manipulateString) }
+
+        // We should be able to resolve all calls to size
+        calls = result.calls("size")
+        calls.forEach { assertContains(it.invokes, size) }
+    }
+
+    @Test
+    fun testAliasLoop() {
+        val file = File("src/test/resources/cxx/alias_loop.cpp")
+        val result =
+            analyze(listOf(file), file.parentFile.toPath(), true) {
+                it.registerLanguage<CPPLanguage>()
+            }
+        assertNotNull(result)
+        with(result) {
+            val a = result.variables["a"]
+            assertNotNull(a)
+            assertEquals(assertResolvedType("ABC::A"), a.type)
+        }
     }
 }

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXInferenceTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXInferenceTest.kt
@@ -31,6 +31,7 @@ import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class CXXInferenceTest {
     @Test
@@ -66,5 +67,29 @@ class CXXInferenceTest {
 
         val someClass = util.records["SomeClass"]
         assertNotNull(someClass)
+    }
+
+    @Test
+    fun testTrickyInference() {
+        val file = File("src/test/resources/cxx/tricky_inference.cpp")
+        val tu =
+            analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
+                it.registerLanguage<CPPLanguage>()
+                it.loadIncludes(false)
+                it.addIncludesToGraph(false)
+            }
+        assertNotNull(tu)
+
+        val some = tu.namespaces["some"]
+        assertNotNull(some)
+        assertTrue(some.isInferred)
+
+        val json = some.records["json"]
+        assertNotNull(json)
+        assertTrue(json.isInferred)
+
+        val iterator = json.records["iterator"]
+        assertNotNull(iterator)
+        assertTrue(iterator.isInferred)
     }
 }

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXResolveTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXResolveTest.kt
@@ -52,22 +52,22 @@ class CXXResolveTest {
         val main = tu.functions["main"]
         assertNotNull(main)
 
-        // 0, and 1 are construct expressions -> our "real" calls start at index 2
-        val aFoo = main.calls.getOrNull(2)
+        // 0, 1 and 2 are construct expressions -> our "real" calls start at index 3
+        val aFoo = main.calls.getOrNull(3)
         assertIs<MemberCallExpression>(aFoo)
         assertLocalName("foo", aFoo)
         assertLocalName("a", aFoo.base)
         // a.foo should connect to A::foo
         assertLocalName("A", (aFoo.invokes.firstOrNull() as? MethodDeclaration)?.recordDeclaration)
 
-        val bFoo = main.calls.getOrNull(3)
+        val bFoo = main.calls.getOrNull(4)
         assertIs<MemberCallExpression>(bFoo)
         assertLocalName("foo", bFoo)
         assertLocalName("b", bFoo.base)
         // b.foo should connect to B::foo
         assertLocalName("B", (bFoo.invokes.firstOrNull() as? MethodDeclaration)?.recordDeclaration)
 
-        val foo = main.calls.getOrNull(4)
+        val foo = main.calls.getOrNull(5)
         assertNotNull(foo)
 
         // foo should be connected to an inferred non-method function
@@ -77,7 +77,7 @@ class CXXResolveTest {
         assertFalse(func is MethodDeclaration)
         assertTrue(func.isInferred)
 
-        val cFoo = main.calls.getOrNull(5)
+        val cFoo = main.calls.getOrNull(6)
         assertNotNull(cFoo)
 
         // c.foo should connect to C::foo

--- a/cpg-language-cxx/src/test/resources/cxx/alias.cpp
+++ b/cpg-language-cxx/src/test/resources/cxx/alias.cpp
@@ -1,5 +1,12 @@
 namespace std {
-    class string {};
+    class string {
+public:
+        int size() {
+            return 1;
+        }
+
+        class iterator {};
+    };
 }
 
 // this is completely equivalent to a typedef
@@ -20,4 +27,12 @@ int main() {
 
     manipulateString(s1);
     manipulateString(s2);
+
+    s1.size();
+    s2.size();
+
+    mystring1::iterator it1;
+    mystring2::iterator it2;
+    std::string it3;
+    estd::string it4;
 }

--- a/cpg-language-cxx/src/test/resources/cxx/alias_loop.cpp
+++ b/cpg-language-cxx/src/test/resources/cxx/alias_loop.cpp
@@ -1,0 +1,13 @@
+namespace ABC {
+    struct A {};
+}
+
+namespace ABC {
+    // not sure why this is even possible, but somehow we can define this
+    // type as itself in this partial namespace
+    using A = ABC::A;
+
+    void test() {
+        A a;
+    }
+}

--- a/cpg-language-cxx/src/test/resources/cxx/enum.cpp
+++ b/cpg-language-cxx/src/test/resources/cxx/enum.cpp
@@ -1,0 +1,9 @@
+enum MyEnum {
+  THIS = 0,
+  THAT = 1,
+  THE_OTHER = 2,
+};
+
+int main() {
+  return MyEnum::THE_OTHER;
+}

--- a/cpg-language-cxx/src/test/resources/cxx/parenthesis.cpp
+++ b/cpg-language-cxx/src/test/resources/cxx/parenthesis.cpp
@@ -3,6 +3,8 @@
 #include <cstddef>
 #include <cstdint>
 
+typedef int size_t;
+
 int main() {
 	// this cast could be mistaken for a call expression
 	size_t count = (size_t)(42);

--- a/cpg-language-cxx/src/test/resources/cxx/tricky_inference.cpp
+++ b/cpg-language-cxx/src/test/resources/cxx/tricky_inference.cpp
@@ -1,0 +1,37 @@
+// The headers are just there to make it compile with clang, but we will not parse headers.
+// You can use `clang++ -std=c++20 tricky_inference.cpp` to check, if it will compile.
+#include "tricky_inference.h"
+
+// We do not know "some::json", but this is a typedef to it.
+// One could argue that "using some::json" might be more appropriate,
+// but this is inspired by actual real-world code. But, this actually
+// gives us the advantage, that we know that "json" is a type and not
+// a namespace, so we need to use this information.
+using json = some::json;
+
+// Next, we are creating some kind of class that only uses our "json"
+// object, but does not actually call any functions on it. We could
+// probably conform at this point, that we are dealing with a record
+// and could infer it (since we do not know it).
+class wrapper {
+public:
+    json* get() {
+        return &j;
+    }
+
+private:
+    json j;
+};
+
+// For some more complexity, let's refer to a sub-class of it
+void iterator(json::iterator& it) {
+    if (!it.hasNext()) {
+       return;
+    }
+}
+
+// And lastly, finally call a method on it, so we can know it's
+// a class.
+void* get_data(json* j) {
+    return j->data;
+}

--- a/cpg-language-cxx/src/test/resources/cxx/tricky_inference.h
+++ b/cpg-language-cxx/src/test/resources/cxx/tricky_inference.h
@@ -1,0 +1,12 @@
+namespace some {
+    class json {
+public:
+        class iterator {
+public:
+            bool hasNext() {
+                return false;
+            }
+        };
+        void* data;
+    };
+}

--- a/cpg-language-cxx/src/test/resources/cxx/using.cpp
+++ b/cpg-language-cxx/src/test/resources/cxx/using.cpp
@@ -1,26 +1,38 @@
 namespace std
- {
-   class string
-   {
-   public:
-     const char *c_str() const
-     {
-       return "mock";
-     }
-   };
- }
-
-void function1()
 {
-   using namespace std;
-   string s;
-   s.c_str();
-}
-
-void function2()
-  {
-    using std::string;
-    string s;
-    s.c_str();
+  namespace inner {
+    class secret {
+      void someFunction() {
+        secret* s = new secret();
+      }
+    };
   }
 
+  class string
+  {
+  public:
+    const char *c_str() const
+    {
+      return "mock";
+    }
+  };
+
+  class other {
+    class sub {};
+  private:
+    void doSomething() {
+      inner::secret secret;
+      sub sub;
+      other::sub sub2;
+    }
+  };
+}
+
+using namespace std;
+
+int main()
+{
+  inner::secret secret;
+  string s;
+  s.c_str();
+}

--- a/cpg-language-cxx/src/test/resources/variables_extended/cpp/external_class.h
+++ b/cpg-language-cxx/src/test/resources/variables_extended/cpp/external_class.h
@@ -1,3 +1,4 @@
+#pragma once
 using namespace std;
 static string staticVarName;
 

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontend.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontend.kt
@@ -322,7 +322,9 @@ class GoLanguageFrontend(language: Language<GoLanguageFrontend>, ctx: Translatio
                     // scope to avoid namespace issues
                     var record =
                         scopeManager.withScope(scopeManager.globalScope) {
-                            specificationHandler.buildRecordDeclaration(type, name)
+                            var record = specificationHandler.buildRecordDeclaration(type, name)
+                            scopeManager.addDeclaration(record)
+                            record
                         }
 
                     record.toType()

--- a/cpg-language-go/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/DeclarationTest.kt
+++ b/cpg-language-go/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/DeclarationTest.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.frontends.golang
 
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.*
+import de.fraunhofer.aisec.cpg.graph.scopes.GlobalScope
 import de.fraunhofer.aisec.cpg.graph.statements.ReturnStatement
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.ObjectType
@@ -87,6 +88,11 @@ class DeclarationTest {
             }
         assertNotNull(tu)
 
+        // we should have this pseudo-record in the global scope
+        val structFieldInt = tu.records["struct{field int}"]
+        assertNotNull(structFieldInt)
+        assertIs<GlobalScope>(structFieldInt.scope)
+
         val p = tu.namespaces["p"]
         assertNotNull(p)
 
@@ -145,6 +151,10 @@ class DeclarationTest {
 
         val record = type.recordDeclaration
         assertNotNull(record)
+        assertLocalName("struct{field int}", record)
+
+        val field = record.fields["field"]
+        assertNotNull(field)
 
         val init = s.initializer
         assertIs<InitializerListExpression>(init)
@@ -154,7 +164,7 @@ class DeclarationTest {
 
         val key = keyValue.key
         assertNotNull(key)
-        assertRefersTo(key, record.fields["field"])
+        assertRefersTo(key, field)
     }
 
     @Test
@@ -273,24 +283,24 @@ class DeclarationTest {
         with(tu) {
             val values =
                 mapOf(
-                    "zeroShift" to Pair(0, objectType("int")),
-                    "zeroAnd" to Pair(0, objectType("int")),
-                    "one" to Pair(1, objectType("p.custom")),
-                    "oneAsWell" to Pair(1, objectType("p.custom")),
-                    "oneShift" to Pair(1, primitiveType("int")),
-                    "two" to Pair(2, primitiveType("int")),
-                    "twoShift" to Pair(2, primitiveType("int")),
-                    "three" to Pair(3, primitiveType("int")),
-                    "threeOr" to Pair(3, primitiveType("int")),
-                    "threeXor" to Pair(3, primitiveType("int")),
-                    "four" to Pair(4, primitiveType("int")),
-                    "tenAsWell" to Pair(10, primitiveType("int")),
-                    "five" to Pair(5, primitiveType("int")),
-                    "fiveAsWell" to Pair(5, primitiveType("int")),
-                    "six" to Pair(6, primitiveType("int")),
-                    "fivehundred" to Pair(500, primitiveType("int")),
-                    "sixhundred" to Pair(600, primitiveType("int")),
-                    "onehundredandfive" to Pair(105, primitiveType("int")),
+                    "zeroShift" to Pair(0, assertResolvedType("int")),
+                    "zeroAnd" to Pair(0, assertResolvedType("int")),
+                    "one" to Pair(1, assertResolvedType("p.custom")),
+                    "oneAsWell" to Pair(1, assertResolvedType("p.custom")),
+                    "oneShift" to Pair(1, assertResolvedType("int")),
+                    "two" to Pair(2, assertResolvedType("int")),
+                    "twoShift" to Pair(2, assertResolvedType("int")),
+                    "three" to Pair(3, assertResolvedType("int")),
+                    "threeOr" to Pair(3, assertResolvedType("int")),
+                    "threeXor" to Pair(3, assertResolvedType("int")),
+                    "four" to Pair(4, assertResolvedType("int")),
+                    "tenAsWell" to Pair(10, assertResolvedType("int")),
+                    "five" to Pair(5, assertResolvedType("int")),
+                    "fiveAsWell" to Pair(5, assertResolvedType("int")),
+                    "six" to Pair(6, assertResolvedType("int")),
+                    "fivehundred" to Pair(500, assertResolvedType("int")),
+                    "sixhundred" to Pair(600, assertResolvedType("int")),
+                    "onehundredandfive" to Pair(105, assertResolvedType("int")),
                 )
             values.forEach {
                 val variable = tu.variables[it.key]

--- a/cpg-language-go/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
+++ b/cpg-language-go/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
@@ -125,7 +125,7 @@ class GoLanguageFrontendTest : BaseTest() {
         assertNotNull(decl)
 
         val new = assertIs<NewExpression>(decl.firstAssignment)
-        with(tu) { assertEquals(objectType("p.MyStruct").pointer(), new.type) }
+        with(tu) { assertEquals(assertResolvedType("p.MyStruct").pointer(), new.type) }
 
         val construct = new.initializer as? ConstructExpression
         assertNotNull(construct)
@@ -727,7 +727,7 @@ class GoLanguageFrontendTest : BaseTest() {
         assertNotNull(c)
         with(tu) {
             // type will be inferred from the function declaration
-            assertEquals(objectType("p.MyStruct").pointer(), c.type)
+            assertEquals(assertResolvedType("p.MyStruct").pointer(), c.type)
         }
 
         val newMyStructCall = assertIs<CallExpression>(c.firstAssignment)

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguage.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguage.kt
@@ -71,6 +71,7 @@ open class JavaLanguage :
     @JsonIgnore
     override val builtInTypes =
         mapOf(
+            "void" to IncompleteType(language = this),
             // Boolean Types:
             // https://docs.oracle.com/javase/specs/jls/se19/html/jls-4.html#jls-4.2.5
             "boolean" to BooleanType("boolean", language = this),

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaCallResolverHelper.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaCallResolverHelper.kt
@@ -29,12 +29,12 @@ import de.fraunhofer.aisec.cpg.ScopeManager
 import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguage
 import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
-import de.fraunhofer.aisec.cpg.graph.objectType
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberCallExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Reference
 import de.fraunhofer.aisec.cpg.graph.types.HasType
 import de.fraunhofer.aisec.cpg.graph.types.recordDeclaration
+import de.fraunhofer.aisec.cpg.graph.unknownType
 import de.fraunhofer.aisec.cpg.helpers.Util
 import de.fraunhofer.aisec.cpg.passes.SymbolResolver.Companion.LOGGER
 
@@ -57,7 +57,7 @@ class JavaCallResolverHelper {
             curClass: RecordDeclaration,
             scopeManager: ScopeManager
         ): Boolean {
-            // Because the "super" keyword still refers to "this" (but casted to another class), we
+            // Because the "super" keyword still refers to "this" (but cast to another class), we
             // still need to connect the super reference to the receiver of this method.
             val func = scopeManager.currentFunction
             if (func is MethodDeclaration) {
@@ -113,7 +113,9 @@ class JavaCallResolverHelper {
         ): RecordDeclaration? {
             val baseName = callee.base.name.parent ?: return null
 
-            val type = curClass.objectType(baseName)
+            val type =
+                callee.ctx?.typeManager?.lookupResolvedType(baseName.toString())
+                    ?: callee.unknownType()
             if (type in curClass.implementedInterfaces) {
                 // Basename is an interface -> BaseName.super refers to BaseName itself
                 return type.recordDeclaration

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaExternalTypeHierarchyResolver.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaExternalTypeHierarchyResolver.kt
@@ -33,6 +33,7 @@ import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguage
 import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.helpers.CommonPath
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
@@ -46,9 +47,11 @@ import org.slf4j.LoggerFactory
 class JavaExternalTypeHierarchyResolver(ctx: TranslationContext) : ComponentPass(ctx) {
     override fun accept(component: Component) {
         val provider =
-            object : ContextProvider, LanguageProvider {
+            object : ContextProvider, LanguageProvider, ScopeProvider {
                 override val language = JavaLanguage()
                 override val ctx: TranslationContext = this@JavaExternalTypeHierarchyResolver.ctx
+                override val scope: Scope?
+                    get() = scopeManager.globalScope
             }
         val resolver = CombinedTypeSolver()
 
@@ -68,16 +71,23 @@ class JavaExternalTypeHierarchyResolver(ctx: TranslationContext) : ComponentPass
         }
 
         // Iterate over all known types and add their (direct) supertypes.
-        for (t in HashSet(typeManager.firstOrderTypes)) {
-            // TODO: Do we have to check if the type's language is JavaLanguage?
+        for (t in typeManager.firstOrderTypes) {
             val symbol = resolver.tryToSolveType(t.typeName)
             if (symbol.isSolved) {
                 try {
                     val resolvedSuperTypes = symbol.correspondingDeclaration.getAncestors(true)
                     for (anc in resolvedSuperTypes) {
+                        // We need to try to resolve the type first in order to create weirdly
+                        // scoped types
+                        var superType = typeManager.lookupResolvedType(anc.qualifiedName)
+
+                        // Otherwise, we can create this in the global scope
+                        if (superType == null) {
+                            superType = provider.objectType(anc.qualifiedName)
+                            superType.typeOrigin = Type.Origin.RESOLVED
+                        }
+
                         // Add all resolved supertypes to the type.
-                        val superType = provider.objectType(anc.qualifiedName)
-                        superType.typeOrigin = Type.Origin.RESOLVED
                         t.superTypes.add(superType)
                     }
                 } catch (e: UnsolvedSymbolException) {

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontendTest.kt
@@ -187,12 +187,23 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         scope = firstCatch.scope
         assertNotNull(scope)
 
-        // first exception type was? resolved, so we can expect a FQN
-        assertEquals(tu.objectType("java.lang.NumberFormatException"), firstCatch.parameter?.type)
-        // second one could not be resolved so we do not have an FQN
-        assertEquals(tu.objectType("NotResolvableTypeException"), catchClauses[1].parameter?.type)
-        // third type should have been resolved through the import
-        assertEquals(tu.objectType("some.ImportedException"), (catchClauses[2].parameter)?.type)
+        with(tu) {
+            // first exception type was? resolved, so we can expect a FQN
+            assertEquals(
+                assertResolvedType("java.lang.NumberFormatException"),
+                firstCatch.parameter?.type
+            )
+            // second one could not be resolved so we do not have an FQN
+            assertEquals(
+                assertResolvedType("NotResolvableTypeException"),
+                catchClauses[1].parameter?.type
+            )
+            // third type should have been resolved through the import
+            assertEquals(
+                assertResolvedType("some.ImportedException"),
+                (catchClauses[2].parameter)?.type
+            )
+        }
 
         // and 1 finally
         val finallyBlock = tryStatement.finallyBlock
@@ -603,6 +614,7 @@ internal class JavaLanguageFrontendTest : BaseTest() {
             }
         val tu =
             findByUniqueName(result.components.flatMap { it.translationUnits }, file1.toString())
+
         val namespace = tu.declarations<NamespaceDeclaration>(0)
         assertNotNull(namespace)
 
@@ -617,7 +629,7 @@ internal class JavaLanguageFrontendTest : BaseTest() {
         val receiver = (lhs?.base as? Reference)?.refersTo as? VariableDeclaration?
         assertNotNull(receiver)
         assertLocalName("this", receiver)
-        assertEquals(tu.objectType("my.Animal"), receiver.type)
+        assertEquals(tu.assertResolvedType("my.Animal"), receiver.type)
     }
 
     @Test

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypeTests.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypeTests.kt
@@ -117,6 +117,11 @@ internal class TypeTests : BaseTest() {
         val level1b = assertNotNull(result.records["multistep.Level1B"]).toType()
         val level2 = assertNotNull(result.records["multistep.Level2"]).toType()
         val unrelated = assertNotNull(result.records["multistep.Unrelated"]).toType()
+        println(
+            result.finalCtx.typeManager.firstOrderTypes
+                .filter { it.typeName == "multistep.Root" }
+                .map { it.superTypes }
+        )
         getCommonTypeTestGeneral(root, level0, level1, level1b, level2, unrelated)
     }
 
@@ -164,7 +169,7 @@ internal class TypeTests : BaseTest() {
 
         // Check unrelated type behavior: No common root class
         for (t in listOf(root, level0, level1, level1b, level2)) {
-            assertEquals(null, setOf(unrelated, t).commonType)
+            assertFullName("java.lang.Object", setOf(unrelated, t).commonType)
         }
     }
 }

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguage.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguage.kt
@@ -57,5 +57,12 @@ class LLVMIRLanguage : Language<LLVMIRLanguageFrontend>() {
             "fp128" to FloatingPointType("fp128", 128, this, NumericType.Modifier.SIGNED),
             "x86_fp80" to FloatingPointType("x86_fp80", 80, this, NumericType.Modifier.SIGNED),
             "ppc_fp128" to FloatingPointType("ppc_fp128", 128, this, NumericType.Modifier.SIGNED),
+
+            // these are not real LLVM-IR types, but we use them to differentiate unsigned types
+            "ui1" to IntegerType("ui1", 1, this, NumericType.Modifier.UNSIGNED),
+            "ui8" to IntegerType("ui8", 8, this, NumericType.Modifier.UNSIGNED),
+            "ui32" to IntegerType("ui32", 32, this, NumericType.Modifier.UNSIGNED),
+            "ui64" to IntegerType("ui64", 64, this, NumericType.Modifier.UNSIGNED),
+            "ui128" to IntegerType("ui128", 128, this, NumericType.Modifier.UNSIGNED),
         )
 }

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontend.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontend.kt
@@ -211,6 +211,10 @@ class LLVMIRLanguageFrontend(language: Language<LLVMIRLanguageFrontend>, ctx: Tr
                     val record = declarationHandler.handleStructureType(typeRef, alreadyVisited)
                     record.toType()
                 }
+                LLVMFunctionTypeKind -> {
+                    // we are not really interested in function types in this frontend
+                    unknownType()
+                }
                 else -> {
                     objectType(typeStr)
                 }

--- a/cpg-language-llvm/src/test/resources/log4j2.xml
+++ b/cpg-language-llvm/src/test/resources/log4j2.xml
@@ -1,0 +1,14 @@
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss,SSS} %-5p %C{1} %m%n"/>
+            <ThresholdFilter level="TRACE"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger level="DEBUG" name="de.fraunhofer.aisec.cpg"/>
+        <Root level="DEBUG">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/ExpressionHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/ExpressionHandler.kt
@@ -377,8 +377,11 @@ class ExpressionHandler(frontend: PythonLanguageFrontend) :
     }
 
     private fun isImport(name: Name): Boolean {
-        val decl = frontend.scopeManager.findSymbols(name).filterIsInstance<ImportDeclaration>()
-        return decl.isNotEmpty()
+        val decl =
+            frontend.scopeManager.currentScope
+                ?.lookupSymbol(name.localName, replaceImports = false)
+                ?.filterIsInstance<ImportDeclaration>()
+        return decl?.isNotEmpty() ?: false
     }
 
     private fun handleName(node: Python.ASTName): Expression {

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
@@ -49,47 +49,48 @@ class PythonFrontendTest : BaseTest() {
                 it.registerLanguage<PythonLanguage>()
             }
         assertNotNull(tu)
+        with(tu) {
+            val p = tu.namespaces["literal"]
+            assertNotNull(p)
+            assertLocalName("literal", p)
 
-        val p = tu.namespaces["literal"]
-        assertNotNull(p)
-        assertLocalName("literal", p)
+            val b = p.variables["b"]
+            assertNotNull(b)
+            assertLocalName("b", b)
+            assertEquals(assertResolvedType("bool"), b.type)
+            assertEquals(true, (b.firstAssignment as? Literal<*>)?.value)
 
-        val b = p.variables["b"]
-        assertNotNull(b)
-        assertLocalName("b", b)
-        assertEquals(tu.primitiveType("bool"), b.type)
-        assertEquals(true, (b.firstAssignment as? Literal<*>)?.value)
+            val i = p.variables["i"]
+            assertNotNull(i)
+            assertLocalName("i", i)
+            assertEquals(assertResolvedType("int"), i.type)
+            assertEquals(42L, (i.firstAssignment as? Literal<*>)?.value)
 
-        val i = p.variables["i"]
-        assertNotNull(i)
-        assertLocalName("i", i)
-        assertEquals(tu.primitiveType("int"), i.type)
-        assertEquals(42L, (i.firstAssignment as? Literal<*>)?.value)
+            val f = p.variables["f"]
+            assertNotNull(f)
+            assertLocalName("f", f)
+            assertEquals(assertResolvedType("float"), f.type)
+            assertEquals(1.0, (f.firstAssignment as? Literal<*>)?.value)
 
-        val f = p.variables["f"]
-        assertNotNull(f)
-        assertLocalName("f", f)
-        assertEquals(tu.primitiveType("float"), f.type)
-        assertEquals(1.0, (f.firstAssignment as? Literal<*>)?.value)
+            val c = p.variables["c"]
+            assertNotNull(c)
+            assertLocalName("c", c)
+            // assertEquals(tu.primitiveType("complex"), c.type) TODO: this is currently "UNKNOWN"
+            // assertEquals("(3+5j)", (c.firstAssignment as? Literal<*>)?.value) // TODO: this is
+            // currently a binary op
 
-        val c = p.variables["c"]
-        assertNotNull(c)
-        assertLocalName("c", c)
-        // assertEquals(tu.primitiveType("complex"), c.type) TODO: this is currently "UNKNOWN"
-        // assertEquals("(3+5j)", (c.firstAssignment as? Literal<*>)?.value) // TODO: this is
-        // currently a binary op
+            val t = p.variables["t"]
+            assertNotNull(t)
+            assertLocalName("t", t)
+            assertEquals(assertResolvedType("str"), t.type)
+            assertEquals("Hello", (t.firstAssignment as? Literal<*>)?.value)
 
-        val t = p.variables["t"]
-        assertNotNull(t)
-        assertLocalName("t", t)
-        assertEquals(tu.primitiveType("str"), t.type)
-        assertEquals("Hello", (t.firstAssignment as? Literal<*>)?.value)
-
-        val n = p.variables["n"]
-        assertNotNull(n)
-        assertLocalName("n", n)
-        assertEquals(tu.objectType("None"), n.type)
-        assertEquals(null, (n.firstAssignment as? Literal<*>)?.value)
+            val n = p.variables["n"]
+            assertNotNull(n)
+            assertLocalName("n", n)
+            assertEquals(assertResolvedType("None"), n.type)
+            assertEquals(null, (n.firstAssignment as? Literal<*>)?.value)
+        }
     }
 
     @Test

--- a/cpg-neo4j/src/test/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/ApplicationTest.kt
+++ b/cpg-neo4j/src/test/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/ApplicationTest.kt
@@ -62,8 +62,8 @@ class ApplicationTest {
     @Test
     fun testSerializeCpgViaOGM() {
         val (application, translationResult) = createTranslationResult()
-        // TODO: this was originally 32 nodes, it seems we can now resolve less :(
-        assertEquals(34, translationResult.functions.size)
+        // 22 inferred functions, 1 inferred method, 2 inferred constructors, 11 regular functions
+        assertEquals(36, translationResult.functions.size)
 
         val (nodes, edges) = application.translateCPGToOGMBuilders(translationResult)
         val graph = application.buildJsonGraph(nodes, edges)
@@ -95,8 +95,8 @@ class ApplicationTest {
     @Test
     fun testExportToJson() {
         val (application, translationResult) = createTranslationResult()
-        // TODO: this was originally 32 nodes, it seems we can now resolve less :(
-        assertEquals(34, translationResult.functions.size)
+        // 22 inferred functions, 1 inferred method, 2 inferred constructors, 11 regular functions
+        assertEquals(36, translationResult.functions.size)
         val path = createTempFile().toFile()
         application.exportToJson(translationResult, path)
         assert(path.length() > 0)

--- a/cpg-neo4j/src/test/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Neo4JTest.kt
+++ b/cpg-neo4j/src/test/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Neo4JTest.kt
@@ -43,8 +43,8 @@ class Neo4JTest {
     fun testPush() {
         val (application, translationResult) = createTranslationResult()
 
-        // TODO: this was originally 32 nodes, it seems we can now resolve less :(
-        assertEquals(34, translationResult.functions.size)
+        // 22 inferred functions, 1 inferred method, 2 inferred constructors, 11 regular functions
+        assertEquals(36, translationResult.functions.size)
 
         application.pushToNeo4j(translationResult)
 
@@ -55,7 +55,9 @@ class Neo4JTest {
             val functions = session.loadAll(FunctionDeclaration::class.java)
             assertNotNull(functions)
 
-            assertEquals(34, functions.size)
+            // 22 inferred functions, 1 inferred method, 2 inferred constructors, 11 regular
+            // functions
+            assertEquals(36, functions.size)
 
             transaction.commit()
         }


### PR DESCRIPTION
This PR tries to implement concepts described in https://github.com/Fraunhofer-AISEC/cpg/issues/1533. However, while #1533 describes a full blown concept of type references, it seems that this is not easily doable.

Therefore, I re-visited the idea of "normalising" types during a pass. The main idea is that a `Type` is now not globally unique, but it is only unique within its `scope`. Therefore a type `string` within one function body and a `string` in another function body will result in two different type objects. While this introduces more type nodes, it also allows us to rename individual type objects in a single scope to their actual FQN.

Two type objects are now equal based on name and scoped if they are unresolved and based on their name if resolved.