### PR TITLE
Added basic implementation of operator overloading

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -35,7 +35,6 @@ import de.fraunhofer.aisec.cpg.graph.types.FunctionPointerType
 import de.fraunhofer.aisec.cpg.graph.types.IncompleteType
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.helpers.Util
-import de.fraunhofer.aisec.cpg.passes.SymbolResolver
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 import java.util.*
 import java.util.function.Predicate

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
@@ -39,6 +39,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.BinaryOperator
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.graph.unknownType
+import de.fraunhofer.aisec.cpg.passes.SymbolResolver
 import java.io.File
 import kotlin.reflect.KClass
 import kotlin.reflect.full.primaryConstructor

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageTraits.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageTraits.kt
@@ -237,6 +237,21 @@ interface HasOperatorOverloading : LanguageTrait {
      * the name of the function.
      */
     val overloadedOperatorNames: Map<Pair<KClass<out HasOverloadedOperation>, String>, Symbol>
+
+    /**
+     * Returns the matching operator code for [name] in [overloadedOperatorNames]. While
+     * [overloadedOperatorNames] can have multiple entries for a single operator code (e.g. to
+     * differentiate between unary and binary ops), we only ever allow one distinct operator code
+     * for a specific symbol. If non such distinct operator code is found, null is returned.
+     */
+    fun operatorCodeFor(name: Symbol): String? {
+        return overloadedOperatorNames
+            .filterValues { it == name }
+            .keys
+            .map { it.second }
+            .distinct()
+            .singleOrNull()
+    }
 }
 
 /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageTraits.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageTraits.kt
@@ -264,13 +264,6 @@ inline infix fun <reified T : HasOverloadedOperation> KClass<T>.of(
     return Pair(T::class, operatorCode)
 }
 
-/** Checks whether the [Name] for a function is a known operator name. */
-context(LanguageProvider)
-val Name.isKnownOperatorName: Boolean
-    get() {
-        return this.localName.isKnownOperatorName
-    }
-
 /** Checks whether the name for a function (as [CharSequence]) is a known operator name. */
 context(LanguageProvider)
 val CharSequence.isKnownOperatorName: Boolean
@@ -280,5 +273,13 @@ val CharSequence.isKnownOperatorName: Boolean
             return false
         }
 
-        return language.overloadedOperatorNames.containsValue(this)
+        // If this is a parsed name, we only are interested in the local name
+        val name =
+            if (this is Name) {
+                this.localName
+            } else {
+                this
+            }
+
+        return language.overloadedOperatorNames.containsValue(name)
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageTraits.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageTraits.kt
@@ -29,6 +29,8 @@ import de.fraunhofer.aisec.cpg.ScopeManager
 import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.graph.HasOperatorCode
 import de.fraunhofer.aisec.cpg.graph.HasOverloadedOperation
+import de.fraunhofer.aisec.cpg.graph.LanguageProvider
+import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
@@ -246,3 +248,16 @@ inline infix fun <reified T : HasOverloadedOperation> KClass<T>.of(
 ): Pair<KClass<T>, String> {
     return Pair(T::class, operatorCode)
 }
+
+
+/** Checks whether the [Name] for a function is a known operator name. */
+context(LanguageProvider)
+val Name.isKnownOperatorName: Boolean
+    get() {
+        val language = language
+        if (language !is HasOperatorOverloading) {
+            return false
+        }
+
+        return language.overloadedOperatorNames.containsValue(this.localName)
+    }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageTraits.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageTraits.kt
@@ -249,15 +249,21 @@ inline infix fun <reified T : HasOverloadedOperation> KClass<T>.of(
     return Pair(T::class, operatorCode)
 }
 
-
 /** Checks whether the [Name] for a function is a known operator name. */
 context(LanguageProvider)
 val Name.isKnownOperatorName: Boolean
