### PR TITLE
`implicit()` only triggers code/location update now if its not empty

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -256,8 +256,12 @@ interface RawNodeTypeProvider<T> : MetadataProvider
  * This also sets [Node.isImplicit] to true.
  */
 fun <T : Node> T.implicit(code: String? = null, location: PhysicalLocation? = null): T {
-    this.code = code
-    this.location = location
+    if (code != null) {
+        this.code = code
+    }
+    if (location != null) {
+        this.location = location
+    }
     this.isImplicit = true
 
     return this


### PR DESCRIPTION
Otherwise, we override the code/location again.
