### PR TITLE
Resolving imports and symbols according to import dependencies

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
@@ -25,9 +25,12 @@
  */
 package de.fraunhofer.aisec.cpg.graph
 
+import de.fraunhofer.aisec.cpg.PopulatedByPass
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
+import de.fraunhofer.aisec.cpg.passes.ImportDependencyMap
+import de.fraunhofer.aisec.cpg.passes.ImportResolver
 import org.neo4j.ogm.annotation.Relationship
 
 /**
@@ -42,6 +45,10 @@ open class Component : Node() {
     val translationUnitEdges = astEdgesOf<TranslationUnitDeclaration>()
     /** All translation units belonging to this application. */
     val translationUnits by unwrapping(Component::translationUnitEdges)
+
+    @PopulatedByPass(ImportResolver::class)
+    var importDependencies: ImportDependencyMap =
+        mutableMapOf<TranslationUnitDeclaration, MutableSet<TranslationUnitDeclaration>>()
 
     @Synchronized
     fun addTranslationUnit(tu: TranslationUnitDeclaration) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
@@ -32,6 +32,7 @@ import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import de.fraunhofer.aisec.cpg.passes.ImportDependencyMap
 import de.fraunhofer.aisec.cpg.passes.ImportResolver
 import org.neo4j.ogm.annotation.Relationship
+import org.neo4j.ogm.annotation.Transient
 
 /**
  * A node which presents some kind of complete piece of software, e.g., an application, a library,
@@ -46,6 +47,7 @@ open class Component : Node() {
     /** All translation units belonging to this application. */
     val translationUnits by unwrapping(Component::translationUnitEdges)
 
+    @Transient
     @PopulatedByPass(ImportResolver::class)
     var importDependencies: ImportDependencyMap =
         mutableMapOf<TranslationUnitDeclaration, MutableSet<TranslationUnitDeclaration>>()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
@@ -29,7 +29,7 @@ import de.fraunhofer.aisec.cpg.PopulatedByPass
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
-import de.fraunhofer.aisec.cpg.passes.ImportDependencyMap
+import de.fraunhofer.aisec.cpg.passes.ImportDependencies
 import de.fraunhofer.aisec.cpg.passes.ImportResolver
 import org.neo4j.ogm.annotation.Relationship
 import org.neo4j.ogm.annotation.Transient
@@ -49,8 +49,7 @@ open class Component : Node() {
 
     @Transient
     @PopulatedByPass(ImportResolver::class)
-    var importDependencies: ImportDependencyMap =
-        mutableMapOf<TranslationUnitDeclaration, MutableSet<TranslationUnitDeclaration>>()
+    var importDependencies = ImportDependencies(translationUnits)
 
     @Synchronized
     fun addTranslationUnit(tu: TranslationUnitDeclaration) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -776,3 +776,17 @@ fun Expression?.unwrapReference(): Reference? {
         else -> null
     }
 }
