### PR TITLE
Add .c++ as file extension for cpp language

### DIFF
--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CPPLanguage.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CPPLanguage.kt
@@ -48,7 +48,7 @@ open class CPPLanguage :
     HasUnknownType,
     HasFunctionalCasts,
     HasFunctionOverloading {
-    override val fileExtensions = listOf("cpp", "cc", "cxx", "hpp", "hh")
+    override val fileExtensions = listOf("cpp", "cc", "cxx", "c++", "hpp", "hh")
     override val elaboratedTypeSpecifier = listOf("class", "struct", "union", "enum")
     override val unknownTypeString = listOf("auto")
 


### PR DESCRIPTION
`.c++` is also sometimes used for c++ source files.