### PR TITLE
Fixed crash in `CXXExtraPass::convertOperators`

### DIFF
--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CXXExtraPass.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CXXExtraPass.kt
@@ -116,7 +116,7 @@ class CXXExtraPass(ctx: TranslationContext) : ComponentPass(ctx) {
             //   referred to in the op.
             val cast = newCastExpression().codeAndLocationFrom(fakeUnaryOp)
             cast.language = language
-            cast.castType = language.objectType(fakeUnaryOp.input.name)
+            cast.castType = fakeUnaryOp.objectType(fakeUnaryOp.input.name)
 
             // * create a unary operator with the rhs of the binary operator (and the same
             //   operator code).

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
@@ -1740,4 +1740,22 @@ internal class CXXLanguageFrontendTest : BaseTest() {
         val test = result.functions["test"]
         assertNotNull(test)
     }
+
+    @Test
+    @Throws(Exception::class)
+    fun testCastToInferredType() {
+        val file = File("src/test/resources/c/cast_to_inferred.c")
+        val tu =
+            analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
+                it.registerLanguage<CLanguage>()
+            }
+        assertNotNull(tu)
+
+        val assign = tu.assigns.firstOrNull()
+        assertNotNull(assign)
+
+        val cast = assign.rhs.singleOrNull()
+        assertIs<CastExpression>(cast)
+        assertLocalName("mytype", cast.castType)
+    }
 }

--- a/cpg-language-cxx/src/test/resources/c/cast_to_inferred.c
+++ b/cpg-language-cxx/src/test/resources/c/cast_to_inferred.c
@@ -1,0 +1,6 @@
+int foo(const mytype *p)
+{
+	mytype *v;
+	*v = (mytype)*p;
+	return 0;
+}


### PR DESCRIPTION
This is more a band-aid, than an actually "healing". The issue is that we often use the `language` to get a translation context in passes. But (sometimes) the language does not have it, since it is created using `registerLanguage` even before a translation context exists.

In an attempted fix, I am now using the translation context of a different node, but we should really think about how to deal with that in the future.

Fixes #1617
