### PR TITLE
Cleanup of `SymbolResolver`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/Type.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/Type.kt
@@ -304,7 +304,12 @@ var Type.recordDeclaration: RecordDeclaration?
         }
     }
 
+/**
+ * This interfaces specifies that this node (most likely a [Declaration]) declares a type. This is
+ * used by [TypeResolver.resolveType] to find appropriate symbols and declarations.
+ */
 interface DeclaresType {
 
+    /** The [Type] that is being declared. */
     val declaredType: Type
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/InferenceHelper.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/InferenceHelper.kt
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2024, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+import de.fraunhofer.aisec.cpg.CallResolutionResult
+import de.fraunhofer.aisec.cpg.InferenceConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
+import de.fraunhofer.aisec.cpg.frontends.HasGlobalVariables
+import de.fraunhofer.aisec.cpg.frontends.HasImplicitReceiver
+import de.fraunhofer.aisec.cpg.frontends.HasStructs
+import de.fraunhofer.aisec.cpg.frontends.Language
+import de.fraunhofer.aisec.cpg.graph.Name
+import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.declarations.*
+import de.fraunhofer.aisec.cpg.graph.newFieldDeclaration
+import de.fraunhofer.aisec.cpg.graph.scopes.NameScope
+import de.fraunhofer.aisec.cpg.graph.scopes.RecordScope
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberExpression
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.Reference
+import de.fraunhofer.aisec.cpg.graph.types.ObjectType
+import de.fraunhofer.aisec.cpg.graph.types.Type
+import de.fraunhofer.aisec.cpg.graph.types.recordDeclaration
+import de.fraunhofer.aisec.cpg.graph.unknownType
+import de.fraunhofer.aisec.cpg.passes.Pass.Companion.log
+import de.fraunhofer.aisec.cpg.passes.SymbolResolver
+import de.fraunhofer.aisec.cpg.passes.TypeResolver
+import de.fraunhofer.aisec.cpg.passes.getPossibleContainingTypes
+import de.fraunhofer.aisec.cpg.passes.inference.Inference.TypeInferenceObserver
+import de.fraunhofer.aisec.cpg.passes.inference.inferFunction
+import de.fraunhofer.aisec.cpg.passes.inference.inferMethod
+import de.fraunhofer.aisec.cpg.passes.inference.startInference
+import kotlin.collections.forEach
+
+internal fun TranslationContext.tryNamespaceInference(
+    name: Name,
+    locationHint: Node?
+): NamespaceDeclaration? {
+    return scopeManager.globalScope
+        ?.astNode
+        ?.startInference(this)
+        ?.inferNamespaceDeclaration(name, null, locationHint)
+}
+
+/**
+ * Tries to infer a [RecordDeclaration] from an unresolved [Type]. This will return `null`, if
+ * inference was not possible, or if it was turned off in the [InferenceConfiguration].
+ *
+ * If [updateType] is set to true, also the [ObjectType.recordDeclaration] is adjusted. This is only
+ * needed if we call this function in the [SymbolResolver] (and not in the [TypeResolver]).
+ */
+internal fun TranslationContext.tryRecordInference(
+    type: Type,
+    locationHint: Node? = null,
+    updateType: Boolean = false,
+): RecordDeclaration? {
+    val kind =
+        if (type.language is HasStructs) {
+            "struct"
+        } else {
+            "class"
+        }
+    // Determine the scope where we want to start our inference
+    var (scope, _) = scopeManager.extractScope(type)
+
+    if (scope !is NameScope) {
+        scope = null
+    }
+
+    var holder = scope?.astNode
+
+    // If we could not find a scope, but we have an FQN, we can try to infer a namespace (or a
+    // parent record)
+    var parentName = type.name.parent
+    if (scope == null && parentName != null) {
+        // At this point, we need to check whether we have any type reference to our parent
+        // name. If we have (e.g. it is used in a function parameter, variable, etc.), then we
+        // have a high chance that this is actually a parent record and not a namespace
+        var parentType = typeManager.lookupResolvedType(parentName)
+        holder =
+            if (parentType != null) {
+                tryRecordInference(parentType, locationHint = locationHint)
+            } else {
+                tryNamespaceInference(parentName, locationHint = locationHint)
+            }
+    }
+
+    val record =
+        (holder ?: this.scopeManager.globalScope?.astNode)
+            ?.startInference(this)
+            ?.inferRecordDeclaration(type, kind, locationHint)
+
+    // update the type's record. Because types are only unique per scope, we potentially need to
+    // update multiple type nodes, i.e., all type nodes whose FQN match the inferred record
+    if (updateType && record != null) {
+        typeManager.firstOrderTypes
+            .filter { it.name == record.name }
+            .forEach { it.recordDeclaration = record }
+    }
+
+    return record
+}
+
+/**
+ * Tries to infer a [VariableDeclaration] out of a [Reference]. This will return `null`, if
+ * inference was not possible, or if it was turned off in the [InferenceConfiguration].
+ *
+ * We mainly try to infer global variables and fields here, since these are possibly parts of the
+ * code we do not "see". We do not try to infer local variables, because we are under the assumption
+ * that even with incomplete code, we at least have the complete current function code.
+ */
+internal fun TranslationContext.tryVariableInference(
+    language: Language<*>?,
+    ref: Reference,
+): Declaration? {
+    var currentRecordType = scopeManager.currentRecord?.toType() as? ObjectType
+    return if (
+        language is HasImplicitReceiver &&
+            !ref.name.isQualified() &&
+            !ref.isStaticAccess &&
+            currentRecordType != null
+    ) {
+        // This could potentially be a reference to a field with an implicit receiver call
+        tryFieldInference(ref, currentRecordType)
+    } else if (ref.name.isQualified()) {
+        // For now, we only infer globals at the top-most global level, i.e., no globals in
+        // namespaces
+        val (scope, _) = scopeManager.extractScope(ref, null)
+        when (scope) {
+            is NameScope -> {
+                log.warn(
+                    "We should infer a namespace variable ${ref.name} at this point, but this is not yet implemented."
+                )
+                null
+            }
+            else -> {
+                log.warn(
+                    "We should infer a variable ${ref.name} in ${scope}, but this is not yet implemented."
+                )
+                null
+            }
+        }
+    } else if (ref.language is HasGlobalVariables) {
+        // We can try to infer a possible global variable (at top-level), if the language supports
+        // this
+        scopeManager.globalScope?.astNode?.startInference(this)?.inferVariableDeclaration(ref)
+    } else {
+        // Nothing to infer
+        null
+    }
+}
+
+/**
+ * Tries to infer a [FieldDeclaration] from an unresolved [MemberExpression] or [Reference] (if the
+ * language has [HasImplicitReceiver]). This will return `null`, if inference was not possible, or
+ * if it was turned off in the [InferenceConfiguration].
+ */
+internal fun TranslationContext.tryFieldInference(
+    ref: Reference,
+    targetType: ObjectType
+): ValueDeclaration? {
+    // We only want to infer fields here, this can either happen if we have a reference with an
+    // implicit receiver or if we have a scoped reference and the scope points to a record
+    val (scope, _) = scopeManager.extractScope(ref)
+    if (scope != null && scope !is RecordScope) {
+        return null
+    }
+
+    var record = targetType.recordDeclaration
+    if (record == null) {
+        // We access an unknown field of an unknown record. so we need to handle that along the
+        // way as well
+        record = tryRecordInference(targetType, locationHint = ref, updateType = true)
+    }
+
+    if (record == null) {
+        log.error(
+            "There is no matching record in the record map. Can't identify which field is used."
+        )
+        return null
+    }
+
+    val declaration =
+        ref.newFieldDeclaration(
+            ref.name.localName,
+            // we will set the type later through the type inference observer
+            record.unknownType(),
+            listOf(),
+            null,
+            false,
+        )
+    record.addField(declaration)
+    declaration.language = record.language
+    declaration.isInferred = true
+
+    // We might be able to resolve the type later (or better), if a type is
+    // assigned to our reference later
+    ref.registerTypeObserver(TypeInferenceObserver(declaration))
+
+    return declaration
+}
+
+internal fun TranslationContext.tryFunctionInference(
+    call: CallExpression,
+    result: CallResolutionResult,
+): List<FunctionDeclaration> {
+    // We need to see, whether we have any suitable base (e.g. a class) or not; There are two
+    // main cases
+    // a) we have a member expression -> easy
+    // b) we have a call expression -> not so easy. This could be a member call with an implicit
+    //    this (in which case we want to explore the base type). But that is only possible if
+    //    the callee is not qualified, because otherwise we are in a static call like
+    //    MyClass::doSomething() or in a namespace call (in case we do not want to explore the
+    //    base type here yet). This will change in a future PR.
+    val (suitableBases, bestGuess) =
+        if (call.callee is MemberExpression || !call.callee.name.isQualified()) {
+            getPossibleContainingTypes(call)
+        } else {
+            Pair(setOf(), null)
+        }
+
+    return if (suitableBases.isEmpty()) {
+        // Resolution has provided no result, we can forward this to the inference system,
+        // if we want. While this is definitely a function, it could still be a function
+        // inside a namespace. We therefore have two possible start points, a namespace
+        // declaration or a translation unit. Nothing else is allowed (fow now). We can
+        // re-use the information in the ResolutionResult, since this already contains the
+        // actual start scope (e.g. in case the callee has an FQN).
+        var scope = result.actualStartScope
+        if (scope !is NameScope) {
+            scope = scopeManager.globalScope
+        }
+        val func =
+            when (val start = scope?.astNode) {
+                is TranslationUnitDeclaration -> start.inferFunction(call, ctx = this)
+                is NamespaceDeclaration -> start.inferFunction(call, ctx = this)
+                else -> null
+            }
+        listOfNotNull(func)
+    } else {
+        tryMethodInference(call, suitableBases, bestGuess)
+    }
+}
+
+/**
+ * Creates an inferred element for each RecordDeclaration
+ *
+ * @param call
+ * @param possibleContainingTypes
+ */
+internal fun TranslationContext.tryMethodInference(
+    call: CallExpression,
+    possibleContainingTypes: Set<Type>,
+    bestGuess: Type?,
+): List<FunctionDeclaration> {
+    var records =
+        possibleContainingTypes.mapNotNull {
+            val root = it.root as? ObjectType
+            root?.recordDeclaration
+        }
+
+    // We access an unknown method of an unknown record. so we need to handle that
+    // along the way as well. We prefer the base type
+    if (records.isEmpty()) {
+        records =
+            listOfNotNull(
+                tryRecordInference(
+                    bestGuess?.root ?: call.unknownType(),
+                    locationHint = call,
+                    updateType = true
+                )
+            )
+    }
+    records = records.distinct()
+
+    return records.mapNotNull { record -> record.inferMethod(call, ctx = this) }
+}

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -31,7 +31,6 @@ import de.fraunhofer.aisec.cpg.frontends.*
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.scopes.NameScope
-import de.fraunhofer.aisec.cpg.graph.scopes.RecordScope
 import de.fraunhofer.aisec.cpg.graph.scopes.Symbol
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.*
@@ -39,13 +38,13 @@ import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker.ScopedWalker
 import de.fraunhofer.aisec.cpg.helpers.Util
 import de.fraunhofer.aisec.cpg.helpers.replace
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
-import de.fraunhofer.aisec.cpg.passes.inference.Inference.TypeInferenceObserver
-import de.fraunhofer.aisec.cpg.passes.inference.inferFunction
-import de.fraunhofer.aisec.cpg.passes.inference.inferMethod
 import de.fraunhofer.aisec.cpg.passes.inference.startInference
 import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import tryFieldInference
+import tryFunctionInference
+import tryVariableInference
 
 /**
  * Creates new connections between the place where a variable is declared and where it is used.
@@ -162,28 +161,31 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         return target
     }
 
-    protected fun handleReference(currentClass: RecordDeclaration?, current: Node?) {
-        val language = current?.language
-
-        if (current !is Reference || current is MemberExpression) return
+    protected fun handleReference(currentClass: RecordDeclaration?, ref: Reference) {
+        val language = ref.language
 
         // Ignore references to anonymous identifiers, if the language supports it (e.g., the _
         // identifier in Go)
         if (
-            language is HasAnonymousIdentifier &&
-                current.name.localName == language.anonymousIdentifier
+            language is HasAnonymousIdentifier && ref.name.localName == language.anonymousIdentifier
         ) {
+            return
+        }
+
+        // Ignore references to "super" if the language has super expressions, because they will be
+        // handled separately in handleMemberExpression
+        if (language is HasSuperClasses && ref.name.localName == language.superClassKeyword) {
             return
         }
 
         // Find a list of candidate symbols. Currently, this is only used the in the "next-gen" call
         // resolution, but in future this will also be used in resolving regular references.
-        current.candidates = scopeManager.lookupSymbolByName(current.name, current.location).toSet()
+        ref.candidates = scopeManager.lookupSymbolByName(ref.name, ref.location).toSet()
 
         // Preparation for a future without legacy call resolving. Taking the first candidate is not
         // ideal since we are running into an issue with function pointers here (see workaround
         // below).
-        var wouldResolveTo = current.candidates.singleOrNull()
+        var wouldResolveTo = ref.candidates.singleOrNull()
 
         // For now, we need to ignore reference expressions that are directly embedded into call
         // expressions, because they are the "callee" property. In the future, we will use this
@@ -194,7 +196,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         // of this call expression back to its original variable declaration. In the future, we want
         // to extend this particular code to resolve all callee references to their declarations,
         // i.e., their function definitions and get rid of the separate CallResolver.
-        if (current.resolutionHelper is CallExpression) {
+        if (ref.resolutionHelper is CallExpression) {
             // Peek into the declaration, and if it is only one declaration and a variable, we can
             // proceed normally, as we are running into the special case explained above. Otherwise,
             // we abort here (for now).
@@ -208,7 +210,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         // percentage of references now.
         if (wouldResolveTo is FunctionDeclaration) {
             // We need to invoke the legacy resolver, just to be sure
-            var legacy = scopeManager.resolveReference(current)
+            var legacy = scopeManager.resolveReference(ref)
 
             // This is just for us to catch these differences in symbol resolving in the future. The
             // difference is pretty much only that the legacy system takes parameters of the
@@ -225,92 +227,27 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         // Only consider resolving, if the language frontend did not specify a resolution. If we
         // already have populated the wouldResolveTo variable, we can re-use this instead of
         // resolving again
-        var refersTo = current.refersTo ?: wouldResolveTo
+        var refersTo = ref.refersTo ?: wouldResolveTo
 
         var recordDeclType: Type? = null
         if (currentClass != null) {
             recordDeclType = currentClass.toType()
         }
 
-        val helperType = current.resolutionHelper?.type
+        val helperType = ref.resolutionHelper?.type
         if (helperType is FunctionPointerType && refersTo == null) {
-            refersTo = resolveMethodFunctionPointer(current, helperType)
+            refersTo = resolveMethodFunctionPointer(ref, helperType)
         }
 
-        // only add new nodes for non-static unknown
-        if (
-            refersTo == null &&
-                !current.isStaticAccess &&
-                recordDeclType != null &&
-                recordDeclType.recordDeclaration != null
-        ) {
-            // Maybe we are referring to a field instead of a local var
-            val field = resolveMember(recordDeclType, current)
-            if (field != null) {
-                refersTo = field
-            }
-        }
-
-        // TODO: we need to do proper scoping (and merge it with the code above), but for now
-        //  this just enables CXX static fields
-        if (refersTo == null && language != null && current.name.isQualified()) {
-            recordDeclType = getEnclosingTypeOf(current)
-            val field = resolveMember(recordDeclType, current)
-            if (field != null) {
-                refersTo = field
-            }
-        }
-
+        // If we did not resolve the reference up to this point, we can try to infer the declaration
         if (refersTo == null) {
-            // We can try to infer a possible global variable, if the language supports this
-            refersTo = tryGlobalVariableInference(current)
+            refersTo = ctx.tryVariableInference(language, ref)
         }
 
         if (refersTo != null) {
-            current.refersTo = refersTo
+            ref.refersTo = refersTo
         } else {
-            Util.warnWithFileLocation(
-                current,
-                log,
-                "Did not find a declaration for ${current.name}"
-            )
-        }
-    }
-
-    /**
-     * Tries to infer a global variable from an unresolved [Reference]. This will return `null`, if
-     * inference was not possible, or if it was turned off in the [InferenceConfiguration].
-     */
-    private fun tryGlobalVariableInference(ref: Reference): Declaration? {
-        if (ref.language !is HasGlobalVariables) {
-            return null
-        }
-
-        // For now, we only infer globals at the top-most global level, i.e., no globals in
-        // namespaces
-        if (ref.name.isQualified()) {
-            return null
-        }
-
-        // Forward this to our inference system. This will also check whether and how inference is
-        // configured.
-        return scopeManager.globalScope?.astNode?.startInference(ctx)?.inferVariableDeclaration(ref)
-    }
-
-    /**
-     * We get the type of the "scope" this node is in. (e.g. for a field, we drop the field's name
-     * and have the class)
-     */
-    protected fun getEnclosingTypeOf(current: Node): Type {
-        val language = current.language
-
-        return if (language != null && language.namespaceDelimiter.isNotEmpty()) {
-            val parentName = (current.name.parent ?: current.name).toString()
-            var type = current.objectType(parentName)
-            TypeResolver.resolveType(type)
-            type
-        } else {
-            current.unknownType()
+            Util.warnWithFileLocation(ref, log, "Did not find a declaration for ${ref.name}")
         }
     }
 
@@ -356,17 +293,22 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         }
 
         val baseType = base.type.root
