### PR TITLE
Added `add(index, element)` for `UnwrappedEdgeList`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeList.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeList.kt
@@ -100,6 +100,16 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
         edges.forEach { handleOnRemove(it) }
     }
 
+    /**
+     * This function creates a new edge (of [EdgeType]) to/from the specified node [target]
+     * (depending on [outgoing]) and adds it to the specified index in the list.
+     */
+    fun add(index: Int, target: NodeType) {
+        val edge = createEdge(target, init, this.outgoing)
+
+        return add(index, edge)
+    }
+
     override fun add(index: Int, element: EdgeType) {
         // Make sure, the index is always set
         element.index = this.size

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeList.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeList.kt
@@ -40,7 +40,7 @@ class UnwrappedEdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
 ) : UnwrappedEdgeCollection<NodeType, EdgeType>(list), MutableList<NodeType> {
 
     override fun add(index: Int, element: NodeType) {
-        TODO("Not yet implemented")
+        return list.add(index, element)
     }
 
     override fun addAll(index: Int, elements: Collection<NodeType>): Boolean {

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeListTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeListTest.kt
@@ -51,7 +51,8 @@ class EdgeListTest {
                 assertEquals(i, edge.index, "index mismatch $i != ${edge.index}")
             }
 
-            // insert something at position 1, this should shift the existing two entries + 1
+            // insert something at position 1, this should shift the existing entries (after the
+            // position) + 1
             list.add(1, AstEdge(node1, node4))
             assertEquals(3, list.size)
 

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeListTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeListTest.kt
@@ -26,6 +26,9 @@
 package de.fraunhofer.aisec.cpg.graph.edges.collections
 
 import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
+import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdges
 import de.fraunhofer.aisec.cpg.graph.newLiteral
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -50,6 +53,39 @@ class UnwrappedEdgeListTest {
             assertEquals(1, node2.prevEOGEdges.size)
             assertEquals(1, node3.prevEOGEdges.size)
             assertEquals(1, node3.prevEOG.size)
+        }
+    }
+
+    @Test
+    fun testAddIndex() {
+        with(TestLanguageFrontend()) {
+            var node1 = newLiteral(1)
+            var node2 = newLiteral(2)
+            var node3 = newLiteral(3)
+            var node4 = newLiteral(4)
+
+            var list = AstEdges<Node, AstEdge<Node>>(thisRef = node1)
+            list += node2
+            list += node3
+
+            assertEquals(2, list.size)
+            list.forEachIndexed { i, edge ->
+                assertEquals(i, edge.index, "index mismatch $i != ${edge.index}")
+            }
+
+            // insert something at position 1 (using the unwrapped list), this should shift the
+            // existing entries (after the position) + 1
+            var unwrapped = list.unwrap()
+            unwrapped.add(1, node4)
+            assertEquals(3, list.size)
+
+            // indices should still be in sync afterward
+            list.forEachIndexed { i, edge ->
+                assertEquals(i, edge.index, "index mismatch $i != ${edge.index}")
+            }
+
+            // the order should be node2, node4, node3
+            assertEquals<List<Node>>(listOf(node2, node4, node3), unwrapped)
         }
     }
 


### PR DESCRIPTION
This adds support for adding nodes at a specific location in an unwrapped edge list.
