### PR TITLE
Introducing `DynamicType` and removing usage of `AutoType` from python

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
@@ -241,20 +241,27 @@ abstract class Language<T : LanguageFrontend<*, *>>() : Node() {
     open fun shouldPropagateType(hasType: HasType, srcType: Type): Boolean {
         val nodeType = hasType.type
 
-        // We only want to add certain types, in case we have a numeric type
-        if (nodeType is NumericType) {
-            // We do not allow to propagate non-numeric types into numeric types
-            return if (srcType !is NumericType) {
+        return when {
+            // We only want to add certain types, in case we have a numeric type
+            nodeType is NumericType -> {
+                // We do not allow to propagate non-numeric types into numeric types
+                if (srcType !is NumericType) {
+                    false
+                } else {
+                    val srcWidth = srcType.bitWidth
+                    val lhsWidth = nodeType.bitWidth
+                    // Do not propagate anything if the new type is too big for the current type.
+                    return !(lhsWidth != null && srcWidth != null && lhsWidth < srcWidth)
+                }
+            }
+            // We do not want to propagate a dynamic type
+            srcType is DynamicType -> {
                 false
-            } else {
-                val srcWidth = srcType.bitWidth
-                val lhsWidth = nodeType.bitWidth
-                // Do not propagate anything if the new type is too big for the current type.
-                return !(lhsWidth != null && srcWidth != null && lhsWidth < srcWidth)
+            }
+            else -> {
+                true
             }
         }
-
-        return true
     }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/TypeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/TypeBuilder.kt
@@ -49,6 +49,10 @@ fun LanguageProvider.incompleteType(): Type {
     return IncompleteType(this.language)
 }
 
+fun LanguageProvider.dynamicType(): Type {
+    return DynamicType(this.language)
+}
+
 /** Returns a [PointerType] that describes an array reference to the current type. */
 fun Type.array(): Type {
     val type = this.reference(PointerType.PointerOrigin.ARRAY)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/FunctionDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/FunctionDeclaration.kt
@@ -49,7 +49,11 @@ import org.neo4j.ogm.annotation.Relationship
 
 /** Represents the declaration or definition of a function. */
 open class FunctionDeclaration :
-    ValueDeclaration(), DeclarationHolder, EOGStarterHolder, HasType.TypeObserver, HasSecondaryTypeEdge {
+    ValueDeclaration(),
+    DeclarationHolder,
+    EOGStarterHolder,
+    HasType.TypeObserver,
+    HasSecondaryTypeEdge {
     @Relationship("BODY") var bodyEdge = astOptionalEdgeOf<Statement>()
     /** The function body. Usually a [Block]. */
     var body by unwrapping(FunctionDeclaration::bodyEdge)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/FunctionDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/FunctionDeclaration.kt
@@ -36,7 +36,11 @@ import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Block
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
+import de.fraunhofer.aisec.cpg.graph.types.DynamicType
+import de.fraunhofer.aisec.cpg.graph.types.FunctionType.Companion.buildSignature
+import de.fraunhofer.aisec.cpg.graph.types.FunctionType.Companion.computeType
 import de.fraunhofer.aisec.cpg.graph.types.HasSecondaryTypeEdge
+import de.fraunhofer.aisec.cpg.graph.types.HasType
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
 import java.util.*
@@ -45,7 +49,7 @@ import org.neo4j.ogm.annotation.Relationship
 
 /** Represents the declaration or definition of a function. */
 open class FunctionDeclaration :
-    ValueDeclaration(), DeclarationHolder, EOGStarterHolder, HasSecondaryTypeEdge {
+    ValueDeclaration(), DeclarationHolder, EOGStarterHolder, HasType.TypeObserver, HasSecondaryTypeEdge {
     @Relationship("BODY") var bodyEdge = astOptionalEdgeOf<Statement>()
     /** The function body. Usually a [Block]. */
     var body by unwrapping(FunctionDeclaration::bodyEdge)
@@ -99,18 +103,7 @@ open class FunctionDeclaration :
     }
 
     val signature: String
-        get() =
-            name.localName +
-                parameters.joinToString(COMMA + WHITESPACE, BRACKET_LEFT, BRACKET_RIGHT) {
-                    it.type.typeName
-                } +
-                (if (returnTypes.size == 1) {
-                    returnTypes.first().typeName
-                } else {
-                    returnTypes.joinToString(COMMA + WHITESPACE, BRACKET_LEFT, BRACKET_RIGHT) {
-                        it.typeName
-                    }
-                })
+        get() = buildSignature(this, returnTypes)
 
     fun isOverrideCandidate(other: FunctionDeclaration): Boolean {
         return other.name.localName == name.localName &&
@@ -204,6 +197,27 @@ open class FunctionDeclaration :
 
     override val secondaryTypes: List<Type>
         get() = returnTypes + throwsTypes + signatureTypes
+
+    override fun typeChanged(newType: Type, src: HasType) {
+        // We cannot really change the "type" of a function declaration, we want to stick to the
+        // assigned type
+    }
+
+    override fun assignedTypeChanged(assignedTypes: Set<Type>, src: HasType) {
+        // We want to propagate the assigned types to the return type of the function and adjust the
+        // function's type accordingly, but we only do this for dynamic types. And we only support
+        // one return type for now.
+        if (returnTypes.singleOrNull() !is DynamicType) {
+            return
+        }
+
+        // Build new function types out of our function declaration and the assigned types
+        var returnFuncTypes =
+            assignedTypes.map { computeType(this, returnTypes = listOf(it)) }.toSet()
+
+        // And assign it us
+        addAssignedTypes(returnFuncTypes)
+    }
 
     companion object {
         const val WHITESPACE = " "

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
@@ -254,7 +254,15 @@ open class CallExpression :
     }
 
     override fun assignedTypeChanged(assignedTypes: Set<Type>, src: HasType) {
-        // Nothing to do
+        // Propagate assigned func types from the function declaration to the call expression
+        val assignedFuncTypes = assignedTypes.filterIsInstance<FunctionType>()
+        assignedFuncTypes.forEach {
+            if (it.returnTypes.size == 1) {
+                addAssignedType(it.returnTypes.single())
+            } else if (it.returnTypes.size > 1) {
+                addAssignedType(TupleType(it.returnTypes))
+            }
+        }
     }
 
     override fun toString(): String {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/DynamicType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/DynamicType.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.frontends.Language
+import de.fraunhofer.aisec.cpg.graph.dynamicType
 
 /**
  * This type represents a [Type] that is dynamically determined at run-time. This is used for a
@@ -33,10 +34,10 @@ import de.fraunhofer.aisec.cpg.frontends.Language
  */
 class DynamicType(override var language: Language<*>) : Type("dynamic", language) {
     override fun reference(pointer: PointerType.PointerOrigin?): Type {
-        throw IllegalArgumentException("Cannot reference a dynamic type")
+        return dynamicType()
     }
 
     override fun dereference(): Type {
-        throw IllegalArgumentException("Cannot dereference a dynamic type")
+        return dynamicType()
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/DynamicType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/DynamicType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Fraunhofer AISEC. All rights reserved.
+ * Copyright (c) 2024, Fraunhofer AISEC. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,28 +26,17 @@
 package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.frontends.Language
-import de.fraunhofer.aisec.cpg.graph.unknownType
 
 /**
- * This type represents a [Type] that uses auto-inference (usually from an initializer) to determine
- * its actual type. It is commonly used in languages that have a special keyword, such as `auto` in
- * C++.
- *
- * Things to consider:
- * 1) This is intentionally a distinct type and not the [UnknownType]. The type is known to the
- *    compiler (or to us) at some point, e.g., after an assignment, but it is not specifically
- *    specified in the source-code.
- * 2) This should not be used to languages that have dynamic types. Once auto-type who was assigned
- *    to [Expression.type] is "resolved", it should be replaced by the actual type that it
- *    represents. Contrary to that, a [DynamicType] can change its internal type representation at
- *    any point, e.g., after the next assignment.
+ * This type represents a [Type] that is dynamically determined at run-time. This is used for a
+ * [Language], which has dynamic runtime typing, such as Python or Java/TypeScript.
  */
-class AutoType(language: Language<*>) : Type("auto", language) {
+class DynamicType(override var language: Language<*>) : Type("dynamic", language) {
     override fun reference(pointer: PointerType.PointerOrigin?): Type {
-        return PointerType(this, pointer)
+        throw IllegalArgumentException("Cannot reference a dynamic type")
     }
 
     override fun dereference(): Type {
-        return unknownType()
+        throw IllegalArgumentException("Cannot dereference a dynamic type")
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionType.kt
@@ -85,6 +85,14 @@ constructor(
             return type
         }
 
+        /**
+         * This helper function builds a function signature out of an existing [FunctionDeclaration]
+         * and potential return types.
+         *
+         * Its main use-case is to have a human-readable representation of the function type. For
+         * example `foo(Bar)string` for a function `foo` with parameter types `Bar` and return type
+         * `string`.
+         */
         fun buildSignature(func: FunctionDeclaration, returnTypes: List<Type>): String =
             func.name.localName +
                 func.parameters.joinToString(COMMA + WHITESPACE, BRACKET_LEFT, BRACKET_RIGHT) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionType.kt
@@ -28,6 +28,10 @@ package de.fraunhofer.aisec.cpg.graph.types
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.ContextProvider
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration.Companion.BRACKET_LEFT
+import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration.Companion.BRACKET_RIGHT
+import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration.Companion.COMMA
+import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration.Companion.WHITESPACE
 import de.fraunhofer.aisec.cpg.graph.unknownType
 
 /**
@@ -67,16 +71,29 @@ constructor(
          * This helper function computes a [FunctionType] out of an existing [FunctionDeclaration].
          */
         @JvmStatic
-        fun ContextProvider.computeType(func: FunctionDeclaration): FunctionType {
+        fun computeType(func: FunctionDeclaration, returnTypes: List<Type> = func.returnTypes.toList()): FunctionType {
             val type =
                 FunctionType(
-                    func.signature,
+                    buildSignature(func, returnTypes),
                     func.parameters.map { it.type },
-                    func.returnTypes.toList(),
+                    returnTypes,
                     func.language,
                 )
 
             return type
         }
+
+        fun buildSignature(func: FunctionDeclaration, returnTypes: List<Type>): String =
+            func.name.localName +
+                func.parameters.joinToString(COMMA + WHITESPACE, BRACKET_LEFT, BRACKET_RIGHT) {
+                    it.type.typeName
+                } +
+                (if (returnTypes.size == 1) {
+                    returnTypes.first().typeName
+                } else {
+                    returnTypes.joinToString(COMMA + WHITESPACE, BRACKET_LEFT, BRACKET_RIGHT) {
+                        it.typeName
+                    }
+                })
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionType.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.frontends.Language
-import de.fraunhofer.aisec.cpg.graph.ContextProvider
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration.Companion.BRACKET_LEFT
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration.Companion.BRACKET_RIGHT
@@ -71,7 +70,10 @@ constructor(
          * This helper function computes a [FunctionType] out of an existing [FunctionDeclaration].
          */
         @JvmStatic
-        fun computeType(func: FunctionDeclaration, returnTypes: List<Type> = func.returnTypes.toList()): FunctionType {
+        fun computeType(
+            func: FunctionDeclaration,
+            returnTypes: List<Type> = func.returnTypes.toList(),
+        ): FunctionType {
             val type =
                 FunctionType(
                     buildSignature(func, returnTypes),

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/HasType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/HasType.kt
@@ -44,9 +44,9 @@ import de.fraunhofer.aisec.cpg.graph.unknownType
 interface HasType : LanguageProvider {
 
     /**
-     * This property refers to the *definite* [Type] that the [Node] has during *compile-time*. If you are unsure about
-     * what it's type is, you should prefer to set it to the [UnknownType]. It is usually one of the
-     * following:
+     * This property refers to the *definite* [Type] that the [Node] has during *compile-time*. If
+     * you are unsure about what it's type is, you should prefer to set it to the [UnknownType]. It
+     * is usually one of the following:
      * - the type declared by the [Node], e.g., by a [ValueDeclaration]
      * - intrinsically tied to the node, e.g. an [IntegerType] in an integer [Literal]
      * - the [Type] of a declaration a node is referring to, e.g., in a [Reference]
@@ -56,10 +56,10 @@ interface HasType : LanguageProvider {
     var type: Type
 
     /**
-     * This property refers to a list of [Type] nodes which are assigned to that [Node] at-runtime. This could
-     * be different from the [HasType.type]. A common example is that a node could contain an
-     * interface as a [HasType.type], but the actual implementation of the type as one of the
-     * [assignedTypes]. This could potentially also be empty, if we don't see any assignments to
+     * This property refers to a list of [Type] nodes which are assigned to that [Node] at-runtime.
+     * This could be different from the [HasType.type]. A common example is that a node could
+     * contain an interface as a [HasType.type], but the actual implementation of the type as one of
+     * the [assignedTypes]. This could potentially also be empty, if we don't see any assignments to
      * this expression.
      *
      * Note: in order to properly inform observers, one should NOT use the regular [MutableSet.add]

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/HasType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/HasType.kt
@@ -246,6 +246,18 @@ class InitializerTypePropagation(private var decl: HasType, private var tupleIdx
     }
 
     override fun assignedTypeChanged(assignedTypes: Set<Type>, src: HasType) {
-        // TODO
+        // Also propagate the assigned types to the declaration. This is important for languages
+        // with dynamic types because we rely on the assigned types and the dynamic type always
+        // stays the "dynamic type".
+        val assignedTypes =
+            assignedTypes.map {
+                if (it is TupleType && tupleIdx != -1) {
+                    it.types.getOrElse(tupleIdx) { decl.unknownType() }
+                } else {
+                    it
+                }
+            }
+
+        decl.addAssignedTypes(assignedTypes.toSet())
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/HasType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/HasType.kt
@@ -44,7 +44,7 @@ import de.fraunhofer.aisec.cpg.graph.unknownType
 interface HasType : LanguageProvider {
 
     /**
-     * This property refers to the *definite* [Type] that the [Node] has. If you are unsure about
+     * This property refers to the *definite* [Type] that the [Node] has during *compile-time*. If you are unsure about
      * what it's type is, you should prefer to set it to the [UnknownType]. It is usually one of the
      * following:
      * - the type declared by the [Node], e.g., by a [ValueDeclaration]
@@ -56,7 +56,7 @@ interface HasType : LanguageProvider {
     var type: Type
 
     /**
-     * This property refers to a list of [Type] nodes which are assigned to that [Node]. This could
+     * This property refers to a list of [Type] nodes which are assigned to that [Node] at-runtime. This could
      * be different from the [HasType.type]. A common example is that a node could contain an
      * interface as a [HasType.type], but the actual implementation of the type as one of the
      * [assignedTypes]. This could potentially also be empty, if we don't see any assignments to

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -532,9 +532,9 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
                 source is MemberCallExpression &&
                     (source.base?.type is DynamicType || source.base?.type is UnknownType)
             ) {
-                ctx.scopeManager.extractScope(source, language, source.scope)
+                ScopeManager.ScopeExtraction(null, Name(""))
             } else {
-                null
+                ctx.scopeManager.extractScope(source, language, source.scope)
             }
 
         // If we could not extract the scope (even though one was specified), we can only return an

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -523,8 +523,19 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
             )
         val language = source.language
 
-        // Set the start scope. This can either be the call's scope or a scope specified in an FQN
-        val extractedScope = ctx.scopeManager.extractScope(source, language, source.scope)
+        // Set the start scope. This can either be the call's scope or a scope specified in an FQN.
+        // If our base is a dynamic or unknown type, we can skip the scope extraction because it
+        // will always
+        // fail
+        val extractedScope =
+            if (
+                source is MemberCallExpression &&
+                    (source.base?.type is DynamicType || source.base?.type is UnknownType)
+            ) {
+                ctx.scopeManager.extractScope(source, language, source.scope)
+            } else {
+                null
+            }
 
         // If we could not extract the scope (even though one was specified), we can only return an
         // empty result

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -525,12 +525,13 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
         // Set the start scope. This can either be the call's scope or a scope specified in an FQN.
         // If our base is a dynamic or unknown type, we can skip the scope extraction because it
-        // will always
-        // fail
+        // will always fail
         val extractedScope =
             if (
                 source is MemberCallExpression &&
-                    (source.base?.type is DynamicType || source.base?.type is UnknownType)
+                    (source.base?.type is DynamicType ||
+                        source.base?.type is UnknownType ||
+                        source.base?.type is AutoType)
             ) {
                 ScopeManager.ScopeExtraction(null, Name(""))
             } else {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
@@ -71,6 +71,7 @@ open class TypeResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         if (node is HasType) {
             var type = node.type.root
             handleType(type)
+            node.assignedTypes.forEach { handleType(it.root) }
         } else if (node is DeclaresType) {
             handleType(node.declaredType)
         }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypeTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypeTest.kt
@@ -80,8 +80,8 @@ class TypeTest {
     fun testDynamicType() {
         with(TestLanguageFrontend()) {
             var type = dynamicType()
-            assertFails { type.reference(PointerType.PointerOrigin.ARRAY) }
-            assertFails { type.dereference() }
+            assertIs<DynamicType>(type.reference(PointerType.PointerOrigin.ARRAY))
+            assertIs<DynamicType>(type.dereference())
         }
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypeTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/TypeTest.kt
@@ -75,4 +75,13 @@ class TypeTest {
             assertLocalName("myNewClass***", type)
         }
     }
+
+    @Test
+    fun testDynamicType() {
+        with(TestLanguageFrontend()) {
+            var type = dynamicType()
+            assertFails { type.reference(PointerType.PointerOrigin.ARRAY) }
+            assertFails { type.dereference() }
+        }
+    }
 }

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DeclarationHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DeclarationHandler.kt
@@ -212,14 +212,14 @@ class DeclarationHandler(frontend: PythonLanguageFrontend) :
         isKwoOnly: Boolean = false,
         defaultValue: Expression? = null,
     ): ParameterDeclaration {
-        val type = frontend.typeOf(node.annotation)
         val arg =
             newParameterDeclaration(
                 name = node.arg,
-                type = type,
+                type = dynamicType(),
                 variadic = isVariadic,
                 rawNode = node,
             )
+        arg.assignedTypes += frontend.typeOf(node.annotation)
         defaultValue?.let { arg.default = it }
         if (isPosOnly) {
             arg.modifiers += MODIFIER_POSITIONAL_ONLY_ARGUMENT

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/ExpressionHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/ExpressionHandler.kt
@@ -505,7 +505,7 @@ class ExpressionHandler(frontend: PythonLanguageFrontend) :
                 is Float,
                 is Double -> primitiveType("float")
                 else -> {
-                    autoType()
+                    unknownType()
                 }
             }
         return newLiteral(node.value, type = tpe, rawNode = node)

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
@@ -40,10 +40,10 @@ import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.helpers.Util.warnWithFileLocation
 import de.fraunhofer.aisec.cpg.helpers.neo4j.SimpleNameConverter
 import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
-import org.neo4j.ogm.annotation.Transient
-import org.neo4j.ogm.annotation.typeconversion.Convert
 import java.io.File
 import kotlin.reflect.KClass
+import org.neo4j.ogm.annotation.Transient
+import org.neo4j.ogm.annotation.typeconversion.Convert
 
 /** The Python language. */
 class PythonLanguage :

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
@@ -30,8 +30,8 @@ import de.fraunhofer.aisec.cpg.frontends.*
 import de.fraunhofer.aisec.cpg.graph.HasOverloadedOperation
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.autoType
 import de.fraunhofer.aisec.cpg.graph.declarations.ParameterDeclaration
+import de.fraunhofer.aisec.cpg.graph.primitiveType
 import de.fraunhofer.aisec.cpg.graph.scopes.Symbol
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.BinaryOperator
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Reference
@@ -40,10 +40,10 @@ import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.helpers.Util.warnWithFileLocation
 import de.fraunhofer.aisec.cpg.helpers.neo4j.SimpleNameConverter
 import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
-import java.io.File
-import kotlin.reflect.KClass
 import org.neo4j.ogm.annotation.Transient
 import org.neo4j.ogm.annotation.typeconversion.Convert
+import java.io.File
+import kotlin.reflect.KClass
 
 /** The Python language. */
 class PythonLanguage :
@@ -187,14 +187,13 @@ class PythonLanguage :
         get() = PythonValueEvaluator()
 
     override fun propagateTypeOfBinaryOperation(operation: BinaryOperator): Type {
-        val autoType = autoType()
         if (
             operation.operatorCode == "/" &&
                 operation.lhs.type is NumericType &&
                 operation.rhs.type is NumericType
         ) {
             // In Python, the / operation automatically casts the result to a float
-            return getSimpleTypeOf("float") ?: autoType
+            return primitiveType("float")
         } else if (
             operation.operatorCode == "//" &&
                 operation.lhs.type is NumericType &&
@@ -203,9 +202,9 @@ class PythonLanguage :
             return if (operation.lhs.type is IntegerType && operation.rhs.type is IntegerType) {
                 // In Python, the // operation keeps the type as an int if both inputs are integers
                 // or casts it to a float otherwise.
-                getSimpleTypeOf("int") ?: autoType
+                primitiveType("int")
             } else {
-                getSimpleTypeOf("float") ?: autoType
+                primitiveType("float")
             }
         }
 

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
@@ -168,8 +168,8 @@ class PythonLanguageFrontend(ctx: TranslationContext, language: Language<PythonL
     override fun typeOf(type: Python.AST.AST?): Type {
         return when (type) {
             null -> {
-                // No type information -> we return an autoType to infer things magically
-                autoType()
+                // No type information -> we return a dynamic type to infer things magically
+                dynamicType()
             }
 
             is Python.AST.Name -> {

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
@@ -789,7 +789,7 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
      */
     private fun handleAnnAssign(node: Python.AST.AnnAssign): AssignExpression {
         val lhs = frontend.expressionHandler.handle(node.target)
-        lhs.type = frontend.typeOf(node.annotation)
+        lhs.assignedTypes += frontend.typeOf(node.annotation)
         val rhs = node.value?.let { listOf(frontend.expressionHandler.handle(it)) } ?: emptyList()
         return newAssignExpression(lhs = listOf(lhs), rhs = rhs, rawNode = node)
     }
@@ -826,7 +826,7 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
         val lhs = node.targets.map { frontend.expressionHandler.handle(it) }
         node.type_comment?.let { typeComment ->
             val tpe = frontend.typeOf(typeComment)
-            lhs.forEach { it.type = tpe }
+            lhs.forEach { it.assignedTypes += tpe }
         }
         val rhs = frontend.expressionHandler.handle(node.value)
         if (rhs is List<*>)

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
@@ -103,7 +103,7 @@ class PythonAddDeclarationsPass(ctx: TranslationContext) : ComponentPass(ctx), L
 
         // Look for a potential scope modifier for this reference
         var targetScope =
-            scopeManager.currentScope?.predefinedLookupScopes[ref.name.toString()]?.targetScope
+            scopeManager.currentScope.predefinedLookupScopes[ref.name.toString()]?.targetScope
 
         // Try to see whether our symbol already exists. There are basically three rules to follow
         // here.

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
@@ -39,6 +39,7 @@ import de.fraunhofer.aisec.cpg.graph.edges.*
 import de.fraunhofer.aisec.cpg.graph.edges.scopes.ImportStyle
 import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
+import de.fraunhofer.aisec.cpg.graph.types.DynamicType
 import de.fraunhofer.aisec.cpg.graph.types.ListType
 import de.fraunhofer.aisec.cpg.graph.types.MapType
 import de.fraunhofer.aisec.cpg.graph.types.ObjectType
@@ -190,7 +191,7 @@ class PythonFrontendTest : BaseTest() {
         val s = bar.parameters.firstOrNull()
         assertNotNull(s)
         assertLocalName("s", s)
-        assertEquals(tu.primitiveType("str"), s.type)
+        assertContains(s.assignedTypes, tu.primitiveType("str"))
 
         assertLocalName("bar", bar)
 
@@ -546,9 +547,10 @@ class PythonFrontendTest : BaseTest() {
         val fromOther = tu.functions["from_other"]
         assertNotNull(fromOther)
 
-        val paramType = fromOther.parameters.firstOrNull()?.type
-        assertNotNull(paramType)
-        assertEquals(other.toType(), paramType)
+        val param = fromOther.parameters.firstOrNull()
+        assertNotNull(param)
+        assertIs<DynamicType>(param.type)
+        assertContains(param.assignedTypes, other.toType())
     }
 
     @Test
@@ -1516,7 +1518,10 @@ class PythonFrontendTest : BaseTest() {
             assertNotNull(bar)
 
             assertEquals(assertResolvedType("int"), bar.returnTypes.singleOrNull())
-            assertEquals(assertResolvedType("int"), bar.parameters.firstOrNull()?.type)
+
+            val param = bar.parameters.firstOrNull()
+            assertNotNull(param)
+            assertContains(param.assignedTypes, assertResolvedType("int"))
             assertEquals(assertResolvedType("complex_class.Foo"), bar.receiver?.type)
         }
     }

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/TypeTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/TypeTest.kt
@@ -58,8 +58,10 @@ class TypeTest {
 
         val bar = result.variables["bar"]
         assertNotNull(bar)
+        assertEquals(setOf("dfg_type.Bar"), bar.assignedTypes.map { it.typeName }.toSet())
 
         val a = result.variables["a"]
         assertNotNull(a)
+        assertEquals(setOf("str", "int"), a.assignedTypes.map { it.typeName }.toSet())
     }
 }

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/TypeTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/TypeTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.frontends.python
+
+import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.test.analyze
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class TypeTest {
+    @Test
+    fun testDFGBasedType() {
+        val topLevel = Path.of("src", "test", "resources", "python")
+        val result =
+            analyze(listOf(topLevel.resolve("dfg_type.py").toFile()), topLevel, true) {
+                it.registerLanguage<PythonLanguage>()
+            }
+        assertNotNull(result)
+
+        val my = result.variables["my"]
+        assertNotNull(my)
+
+        val funcBar = result.functions["bar"]
+        assertNotNull(funcBar)
+        assertEquals(
+            setOf("bar()dynamic", "bar()dfg_type.Bar"),
+            funcBar.assignedTypes.map { it.typeName }.toSet(),
+        )
+
+        val barCall = result.mcalls["bar"]
+        assertNotNull(barCall)
+        assertEquals(setOf("dfg_type.Bar"), barCall.assignedTypes.map { it.typeName }.toSet())
+
+        val bar = result.variables["bar"]
+        assertNotNull(bar)
+
+        val a = result.variables["a"]
+        assertNotNull(a)
+    }
+}

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/statementHandler/StatementHandlerTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/statementHandler/StatementHandlerTest.kt
@@ -222,12 +222,12 @@ class StatementHandlerTest : BaseTest() {
             // type comments
             val a = result.refs["a"]
             assertNotNull(a)
-            assertEquals(assertResolvedType("int"), a.type)
+            assertContains(a.assignedTypes, assertResolvedType("int"))
 
             // type annotation
             val b = result.refs["b"]
             assertNotNull(b)
-            assertEquals(assertResolvedType("str"), b.type)
+            assertContains(b.assignedTypes, assertResolvedType("str"))
         }
     }
 

--- a/cpg-language-python/src/test/resources/python/dfg_type.py
+++ b/cpg-language-python/src/test/resources/python/dfg_type.py
@@ -1,0 +1,16 @@
+class Foo:
+    def bar(self):
+        return Bar()
+
+
+class Bar:
+    def baz(self):
+        if True:
+            return "bar"
+        else:
+            return 2
+
+
+my = Foo() # "my" is of type Foo
+bar = my.bar() # "bar" is of type Bar
+a = bar.baz() # "a" is of type str | int

--- a/docs/docs/CPG/impl/types.md
+++ b/docs/docs/CPG/impl/types.md
@@ -29,6 +29,7 @@ The `assignedTypes` of `obj` will be a set containing `A` and `B` (plus the inte
 
 ## Dynamically Typed Languages
 
-Dynamically typed languages such as Python or JavaScript present an extra challenge because for most (if not all) variables, the type is not known at compile-time. In these languages, the type of a variable can change at runtime, and the CPG needs to be able to represent this. We therefore introduce a special `DynamicType` type class and assign it to `type` of most nodes. There are two exceptions to this rule:
+Dynamically typed languages such as Python or JavaScript present an extra challenge because for most (if not all) variables, the type is not known at compile-time. In these languages, the type of a variable can change at runtime, and the CPG needs to be able to represent this. We therefore introduce a special `DynamicType` type class and assign it to `type` of most nodes. There are some exceptions to this rule:
 - `ConstructExpression`: When we construct an object, we know the type of the object at compile-time, so we set the `type` to the type of the object.
 - `Literal`: When we have a literal, we also know the type at compile-time, so we set the `type` to the type of the literal, for example `str` for string-based literals in Python.
+- Lists, dictionaries, comprehensions: When we encounter a collection comprehension, list or dictionary expressions, we also know a partial type at compile-time, so we set the `type` to the type of the collection, e.g. a list or a dictionary in Python.

--- a/docs/docs/CPG/impl/types.md
+++ b/docs/docs/CPG/impl/types.md
@@ -1,0 +1,34 @@
+# Types
+
+We currently maintain a rather complex type system in the CPG, with several layers of inheritance. The most basic abstract type is `Type`, which holds properties common to all types.
+
+## `HasType`
+
+Not all nodes in the CPG have a type. For example, a `NamespaceDeclaration` does not have a type, but a `FunctionDeclaration` has a corresponding `FunctionType`. To make this distinction, we have the `HasType` interface, which is implemented by all nodes that have a type. The `HasType` interface requires mainly the implementation of two properties:
+
+### `type`
+
+This refers to the type of the node at *compile-time* and is a single `Type` object. For example, when declaring a variable `int i` in C/C++, the `type` of the variable `i` is `int`. 
+
+Often, languages allow to skip setting the explicitly, for example using `var i = 1` in Java. In this case, the type is inferred by the compiler and set to `int`. This still happens at compile-time, since the compiler is able to deduce the type, and it will stay the same during runtime. To simulate this, the initial `type` will be set to `AutoType`. Once we know the correct type, the CPG will also infer the type of the variable `i` to `int` through its type-observer system and replace the `AutoType` with the correct type.
+
+### `assignedTypes`
+
+The second property is `assignedTypes`, which is a set of `Type` objects. This property is used to store the types that are assigned to the node at *runtime*. For example considering the following C++ code:
+
+```cpp
+Interface obj;
+if (something) {
+    obj = new A();
+} else {
+    obj = new B();
+}
+```
+
+The `assignedTypes` of `obj` will be a set containing `A` and `B` (plus the interface `Interface` itself), since the type of `obj` can be either `A` or `B` at runtime. This feature is especially important for languages that allow dynamic typing, such as JavaScript or Python, where the type of a variable can change at runtime (see [below](#dynamically-typed-languages)).
+
+## Dynamically Typed Languages
+
+Dynamically typed languages such as Python or JavaScript present an extra challenge because for most (if not all) variables, the type is not known at compile-time. In these languages, the type of a variable can change at runtime, and the CPG needs to be able to represent this. We therefore introduce a special `DynamicType` type class and assign it to `type` of most nodes. There are two exceptions to this rule:
+- `ConstructExpression`: When we construct an object, we know the type of the object at compile-time, so we set the `type` to the type of the object.
+- `Literal`: When we have a literal, we also know the type at compile-time, so we set the `type` to the type of the literal, for example `str` for string-based literals in Python.

--- a/docs/mkdocs.yaml
+++ b/docs/mkdocs.yaml
@@ -179,6 +179,7 @@ nav:
       - "Scopes and Symbols": CPG/impl/scopes.md
       - "Passes": CPG/impl/passes.md
       - "Symbol Resolution": CPG/impl/symbol-resolver.md
+      - "Type System": CPG/impl/types.md
   - "Contributing":
       - "Contributing to the CPG library": Contributing/index.md
     # This assumes that the most recent dokka build was generated with the "main" tag!


### PR DESCRIPTION
This PR introduces a new `Type`,  the `DynamicType`. It is needed for programming languages that do not have static typing, such as TypeScript or Python. In these languages, the type is determined at run-time. Therefore, neither of our existing `AutoType` or `UnknownType` types completely catch the dynamics.

This PR adds the basic concept of the type itself and uses it very sparsely for function parameters, which previously were of `AutoType`. 