-        current.refersTo = resolveMember(baseType, current)
+        if (baseType is ObjectType) {
+            current.refersTo = resolveMember(baseType, current)
+        }
     }
 
-    protected fun resolveMember(containingClass: Type, reference: Reference): ValueDeclaration? {
+    protected fun resolveMember(
+        containingClass: ObjectType,
+        reference: Reference
+    ): ValueDeclaration? {
         if (isSuperclassReference(reference)) {
             // if we have a "super" on the member side, this is a member call. We need to resolve
             // this in the call resolver instead
             return null
         }
         var member: ValueDeclaration? = null
-        var type = containingClass
+        var type: Type = containingClass
 
         // Check for a possible overloaded operator->
         if (
@@ -390,6 +332,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
         val record = type.recordDeclaration
         if (record != null) {
+            // TODO(oxisto): This should use symbols rather than the AST fields
             member =
                 record.fields
                     .filter { it.name.lastPartsMatch(reference.name) }
@@ -404,87 +347,16 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
                     .map { it.definition }
                     .firstOrNull()
         }
+
         if (member == null && record is EnumDeclaration) {
             member = record.entries[reference.name.localName]
         }
 
-        if (member != null) {
-            return member
+        if (member == null) {
+            member = ctx.tryFieldInference(reference, containingClass)
         }
 
-        // This is a little bit of a workaround, but at least this makes sure we are not inferring a
-        // record, where a namespace already exist
-        val (scope, _) = scopeManager.extractScope(reference, null)
-        return if (scope == null) {
-            handleUnknownField(containingClass, reference)
-        } else {
-            // Workaround needed for Java. If we already have a record scope, use the "old"
-            // inference function
-            when (scope) {
-                is RecordScope -> handleUnknownField(containingClass, reference)
-                is NameScope -> {
-                    log.warn(
-                        "We should infer a namespace variable ${reference.name} at this point, but this is not yet implemented."
-                    )
-                    null
-                }
-                else -> {
-                    log.warn(
-                        "We should infer a variable ${reference.name} in ${scope}, but this is not yet implemented."
-                    )
-                    null
-                }
-            }
-        }
-    }
-
-    // TODO(oxisto): Move to inference class
-    protected fun handleUnknownField(base: Type, ref: Reference): FieldDeclaration? {
-        val name = ref.name
-
-        // unwrap a potential pointer-type
-        if (base is PointerType) {
-            return handleUnknownField(base.elementType, ref)
-        }
-
-        var record = base.recordDeclaration
-        if (record == null) {
-            // We access an unknown field of an unknown record. so we need to handle that along the
-            // way as well
-            record = ctx.tryRecordInference(base, locationHint = ref)
-        }
-
-        if (record == null) {
-            log.error(
-                "There is no matching record in the record map. Can't identify which field is used."
-            )
-            return null
-        }
-
-        val target = record.fields.firstOrNull { it.name.lastPartsMatch(name) }
-
-        return if (target != null) {
-            target
-        } else {
-            val declaration =
-                newFieldDeclaration(
-                    name.localName,
-                    // we will set the type later through the type inference observer
-                    record.unknownType(),
-                    listOf(),
-                    null,
-                    false,
-                )
-            record.addField(declaration)
-            declaration.language = record.language
-            declaration.isInferred = true
-
-            // We might be able to resolve the type later (or better), if a type is
-            // assigned to our reference later
-            ref.registerTypeObserver(TypeInferenceObserver(declaration))
-
-            declaration
-        }
+        return member
     }
 
     protected fun handle(node: Node?, currClass: RecordDeclaration?) {
@@ -552,7 +424,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         // callee
         var candidates =
             if (useLegacyResolution) {
-                val (possibleTypes, _) = getPossibleContainingTypes(call)
+                val (possibleTypes, _) = ctx.getPossibleContainingTypes(call)
                 resolveMemberByName(callee.name.localName, possibleTypes).toSet()
             } else {
                 callee.candidates
@@ -585,7 +457,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
                 call.invokes = result.bestViable.toMutableList()
             }
             UNRESOLVED -> {
-                call.invokes = tryFunctionInference(call, result).toMutableList()
+                call.invokes = ctx.tryFunctionInference(call, result).toMutableList()
             }
         }
 
@@ -699,36 +571,6 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         return candidates
     }
 
-    /**
-     * Creates an inferred element for each RecordDeclaration
-     *
-     * @param possibleContainingTypes
-     * @param call
-     */
-    protected fun createMethodDummies(
-        possibleContainingTypes: Set<Type>,
-        bestGuess: Type?,
-        call: CallExpression
-    ): List<FunctionDeclaration> {
-        var records =
-            possibleContainingTypes.mapNotNull {
-                val root = it.root as? ObjectType
-                root?.recordDeclaration
-            }
-
-        // We access an unknown method of an unknown record. so we need to handle that
-        // along the way as well. We prefer the base type
-        if (records.isEmpty()) {
-            records =
-                listOfNotNull(
-                    ctx.tryRecordInference(bestGuess?.root ?: unknownType(), locationHint = call)
-                )
-        }
-        records = records.distinct()
-
-        return records.mapNotNull { record -> record.inferMethod(call, ctx = ctx) }
-    }
-
     protected fun handleConstructExpression(constructExpression: ConstructExpression) {
         if (constructExpression.instantiates != null && constructExpression.constructor != null)
             return
@@ -810,32 +652,6 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         return resolveWithArguments(candidates, op.operatorArguments, op as Expression)
     }
 
-    /**
-     * Returns a set of types in which the callee of our [call] could reside in. More concretely, it
-     * returns a [Pair], where the first element is the set of types and the second is our best
-     * guess.
-     */
-    protected fun getPossibleContainingTypes(call: CallExpression): Pair<Set<Type>, Type?> {
-        val possibleTypes = mutableSetOf<Type>()
-        var bestGuess: Type? = null
-        if (call is MemberCallExpression) {
-            call.base?.let { base ->
-                bestGuess = base.type
-                possibleTypes.add(base.type)
-                possibleTypes.addAll(base.assignedTypes)
-            }
-        } else {
-            // This could be a C++ member call with an implicit this (which we do not create), so
-            // let's add the current class to the possible list
-            scopeManager.currentRecord?.toType()?.let {
-                bestGuess = it
-                possibleTypes.add(it)
-            }
-        }
-
-        return Pair(possibleTypes, bestGuess)
-    }
-
     protected fun getInvocationCandidatesFromParents(
         name: Symbol,
         possibleTypes: Set<RecordDeclaration>,
@@ -909,48 +725,6 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
                 ?.createInferredConstructor(constructExpression.signature)
     }
 
-    fun tryFunctionInference(
-        call: CallExpression,
-        result: CallResolutionResult,
-    ): List<FunctionDeclaration> {
-        // We need to see, whether we have any suitable base (e.g. a class) or not; There are two
-        // main cases
-        // a) we have a member expression -> easy
-        // b) we have a call expression -> not so easy. This could be a member call with an implicit
-        //    this (in which case we want to explore the base type). But that is only possible if
-        //    the callee is not qualified, because otherwise we are in a static call like
-        //    MyClass::doSomething() or in a namespace call (in case we do not want to explore the
-        //    base type here yet). This will change in a future PR.
-        val (suitableBases, bestGuess) =
-            if (call.callee is MemberExpression || !call.callee.name.isQualified()) {
-                getPossibleContainingTypes(call)
-            } else {
-                Pair(setOf(), null)
-            }
-
-        return if (suitableBases.isEmpty()) {
-            // Resolution has provided no result, we can forward this to the inference system,
-            // if we want. While this is definitely a function, it could still be a function
-            // inside a namespace. We therefore have two possible start points, a namespace
-            // declaration or a translation unit. Nothing else is allowed (fow now). We can
-            // re-use the information in the ResolutionResult, since this already contains the
-            // actual start scope (e.g. in case the callee has an FQN).
-            var scope = result.actualStartScope
-            if (scope !is NameScope) {
-                scope = scopeManager.globalScope
-            }
-            val func =
-                when (val start = scope?.astNode) {
-                    is TranslationUnitDeclaration -> start.inferFunction(call, ctx = ctx)
-                    is NamespaceDeclaration -> start.inferFunction(call, ctx = ctx)
-                    else -> null
-                }
-            listOfNotNull(func)
-        } else {
-            createMethodDummies(suitableBases, bestGuess, call)
-        }
-    }
-
     companion object {
         val LOGGER: Logger = LoggerFactory.getLogger(SymbolResolver::class.java)
 
@@ -976,67 +750,29 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
     }
 }
 
-fun TranslationContext.tryNamespaceInference(
-    name: Name,
-    locationHint: Node?
-): NamespaceDeclaration? {
-    return scopeManager.globalScope
-        ?.astNode
-        ?.startInference(this)
-        ?.inferNamespaceDeclaration(name, null, locationHint)
-}
-
 /**
- * Tries to infer a [RecordDeclaration] from an unresolved [Type]. This will return `null`, if
- * inference was not possible, or if it was turned off in the [InferenceConfiguration].
+ * Returns a set of types in which the callee of our [call] could reside in. More concretely, it
+ * returns a [Pair], where the first element is the set of types and the second is our best guess.
  */
-fun TranslationContext.tryRecordInference(
-    type: Type,
-    locationHint: Node? = null
-): RecordDeclaration? {
-    val kind =
-        if (type.language is HasStructs) {
-            "struct"
-        } else {
-            "class"
+internal fun TranslationContext.getPossibleContainingTypes(
+    call: CallExpression
+): Pair<Set<Type>, Type?> {
+    val possibleTypes = mutableSetOf<Type>()
+    var bestGuess: Type? = null
+    if (call is MemberCallExpression) {
+        call.base?.let { base ->
+            bestGuess = base.type
+            possibleTypes.add(base.type)
+            possibleTypes.addAll(base.assignedTypes)
         }
-    // Determine the scope where we want to start our inference
-    var (scope, _) = scopeManager.extractScope(type)
-
-    if (scope !is NameScope) {
-        scope = null
+    } else if (call.language is HasImplicitReceiver) {
+        // This could be a member call with an implicit receiver, so let's add the current class
+        // to the possible list
+        scopeManager.currentRecord?.toType()?.let {
+            bestGuess = it
+            possibleTypes.add(it)
+        }
     }
 
-    var holder = scope?.astNode
-
-    // If we could not find a scope, but we have an FQN, we can try to infer a namespace (or a
-    // parent record)
-    var parentName = type.name.parent
-    if (scope == null && parentName != null) {
-        // At this point, we need to check whether we have any type reference to our parent
-        // name. If we have (e.g. it is used in a function parameter, variable, etc.), then we
-        // have a high chance that this is actually a parent record and not a namespace
-        var parentType = typeManager.lookupResolvedType(parentName)
-        holder =
-            if (parentType != null) {
-                tryRecordInference(parentType, locationHint = locationHint)
-            } else {
-                tryNamespaceInference(parentName, locationHint = locationHint)
-            }
-    }
-
-    val record =
-        (holder ?: this.scopeManager.globalScope?.astNode)
-            ?.startInference(this)
-            ?.inferRecordDeclaration(type, kind, locationHint)
-
-    // update the type's record. Because types are only unique per scope, we potentially need to
-    // update multiple type nodes, i.e., all type nodes whose FQN match the inferred record
-    if (record != null) {
-        typeManager.firstOrderTypes
-            .filter { it.name == record.name }
-            .forEach { it.recordDeclaration = record }
-    }
-
-    return record
+    return Pair(possibleTypes, bestGuess)
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -241,7 +241,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
         // If we did not resolve the reference up to this point, we can try to infer the declaration
         if (refersTo == null) {
-            refersTo = ctx.tryVariableInference(language, ref)
+            refersTo = tryVariableInference(ref)
         }
 
         if (refersTo != null) {
@@ -353,7 +353,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         }
 
         if (member == null) {
-            member = ctx.tryFieldInference(reference, containingClass)
+            member = tryFieldInference(reference, containingClass)
         }
 
         return member
@@ -424,7 +424,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         // callee
         var candidates =
             if (useLegacyResolution) {
-                val (possibleTypes, _) = ctx.getPossibleContainingTypes(call)
+                val (possibleTypes, _) = getPossibleContainingTypes(call)
                 resolveMemberByName(callee.name.localName, possibleTypes).toSet()
             } else {
                 callee.candidates
@@ -457,7 +457,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
                 call.invokes = result.bestViable.toMutableList()
             }
             UNRESOLVED -> {
-                call.invokes = ctx.tryFunctionInference(call, result).toMutableList()
+                call.invokes = tryFunctionInference(call, result).toMutableList()
             }
         }
 
@@ -754,9 +754,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
  * Returns a set of types in which the callee of our [call] could reside in. More concretely, it
  * returns a [Pair], where the first element is the set of types and the second is our best guess.
  */
-internal fun TranslationContext.getPossibleContainingTypes(
-    call: CallExpression
-): Pair<Set<Type>, Type?> {
+internal fun Pass<*>.getPossibleContainingTypes(call: CallExpression): Pair<Set<Type>, Type?> {
     val possibleTypes = mutableSetOf<Type>()
     var bestGuess: Type? = null
     if (call is MemberCallExpression) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -39,12 +39,12 @@ import de.fraunhofer.aisec.cpg.helpers.Util
 import de.fraunhofer.aisec.cpg.helpers.replace
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
 import de.fraunhofer.aisec.cpg.passes.inference.startInference
+import de.fraunhofer.aisec.cpg.passes.inference.tryFieldInference
+import de.fraunhofer.aisec.cpg.passes.inference.tryFunctionInference
+import de.fraunhofer.aisec.cpg.passes.inference.tryVariableInference
 import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import tryFieldInference
-import tryFunctionInference
-import tryVariableInference
 
 /**
  * Creates new connections between the place where a variable is declared and where it is used.

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
@@ -34,7 +34,7 @@ import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.graph.types.recordDeclaration
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
-import tryRecordInference
+import de.fraunhofer.aisec.cpg.passes.inference.tryRecordInference
 
 /**
  * The purpose of this [Pass] is to establish a relationship between [Type] nodes (more specifically

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
@@ -34,6 +34,7 @@ import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.graph.types.recordDeclaration
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
+import tryRecordInference
 
 /**
  * The purpose of this [Pass] is to establish a relationship between [Type] nodes (more specifically

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
@@ -180,7 +180,10 @@ internal fun Pass<*>.tryVariableInference(
  * until the symbol resolver, in case we really "see" the record, e.g., if we parse the std headers.
  * If we did not "see" its declaration, we can infer it now.
  */
-internal fun Pass<*>.tryFieldInference(ref: Reference, targetType: ObjectType): VariableDeclaration? {
+internal fun Pass<*>.tryFieldInference(
+    ref: Reference,
+    targetType: ObjectType
+): VariableDeclaration? {
     // We only want to infer fields here, this can either happen if we have a reference with an
     // implicit receiver or if we have a scoped reference and the scope points to a record
     val (scope, _) = scopeManager.extractScope(ref)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
@@ -23,6 +23,8 @@
  *                    \______/ \__|       \______/
  *
  */
+package de.fraunhofer.aisec.cpg.passes.inference
+
 import de.fraunhofer.aisec.cpg.CallResolutionResult
 import de.fraunhofer.aisec.cpg.InferenceConfiguration
 import de.fraunhofer.aisec.cpg.frontends.HasGlobalVariables
@@ -47,9 +49,6 @@ import de.fraunhofer.aisec.cpg.passes.SymbolResolver
 import de.fraunhofer.aisec.cpg.passes.TypeResolver
 import de.fraunhofer.aisec.cpg.passes.getPossibleContainingTypes
 import de.fraunhofer.aisec.cpg.passes.inference.Inference.TypeInferenceObserver
-import de.fraunhofer.aisec.cpg.passes.inference.inferFunction
-import de.fraunhofer.aisec.cpg.passes.inference.inferMethod
-import de.fraunhofer.aisec.cpg.passes.inference.startInference
 import kotlin.collections.forEach
 
 internal fun Pass<*>.tryNamespaceInference(name: Name, locationHint: Node?): NamespaceDeclaration? {

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
@@ -110,8 +110,7 @@ class PythonAddDeclarationsPass(ctx: TranslationContext) : ComponentPass(ctx) {
                             newFieldDeclaration(node.name)
                         }
                     } else {
-                        val v = newVariableDeclaration(node.name)
-                        v
+                        newVariableDeclaration(node.name)
                     }
                 } else {
                     newFieldDeclaration(node.name)

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
@@ -1336,10 +1336,8 @@ class PythonFrontendTest : BaseTest() {
                 it.registerLanguage<PythonLanguage>()
             }
         assertNotNull(result)
-        assertEquals(2, result.variables.size)
-        // Note, that "pi" is incorrectly inferred as a field declaration. This is a known bug in
-        // the inference system (and not in the python module) and will be handled separately.
-        assertEquals(listOf("mypi", "pi"), result.variables.map { it.name.localName })
+        assertEquals(1, result.variables.size)
+        assertEquals(listOf("mypi"), result.variables.map { it.name.localName })
     }
 
     @Test

--- a/cpg-language-typescript/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/TypescriptLanguageFrontendTest.kt
+++ b/cpg-language-typescript/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/TypescriptLanguageFrontendTest.kt
@@ -262,7 +262,7 @@ class TypeScriptLanguageFrontendTest {
         assertLocalName("Users", usersComponent)
         assertEquals(1, usersComponent.constructors.size)
         assertEquals(2, usersComponent.methods.size)
-        assertEquals(/*0*/ 2 /* because of dummy nodes */, usersComponent.fields.size)
+        assertEquals(0, usersComponent.fields.size)
 
         val render = usersComponent.methods["render"]
         assertNotNull(render)


### PR DESCRIPTION
Unfortunatly, this cannot really be split into smaller pieces. It basically does the following:
- Move all inference related functions out of the symbol resolver and into a separate helper file
- Remove unnecessary calls to resolve member expressions in handleReference

I can try to add the needed language trait in a separate PR (see #1778). This also needs smaller adjustments in the python and typescript frontend. Mostly tests that previously asserted the "wrong" thing, are now asserting the correct resolution.

Fixes #1769
