### PR TITLE
Fixed Neo4J import of `ImportDeclaration`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ImportDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ImportDeclaration.kt
@@ -31,7 +31,9 @@ import de.fraunhofer.aisec.cpg.graph.scopes.FileScope
 import de.fraunhofer.aisec.cpg.graph.scopes.NameScope
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.graph.scopes.SymbolMap
+import de.fraunhofer.aisec.cpg.helpers.neo4j.NameConverter
 import de.fraunhofer.aisec.cpg.passes.ImportResolver
+import org.neo4j.ogm.annotation.typeconversion.Convert
 
 /**
  * This class represents a real *import* of one or more symbols of a specified [NameScope] (e.g.,
@@ -128,7 +130,7 @@ class ImportDeclaration : Declaration() {
      *   imported symbol.
      * * If an alias is used, the [name] of this declaration is set to the value of [alias].
      */
-    var import: Name = Name(EMPTY_NAME)
+    @Convert(NameConverter::class) var import: Name = Name(EMPTY_NAME)
 
     /**
      * Some languages support the use of aliases in importing symbols, for example to avoid
@@ -139,7 +141,7 @@ class ImportDeclaration : Declaration() {
      * different names. However, in practice, it is easier to have this as an extra property to
      * quickly identify imports with aliases.
      */
-    var alias: Name? = null
+    @Convert(NameConverter::class) var alias: Name? = null
 
     /**
      * In some languages (such as Go), we can specify packages to fetch from external sources. In

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ImportDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ImportDeclaration.kt
@@ -31,9 +31,9 @@ import de.fraunhofer.aisec.cpg.graph.scopes.FileScope
 import de.fraunhofer.aisec.cpg.graph.scopes.NameScope
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.graph.scopes.SymbolMap
-import de.fraunhofer.aisec.cpg.helpers.neo4j.NameConverter
+import de.fraunhofer.aisec.cpg.helpers.neo4j.SimpleNameConverter
 import de.fraunhofer.aisec.cpg.passes.ImportResolver
-import org.neo4j.ogm.annotation.Transient
+import org.neo4j.ogm.annotation.typeconversion.Convert
 
 /**
  * This class represents a real *import* of one or more symbols of a specified [NameScope] (e.g.,
@@ -130,7 +130,7 @@ class ImportDeclaration : Declaration() {
      *   imported symbol.
      * * If an alias is used, the [name] of this declaration is set to the value of [alias].
      */
-    @Transient var import: Name = Name(EMPTY_NAME)
+    @Convert(value = SimpleNameConverter::class) var import: Name = Name(EMPTY_NAME)
 
     /**
      * Some languages support the use of aliases in importing symbols, for example to avoid
@@ -141,7 +141,7 @@ class ImportDeclaration : Declaration() {
      * different names. However, in practice, it is easier to have this as an extra property to
      * quickly identify imports with aliases.
      */
-    @Transient var alias: Name? = null
+    @Convert(value = SimpleNameConverter::class) var alias: Name? = null
 
     /**
      * In some languages (such as Go), we can specify packages to fetch from external sources. In
@@ -159,5 +159,7 @@ class ImportDeclaration : Declaration() {
      * A list of symbols that this declaration imports. This will be populated by
      * [ImportResolver.handleImportDeclaration].
      */
-    @PopulatedByPass(ImportResolver::class) var importedSymbols: SymbolMap = mutableMapOf()
+    @Transient
+    @PopulatedByPass(ImportResolver::class)
+    var importedSymbols: SymbolMap = mutableMapOf()
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ImportDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ImportDeclaration.kt
@@ -33,7 +33,7 @@ import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.graph.scopes.SymbolMap
 import de.fraunhofer.aisec.cpg.helpers.neo4j.NameConverter
 import de.fraunhofer.aisec.cpg.passes.ImportResolver
-import org.neo4j.ogm.annotation.typeconversion.Convert
+import org.neo4j.ogm.annotation.Transient
 
 /**
  * This class represents a real *import* of one or more symbols of a specified [NameScope] (e.g.,
@@ -130,7 +130,7 @@ class ImportDeclaration : Declaration() {
      *   imported symbol.
      * * If an alias is used, the [name] of this declaration is set to the value of [alias].
      */
