### PR TITLE
Python: merge async with non-async code

### DIFF
--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/Python.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/Python.kt
@@ -138,23 +138,37 @@ interface Python {
     sealed class ASTBASEstmt(pyObject: PyObject) : AST(pyObject), WithPythonLocation
 
     /**
+     * ast.FunctionDef and ast.AsyncFunctionDef are not related according to the Python syntax.
+     * However, they are so similar, that we make use of this interface to avoid a lot of duplicate
+     * code.
+     */
+    sealed class NormalOrAsyncFunctionDef(pyObject: PyObject) : ASTBASEstmt(pyObject) {
+        abstract val name: String
+        abstract val args: ASTarguments
+        abstract val body: List<ASTBASEstmt>
+        abstract val decorator_list: List<ASTBASEexpr>
+        abstract val returns: ASTBASEexpr?
+        abstract val type_comment: String?
+    }
+
+    /**
      * ```
      * ast.FunctionDef = class FunctionDef(stmt)
      *  |  FunctionDef(identifier name, arguments args, stmt* body, expr* decorator_list, expr? returns, string? type_comment)
      * ```
      */
-    class ASTFunctionDef(pyObject: PyObject) : ASTBASEstmt(pyObject) {
-        val name: String by lazy { "name" of pyObject }
+    class ASTFunctionDef(pyObject: PyObject) : NormalOrAsyncFunctionDef(pyObject) {
+        override val name: String by lazy { "name" of pyObject }
 
-        val args: ASTarguments by lazy { "args" of pyObject }
+        override val args: ASTarguments by lazy { "args" of pyObject }
 
-        val body: List<ASTBASEstmt> by lazy { "body" of pyObject }
+        override val body: List<ASTBASEstmt> by lazy { "body" of pyObject }
 
-        val decorator_list: List<ASTBASEexpr> by lazy { "decorator_list" of pyObject }
+        override val decorator_list: List<ASTBASEexpr> by lazy { "decorator_list" of pyObject }
 
-        val returns: ASTBASEexpr? by lazy { "returns" of pyObject }
+        override val returns: ASTBASEexpr? by lazy { "returns" of pyObject }
 
-        val type_comment: String? by lazy { "type_comment" of pyObject }
+        override val type_comment: String? by lazy { "type_comment" of pyObject }
     }
 
     /**
@@ -163,18 +177,18 @@ interface Python {
      *  |  AsyncFunctionDef(identifier name, arguments args, stmt* body, expr* decorator_list, expr? returns, string? type_comment)
      * ```
      */
-    class ASTAsyncFunctionDef(pyObject: PyObject) : ASTBASEstmt(pyObject) {
-        val name: String by lazy { "name" of pyObject }
+    class ASTAsyncFunctionDef(pyObject: PyObject) : NormalOrAsyncFunctionDef(pyObject) {
+        override val name: String by lazy { "name" of pyObject }
 
-        val args: ASTarguments by lazy { "args" of pyObject }
+        override val args: ASTarguments by lazy { "args" of pyObject }
 
-        val body: List<ASTBASEstmt> by lazy { "body" of pyObject }
+        override val body: List<ASTBASEstmt> by lazy { "body" of pyObject }
 
-        val decorator_list: List<ASTBASEexpr> by lazy { "decorator_list" of pyObject }
+        override val decorator_list: List<ASTBASEexpr> by lazy { "decorator_list" of pyObject }
 
-        val returns: ASTBASEexpr? by lazy { "returns" of pyObject }
+        override val returns: ASTBASEexpr? by lazy { "returns" of pyObject }
 
-        val type_comment: String? by lazy { "type_comment" of pyObject }
+        override val type_comment: String? by lazy { "type_comment" of pyObject }
     }
 
     /**

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/Python.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/Python.kt
@@ -362,7 +362,7 @@ interface Python {
          * are so similar, that we make use of this interface to avoid a lot of duplicate code.
          */
         interface NormalOrAsyncWith : AsyncOrNot {
-            val items: withitem
+            val items: kotlin.collections.List<withitem>
             val body: kotlin.collections.List<BaseStmt>
             val type_comment: String?
         }
@@ -374,7 +374,7 @@ interface Python {
          * ```
          */
         class With(pyObject: PyObject) : BaseStmt(pyObject), NormalOrAsyncWith {
-            override val items: withitem by lazy { "items" of pyObject }
+            override val items: kotlin.collections.List<withitem> by lazy { "items" of pyObject }
             override val body: kotlin.collections.List<BaseStmt> by lazy { "body" of pyObject }
             override val type_comment: String? by lazy { "type_comment" of pyObject }
         }
@@ -386,7 +386,7 @@ interface Python {
          * ```
          */
         class AsyncWith(pyObject: PyObject) : BaseStmt(pyObject), NormalOrAsyncWith, IsAsync {
-            override val items: withitem by lazy { "items" of pyObject }
+            override val items: kotlin.collections.List<withitem> by lazy { "items" of pyObject }
             override val body: kotlin.collections.List<BaseStmt> by lazy { "body" of pyObject }
             override val type_comment: String? by lazy { "type_comment" of pyObject }
         }

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/Python.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/Python.kt
@@ -141,9 +141,10 @@ interface Python {
      * Several classes are duplicated in the python AST for async and non-async variants. This
      * interface is a common interface for those AST classes.
      */
-    interface AsyncOrNot : WithPythonLocation {
-        var isAsync: Boolean
-    }
+    interface AsyncOrNot : WithPythonLocation
+
+    /** This interface denotes that this is an "async" node. */
+    interface IsAsync : AsyncOrNot
 
     /**
      * ast.FunctionDef and ast.AsyncFunctionDef are not related according to the Python syntax.
@@ -177,8 +178,6 @@ interface Python {
         override val returns: ASTBASEexpr? by lazy { "returns" of pyObject }
 
         override val type_comment: String? by lazy { "type_comment" of pyObject }
-
-        override var isAsync: Boolean = false
     }
 
     /**
@@ -188,7 +187,7 @@ interface Python {
      * ```
      */
     class ASTAsyncFunctionDef(pyObject: PyObject) :
-        ASTBASEstmt(pyObject), NormalOrAsyncFunctionDef {
+        ASTBASEstmt(pyObject), NormalOrAsyncFunctionDef, IsAsync {
         override val name: String by lazy { "name" of pyObject }
 
         override val args: ASTarguments by lazy { "args" of pyObject }
@@ -200,8 +199,6 @@ interface Python {
         override val returns: ASTBASEexpr? by lazy { "returns" of pyObject }
 
         override val type_comment: String? by lazy { "type_comment" of pyObject }
-
-        override var isAsync: Boolean = true
     }
 
     /**
@@ -305,7 +302,6 @@ interface Python {
         override val body: List<ASTBASEstmt> by lazy { "body" of pyObject }
         override val orelse: List<ASTBASEstmt> by lazy { "orelse" of pyObject }
         override val type_comment: String? by lazy { "type_comment" of pyObject }
-        override var isAsync: Boolean = false
     }
 
     /**
@@ -314,13 +310,12 @@ interface Python {
      *  |  AsyncFor(expr target, expr iter, stmt* body, stmt* orelse, string? type_comment)
      * ```
      */
-    class ASTAsyncFor(pyObject: PyObject) : ASTBASEstmt(pyObject), NormalOrAsyncFor {
+    class ASTAsyncFor(pyObject: PyObject) : ASTBASEstmt(pyObject), NormalOrAsyncFor, IsAsync {
         override val target: ASTBASEexpr by lazy { "target" of pyObject }
         override val iter: ASTBASEexpr by lazy { "iter" of pyObject }
         override val body: List<ASTBASEstmt> by lazy { "body" of pyObject }
         override val orelse: List<ASTBASEstmt> by lazy { "orelse" of pyObject }
         override val type_comment: String? by lazy { "type_comment" of pyObject }
-        override var isAsync: Boolean = true
     }
 
     /**
@@ -367,7 +362,6 @@ interface Python {
         override val items: ASTwithitem by lazy { "items" of pyObject }
         override val body: List<ASTBASEstmt> by lazy { "body" of pyObject }
         override val type_comment: String? by lazy { "type_comment" of pyObject }
-        override var isAsync: Boolean = false
     }
 
     /**
@@ -376,11 +370,10 @@ interface Python {
      *  |  AsyncWith(withitem* items, stmt* body, string? type_comment)
      * ```
      */
-    class ASTAsyncWith(pyObject: PyObject) : ASTBASEstmt(pyObject), NormalOrAsyncWith {
+    class ASTAsyncWith(pyObject: PyObject) : ASTBASEstmt(pyObject), NormalOrAsyncWith, IsAsync {
         override val items: ASTwithitem by lazy { "items" of pyObject }
         override val body: List<ASTBASEstmt> by lazy { "body" of pyObject }
         override val type_comment: String? by lazy { "type_comment" of pyObject }
-        override var isAsync: Boolean = true
     }
 
     /**

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/Python.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/Python.kt
@@ -269,17 +269,29 @@ interface Python {
     }
 
     /**
+     * ast.For and ast.AsyncFor are not related according to the Python syntax. However, they are so
+     * similar, that we make use of this interface to avoid a lot of duplicate code.
+     */
+    sealed class NormalOrAsyncFor(pyObject: PyObject) : ASTBASEstmt(pyObject) {
+        abstract val target: ASTBASEexpr
+        abstract val iter: ASTBASEexpr
+        abstract val body: List<ASTBASEstmt>
+        abstract val orelse: List<ASTBASEstmt>
+        abstract val type_comment: String?
+    }
+
+    /**
      * ```
      * ast.For = class For(stmt)
      *  |  For(expr target, expr iter, stmt* body, stmt* orelse, string? type_comment)
      * ```
      */
-    class ASTFor(pyObject: PyObject) : ASTBASEstmt(pyObject) {
-        val target: ASTBASEexpr by lazy { "target" of pyObject }
-        val iter: ASTBASEexpr by lazy { "iter" of pyObject }
-        val body: List<ASTBASEstmt> by lazy { "body" of pyObject }
-        val orelse: List<ASTBASEstmt> by lazy { "orelse" of pyObject }
-        val type_comment: String? by lazy { "type_comment" of pyObject }
+    class ASTFor(pyObject: PyObject) : NormalOrAsyncFor(pyObject) {
+        override val target: ASTBASEexpr by lazy { "target" of pyObject }
+        override val iter: ASTBASEexpr by lazy { "iter" of pyObject }
+        override val body: List<ASTBASEstmt> by lazy { "body" of pyObject }
+        override val orelse: List<ASTBASEstmt> by lazy { "orelse" of pyObject }
+        override val type_comment: String? by lazy { "type_comment" of pyObject }
     }
 
     /**
@@ -288,12 +300,12 @@ interface Python {
      *  |  AsyncFor(expr target, expr iter, stmt* body, stmt* orelse, string? type_comment)
      * ```
      */
-    class ASTAsyncFor(pyObject: PyObject) : ASTBASEstmt(pyObject) {
-        val target: ASTBASEexpr by lazy { "target" of pyObject }
-        val iter: ASTBASEexpr by lazy { "iter" of pyObject }
-        val body: List<ASTBASEstmt> by lazy { "body" of pyObject }
-        val orelse: List<ASTBASEstmt> by lazy { "orelse" of pyObject }
-        val type_comment: String? by lazy { "type_comment" of pyObject }
+    class ASTAsyncFor(pyObject: PyObject) : NormalOrAsyncFor(pyObject) {
+        override val target: ASTBASEexpr by lazy { "target" of pyObject }
+        override val iter: ASTBASEexpr by lazy { "iter" of pyObject }
+        override val body: List<ASTBASEstmt> by lazy { "body" of pyObject }
+        override val orelse: List<ASTBASEstmt> by lazy { "orelse" of pyObject }
+        override val type_comment: String? by lazy { "type_comment" of pyObject }
     }
 
     /**

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/Python.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/Python.kt
@@ -50,7 +50,7 @@ interface Python {
          * `ast.stmt` [AST.BaseStmt] and `ast.expr` [AST.BaseExpr] nodes have extra location
          * properties as implemented here.
          */
-        interface WithASTLocation { // TODO make the fields accessible `by lazy`
+        interface WithLocation { // TODO make the fields accessible `by lazy`
             val pyObject: PyObject
 
             /** Maps to the `lineno` filed from Python's ast. */
@@ -144,13 +144,13 @@ interface Python {
          *  |  | Continue
          * ```
          */
-        sealed class BaseStmt(pyObject: PyObject) : AST(pyObject), WithASTLocation
+        sealed class BaseStmt(pyObject: PyObject) : AST(pyObject), WithLocation
 
         /**
          * Several classes are duplicated in the python AST for async and non-async variants. This
          * interface is a common interface for those AST classes.
          */
-        interface AsyncOrNot : WithASTLocation
+        interface AsyncOrNot : WithLocation
 
         /** This interface denotes that this is an "async" node. */
         interface IsAsync : AsyncOrNot
@@ -537,7 +537,7 @@ interface Python {
          *
          * ast.expr = class expr(AST)
          */
-        sealed class BaseExpr(pyObject: PyObject) : AST(pyObject), WithASTLocation
+        sealed class BaseExpr(pyObject: PyObject) : AST(pyObject), WithLocation
 
         /**
          * ```
@@ -1265,7 +1265,7 @@ interface Python {
          *  |  arg(identifier arg, expr? annotation, string? type_comment)
          * ```
          */
-        class arg(pyObject: PyObject) : AST(pyObject), WithASTLocation {
+        class arg(pyObject: PyObject) : AST(pyObject), WithLocation {
             val arg: String by lazy { "arg" of pyObject }
             val annotation: BaseExpr? by lazy { "annotation" of pyObject }
             val type_comment: String? by lazy { "type_comment" of pyObject }

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/Python.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/Python.kt
@@ -333,15 +333,25 @@ interface Python {
     }
 
     /**
+     * ast.With and ast.AsyncWith are not related according to the Python syntax. However, they are
+     * so similar, that we make use of this interface to avoid a lot of duplicate code.
+     */
+    sealed class NormalOrAsyncWith(pyObject: PyObject) : ASTBASEstmt(pyObject) {
+        abstract val items: ASTwithitem
+        abstract val body: List<ASTBASEstmt>
+        abstract val type_comment: String?
+    }
+
+    /**
      * ```
      * ast.With = class With(stmt)
      *  |  With(withitem* items, stmt* body, string? type_comment)
      * ```
      */
-    class ASTWith(pyObject: PyObject) : ASTBASEstmt(pyObject) {
-        val items: ASTwithitem by lazy { "items" of pyObject }
-        val body: List<ASTBASEstmt> by lazy { "body" of pyObject }
-        val type_comment: String? by lazy { "type_comment" of pyObject }
+    class ASTWith(pyObject: PyObject) : NormalOrAsyncWith(pyObject) {
+        override val items: ASTwithitem by lazy { "items" of pyObject }
+        override val body: List<ASTBASEstmt> by lazy { "body" of pyObject }
+        override val type_comment: String? by lazy { "type_comment" of pyObject }
     }
 
     /**
@@ -350,12 +360,10 @@ interface Python {
      *  |  AsyncWith(withitem* items, stmt* body, string? type_comment)
      * ```
      */
-    class ASTAsyncWith(pyObject: PyObject) : ASTBASEstmt(pyObject) {
-        val target: ASTBASEexpr by lazy { "target" of pyObject }
-        val iter: ASTBASEexpr by lazy { "iter" of pyObject }
-        val body: List<ASTBASEstmt> by lazy { "body" of pyObject }
-        val orelse: List<ASTBASEstmt> by lazy { "orelse" of pyObject }
-        val type_comment: String? by lazy { "type_comment" of pyObject }
+    class ASTAsyncWith(pyObject: PyObject) : NormalOrAsyncWith(pyObject) {
+        override val items: ASTwithitem by lazy { "items" of pyObject }
+        override val body: List<ASTBASEstmt> by lazy { "body" of pyObject }
+        override val type_comment: String? by lazy { "type_comment" of pyObject }
     }
 
     /**

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
@@ -234,7 +234,7 @@ class PythonLanguageFrontend(language: Language<PythonLanguageFrontend>, ctx: Tr
     }
 
     override fun locationOf(astNode: Python.AST.AST): PhysicalLocation? {
-        return if (astNode is Python.AST.WithASTLocation) {
+        return if (astNode is Python.AST.WithLocation) {
             PhysicalLocation(
                 uri,
                 Region(

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
@@ -432,7 +432,7 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
     }
 
     fun handleDeclaratorList(
-        node: Python.AST.WithASTLocation,
+        node: Python.AST.WithLocation,
         decoratorList: List<Python.AST.BaseExpr>
     ): List<Annotation> {
         val annotations = mutableListOf<Annotation>()
@@ -492,7 +492,7 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
      */
     private fun makeBlock(
         stmts: List<Python.AST.BaseStmt>,
-        parentNode: Python.AST.WithASTLocation
+        parentNode: Python.AST.WithLocation
     ): Block {
         val result = newBlock()
         for (stmt in stmts) {

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
@@ -66,8 +66,7 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
             is Python.ASTRaise,
             is Python.ASTTry,
             is Python.ASTTryStar,
-            is Python.ASTWith,
-            is Python.ASTAsyncWith ->
+            is Python.NormalOrAsyncWith ->
                 newProblemExpression(
                     "The statement of class ${node.javaClass} is not supported yet",
                     rawNode = node

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
@@ -429,7 +429,7 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
         return handleDeclaratorList(node, node.decorator_list)
     }
 
-    fun handleDeclaratorList(
+    private fun handleDeclaratorList(
         node: Python.WithPythonLocation,
         decoratorList: List<Python.ASTBASEexpr>
     ): List<Annotation> {

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandlerTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandlerTest.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.frontends.python
 
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.test.analyze
+import de.fraunhofer.aisec.cpg.test.analyzeAndGetFirstTU
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertContains
@@ -85,5 +86,23 @@ class StatementHandlerTest {
         val variadicArg = func.parameters["args"]
         assertNotNull(variadicArg, "Failed to find variadic argc")
         assertEquals(true, variadicArg.isVariadic)
+    }
+
+    @Test
+    fun testAsync() {
+        val topLevel = Path.of("src", "test", "resources", "python")
+        val tu =
+            analyzeAndGetFirstTU(listOf(topLevel.resolve("async.py").toFile()), topLevel, true) {
+                it.registerLanguage<PythonLanguage>()
+            }
+        assertNotNull(tu)
+
+        val myFunc = tu.functions["my_func"]
+        assertNotNull(myFunc)
+        assertEquals(1, myFunc.parameters.size)
+
+        val myOtherFunc = tu.functions["my_other_func"]
+        assertNotNull(myOtherFunc)
+        assertEquals(1, myOtherFunc.parameters.size)
     }
 }

--- a/cpg-language-python/src/test/resources/python/async.py
+++ b/cpg-language-python/src/test/resources/python/async.py
@@ -1,0 +1,11 @@
+import asyncio
+
+
+async def my_func(i: int):
+    async for obj in generator:
+        pass
+
+    await asyncio.sleep(i)
+
+def my_other_func(i: int):
+    pass


### PR DESCRIPTION
I'm a bit undecided whether or not I like this:

Pro:
- less duplicate code

Con:
- we break the strict 1:1 mapping of Python's ast classes to Kotlin classes in `Python.kt`. This was one of the design goals... @oxisto Is there a smarter kotlin way to not have the extra classes & relationship in Python.kt and still remove the duplicate code?