### PR TITLE
Fix cycle in CDG pass

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlDependenceGraphPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlDependenceGraphPass.kt
@@ -151,13 +151,16 @@ open class ControlDependenceGraphPass(ctx: TranslationContext) : EOGStarterPass(
                                 if (
                                     update &&
                                         alreadySeen.none {
-                                            it.first == entry.first && it.second == entry.second
+                                            it.first == entry.first &&
+                                                it.second.containsAll(entry.second)
                                         }
                                 )
                                     dominatorsList.add(entry)
                                 else finalDominators.add(entry)
                             }
-                            alreadySeen.none { it.first == newK && it.second == newV } -> {
+                            alreadySeen.none {
+                                it.first == newK && it.second.containsAll(newV)
+                            } -> {
                                 // We don't have an entry yet => add a new one
                                 val newEntry = Pair(newK, newV.toMutableSet())
                                 dominatorsList.add(newEntry)

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
@@ -34,6 +34,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.ObjectType
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
+import de.fraunhofer.aisec.cpg.passes.ControlDependenceGraphPass
 import de.fraunhofer.aisec.cpg.sarif.Region
 import de.fraunhofer.aisec.cpg.test.*
 import java.nio.file.Path
@@ -41,6 +42,22 @@ import kotlin.math.pow
 import kotlin.test.*
 
 class PythonFrontendTest : BaseTest() {
+
+    @Test
+    fun test1740EndlessCDG() {
+        val topLevel = Path.of("src", "test", "resources", "python")
+        val tu =
+            analyzeAndGetFirstTU(
+                listOf(topLevel.resolve("1740_endless_cdg_loop.py").toFile()),
+                topLevel,
+                true
+            ) {
+                it.registerLanguage<PythonLanguage>()
+                it.registerPass<ControlDependenceGraphPass>()
+            }
+        assertNotNull(tu)
+    }
+
     @Test
     fun testLiteral() {
         val topLevel = Path.of("src", "test", "resources", "python")

--- a/cpg-language-python/src/test/resources/python/1740_endless_cdg_loop.py
+++ b/cpg-language-python/src/test/resources/python/1740_endless_cdg_loop.py
@@ -1,0 +1,6 @@
+def this_will_loop():
+    double_nested_list = {}
+    for key, value in double_nested_list:
+        if True:
+            for subkey, subvalue in value:
+                pass


### PR DESCRIPTION
When generating the CDG, we had a cycle because we accepted smaller states as "unique" when lifting up some stuff after the EOG iteration. This doesn't make sense and is fixed by improved checks.

Fixes #1740 