### PR TITLE
Added language trait `HasImplicitReceiver`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageTraits.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageTraits.kt
@@ -124,6 +124,15 @@ interface HasSuperClasses : LanguageTrait {
 }
 
 /**
+ * A language trait, that specifies that this language has support for implicit receiver, e.g., that
+ * one can omit references to a base such as `this`.
+ */
+interface HasImplicitReceiver : LanguageTrait {
+
+    val receiverName: String
+}
+
+/**
  * A language trait, that specifies that this language has certain qualifiers. If so, we should
  * consider them when parsing the types.
  */

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CPPLanguage.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CPPLanguage.kt
@@ -56,7 +56,8 @@ open class CPPLanguage :
     HasUnknownType,
     HasFunctionStyleCasts,
     HasFunctionOverloading,
-    HasOperatorOverloading {
+    HasOperatorOverloading,
+    HasImplicitReceiver {
     override val fileExtensions = listOf("cpp", "cc", "cxx", "c++", "hpp", "hh")
     override val elaboratedTypeSpecifier = listOf("class", "struct", "union", "enum")
     override val unknownTypeString = listOf("auto")
@@ -317,4 +318,7 @@ open class CPPLanguage :
 
         return Pair(false, listOf())
     }
+
+    override val receiverName: String
+        get() = "this"
 }

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguage.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguage.kt
@@ -45,7 +45,8 @@ open class JavaLanguage :
     HasQualifier,
     HasUnknownType,
     HasShortCircuitOperators,
-    HasFunctionOverloading {
+    HasFunctionOverloading,
+    HasImplicitReceiver {
     override val fileExtensions = listOf("java")
     override val namespaceDelimiter = "."
     @Transient override val frontend: KClass<out JavaLanguageFrontend> = JavaLanguageFrontend::class
@@ -116,4 +117,6 @@ open class JavaLanguage :
 
     override val startCharacter = '<'
     override val endCharacter = '>'
+    override val receiverName: String
+        get() = "this"
 }


### PR DESCRIPTION
This is needed in preparation for #1777 to better handle access to fields/members of a class when an implicit receiver is used.
