### PR TITLE
fix doc string urls

### DIFF
--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/ExpressionHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/ExpressionHandler.kt
@@ -84,9 +84,8 @@ class ExpressionHandler(frontend: PythonLanguageFrontend) :
     }
 
     /**
-     * Translates a Python (Named
-     * Expression)[https://docs.python.org/3/library/ast.html#ast.NamedExpr] into an
-     * [AssignExpression].
+     * Translates a Python [`NamedExpr`](https://docs.python.org/3/library/ast.html#ast.NamedExpr)
+     * into an [AssignExpression].
      *
      * As opposed to the Assign node, both target and value must be single nodes.
      */
@@ -183,7 +182,7 @@ class ExpressionHandler(frontend: PythonLanguageFrontend) :
 
     /**
      * This method handles the python
-     * [`BoolOp` expression](https://docs.python.org/3/library/ast.html#ast.BoolOp).
+     * [`BoolOp`](https://docs.python.org/3/library/ast.html#ast.BoolOp).
      *
      * Generates a (potentially nested) [BinaryOperator] from a `BoolOp`. Less than two operands in
      * [Python.AST.BoolOp.values] don't make sense and will generate a [ProblemExpression]. If only

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
@@ -84,7 +84,7 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
     }
 
     /**
-     * Translates a Python (https://docs.python.org/3/library/ast.html#ast.Assert] into a
+     * Translates a Python [`Assert`](https://docs.python.org/3/library/ast.html#ast.Assert) into a
      * [AssertStatement].
      */
     private fun handleAssert(node: Python.AST.Assert): AssertStatement {


### PR DESCRIPTION
Someone started to include URLs in the doc strings for some reason. This PR fixes the broken URLs. We should probably also include URLs for all the other functions if this is something we'd like to have...