-    @Convert(NameConverter::class) var import: Name = Name(EMPTY_NAME)
+    @Transient var import: Name = Name(EMPTY_NAME)
 
     /**
      * Some languages support the use of aliases in importing symbols, for example to avoid
@@ -141,7 +141,7 @@ class ImportDeclaration : Declaration() {
      * different names. However, in practice, it is easier to have this as an extra property to
      * quickly identify imports with aliases.
      */
-    @Convert(NameConverter::class) var alias: Name? = null
+    @Transient var alias: Name? = null
 
     /**
      * In some languages (such as Go), we can specify packages to fetch from external sources. In

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/neo4j/SimpleNameConverter.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/neo4j/SimpleNameConverter.kt
@@ -44,7 +44,7 @@ class SimpleNameConverter : AttributeConverter<Name, String> {
         }
 
         // We cannot really know what the actual delimiter was, so we need to supply some delimiters
-        // and hope for the best. Unfortunately, we do not get access to the "language" node here..
-        return parseName(value, "", ".", ",", "::")
+        // and hope for the best. Unfortunately, we do not get access to the "language" node here...
+        return parseName(value, ".", ",", "::")
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/neo4j/SimpleNameConverter.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/neo4j/SimpleNameConverter.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.helpers.neo4j
+
+import de.fraunhofer.aisec.cpg.graph.Name
+import de.fraunhofer.aisec.cpg.graph.parseName
+import org.neo4j.ogm.typeconversion.AttributeConverter
+
+/**
+ * This converter converts a [Name] into a single [String] (in contrast to the [NameConverter],
+ * which splits it up into several properties).
+ */
+class SimpleNameConverter : AttributeConverter<Name, String> {
+    override fun toGraphProperty(value: Name?): String {
+        return value.toString()
+    }
+
+    override fun toEntityAttribute(value: String?): Name? {
+        if (value == null) {
+            return null
+        }
+
+        // We cannot really know what the actual delimiter was, so we need to supply some delimiters
+        // and hope for the best. Unfortunately, we do not get access to the "language" node here..
+        return parseName(value, "", ".", ",", "::")
+    }
+}

--- a/cpg-neo4j/build.gradle.kts
+++ b/cpg-neo4j/build.gradle.kts
@@ -54,4 +54,6 @@ dependencies {
     // Command line interface support
     api(libs.picocli)
     annotationProcessor(libs.picocli.codegen)
+
+    testImplementation(testFixtures(projects.cpgCore))
 }

--- a/cpg-neo4j/src/test/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Neo4JTest.kt
+++ b/cpg-neo4j/src/test/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Neo4JTest.kt
@@ -25,7 +25,11 @@
  */
 package de.fraunhofer.aisec.cpg_vis_neo4j
 
+import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.Name
+import de.fraunhofer.aisec.cpg.graph.builder.translationResult
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.ImportDeclaration
 import de.fraunhofer.aisec.cpg.graph.functions
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -58,5 +62,35 @@ class Neo4JTest {
 
         session.clear()
         sessionAndSessionFactoryPair.second.close()
+    }
+
+    @Test
+    fun testSimpleNameConverter() {
+        val result =
+            with(TestLanguageFrontend()) {
+                translationResult {
+                    val import = ImportDeclaration()
+                    import.name = Name("myname")
+                    import.alias = Name("myname", Name("myparent"), "::")
+                    additionalNodes += import
+                }
+            }
+
+        val app = Application()
+        app.pushToNeo4j(result)
+
+        val sessionAndSessionFactoryPair = app.connect()
+
+        val session = sessionAndSessionFactoryPair.first
+        session.beginTransaction().use { transaction ->
+            val imports = session.loadAll(ImportDeclaration::class.java)
+            assertNotNull(imports)
+
+            var loadedImport = imports.singleOrNull()
+            assertNotNull(loadedImport)
+            assertEquals("myname", loadedImport.alias?.localName)
+
+            transaction.commit()
+        }
     }
 }


### PR DESCRIPTION
The `ImportDeclaration` was trying to use the `Name` class without a converter, but unfortunately, we cannot add the prefix to the converter, so having three converters in the same file would override all properties.

Therefore, we are simply converting `alias` and `import` to a string.
