### PR TITLE
Switching to codecov for code coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,11 +41,6 @@ jobs:
       - name: Setup neo4j
         run: |
           docker run -d --env NEO4J_AUTH=neo4j/password -p7474:7474 -p7687:7687 neo4j || true
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
       - name: Determine Version
         run: |
           # determine version from tag
@@ -67,6 +62,8 @@ jobs:
           if [ -d "/opt/hostedtoolcache/Python" ]; then
             find /opt/hostedtoolcache/Python/ -name libjep.so -exec sudo cp '{}' /usr/lib/ \;
           fi
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Build ${{ env.version }}
         run: |
           ./gradlew --parallel -Pversion=$VERSION spotlessCheck -x spotlessApply build -x distZip -x distTar koverXmlReport performanceTest integrationTest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,6 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of SonarQube analysis
       - run: |
           cp gradle.properties.example gradle.properties
       - uses: actions/setup-java@v4
@@ -66,7 +64,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
       - name: Build ${{ env.version }}
         run: |
-          ./gradlew --parallel -Pversion=$VERSION spotlessCheck -x spotlessApply build -x distZip -x distTar koverXmlReport performanceTest integrationTest
+          ./gradlew --parallel -Pversion=$VERSION spotlessCheck -x spotlessApply build -x distZip -x distTar koverXmlReport koverHtmlReport performanceTest integrationTest
         id: build
         env:
           VERSION: ${{ env.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,21 +69,17 @@ jobs:
           fi
       - name: Build ${{ env.version }}
         run: |
-          if [ "$SONAR_TOKEN" != "" ]
-          then
-            ./gradlew --parallel -Pversion=$VERSION spotlessCheck -x spotlessApply build -x distZip -x distTar sonar performanceTest integrationTest \
-            -Dsonar.projectKey=Fraunhofer-AISEC_cpg \
-            -Dsonar.organization=fraunhofer-aisec \
-            -Dsonar.host.url=https://sonarcloud.io \
-            -Dsonar.token=$SONAR_TOKEN
-          else
-            ./gradlew --parallel -Pversion=$VERSION spotlessCheck -x spotlessApply build -x distZip -x distTar performanceTest integrationTest
-          fi
+          ./gradlew --parallel -Pversion=$VERSION spotlessCheck -x spotlessApply build -x distZip -x distTar koverXmlReport performanceTest integrationTest
         id: build
         env:
           VERSION: ${{ env.version }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Code Coverage
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          files: ./cpg-all/build/reports/kover/report.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
       - name: Prepare test and coverage reports
         if: ${{ always() }}
         run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,6 @@
 //
 plugins {
     id("org.jetbrains.dokka")
-    id("org.sonarqube")
     id("io.github.gradle-nexus.publish-plugin")
 }
 
@@ -76,18 +75,6 @@ fun generateDokkaWithVersionTag(dokkaMultiModuleTask: org.jetbrains.dokka.gradle
     dokkaMultiModuleTask.pluginsMapConfiguration.set(mapOf)
 }
 
-
-//
-// Configure sonarqube for the whole cpg project
-//
-sonarqube {
-    properties {
-        property("sonar.sourceEncoding", "UTF-8")
-        // The report part is either relative to the submodules or the main module. We want to specify our
-        // aggregated jacoco report here
-        property("sonar.coverage.jacoco.xmlReportPaths", "../cpg-all/build/reports/kover/report.xml,cpg-all/build/reports/kover/report.xml")
-    }
-}
 
 /**
  * Publishing to maven central

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,7 +10,6 @@ dependencies {
     implementation(libs.kotlin.gradle)
     implementation(libs.dokka.gradle)
     implementation(libs.kover.gradle)
-    implementation(libs.sonarqube.gradle)
     implementation(libs.spotless.gradle)
     implementation(libs.nexus.publish.gradle)
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))  // this is only there to be able to import 'LibrariesForLibs' in the convention plugins to access the version catalog in buildSrc

--- a/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts
@@ -148,8 +148,6 @@ val performanceTest = tasks.register<Test>("performanceTest") {
     maxParallelForks = 1
     // make sure that several performance tests (e.g. in different frontends) also do NOT run in parallel
     usesService(serialExecutionService)
-
-    mustRunAfter(tasks.getByPath(":sonar"))
 }
 
 // A build service that ensures serial execution of a group of tasks

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  range: "75...95"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+    patch:
+      default:
+        target: 75%
+

--- a/cpg-all/build.gradle.kts
+++ b/cpg-all/build.gradle.kts
@@ -34,7 +34,3 @@ dependencies {
     kover(projects.cpgAnalysis)
     kover(projects.cpgNeo4j)
 }
-
-val sonar = tasks.getByPath(":sonar")
-sonar.dependsOn(tasks.named("koverHtmlReport"))
-sonar.dependsOn(tasks.named("koverXmlReport"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,6 @@ kotlin = "2.0.20"
 kotlin19 = "1.9.10"
 neo4j = "4.0.10"
 log4j = "2.24.0"
-sonarqube = "5.1.0.4882"
 spotless = "6.25.0"
 nexus-publish = "2.0.0"
 sootup = "1.3.0"
@@ -53,7 +52,6 @@ kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.
 dokka-gradle = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.9.0" } # the dokka plugin is slightly behind the main Kotlin release cycle
 dokka-versioning = { module = "org.jetbrains.dokka:versioning-plugin", version = "1.9.0"}
 kover-gradle = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version = "0.8.0" }
-sonarqube-gradle = { module = "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin", version.ref = "sonarqube" }
 spotless-gradle = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 nexus-publish-gradle = { module = "io.github.gradle-nexus:publish-plugin", version.ref = "nexus-publish" }
 
@@ -78,6 +76,5 @@ sootup = ["sootup-core", "sootup-java-core", "sootup-java-sourcecode", "sootup-j
 [plugins]
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin"}
 dokka = { id = "org.jetbrains.dokka", version.ref = "kotlin" }
-sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 node = { id = "com.github.node-gradle.node", version = "7.1.0"}


### PR DESCRIPTION
Replacing sonarqube with codecov for coverage. Seperate PR for detekt will follow. This also aligns CPG with Codyze.
