### PR TITLE
Workaround to use `astParent` in DFG passes

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
@@ -508,6 +508,7 @@ private constructor(
             registerPass<ControlFlowSensitiveDFGPass>()
             registerPass<FilenameMapper>()
             registerPass<ReplaceCallCastPass>()
+            registerPass<EdgeCachePass>()
             useDefaultPasses = true
             return this
         }


### PR DESCRIPTION
This workaround removes the DFG/EOG nodes from the `EdgeCachPass`, which will now only cache AST nodes. In the future we want to get rid of this pass alltogether.