+
+/** Returns the [TranslationUnitDeclaration] where this node is located in. */
+val Node.translationUnit: TranslationUnitDeclaration?
+    get() {
+        var node: Node? = this
+        while (node != null) {
+            if (node is TranslationUnitDeclaration) {
+                return node
+            }
+            node = node.astParent
+        }
+
+        return null
+    }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Reference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Reference.kt
@@ -46,8 +46,8 @@ import org.neo4j.ogm.annotation.Relationship
  */
 open class Reference : Expression(), HasType.TypeObserver, HasAliases {
     /**
-     * The [Declaration]s this expression might refer to. This will influence the [declaredType] of
-     * this expression.
+     * The [Declaration]s this expression might refer to. This will influence the [type] of this
+     * expression.
      */
     @PopulatedByPass(SymbolResolver::class)
     @Relationship(value = "REFERS_TO")

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
@@ -29,9 +29,15 @@ import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.ImportDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.NamespaceDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.graph.scopes.NameScope
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
+import de.fraunhofer.aisec.cpg.passes.Pass.Companion.log
+
+typealias ImportDependencyMap =
+    MutableMap<TranslationUnitDeclaration, MutableSet<TranslationUnitDeclaration>>
 
 /**
  * This pass looks for [ImportDeclaration] nodes and imports symbols into their respective [Scope]
@@ -39,12 +45,66 @@ import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 class ImportResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
     lateinit var walker: SubgraphWalker.ScopedWalker
+    lateinit var currentComponent: Component
 
     override fun accept(t: Component) {
-        walker = SubgraphWalker.ScopedWalker(scopeManager)
+        currentComponent = t
 
-        walker.registerHandler(::handleImportDeclaration)
+        // Populate the importedBy with all translation units so that we have an entry in our list
+        // for all
+        t.importDependencies =
+            t.translationUnits
+                .map { Pair(it, mutableSetOf<TranslationUnitDeclaration>()) }
+                .associate { it }
+                .toMutableMap()
+
+        // In order to resolve imports as good as possible, we need the information which namespace
+        // does an import on which other
+        walker = SubgraphWalker.ScopedWalker(scopeManager)
+        walker.registerHandler(::collectImportDependencies)
         walker.iterate(t)
+
+        // Now we need to iterate through all translation units
+        walker.clearCallbacks()
+        walker.registerHandler(::handleImportDeclaration)
+        t.importDependencies.resolveDependencies {
+            log.debug("Resolving imports for translation unit {}", it.name)
+            walker.iterate(it)
+        }
+    }
+
+    private fun collectImportDependencies(node: Node?) {
+        if (node !is ImportDeclaration) {
+            return
+        }
+
+        // Let's look for imported namespaces
+        // First, we need to try to resolve the import
+        val list =
+            scopeManager.lookupSymbolByName(node.import, node.location, scope).toMutableList()
+        for (declaration in list) {
+            if (declaration is NamespaceDeclaration) {
+                var namespaceTu = declaration.translationUnit
+                var importTu = node.translationUnit
+                if (namespaceTu == null || importTu == null) {
+                    continue
+                }
+
+                // If they depend on themselves, we don't care
+                if (namespaceTu == importTu) {
+                    continue
+                }
+
+                var list =
+                    currentComponent.importDependencies.computeIfAbsent(importTu) {
+                        mutableSetOf<TranslationUnitDeclaration>()
+                    }
+                var added = list.add(namespaceTu)
+                if (added) {
+                    log.debug("Added {} as an dependency of {}", namespaceTu.name, importTu.name)
+                }
+            }
+        }
     }
 
     private fun handleImportDeclaration(node: Node?) {
@@ -77,5 +137,70 @@ class ImportResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
     override fun cleanup() {
         // Nothing to do
+    }
+}
+
+val Node.translationUnit: TranslationUnitDeclaration?
+    get() {
+        var node: Node? = this
+        while (node != null) {
+            if (node is TranslationUnitDeclaration) {
+                return node
+            }
+            node = node.astParent
+        }
+
+        return null
+    }
+
+fun ImportDependencyMap.nextTranslationUnitWithoutDependencies(): TranslationUnitDeclaration? {
+    // Loop through all to find one without a value
+    for (entry in this.entries) {
+        if (entry.value.isEmpty()) {
+            return entry.key
+        }
+    }
+
+    return null
+}
+
+private fun ImportDependencyMap.markAsDone(tu: TranslationUnitDeclaration) {
+    // Remove it from the map
+    this.remove(tu)
+
+    // And also remove it from all lists
+    this.values.forEach { it.remove(tu) }
+}
+
+fun ImportDependencyMap.resolveDependencies(callback: (tu: TranslationUnitDeclaration) -> Unit) {
+    var dependencies: ImportDependencyMap =
+        this.map { Pair(it.key, it.value.toMutableSet()) }.associate { it }.toMutableMap()
+
+    while (true) {
+        // Try to get the next TU
+        var tu = dependencies.nextTranslationUnitWithoutDependencies()
+        if (tu != null) {
+            // Handle tu
+            callback(tu)
+            // Mark it as done, this will retrieve any dependencies to this TU from the map
+            dependencies.markAsDone(tu)
+        } else {
+            var remaining = dependencies.keys
+            // No translation units without dependencies found. If there are no translation
+            // units left, this means we are done
+            if (remaining.isEmpty()) {
+                break
+            } else {
+                log.warn(
+                    "We still have {} translation units with import dependency problems. We will just process them in any order",
+                    remaining.size
+                )
+                // If there are still translation units left, we have a problem. This might be
+                // cyclic imports or other cases we did not think of yet. We still want to
+                // handle all the TUs, so we just process them in any order
+                remaining.forEach { callback(it) }
+                break
+            }
+        }
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
@@ -122,7 +122,7 @@ class ImportDependencies(tus: MutableList<TranslationUnitDeclaration>) :
 
                 // Add tu
                 list += tu
-                // Mark it as done, this will retrieve any dependencies to this TU from the map
+                // Mark it as done, this will remove any dependencies to this TU from the map
                 markAsDone(tu)
             }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
@@ -37,6 +37,13 @@ import de.fraunhofer.aisec.cpg.graph.translationUnit
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.passes.Pass.Companion.log
 
+/**
+ * This class holds the information about import dependencies between [TranslationUnitDeclaration]
+ * nodes. The dependency is based on which translation unit imports symbols of another translation
+ * unit (usually in the form of a [NamespaceDeclaration]). The idea is to provide a sorted list of
+ * TUs in which to resolve symbols and imports ideally. This is stored in [sortedTranslationUnits]
+ * and is automatically computed the fist time someone accesses the property.
+ */
 class ImportDependencies(tus: MutableList<TranslationUnitDeclaration>) :
     HashMap<TranslationUnitDeclaration, MutableSet<TranslationUnitDeclaration>>() {
 
@@ -55,6 +62,7 @@ class ImportDependencies(tus: MutableList<TranslationUnitDeclaration>) :
         WorkList(this).resolveDependencies()
     }
 
+    /** Adds a dependency from [importer] to [imported]. */
     fun add(importer: TranslationUnitDeclaration, imported: TranslationUnitDeclaration): Boolean {
         var list = this.computeIfAbsent(importer) { mutableSetOf<TranslationUnitDeclaration>() }
         return list.add(imported)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -102,7 +102,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
         // Resolve symbols in our translation units in the order depending on their import
         // dependencies
-        component.importDependencies.resolveDependencies {
+        component.importDependencies.sortedTranslationUnits.forEach {
             log.debug("Resolving symbols of translation unit {}", it.name)
             currentTU = it
             // Gather all resolution EOG starters; and make sure they really do not have a

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -83,7 +83,6 @@ import org.slf4j.LoggerFactory
 open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
     protected lateinit var walker: ScopedWalker
-    lateinit var currentTU: TranslationUnitDeclaration
 
     protected val templateList = mutableListOf<TemplateDeclaration>()
 
@@ -104,10 +103,10 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         // dependencies
         component.importDependencies.sortedTranslationUnits.forEach {
             log.debug("Resolving symbols of translation unit {}", it.name)
-            currentTU = it
+
             // Gather all resolution EOG starters; and make sure they really do not have a
             // predecessor, otherwise we might analyze a node multiple times
-            val nodes = currentTU.allEOGStarters.filter { it.prevEOGEdges.isEmpty() }
+            val nodes = it.allEOGStarters.filter { it.prevEOGEdges.isEmpty() }
 
             for (node in nodes) {
                 walker.iterate(node)
@@ -150,8 +149,8 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
             }
 
             target =
-                (scope?.astNode ?: currentTU)
-                    .startInference(ctx)
+                (scope?.astNode ?: reference.translationUnit)
+                    ?.startInference(ctx)
                     ?.inferFunctionDeclaration(
                         reference.name,
                         null,
@@ -423,7 +422,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
                     call,
                     true,
                     ctx,
-                    currentTU,
+                    call.translationUnit,
                     false
                 )
             if (ok) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -100,11 +100,14 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         walker.clearCallbacks()
         walker.registerHandler(this::handle)
 
-        for (tu in component.translationUnits) {
-            currentTU = tu
+        // Resolve symbols in our translation units in the order depending on their import
+        // dependencies
+        component.importDependencies.resolveDependencies {
+            log.debug("Resolving symbols of translation unit {}", it.name)
+            currentTU = it
             // Gather all resolution EOG starters; and make sure they really do not have a
             // predecessor, otherwise we might analyze a node multiple times
-            val nodes = tu.allEOGStarters.filter { it.prevEOGEdges.isEmpty() }
+            val nodes = currentTU.allEOGStarters.filter { it.prevEOGEdges.isEmpty() }
 
             for (node in nodes) {
                 walker.iterate(node)

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/FluentTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/FluentTest.kt
@@ -36,6 +36,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.IfStatement
 import de.fraunhofer.aisec.cpg.graph.statements.ReturnStatement
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.passes.EvaluationOrderGraphPass
+import de.fraunhofer.aisec.cpg.passes.ImportResolver
 import de.fraunhofer.aisec.cpg.passes.SymbolResolver
 import de.fraunhofer.aisec.cpg.test.*
 import kotlin.test.*
@@ -167,9 +168,12 @@ class FluentTest {
         assertNotNull(lit2.scope)
         assertEquals(2, lit2.value)
 
-        EvaluationOrderGraphPass(result.finalCtx)
-            .accept(result.components.first().translationUnits.first())
-        SymbolResolver(result.finalCtx).accept(result.components.first())
+        var app = result.components.firstOrNull()
+        assertNotNull(app)
+
+        ImportResolver(result.finalCtx).accept(app)
+        EvaluationOrderGraphPass(result.finalCtx).accept(app.translationUnits.first())
+        SymbolResolver(result.finalCtx).accept(app)
 
         // Now the reference should be resolved and the MCE name set
         assertRefersTo(ref, variable)

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolverTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolverTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2024, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.passes
+
+import de.fraunhofer.aisec.cpg.ScopeManager
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationContext
+import de.fraunhofer.aisec.cpg.TypeManager
+import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.builder.translationResult
+import de.fraunhofer.aisec.cpg.graph.newImportDeclaration
+import de.fraunhofer.aisec.cpg.graph.newNamespaceDeclaration
+import de.fraunhofer.aisec.cpg.graph.newTranslationUnitDeclaration
+import de.fraunhofer.aisec.cpg.graph.newVariableDeclaration
+import de.fraunhofer.aisec.cpg.graph.parseName
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class ImportResolverTest {
+    @Test
+    fun testImportOrderResolve() {
+        val frontend =
+            TestLanguageFrontend(
+                ctx =
+                    TranslationContext(
+                        TranslationConfiguration.builder().defaultPasses().build(),
+                        ScopeManager(),
+                        TypeManager()
+                    )
+            )
+        var result =
+            frontend.build {
+                translationResult {
+                    with(frontend) {
+                            // We create two translation units with one namespace each. One file
+                            // directly imports the other namespace (let's start easy). We
+                            // intentionally
+                            // create them in reverse order
+                            var tuB = newTranslationUnitDeclaration("file.b")
+                            scopeManager.resetToGlobal(tuB)
+                            var pkgB = newNamespaceDeclaration("b")
+                            scopeManager.addDeclaration(pkgB)
+                            scopeManager.enterScope(pkgB)
+                            var import = newImportDeclaration(parseName("a"))
+                            scopeManager.addDeclaration(import)
+                            scopeManager.leaveScope(pkgB)
+                            tuB
+                        }
+                        .also { this.addTranslationUnit(it) }
+
+                    with(frontend) {
+                            var tuA = newTranslationUnitDeclaration("file.a")
+                            scopeManager.resetToGlobal(tuA)
+                            var pkgA = newNamespaceDeclaration("a")
+                            scopeManager.addDeclaration(pkgA)
+                            scopeManager.enterScope(pkgA)
+                            var foo = newVariableDeclaration(parseName("a.foo"))
+                            scopeManager.addDeclaration(foo)
+                            scopeManager.leaveScope(pkgA)
+                            tuA
+                        }
+                        .also { this.addTranslationUnit(it) }
+                }
+            }
+
+        assertNotNull(result)
+        var foo = result.variables["a.foo"]
+        assertNotNull(foo)
+
+        var app = result.components.firstOrNull()
+        assertNotNull(app)
+
+        // a has 0 dependency
+        var a =
+            app.importDependencies.entries
+                .filter { it.key.name.localName == "file.a" }
+                .firstOrNull()
+        assertNotNull(a)
+        assertEquals(0, a.value.size)
+
+        // b has 1 dependency (a)
+        var b =
+            app.importDependencies.entries
+                .filter { it.key.name.localName == "file.b" }
+                .firstOrNull()
+        assertNotNull(b)
+        assertEquals(1, b.value.size)
+        assertEquals(setOf(a.key), b.value)
+    }
+}


### PR DESCRIPTION
This PR establishes a dependency graph between translation units using their import declarations. This enables the symbol and import resolver to leverage this information to resolve symbols in an ordered way so that translation units that are depended on are resolved first.