### PR TITLE
Handle nested functions

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/FunctionScope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/FunctionScope.kt
@@ -27,4 +27,4 @@ package de.fraunhofer.aisec.cpg.graph.scopes
 
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 
-class FunctionScope(astNode: FunctionDeclaration) : ValueDeclarationScope(astNode) {}
+class FunctionScope(astNode: FunctionDeclaration) : ValueDeclarationScope(astNode)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/Statement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/Statement.kt
@@ -45,9 +45,9 @@ import org.neo4j.ogm.annotation.Relationship
 @NodeEntity
 abstract class Statement : Node(), DeclarationHolder {
     /**
-     * A list of local variables associated to this statement, defined by their
-     * [VariableDeclaration] extracted from Block because for, while, if, switch can declare locals
-     * in their condition or initializers.
+     * A list of local variables (or other values) associated to this statement, defined by their
+     * [ValueDeclaration] extracted from Block because `for`, `while`, `if`, and `switch` can
+     * declare locals in their condition or initializers.
      *
      * TODO: This is actually an AST node just for a subset of nodes, i.e. initializers in for-loops
      */

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/Statement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/Statement.kt
@@ -28,6 +28,8 @@ package de.fraunhofer.aisec.cpg.graph.statements
 import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
+import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
@@ -43,13 +45,14 @@ import org.neo4j.ogm.annotation.Relationship
 @NodeEntity
 abstract class Statement : Node(), DeclarationHolder {
     /**
-     * A list of local variables associated to this statement, defined by their [ ] extracted from
-     * Block because for, while, if, switch can declare locals in their condition or initializers.
+     * A list of local variables associated to this statement, defined by their
+     * [VariableDeclaration] extracted from Block because for, while, if, switch can declare locals
+     * in their condition or initializers.
      *
      * TODO: This is actually an AST node just for a subset of nodes, i.e. initializers in for-loops
      */
     @Relationship(value = "LOCALS", direction = Relationship.Direction.OUTGOING)
-    var localEdges = astEdgesOf<VariableDeclaration>()
+    var localEdges = astEdgesOf<ValueDeclaration>()
 
     /** Virtual property to access [localEdges] without property edges. */
     var locals by unwrapping(Statement::localEdges)
@@ -66,6 +69,8 @@ abstract class Statement : Node(), DeclarationHolder {
 
     override fun addDeclaration(declaration: Declaration) {
         if (declaration is VariableDeclaration) {
+            addIfNotContains(localEdges, declaration)
+        } else if (declaration is FunctionDeclaration) {
             addIfNotContains(localEdges, declaration)
         }
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Block.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/Block.kt
@@ -45,9 +45,9 @@ open class Block : Expression(), StatementHolder {
     override var statementEdges = astEdgesOf<Statement>()
     override var statements by unwrapping(Block::statementEdges)
     /**
-     * This variable helps to differentiate between static and non static initializer blocks. Static
+     * This variable helps to differentiate between static and non-static initializer blocks. Static
      * initializer blocks are executed when the enclosing declaration is first referred to, e.g.
-     * loaded into the jvm or parsed. Non static initializers are executed on Record construction.
+     * loaded into the jvm or parsed. Non-static initializers are executed on Record construction.
      *
      * If a compound statement is part of a method body, this notion is not relevant.
      */

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
@@ -42,6 +42,33 @@ import kotlin.test.*
 
 class PythonFrontendTest : BaseTest() {
     @Test
+    fun testNestedFunctions() {
+        val topLevel = Path.of("src", "test", "resources", "python")
+        val tu =
+            analyzeAndGetFirstTU(
+                listOf(topLevel.resolve("nested_functions.py").toFile()),
+                topLevel,
+                true
+            ) {
+                it.registerLanguage<PythonLanguage>()
+            }
+        assertNotNull(tu)
+        // Check that all three functions exist
+        val level1 = tu.functions["level1"]
+        assertNotNull(level1)
+        val level2 = tu.functions["level2"]
+        assertNotNull(level2)
+        val level3 = tu.functions["level3"]
+        assertNotNull(level3)
+        // Only level2 and level3 are children of level1
+        assertEquals(setOf(level2, level3), level1.body.functions.toSet())
+        // Only level3 is child of level2
+        assertEquals(setOf(level3), level2.body.functions.toSet())
+        // No child for level3
+        assertEquals(setOf(), level3.body.functions.toSet())
+    }
+
+    @Test
     fun testLiteral() {
         val topLevel = Path.of("src", "test", "resources", "python")
         val tu =

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/statementHandler/StatementHandlerTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/statementHandler/StatementHandlerTest.kt
@@ -286,18 +286,6 @@ class StatementHandlerTest : BaseTest() {
     }
 
     @Test
-    fun testNonlocal() {
-        var file = topLevel.resolve("nonlocal.py").toFile()
-        val result = analyze(listOf(file), topLevel, true) { it.registerLanguage<PythonLanguage>() }
-        assertNotNull(result)
-
-        // There will be only 1 variable declarations because we are currently not adding nested
-        // functions to the AST properly :(
-        var cVariables = result.variables("c")
-        assertEquals(1, cVariables.size)
-    }
-
-    @Test
     fun testNonLocal() {
         var file = topLevel.resolve("nonlocal.py").toFile()
         val result = analyze(listOf(file), topLevel, true) { it.registerLanguage<PythonLanguage>() }

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/statementHandler/StatementHandlerTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/statementHandler/StatementHandlerTest.kt
@@ -297,8 +297,6 @@ class StatementHandlerTest : BaseTest() {
         assertEquals(1, cVariables.size)
     }
 
-    // TODO(oxisto): Re-renable this once we parse nested functions
-    @Ignore
     @Test
     fun testNonLocal() {
         var file = topLevel.resolve("nonlocal.py").toFile()

--- a/cpg-language-python/src/test/resources/python/nested_functions.py
+++ b/cpg-language-python/src/test/resources/python/nested_functions.py
@@ -1,0 +1,13 @@
+def level1():
+    c = 1
+    def level2():
+        d = 1
+        def level3():
+            nonlocal c, d
+            c = c + 2
+            d = d + 1
+            print(c)
+
+        level3()
+    level2()
+level1()


### PR DESCRIPTION
Nested functions have not been added to the AST because they occur inside a `BlockScope` but the `Block` only accepted `VariableDeclaration`s as locals. This is not correct and has been extended to `ValueDeclaration` which also covers the `FunctionDeclaration`.

Fixes #1736 