### PR TITLE
Handling varargs in Python

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
@@ -141,10 +141,10 @@ fun MetadataProvider.newConstructorDeclaration(
 }
 
 /**
- * Creates a new [MethodDeclaration]. The [MetadataProvider] receiver will be used to fill different
- * meta-data using [Node.applyMetadata]. Calling this extension function outside of Kotlin requires
- * an appropriate [MetadataProvider], such as a [LanguageFrontend] as an additional prepended
- * argument.
+ * Creates a new [ParameterDeclaration]. The [MetadataProvider] receiver will be used to fill
+ * different meta-data using [Node.applyMetadata]. Calling this extension function outside of Kotlin
+ * requires an appropriate [MetadataProvider], such as a [LanguageFrontend] as an additional
+ * prepended argument.
  */
 @JvmOverloads
 fun MetadataProvider.newParameterDeclaration(
@@ -158,6 +158,7 @@ fun MetadataProvider.newParameterDeclaration(
 
     node.type = type
     node.isVariadic = variadic
+    // Möglicherweise ist vararg oder nicht.
 
     log(node)
     return node

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
@@ -158,7 +158,6 @@ fun MetadataProvider.newParameterDeclaration(
 
     node.type = type
     node.isVariadic = variadic
-    // Möglicherweise ist vararg oder nicht.
 
     log(node)
     return node

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
@@ -393,7 +393,6 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
         // enforce that posonlyargs can ONLY be used in a positional style, whereas args can be used
         // both in positional as well as keyword style.
         var positionalArguments = args.posonlyargs + args.args
-
         // Handle arguments
         if (recordDeclaration != null) {
             // first argument is the `receiver`
@@ -435,15 +434,7 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
             }
         }
 
-        args.vararg?.let {
-            val problem =
-                newProblemDeclaration(
-                    "`vararg` is not yet supported",
-                    problemType = ProblemNode.ProblemType.TRANSLATION,
-                    rawNode = it
-                )
-            frontend.scopeManager.addDeclaration(problem)
-        }
+        args.vararg?.let { handleArgument(it, isPosOnly = false, isVariadic = true) }
 
         if (args.kwonlyargs.isNotEmpty()) {
             val problem =
@@ -556,9 +547,19 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
         return result
     }
 
-    internal fun handleArgument(node: Python.ASTarg, isPosOnly: Boolean = false) {
+    internal fun handleArgument(
+        node: Python.ASTarg,
+        isPosOnly: Boolean = false,
+        isVariadic: Boolean = false
+    ) {
         val type = frontend.typeOf(node.annotation)
-        val arg = newParameterDeclaration(name = node.arg, type = type, rawNode = node)
+        val arg =
+            newParameterDeclaration(
+                name = node.arg,
+                type = type,
+                variadic = isVariadic,
+                rawNode = node
+            )
         if (isPosOnly) {
             arg.modifiers += MODIFIER_POSITIONAL_ONLY_ARGUMENT
         }

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandlerTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandlerTest.kt
@@ -69,4 +69,21 @@ class StatementHandlerTest {
             assertEquals(idx, param.index)
         }
     }
+
+    @Test
+    fun testVarargsArguments() {
+        val topLevel = Path.of("src", "test", "resources", "python")
+        val file = topLevel.resolve("varargs.py").toFile()
+
+        val result = analyze(listOf(file), topLevel, true) { it.registerLanguage<PythonLanguage>() }
+
+        assertNotNull(result)
+
+        val func = result.functions["test_varargs"]
+        assertNotNull(func, "Function 'test_varargs' should be found")
+
+        val variadicArg = func.parameters["args"]
+        assertNotNull(variadicArg, "Failed to find variadic argc")
+        assertEquals(true, variadicArg.isVariadic)
+    }
 }

--- a/cpg-language-python/src/test/resources/python/varargs.py
+++ b/cpg-language-python/src/test/resources/python/varargs.py
@@ -1,0 +1,2 @@
+def test_varargs(*args):
+    return args


### PR DESCRIPTION
Implements `vararg` support for python. This partially fixes #1653.