### PR TITLE
Using Kotlin 1.9 for cpg-console

### DIFF
--- a/cpg-all/build.gradle.kts
+++ b/cpg-all/build.gradle.kts
@@ -18,10 +18,12 @@ publishing {
 
 dependencies {
     // this exposes all of our (published) modules as dependency
+    api(projects.cpgConsole)
     api(projects.cpgCore)
     api(projects.cpgAnalysis)
     api(projects.cpgNeo4j)
 
+    kover(projects.cpgConsole)
     kover(projects.cpgCore)
     kover(projects.cpgAnalysis)
     kover(projects.cpgNeo4j)

--- a/cpg-console/src/test/kotlin/de/fraunhofer/aisec/cpg/console/ConsoleTest.kt
+++ b/cpg-console/src/test/kotlin/de/fraunhofer/aisec/cpg/console/ConsoleTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.console
+
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.console.CpgConsole.configureREPL
+import kotlin.script.experimental.api.ResultValue
+import kotlin.script.experimental.api.onFailure
+import kotlin.script.experimental.api.valueOrNull
+import kotlin.script.experimental.jvm.KJvmEvaluatedSnippet
+import kotlin.script.experimental.util.LinkedSnippet
+import kotlin.test.Test
+import kotlin.test.assertIs
+import org.junit.jupiter.api.Tag
+
+@Tag("integration")
+class ConsoleTest {
+
+    @Test
+    fun testShell() {
+        var repl = configureREPL()
+        repl.initEngine()
+        repl.eval("import de.fraunhofer.aisec.cpg.TranslationConfiguration")
+        var result = repl.eval("TranslationConfiguration.builder().build()")
+        result.result.onFailure { println(it) }
+
+        var snippet = result.result.valueOrNull()
+        assertIs<LinkedSnippet<*>>(snippet)
+        val evaluated = snippet.get()
+        assertIs<KJvmEvaluatedSnippet>(evaluated)
+        val resultValue = evaluated.result
+        assertIs<ResultValue.Value>(resultValue)
+        val value = resultValue.value
+        assertIs<TranslationConfiguration>(value)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 kotlin = "2.0.0"
+kotlin19 = "1.9.10"
 neo4j = "4.0.10"
 log4j = "2.23.0"
 sonarqube = "5.0.0.4638"
@@ -8,12 +9,12 @@ nexus-publish = "2.0.0"
 
 [libraries]
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin"}
-kotlin-script-runtime = { module = "org.jetbrains.kotlin:kotlin-script-runtime", version.ref = "kotlin"}
-kotlin-scripting-common = { module = "org.jetbrains.kotlin:kotlin-scripting-common", version.ref = "kotlin"}
-kotlin-scripting-jvm = { module = "org.jetbrains.kotlin:kotlin-scripting-jvm", version.ref = "kotlin"}
-kotlin-scripting-dependencies = { module = "org.jetbrains.kotlin:kotlin-scripting-dependencies", version.ref = "kotlin"}
-kotlin-scripting-dependencies-maven-all = { module = "org.jetbrains.kotlin:kotlin-scripting-dependencies-maven-all", version.ref = "kotlin"}
-kotlin-scripting-ide-services = { module = "org.jetbrains.kotlin:kotlin-scripting-ide-services", version.ref = "kotlin"}
+kotlin-script-runtime = { module = "org.jetbrains.kotlin:kotlin-script-runtime", version.ref = "kotlin19"}
+kotlin-scripting-common = { module = "org.jetbrains.kotlin:kotlin-scripting-common", version.ref = "kotlin19"}
+kotlin-scripting-jvm = { module = "org.jetbrains.kotlin:kotlin-scripting-jvm", version.ref = "kotlin19"}
+kotlin-scripting-dependencies = { module = "org.jetbrains.kotlin:kotlin-scripting-dependencies", version.ref = "kotlin19"}
+kotlin-scripting-dependencies-maven-all = { module = "org.jetbrains.kotlin:kotlin-scripting-dependencies-maven-all", version.ref = "kotlin19"}
+kotlin-scripting-ide-services = { module = "org.jetbrains.kotlin:kotlin-scripting-ide-services", version.ref = "kotlin19"}
 kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.8.0"}
 kotlin-ki-shell = { module = "com.github.Kotlin:kotlin-interactive-shell", version = "5b1ff4d821"}
 kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlin"}  # this is only needed for the testFixtures in cpg-core, everywhere else kotlin("test") is used


### PR DESCRIPTION
It seems that the kotlin shell is not (yet) compatbile with Kotlin 2.0. However, it seems that we can just use the scripting host from Kotlin 1.9 and it seems to work.

Fixes #1591
Related to https://github.com/Kotlin/kotlin-interactive-shell/issues/131