+    get() {
+        return this.localName.isKnownOperatorName
+    }
+
+/** Checks whether the name for a function (as [CharSequence]) is a known operator name. */
+context(LanguageProvider)
+val CharSequence.isKnownOperatorName: Boolean
     get() {
         val language = language
         if (language !is HasOperatorOverloading) {
             return false
         }
 
-        return language.overloadedOperatorNames.containsValue(this.localName)
+        return language.overloadedOperatorNames.containsValue(this)
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ArgumentHolder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ArgumentHolder.kt
@@ -53,6 +53,10 @@ interface ArgumentHolder : Holder<Expression> {
         return false
     }
 
+    override fun replace(old: Expression, new: Expression): Boolean {
+        return replaceArgument(old, new)
+    }
+
     /**
      * Replaces the existing argument specified in [old] with the one in [new]. Implementation how
      * to do that might be specific to the argument holder.

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
@@ -107,7 +107,7 @@ fun MetadataProvider.newOperatorDeclaration(
     operatorCode: String,
     recordDeclaration: RecordDeclaration? = null,
     rawNode: Any? = null
-): MethodDeclaration {
+): OperatorDeclaration {
     val node = OperatorDeclaration()
     node.applyMetadata(this, name, rawNode, defaultNamespace = recordDeclaration?.name)
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilder.kt
@@ -287,6 +287,30 @@ fun MetadataProvider.newCallExpression(
  * prepended argument.
  */
 @JvmOverloads
+fun MetadataProvider.newOperatorCallExpression(
+    operatorCode: String,
+    callee: Expression?,
+    rawNode: Any? = null
+): OperatorCallExpression {
+    val node = OperatorCallExpression()
+    node.applyMetadata(this, operatorCode, rawNode)
+
+    node.operatorCode = operatorCode
+    if (callee != null) {
+        node.callee = callee
+    }
+
+    log(node)
+    return node
+}
+
+/**
+ * Creates a new [MemberCallExpression]. The [MetadataProvider] receiver will be used to fill
+ * different meta-data using [Node.applyMetadata]. Calling this extension function outside of Kotlin
+ * requires an appropriate [MetadataProvider], such as a [LanguageFrontend] as an additional
+ * prepended argument.
+ */
+@JvmOverloads
 fun MetadataProvider.newMemberCallExpression(
     callee: Expression?,
     isStatic: Boolean = false,

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -504,6 +504,10 @@ val Node?.nodes: List<Node>
 val Node?.calls: List<CallExpression>
     get() = this.allChildren()
 
+/** Returns all [OperatorCallExpression] children in this graph, starting with this [Node]. */
+val Node?.operatorCalls: List<OperatorCallExpression>
+    get() = this.allChildren()
+
 /** Returns all [MemberCallExpression] children in this graph, starting with this [Node]. */
 val Node?.mcalls: List<MemberCallExpression>
     get() = this.allChildren()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Holder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Holder.kt
@@ -37,6 +37,15 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
  * [CallExpression]).
  */
 interface Holder<NodeTypeToHold : Node> {
+
+    /**
+     * Replaces the existing node specified in [old] with the one in [new]. Implementation how to do
+     * that might be specific to the holder.
+     *
+     * An indication whether this operation was successful needs to be returned.
+     */
+    fun replace(old: NodeTypeToHold, new: NodeTypeToHold): Boolean
+
     /** Adds a [Node] to the list of "held" nodes. */
     operator fun plusAssign(node: NodeTypeToHold)
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Interfaces.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Interfaces.kt
@@ -34,35 +34,6 @@ import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.passes.SymbolResolver
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 
-/** A simple interface that a node has [language]. */
-interface HasLanguage {
-
-    var language: Language<*>?
-}
-
-/** A simple interface that a node has [name] and [location]. */
-interface HasNameAndLocation : HasLanguage {
-
-    val name: Name
-
-    /** Location of the finding in source code. */
-    val location: PhysicalLocation?
-}
-
-/** A simple interface that a node has [scope]. */
-interface HasScope : HasNameAndLocation {
-
-    /** The scope this node lives in. */
-    val scope: Scope?
-}
-
-/** A simple interface to denote that the implementing class has some kind of [operatorCode]. */
-interface HasOperatorCode : HasScope {
-
-    /** The operator code, identifying an operation executed on one or more [Expression]s */
-    val operatorCode: String?
-}
-
 /** Specifies that a certain node has a base on which it executes an operation. */
 interface HasBase : HasOperatorCode {
 
@@ -77,12 +48,19 @@ interface HasBase : HasOperatorCode {
     override val operatorCode: String?
 }
 
+/** A simple interface to denote that the implementing class has some kind of [operatorCode]. */
+interface HasOperatorCode {
+
+    /** The operator code, identifying an operation executed on one or more [Expression]s */
+    val operatorCode: String?
+}
+
 /**
  * Interface that allows us to mark nodes that contain a default value
  *
  * @param <T> type of the default node </T>
  */
-interface HasDefault<T : Node?> : HasScope {
+interface HasDefault<T : Node?> {
     var default: T
 }
 
@@ -90,7 +68,7 @@ interface HasDefault<T : Node?> : HasScope {
  * Specifies that a certain node has an initializer. It is a special case of [ArgumentHolder], in
  * which the initializer is treated as the first (and only) argument.
  */
-interface HasInitializer : HasScope, HasType, ArgumentHolder, AssignmentHolder {
+interface HasInitializer : HasType, ArgumentHolder, AssignmentHolder {
 
     var initializer: Expression?
 
@@ -126,16 +104,38 @@ interface HasInitializer : HasScope, HasType, ArgumentHolder, AssignmentHolder {
  * Some nodes have aliases, i.e., it potentially references another variable. This means that
  * writing to this node, also writes to its [aliases] and vice-versa.
  */
-interface HasAliases : HasScope {
+interface HasAliases {
     /** The aliases which this node has. */
     var aliases: MutableSet<HasAliases>
+}
+
+/** A simple interface that a node has [language]. */
+interface HasLanguage {
+
+    var language: Language<*>?
+}
+
+/** A simple interface that a node has [name] and [location]. */
+interface HasNameAndLocation {
+
+    val name: Name
+
+    /** Location of the finding in source code. */
+    val location: PhysicalLocation?
+}
+
+/** A simple interface that a node has [scope]. */
+interface HasScope {
+
+    /** The scope this node lives in. */
+    val scope: Scope?
 }
 
 /**
  * Specifies that this node (e.g. a [BinaryOperator] contains an operation that can be overloaded by
  * an [OperatorDeclaration].
  */
-interface HasOverloadedOperation : HasOperatorCode {
+interface HasOverloadedOperation : HasLanguage, HasOperatorCode, HasNameAndLocation {
 
     /**
      * Arguments forwarded to the operator. This might not necessarily be all of the regular
@@ -147,5 +147,5 @@ interface HasOverloadedOperation : HasOperatorCode {
      * The base expression this operator works on. The [Type] of this is also the source where the
      * [SymbolResolver] is looking for an overloaded [OperatorDeclaration].
      */
-    val operatorBase: HasType
+    val operatorBase: Expression
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Interfaces.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Interfaces.kt
@@ -34,6 +34,35 @@ import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.passes.SymbolResolver
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 
+/** A simple interface that a node has [language]. */
+interface HasLanguage {
+
+    var language: Language<*>?
+}
+
+/** A simple interface that a node has [name] and [location]. */
+interface HasNameAndLocation : HasLanguage {
+
+    val name: Name
+
+    /** Location of the finding in source code. */
+    val location: PhysicalLocation?
+}
+
+/** A simple interface that a node has [scope]. */
+interface HasScope : HasNameAndLocation {
+
+    /** The scope this node lives in. */
+    val scope: Scope?
+}
+
+/** A simple interface to denote that the implementing class has some kind of [operatorCode]. */
+interface HasOperatorCode : HasScope {
+
+    /** The operator code, identifying an operation executed on one or more [Expression]s */
+    val operatorCode: String?
+}
+
 /** Specifies that a certain node has a base on which it executes an operation. */
 interface HasBase : HasOperatorCode {
 
@@ -48,19 +77,12 @@ interface HasBase : HasOperatorCode {
     override val operatorCode: String?
 }
 
-/** A simple interface to denote that the implementing class has some kind of [operatorCode]. */
-interface HasOperatorCode {
-
-    /** The operator code, identifying an operation executed on one or more [Expression]s */
-    val operatorCode: String?
-}
-
 /**
  * Interface that allows us to mark nodes that contain a default value
  *
  * @param <T> type of the default node </T>
  */
-interface HasDefault<T : Node?> {
+interface HasDefault<T : Node?> : HasScope {
     var default: T
 }
 
@@ -68,7 +90,7 @@ interface HasDefault<T : Node?> {
  * Specifies that a certain node has an initializer. It is a special case of [ArgumentHolder], in
  * which the initializer is treated as the first (and only) argument.
  */
-interface HasInitializer : HasType, ArgumentHolder, AssignmentHolder {
+interface HasInitializer : HasScope, HasType, ArgumentHolder, AssignmentHolder {
 
     var initializer: Expression?
 
@@ -104,38 +126,16 @@ interface HasInitializer : HasType, ArgumentHolder, AssignmentHolder {
  * Some nodes have aliases, i.e., it potentially references another variable. This means that
  * writing to this node, also writes to its [aliases] and vice-versa.
  */
-interface HasAliases {
+interface HasAliases : HasScope {
     /** The aliases which this node has. */
     var aliases: MutableSet<HasAliases>
-}
-
-/** A simple interface that a node has [language]. */
-interface HasLanguage {
-
-    var language: Language<*>?
-}
-
-/** A simple interface that a node has [name] and [location]. */
-interface HasNameAndLocation {
-
-    val name: Name
-
-    /** Location of the finding in source code. */
-    val location: PhysicalLocation?
-}
-
-/** A simple interface that a node has [scope]. */
-interface HasScope {
-
-    /** The scope this node lives in. */
-    val scope: Scope?
 }
 
 /**
  * Specifies that this node (e.g. a [BinaryOperator] contains an operation that can be overloaded by
  * an [OperatorDeclaration].
  */
-interface HasOverloadedOperation : HasLanguage, HasOperatorCode, HasNameAndLocation {
+interface HasOverloadedOperation : HasOperatorCode {
 
     /**
      * Arguments forwarded to the operator. This might not necessarily be all of the regular

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/StatementHolder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/StatementHolder.kt
@@ -50,6 +50,10 @@ interface StatementHolder : Holder<Statement> {
      */
     var statements: MutableList<Statement>
 
+    override fun replace(old: Statement, new: Statement): Boolean {
+        return statementEdges.replace(old, new)
+    }
+
     override operator fun plusAssign(node: Statement) {
         statementEdges += node
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/OperatorDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/OperatorDeclaration.kt
@@ -27,8 +27,6 @@ package de.fraunhofer.aisec.cpg.graph.declarations
 
 import de.fraunhofer.aisec.cpg.frontends.HasOperatorOverloading
 import de.fraunhofer.aisec.cpg.graph.HasOperatorCode
-import de.fraunhofer.aisec.cpg.graph.LanguageProvider
-import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.types.ObjectType
 
 /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/OperatorDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/OperatorDeclaration.kt
@@ -27,6 +27,8 @@ package de.fraunhofer.aisec.cpg.graph.declarations
 
 import de.fraunhofer.aisec.cpg.frontends.HasOperatorOverloading
 import de.fraunhofer.aisec.cpg.graph.HasOperatorCode
+import de.fraunhofer.aisec.cpg.graph.LanguageProvider
+import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.types.ObjectType
 
 /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeList.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeList.kt
@@ -82,6 +82,16 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
         return ok
     }
 
+    fun replace(old: NodeType, new: NodeType): Boolean {
+        val idx = this.indexOfFirst { it.end == old }
+        if (idx != -1) {
+            this[idx] = init(thisRef, new)
+            return true
+        }
+
+        return false
+    }
+
     override fun clear() {
         // Make a copy of our edges so we can pass a copy to our on-remove handler
         val edges = this.toList()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeList.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeList.kt
@@ -82,6 +82,7 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
         return ok
     }
 
+    /** Replaces the first occurrence of an edge with [old] with a new edge to [new]. */
     fun replace(old: NodeType, new: NodeType): Boolean {
         val idx = this.indexOfFirst { it.end == old }
         if (idx != -1) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/BinaryOperator.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/BinaryOperator.kt
@@ -113,7 +113,7 @@ open class BinaryOperator :
         get() = listOf(rhs)
 
     /** The binary operator operators on the [lhs]. [rhs] is part of the [operatorArguments]. */
-    override val operatorBase: HasType
+    override val operatorBase: Expression
         get() = lhs
 
     override fun equals(other: Any?): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
@@ -263,7 +263,7 @@ open class CallExpression :
      * is overloaded. In this case we want the [operatorBase] to point to [callee], so we can take
      * its type to lookup the necessary [OperatorDeclaration].
      */
-    override val operatorBase: HasType
+    override val operatorBase: Expression
         get() = callee
 
     override fun equals(other: Any?): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/MemberExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/MemberExpression.kt
@@ -60,7 +60,7 @@ class MemberExpression : Reference(), HasOverloadedOperation, ArgumentHolder, Ha
     override val operatorArguments: List<Expression>
         get() = listOf()
 
-    override val operatorBase: HasType
+    override val operatorBase: Expression
         get() = base
 
     override fun toString(): String {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/OperatorCallExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/OperatorCallExpression.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.graph.statements.expressions
+
+import de.fraunhofer.aisec.cpg.graph.HasBase
+import de.fraunhofer.aisec.cpg.graph.HasOperatorCode
+import de.fraunhofer.aisec.cpg.graph.Name
+import de.fraunhofer.aisec.cpg.graph.declarations.OperatorDeclaration
+
+/**
+ * This special call expression is used when an operator (such as a [BinaryOperator]) is overloaded.
+ * In this case, we replace the original [BinaryOperator] with an [OperatorCallExpression], which
+ * points to its respective [OperatorDeclaration].
+ */
+class OperatorCallExpression : CallExpression(), HasOperatorCode, HasBase {
+
+    override var operatorCode: String? = null
+
+    override var name: Name
+        get() = Name(operatorCode ?: "")
+        set(_) {
+            // read-only
+        }
+
+    /**
+     * The base object. This is basically a shortcut to accessing the base of the [callee], if it
+     * has one (i.e., if it implements [HasBase]). This is the case for example, if it is a
+     * [MemberExpression].
+     */
+    override val base: Expression?
+        get() {
+            return (callee as? HasBase)?.base
+        }
+}

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/OperatorCallExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/OperatorCallExpression.kt
@@ -25,9 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.graph.statements.expressions
 
-import de.fraunhofer.aisec.cpg.graph.HasBase
-import de.fraunhofer.aisec.cpg.graph.HasOperatorCode
-import de.fraunhofer.aisec.cpg.graph.Name
+import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.OperatorDeclaration
 
 /**
@@ -54,4 +52,25 @@ class OperatorCallExpression : CallExpression(), HasOperatorCode, HasBase {
         get() {
             return (callee as? HasBase)?.base
         }
+}
+
+/**
+ * Creates a new [OperatorCallExpression] to a [OperatorDeclaration] and also sets the
+ * appropriate fields such as [CallExpression.invokes] and [Reference.refersTo].
+ */
+fun operatorCallFromDeclaration(
+    decl: OperatorDeclaration,
+    op: HasOverloadedOperation
+): OperatorCallExpression {
+    return with(decl) {
+        val ref =
+            newMemberExpression(decl.name, op.operatorBase, operatorCode = ".")
+                .implicit(decl.name.localName, location = op.location)
+        ref.refersTo = decl
+        val call =
+            newOperatorCallExpression(operatorCode = op.operatorCode ?: "", ref)
+                .codeAndLocationFrom(ref)
+        call.invokes = mutableListOf(decl)
+        call
+    }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/OperatorCallExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/OperatorCallExpression.kt
@@ -55,8 +55,8 @@ class OperatorCallExpression : CallExpression(), HasOperatorCode, HasBase {
 }
 
 /**
- * Creates a new [OperatorCallExpression] to a [OperatorDeclaration] and also sets the
- * appropriate fields such as [CallExpression.invokes] and [Reference.refersTo].
+ * Creates a new [OperatorCallExpression] to a [OperatorDeclaration] and also sets the appropriate
+ * fields such as [CallExpression.invokes] and [Reference.refersTo].
  */
 fun operatorCallFromDeclaration(
     decl: OperatorDeclaration,

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/UnaryOperator.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/UnaryOperator.kt
@@ -57,7 +57,8 @@ class UnaryOperator : Expression(), HasOverloadedOperation, ArgumentHolder, HasT
         get() = listOf()
 
     /** The unary operator operates on [input]. */
-    override val operatorBase = input
+    override val operatorBase
+        get() = input
 
     /** The operator code. */
     override var operatorCode: String? = null

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveCallExpressionAmbiguityPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveCallExpressionAmbiguityPass.kt
@@ -39,6 +39,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.ObjectType
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
+import de.fraunhofer.aisec.cpg.helpers.replace
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
 import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
 import de.fraunhofer.aisec.cpg.passes.configuration.RequiresLanguageTrait
@@ -170,7 +171,7 @@ fun SubgraphWalker.ScopedWalker.replaceCallWithCast(
     cast.expression = call.arguments.single()
     cast.name = cast.castType.name
 
-    replaceArgument(parent, call, cast)
+    replace(parent, call, cast)
 }
 
 context(ContextProvider)
@@ -188,27 +189,5 @@ fun SubgraphWalker.ScopedWalker.replaceCallWithConstruct(
     construct.arguments = call.arguments
     construct.type = type
 
-    replaceArgument(parent, call, construct)
-}
-
-context(ContextProvider)
-fun SubgraphWalker.ScopedWalker.replaceArgument(parent: Node?, old: Expression, new: Expression) {
-    if (parent !is ArgumentHolder) {
-        Pass.log.error(
-            "Parent AST node of call expression is not an argument holder. Cannot convert to cast expression. Further analysis might not be entirely accurate."
-        )
-        return
-    }
-
-    val success = parent.replaceArgument(old, new)
-    if (!success) {
-        Pass.log.error(
-            "Replacing expression $old was not successful. Further analysis might not be entirely accurate."
-        )
-    } else {
-        old.disconnectFromGraph()
-
-        // Make sure to inform the walker about our change
-        this.registerReplacement(old, new)
-    }
+    replace(parent, call, construct)
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -416,27 +416,6 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         }
     }
 
-    /**
-     * Creates a new [OperatorCallExpression] to a [OperatorDeclaration] and also sets the
-     * appropriate fields such as [CallExpression.invokes] and [Reference.refersTo].
-     */
-    private fun operatorCallFromDeclaration(
-        decl: OperatorDeclaration,
-        op: HasOverloadedOperation
-    ): OperatorCallExpression {
-        return with(decl) {
-            val ref =
-                newMemberExpression(decl.name, op.operatorBase, operatorCode = ".")
-                    .implicit(decl.name.localName, location = op.location)
-            ref.refersTo = decl
-            val call =
-                newOperatorCallExpression(operatorCode = op.operatorCode ?: "", ref)
-                    .codeAndLocationFrom(ref)
-            call.invokes = mutableListOf(decl)
-            call
-        }
-    }
-
     // TODO(oxisto): Move to inference class
     protected fun handleUnknownField(base: Type, ref: Reference): FieldDeclaration? {
         val name = ref.name

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CLanguage.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CLanguage.kt
@@ -27,7 +27,6 @@ package de.fraunhofer.aisec.cpg.frontends.cxx
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import de.fraunhofer.aisec.cpg.frontends.*
-import de.fraunhofer.aisec.cpg.graph.declarations.ParameterDeclaration
 import de.fraunhofer.aisec.cpg.graph.types.*
 import kotlin.reflect.KClass
 import org.neo4j.ogm.annotation.Transient
@@ -128,18 +127,6 @@ open class CLanguage :
         // interchangeable
         if (type.root == targetType.root && type is PointerType && targetType is PointerType) {
             return ImplicitCast
-        }
-
-        // Another special rule is that if we have a const reference (e.g. const T&) in a function
-        // call, this will match the type T because this means that the parameter is given by
-        // reference rather than by value.
-        if (
-            targetType is ReferenceType &&
-                targetType.elementType == type &&
-                targetHint is ParameterDeclaration &&
-                CONST in targetHint.modifiers
-        ) {
-            return DirectMatch
         }
 
         return CastNotPossible

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CPPLanguage.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CPPLanguage.kt
@@ -25,11 +25,14 @@
  */
 package de.fraunhofer.aisec.cpg.frontends.cxx
 
+import de.fraunhofer.aisec.cpg.CallResolutionResult
+import de.fraunhofer.aisec.cpg.SignatureMatches
 import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.*
 import de.fraunhofer.aisec.cpg.graph.HasOverloadedOperation
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.*
+import de.fraunhofer.aisec.cpg.graph.primitiveType
 import de.fraunhofer.aisec.cpg.graph.scopes.Symbol
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.BinaryOperator
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
@@ -37,6 +40,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberCallExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.UnaryOperator
 import de.fraunhofer.aisec.cpg.graph.types.*
+import de.fraunhofer.aisec.cpg.matchesSignature
 import de.fraunhofer.aisec.cpg.passes.*
 import de.fraunhofer.aisec.cpg.passes.inference.startInference
 import kotlin.reflect.KClass
@@ -170,6 +174,17 @@ open class CPPLanguage :
             return match
         }
 
+        // Another special rule is that if we have a (const) reference (e.g. const T&) in a function
+        // call, this will match the type T because this means that the parameter is given by
+        // reference rather than by value.
+        if (
+            targetType is ReferenceType &&
+                targetType.elementType == type &&
+                targetHint is ParameterDeclaration
+        ) {
+            return DirectMatch
+        }
+
         // In C++, it is possible to have conversion constructors. We will not have full support for
         // them yet, but at least we should have some common cases here, such as const char* to
         // std::string
@@ -182,6 +197,29 @@ open class CPPLanguage :
         }
 
         return CastNotPossible
+    }
+
+    override fun bestViableResolution(
+        result: CallResolutionResult
+    ): Pair<Set<FunctionDeclaration>, CallResolutionResult.SuccessKind> {
+        // There is a sort of weird workaround in C++ to select a prefix vs. postfix operator for
+        // increment and decrement operators. See
+        // https://en.cppreference.com/w/cpp/language/operator_incdec. If it is a postfix, we need
+        // to match for a function with a fake "int" parameter
+        val expr = result.source
+        if (
+            expr is UnaryOperator &&
+                (expr.operatorCode == "++" || expr.operatorCode == "--") &&
+                expr.isPostfix
+        ) {
+            result.signatureResults =
+                result.candidateFunctions
+                    .map { Pair(it, it.matchesSignature(listOf(primitiveType("int")))) }
+                    .filter { it.second is SignatureMatches }
+                    .associate { it }
+        }
+
+        return super.bestViableResolution(result)
     }
 
     override val startCharacter = '<'

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclaratorHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclaratorHandler.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.frontends.cxx
 
 import de.fraunhofer.aisec.cpg.ResolveInFrontend
 import de.fraunhofer.aisec.cpg.frontends.HasOperatorOverloading
+import de.fraunhofer.aisec.cpg.frontends.isKnownOperatorName
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.scopes.NameScope
@@ -509,17 +510,6 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
             frontend.declarationHandler.handle(member)
         }
     }
-
-    /** Checks whether the [Name] for a function is a known operator name. */
-    private val Name.isKnownOperatorName: Boolean
-        get() {
-            val language = language
-            if (language !is HasOperatorOverloading) {
-                return false
-            }
-
-            return language.overloadedOperatorNames.containsValue(this.localName)
-        }
 }
 
 /**

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclaratorHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclaratorHandler.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.frontends.cxx
 
 import de.fraunhofer.aisec.cpg.ResolveInFrontend
-import de.fraunhofer.aisec.cpg.frontends.HasOperatorOverloading
 import de.fraunhofer.aisec.cpg.frontends.isKnownOperatorName
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.*

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclaratorHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclaratorHandler.kt
@@ -171,7 +171,7 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
                 // Check if it's an operator
                 name.isKnownOperatorName -> {
                     // retrieve the operator code
-                    var operatorCode = name.localName.drop("operator".length)
+                    val operatorCode = name.localName.drop("operator".length)
                     newOperatorDeclaration(name, operatorCode, rawNode = ctx)
                 }
                 // Check, if it's a constructor. This is the case if the local names of the function
@@ -511,9 +511,9 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
     }
 
     /** Checks whether the [Name] for a function is a known operator name. */
-    val Name.isKnownOperatorName: Boolean
+    private val Name.isKnownOperatorName: Boolean
         get() {
-            var language = language
+            val language = language
             if (language !is HasOperatorOverloading) {
                 return false
             }

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CXXExtraPass.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CXXExtraPass.kt
@@ -35,6 +35,7 @@ import de.fraunhofer.aisec.cpg.graph.scopes.ValueDeclarationScope
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.recordDeclaration
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
+import de.fraunhofer.aisec.cpg.helpers.replace
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
 import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
 

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CXXExtraPass.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CXXExtraPass.kt
@@ -83,7 +83,7 @@ class CXXExtraPass(ctx: TranslationContext) : ComponentPass(ctx) {
             // In theory, we could just keep this meaningless unary expression, but it in order
             // to reduce nodes, we unwrap the reference and exchange it in the arguments of the
             // binary op
-            walker.replaceArgument(parent, node, node.input)
+            walker.replace(parent, node, node.input)
         }
     }
 
@@ -144,7 +144,7 @@ class CXXExtraPass(ctx: TranslationContext) : ComponentPass(ctx) {
 
             // * replace the binary operator with the cast expression in the parent argument
             //   holder
-            walker.replaceArgument(parent, binOp, cast)
+            walker.replace(parent, binOp, cast)
         }
     }
 

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXDeclarationTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXDeclarationTest.kt
@@ -29,6 +29,7 @@ import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.ReturnStatement
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Block
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.OperatorCallExpression
 import de.fraunhofer.aisec.cpg.graph.types.FunctionPointerType
 import de.fraunhofer.aisec.cpg.test.*
 import java.io.File
@@ -242,8 +243,67 @@ class CXXDeclarationTest {
             }
         assertNotNull(result)
 
-        var plusplus = result.operators["operator++"]
+        val integer = result.records["Integer"]
+        assertNotNull(integer)
+
+        val plusplus = integer.operators["operator++"]
         assertNotNull(plusplus)
         assertEquals("++", plusplus.operatorCode)
+
+        val plus = integer.operators("operator+")
+        assertEquals(2, plus.size)
+        assertEquals("+", plus.map { it.operatorCode }.distinct().singleOrNull())
+
+        val main = result.functions["main"]
+        assertNotNull(main)
+
+        val unaryOp = main.operatorCalls["++"]
+        assertNotNull(unaryOp)
+        assertInvokes(unaryOp, plusplus)
+
+        val binaryOp0 = main.operatorCalls("+").getOrNull(0)
+        assertNotNull(binaryOp0)
+        assertInvokes(binaryOp0, plus.getOrNull(0))
+
+        val binaryOp1 = main.operatorCalls("+").getOrNull(1)
+        assertNotNull(binaryOp1)
+        assertInvokes(binaryOp1, plus.getOrNull(1))
+    }
+
+    @Test
+    fun testMemberAccessOperator() {
+        val file = File("src/test/resources/cxx/operators/member_access.cpp")
+        val result =
+            analyze(listOf(file), file.parentFile.toPath(), true) {
+                it.registerLanguage<CPPLanguage>()
+            }
+        assertNotNull(result)
+
+        var proxy = result.records["Proxy"]
+        assertNotNull(proxy)
+
+        var op = proxy.operators["operator->"]
+        assertNotNull(op)
+
+        var data = result.records["Data"]
+        assertNotNull(data)
+
+        var size = data.fields["size"]
+        assertNotNull(size)
+
+        val p = result.refs["p"]
+        assertNotNull(p)
+        assertEquals(proxy.toType(), p.type)
+
+        var sizeRef = result.memberExpressions["size"]
+        assertNotNull(sizeRef)
+        assertRefersTo(sizeRef, size)
+
+        // we should now have an implicit call to our operator in-between "p" and "size"
+        val opCall = sizeRef.base
+        assertNotNull(opCall)
+        assertIs<OperatorCallExpression>(opCall)
+        assertEquals(p, opCall.base)
+        assertInvokes(opCall, op)
     }
 }

--- a/cpg-language-cxx/src/test/resources/calls/cxxprioresolution/methodresolution/overloadnoresolution.cpp
+++ b/cpg-language-cxx/src/test/resources/calls/cxxprioresolution/methodresolution/overloadnoresolution.cpp
@@ -19,6 +19,6 @@ public:
 int main()
 {
     Overloaded overload;
-    cout << overload.calc(1) << '\n';
+    overload.calc(1);
     return 0;
 }

--- a/cpg-language-cxx/src/test/resources/cxx/operators/member_access.cpp
+++ b/cpg-language-cxx/src/test/resources/cxx/operators/member_access.cpp
@@ -1,0 +1,24 @@
+class Data {
+public:
+    int size;
+};
+
+class Proxy {
+public:
+    Proxy() {
+        this->data = new Data();
+    }
+
+    Data* operator->() {
+        return data;
+    }
+
+    Data* data;
+};
+
+int main() {
+    Proxy p;
+    int size = p->size;
+
+    // int another_size = p.operator->()->size;
+}

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguage.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguage.kt
@@ -39,7 +39,6 @@ import org.neo4j.ogm.annotation.Transient
 /** The Java language. */
 open class JavaLanguage :
     Language<JavaLanguageFrontend>(),
-    // HasComplexCallResolution,
     HasClasses,
     HasSuperClasses,
     HasGenerics,

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
@@ -156,16 +156,16 @@ class PythonLanguageFrontend(language: Language<PythonLanguageFrontend>, ctx: Tr
                         // TODO: This might create problem with nested classes
                         parseName(id)
                     } else {
-                        // If it is not, we want place it in the current namespace
-                        scopeManager.currentNamespace.fqn(id)
+                        // otherwise, we can just simply take the unqualified name and the type
+                        // resolver will take care of the rest
+                        id
                     }
 
                 objectType(name)
             }
             else -> {
                 // The AST supplied us with some kind of type information, but we could not parse
-                // it, so we
-                // need to return the unknown type.
+                // it, so we need to return the unknown type.
                 unknownType()
             }
         }

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
@@ -25,6 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.frontends.python
 
+import de.fraunhofer.aisec.cpg.frontends.HasOperatorOverloading
+import de.fraunhofer.aisec.cpg.frontends.isKnownOperatorName
 import de.fraunhofer.aisec.cpg.frontends.python.Python.AST.IsAsync
 import de.fraunhofer.aisec.cpg.frontends.python.PythonLanguage.Companion.MODIFIER_POSITIONAL_ONLY_ARGUMENT
 import de.fraunhofer.aisec.cpg.graph.*
@@ -294,6 +296,19 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
                     newConstructorDeclaration(
                         name = s.name,
                         recordDeclaration = recordDeclaration,
+                        rawNode = s
+                    )
+                } else if (s.name.isKnownOperatorName) {
+                    newOperatorDeclaration(
+                        name = s.name,
+                        recordDeclaration = recordDeclaration,
+                        operatorCode =
+                            (language as HasOperatorOverloading)
+                                .overloadedOperatorNames
+                                .filterValues { it == s.name }
+                                .keys
+                                .firstOrNull()
+                                ?.second ?: "",
                         rawNode = s
                     )
                 } else {

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
@@ -290,6 +290,7 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
         s: Python.AST.NormalOrAsyncFunctionDef,
         recordDeclaration: RecordDeclaration? = null
     ): DeclarationStatement {
+        val language = language
         val result =
             if (recordDeclaration != null) {
                 if (s.name == "__init__") {
@@ -298,17 +299,11 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
                         recordDeclaration = recordDeclaration,
                         rawNode = s
                     )
-                } else if (s.name.isKnownOperatorName) {
+                } else if (language is HasOperatorOverloading && s.name.isKnownOperatorName) {
                     newOperatorDeclaration(
                         name = s.name,
                         recordDeclaration = recordDeclaration,
-                        operatorCode =
-                            (language as HasOperatorOverloading)
-                                .overloadedOperatorNames
-                                .filterValues { it == s.name }
-                                .keys
-                                .firstOrNull()
-                                ?.second ?: "",
+                        operatorCode = language.operatorCodeFor(s.name) ?: "",
                         rawNode = s
                     )
                 } else {

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
@@ -39,6 +39,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.ProblemExpression
 import de.fraunhofer.aisec.cpg.graph.types.FunctionType
+import de.fraunhofer.aisec.cpg.helpers.Util
 import kotlin.collections.plusAssign
 
 class StatementHandler(frontend: PythonLanguageFrontend) :
@@ -300,12 +301,22 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
                         rawNode = s
                     )
                 } else if (language is HasOperatorOverloading && s.name.isKnownOperatorName) {
-                    newOperatorDeclaration(
-                        name = s.name,
-                        recordDeclaration = recordDeclaration,
-                        operatorCode = language.operatorCodeFor(s.name) ?: "",
-                        rawNode = s
-                    )
+                    var decl =
+                        newOperatorDeclaration(
+                            name = s.name,
+                            recordDeclaration = recordDeclaration,
+                            operatorCode = language.operatorCodeFor(s.name) ?: "",
+                            rawNode = s
+                        )
+                    if (decl.operatorCode == "") {
+                        Util.warnWithFileLocation(
+                            decl,
+                            log,
+                            "Could not find operator code for operator {}. This will most likely result in a failure",
+                            s.name
+                        )
+                    }
+                    decl
                 } else {
                     newMethodDeclaration(
                         name = s.name,

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
@@ -439,6 +439,35 @@ class PythonFrontendTest : BaseTest() {
     }
 
     @Test
+    fun testClassTypeAnnotations() {
+        val topLevel = Path.of("src", "test", "resources", "python")
+        val tu =
+            analyzeAndGetFirstTU(
+                listOf(topLevel.resolve("class_type_annotations.py").toFile()),
+                topLevel,
+                true
+            ) {
+                it.registerLanguage<PythonLanguage>()
+            }
+        assertNotNull(tu)
+
+        val other = tu.records["Other"]
+        assertNotNull(other)
+        assertFullName("class_type_annotations.Other", other.toType())
+
+        val foo = tu.records["Foo"]
+        assertNotNull(foo)
+        assertFullName("class_type_annotations.Foo", foo.toType())
+
+        val fromOther = tu.functions["from_other"]
+        assertNotNull(fromOther)
+
+        val paramType = fromOther.parameters.firstOrNull()?.type
+        assertNotNull(paramType)
+        assertEquals(other.toType(), paramType)
+    }
+
+    @Test
     fun testCtor() {
         val topLevel = Path.of("src", "test", "resources", "python")
         val tu =

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandlerTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandlerTest.kt
@@ -116,15 +116,25 @@ class StatementHandlerTest {
 
         with(result) {
             val numberType = assertResolvedType("operator.Number")
+            val strType = assertResolvedType("str")
 
             // we should have an operator call to __add__ (+) now
-            val opCall = result.operatorCalls["+"]
+            var opCall = result.operatorCalls("+").getOrNull(0)
             assertNotNull(opCall)
             assertEquals(numberType, opCall.type)
 
             val add = result.operators["__add__"]
             assertNotNull(add)
             assertEquals(add, opCall.invokes.singleOrNull())
+
+            // ... and one to __pos__ (+)
+            opCall = result.operatorCalls("+").getOrNull(1)
+            assertNotNull(opCall)
+            assertEquals(strType, opCall.type)
+
+            val pos = result.operators["__pos__"]
+            assertNotNull(pos)
+            assertEquals(pos, opCall.invokes.singleOrNull())
         }
     }
 }

--- a/cpg-language-python/src/test/resources/python/class_type_annotations.py
+++ b/cpg-language-python/src/test/resources/python/class_type_annotations.py
@@ -1,0 +1,8 @@
+class Other:
+    j: int
+
+class Foo:
+    i: int
+
+    def from_other(self, other: Other):
+        self.i = other.j

--- a/cpg-language-python/src/test/resources/python/operator.py
+++ b/cpg-language-python/src/test/resources/python/operator.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+
+class Number:
+    i: int
+
+    def __init__(self, i):
+        self.i = i
+
+    def __add__(self, other: Number) -> Number:
+        return Number(self.i + other.i)
+
+
+def main():
+    a = Number(5)
+    b = Number(10)
+    c = a + b
+    print(c)
+
+
+if __name__ == "__main__":
+    main()

--- a/cpg-language-python/src/test/resources/python/operator.py
+++ b/cpg-language-python/src/test/resources/python/operator.py
@@ -10,12 +10,22 @@ class Number:
     def __add__(self, other: Number) -> Number:
         return Number(self.i + other.i)
 
+    def __pos__(self) -> str:
+        return "python is quite crazy"
+
 
 def main():
     a = Number(5)
     b = Number(10)
     c = a + b
     print(c)
+
+    d = +b
+    print(d)
+
+    # the following unfortunately does not work yet because the types of a and b does not seem to propagate to c
+    # currently yet.
+    d = +c
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds basic functionality for resolving operator overloading for languages that support it (via the trait `HasOperatorOverloading` - which is currently python and C++). The respective frontend looks for function declarations that match entries in `overloadedOperatorNames` and creates an `OperatorDeclaration`.

The `SymbolResolver` is then looking for specific expressions (that implement `HasOverloadedOperation`) to see whether the expression is really an overloaded call to an operator declaration. In this case, the expression is **replaced** with an `OperatorCallExpression`, pointing to the respective  `OperatorDeclaration`. This happens only if a declaration was found, currently, no `OperatorDeclaration` is inferred. This might be something for the future.

Currently the following nodes support `HasOverloadedOperation` and should work:
- `BinaryOperator`: Tested in C++ and Python
- `UnaryOperator`: Tested in C++ and Python
- `MemberExpression`: Only really possible in C++, also tested in C++. This is basically the main trick behind every smart pointer framework by overriding the `->` operator.
- `CallExpression`: Not tested

There are probably more expressions, such as array indices, etc. that currently do not implement `HasOverloadedOperation` yet.

This PR depends on the following PRs which need to be resolved first:

- [x] #1605 
- [x] #1607 
- [x] #1608 
- [x] #1646
- [x] #1684 