### PR TITLE
Do not depend on `JavaImportResolver` in cpg-neo4j

### DIFF
--- a/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
+++ b/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
@@ -263,7 +263,6 @@ class Application : Callable<Int> {
     private var passClassList =
         listOf(
             TypeHierarchyResolver::class,
-            JavaImportResolver::class,
             SymbolResolver::class,
             DFGPass::class,
             EvaluationOrderGraphPass::class,


### PR DESCRIPTION
Fixes https://github.com/Fraunhofer-AISEC/cpg/issues/1432 (again)