### PR TITLE
Trying to infer namespace when trying to infer records

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/InferenceConfiguration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/InferenceConfiguration.kt
@@ -37,6 +37,9 @@ private constructor(
     /** Enables or disables the inference system as a whole. */
     val enabled: Boolean,
 
+    /** Enables the inference of namespace declarations. */
+    val inferNamespaces: Boolean,
+
     /** Enables the inference of record declarations. */
     val inferRecords: Boolean,
 
@@ -54,12 +57,15 @@ private constructor(
 ) {
     class Builder(
         private var enabled: Boolean = true,
+        private var inferNamespaces: Boolean = true,
         private var inferRecords: Boolean = true,
         private var inferFunctions: Boolean = true,
         private var inferVariables: Boolean = true,
         private var inferDfgForUnresolvedCalls: Boolean = true
     ) {
         fun enabled(infer: Boolean) = apply { this.enabled = infer }
+
+        fun inferNamespaces(infer: Boolean) = apply { this.inferNamespaces = infer }
 
         fun inferRecords(infer: Boolean) = apply { this.inferRecords = infer }
 
@@ -74,6 +80,7 @@ private constructor(
         fun build() =
             InferenceConfiguration(
                 enabled,
+                inferNamespaces,
                 inferRecords,
                 inferFunctions,
                 inferVariables,

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
@@ -446,15 +446,16 @@ class Inference internal constructor(val start: Node, override val ctx: Translat
         }
     }
 
-    fun inferNamespaceDeclaration(name: Name, path: String?, origin: Node): NamespaceDeclaration {
-        // Here be dragons. Jump to the scope that the node defines directly, so that we can
-        // delegate further operations to the scope manager. We also save the old scope, so we can
-        // restore it.
+    fun inferNamespaceDeclaration(name: Name, path: String?, origin: Node): NamespaceDeclaration? {
+        if (!ctx.config.inferenceConfiguration.inferNamespaces) {
+            return null
+        }
+
         return inferInScopeOf(start) {
             debugWithFileLocation(
                 origin,
                 log,
-                "Inferring a new namespace declaration {} {} in $it",
+                "Inferring a new namespace declaration {} (path: {}) in $it",
                 name,
                 if (path != null) {
                     "with path '$path'"


### PR DESCRIPTION
Otherwise inferred records with an FQN end up in global scope, which does not make sense.
