### PR TITLE
Hotfix: Use GitHub runners again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build:
-    runs-on: [self-hosted, linux, x64, faster]
+    runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This PR is a hot fix because our custom runner is broken