### PR TITLE
Add new function `lookupUniqueTypeSymbolByName`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TypeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TypeManager.kt
@@ -366,7 +366,7 @@ val Collection<Type>.commonType: Type?
  * this can only be used in passes.
  */
 context(Pass<*>)
-fun Reference.doesReferToType(): Type? {
+fun Reference.nameIsType(): Type? {
     // First, check if it is a simple type
     var type = language?.getSimpleTypeOf(name)
     if (type != null) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TypeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TypeManager.kt
@@ -32,7 +32,10 @@ import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.TemplateDeclaration
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.graph.scopes.TemplateScope
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.Reference
 import de.fraunhofer.aisec.cpg.graph.types.*
+import de.fraunhofer.aisec.cpg.passes.Pass
+import de.fraunhofer.aisec.cpg.passes.ResolveCallExpressionAmbiguityPass
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import org.slf4j.Logger
@@ -353,3 +356,29 @@ val Collection<Type>.commonType: Type?
         // root node is 0) and re-wrap the final common type back into the original wrap state
         return commonAncestors.minByOrNull(Type.Ancestor::depth)?.type?.let { typeOp.apply(it) }
     }
+
+/**
+ * A utility function that checks whether our [Reference] refers to a [Type]. This is used by many
+ * passes that replace certain [Reference] nodes with other nodes, e.g., the
+ * [ResolveCallExpressionAmbiguityPass].
+ *
+ * Note: This involves some symbol lookup (using [ScopeManager.lookupUniqueTypeSymbolByName]), so
+ * this can only be used in passes.
+ */
+context(Pass<*>)
+fun Reference.doesReferToType(): Type? {
+    // First, check if it is a simple type
+    var type = language?.getSimpleTypeOf(name)
+    if (type != null) {
+        return type
+    }
+
+    // This could also be a typedef
+    type = scopeManager.typedefFor(name, scope)
+    if (type != null) {
+        return type
+    }
+
+    // Lastly, check if the reference contains a symbol that points to type (declaration)
+    return scopeManager.lookupUniqueTypeSymbolByName(name, scope)?.declaredType
+}

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveCallExpressionAmbiguityPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveCallExpressionAmbiguityPass.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationContext
-import de.fraunhofer.aisec.cpg.doesReferToType
 import de.fraunhofer.aisec.cpg.frontends.Handler
 import de.fraunhofer.aisec.cpg.frontends.HasCallExpressionAmbiguity
 import de.fraunhofer.aisec.cpg.frontends.HasFunctionStyleCasts
@@ -41,6 +40,7 @@ import de.fraunhofer.aisec.cpg.graph.types.ObjectType
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.helpers.replace
+import de.fraunhofer.aisec.cpg.nameIsType
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
 import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
 import de.fraunhofer.aisec.cpg.passes.configuration.RequiresLanguageTrait
@@ -98,7 +98,7 @@ class ResolveCallExpressionAmbiguityPass(ctx: TranslationContext) : TranslationU
         // functional-constructs)
         if (language is HasFunctionStyleConstruction) {
             // Check for our type. We are only interested in object types
-            var type = ref.doesReferToType()
+            var type = ref.nameIsType()
             if (type is ObjectType && !type.isPrimitive) {
                 walker.replaceCallWithConstruct(type, parent, call)
             }
@@ -109,7 +109,7 @@ class ResolveCallExpressionAmbiguityPass(ctx: TranslationContext) : TranslationU
         // argument.
         if (language is HasFunctionStyleCasts && call.arguments.size == 1) {
             // Check if it is type and replace the call
-            var type = ref.doesReferToType()
+            var type = ref.nameIsType()
             if (type != null) {
                 walker.replaceCallWithCast(type, parent, call, false)
             }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
@@ -104,20 +104,7 @@ open class TypeResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         // filter for nodes that implement DeclaresType, because otherwise we will get a lot of
         // constructor declarations and such with the same name. It seems this is ok since most
         // languages will prefer structs/classes over functions when resolving types.
-        var symbols =
-            scopeManager
-                .lookupSymbolByName(type.name, startScope = type.scope) { it is DeclaresType }
-                .filterIsInstance<DeclaresType>()
-
-        // We need to have a single match, otherwise we have an ambiguous type, and we cannot
-        // normalize it.
-        if (symbols.size > 1) {
-            log.warn(
-                "Lookup of type {} returned more than one symbol which declares a type, this is an ambiguity and the following analysis might not be correct.",
-                name
-            )
-        }
-        var declares = symbols.singleOrNull()
+        var declares = scopeManager.lookupUniqueTypeSymbolByName(type.name, type.scope)
 
         // If we did not find any declaration, we can try to infer a record declaration for it
         if (declares == null) {

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CXXExtraPass.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CXXExtraPass.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationContext
-import de.fraunhofer.aisec.cpg.doesReferToType
 import de.fraunhofer.aisec.cpg.frontends.cxx.CLanguage
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
@@ -37,6 +36,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.recordDeclaration
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.helpers.replace
+import de.fraunhofer.aisec.cpg.nameIsType
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
 import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
 
@@ -78,8 +78,8 @@ class CXXExtraPass(ctx: TranslationContext) : ComponentPass(ctx) {
      * the graph.
      */
     private fun removeBracketOperators(node: UnaryOperator, parent: Node?) {
-        var input = node.input
-        if (node.operatorCode == "()" && input is Reference && input.doesReferToType() == null) {
+        val input = node.input
+        if (node.operatorCode == "()" && input is Reference && input.nameIsType() == null) {
             // It was really just parenthesis around an identifier, but we can only make this
             // distinction now.
             //
@@ -114,7 +114,7 @@ class CXXExtraPass(ctx: TranslationContext) : ComponentPass(ctx) {
 
         // If the name (`long` in the example) is a type, then the unary operator (`(long)`)
         // is really a cast and our binary operator is really a unary operator `&addr`.
-        var type = (fakeUnaryOp.input as? Reference)?.doesReferToType()
+        var type = (fakeUnaryOp.input as? Reference)?.nameIsType()
         if (type != null) {
             // We need to perform the following steps:
             // * create a cast expression out of the ()-unary operator, with the type that is

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXExpressionTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXExpressionTest.kt
@@ -45,6 +45,6 @@ class CXXExpressionTest {
         // We should have two calls (int and myint64)
         val casts = tu.casts
         assertEquals(2, casts.size)
-        assertEquals(listOf("int", "myint64"), casts.map { it.name.localName })
+        assertEquals(listOf("int", "long long int"), casts.map { it.name.localName })
     }
 }

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
@@ -81,20 +81,6 @@ import de.fraunhofer.aisec.cpg.passes.inference.startInference
  * In the frontend we only do the assignment, therefore we need to create a new
  * [VariableDeclaration] for `b` and inject a [DeclarationStatement].
  *
- * ## Converting Call Expressions into Cast Expressions
- *
- * In Go, it is possible to convert compatible types by "calling" the type name as a function, such
- * as
- *
- * ```go
- * var i = int(2.0)
- * ```
- *
- * This is also possible with more complex types, such as interfaces or aliased types, as long as
- * they are compatible. Because types in the same package can be defined in multiple files, we
- * cannot decide during the frontend run. Therefore, we need to execute this pass before the
- * [SymbolResolver] and convert certain [CallExpression] nodes into a [CastExpression].
- *
  * ## Adjust Names of Keys in Key Value Expressions to FQN
  *
  * This pass also adjusts the names of keys in a [KeyValueExpression], which is part of an


### PR DESCRIPTION
This adds two new functions `ScopeManager.lookupUniqueTypeSymbolByName` and `Reference.doesReferToType`. This harmonizes a lot of boilerplate code in type resolver, cxx extra pass and resolve ambuigity pass, which were all trying to achieve the same thing.

Fixes #1766
