### PR TITLE
Fix console neo4j login params

### DIFF
--- a/cpg-console/build.gradle.kts
+++ b/cpg-console/build.gradle.kts
@@ -42,6 +42,7 @@ publishing {
 
 application {
     mainClass.set("de.fraunhofer.aisec.cpg.console.CpgConsole")
+    applicationDefaultJvmArgs = listOf("-Xss515m", "-Xmx8g")
 }
 
 repositories {

--- a/cpg-console/src/main/kotlin/de/fraunhofer/aisec/cpg/console/Neo4jPlugin.kt
+++ b/cpg-console/src/main/kotlin/de/fraunhofer/aisec/cpg/console/Neo4jPlugin.kt
@@ -54,8 +54,8 @@ class Neo4jPlugin : Plugin {
 
             if (input.size == 4) {
                 // configure neo4j username and password
-                commands += "neo4j.neo4jPassword = ${input[2]}"
-                commands += "neo4j.neo4jUsername = ${input[3]}"
+                commands += "neo4j.neo4jUsername = \"${input[2]}\""
+                commands += "neo4j.neo4jPassword = \"${input[3]}\""
             }
 
             commands += "neo4j.pushToNeo4j(result)"


### PR DESCRIPTION
There has been two errors in the neo4j export form the cpg-console.
I also propose to use the same JVM settings as in the neo4j app.

Additionally, I noticed, that the neo4j Application, which is utilized for this purpose, has a hard coded `exit(1)` in case of a login error, which also exits the console. I will fix this later on.