### PR TITLE
Rework extensions to follow subgraphs

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -200,19 +200,38 @@ class FulfilledAndFailedPaths(val fulfilled: List<List<Node>>, val failed: List<
  * but not mandatory**. If the list "failed" is empty, the data flow is mandatory.
  */
 fun Node.followPrevFullDFGEdgesUntilHit(predicate: (Node) -> Boolean): FulfilledAndFailedPaths {
-    return followXUntilHit({ currentNode -> currentNode.prevFullDFG }, true, true, predicate)
+    return followXUntilHit(
+        x = { currentNode -> currentNode.prevFullDFG },
+        collectFailedPaths = true,
+        findAllPossiblePaths = true,
+        predicate = predicate
+    )
 }
 
 fun Node.collectAllPrevCDGPaths(interproceduralAnalysis: Boolean): List<List<Node>> {
     // We make everything fail to reach the end of the CDG. Then, we use the stuff collected in the
     // failed paths (everything)
-    return this.followPrevCDGUntilHit(true, true, interproceduralAnalysis) { false }.failed
+    return this.followPrevCDGUntilHit(
+            collectFailedPaths = true,
+            findAllPossiblePaths = true,
+            interproceduralAnalysis = interproceduralAnalysis
+        ) {
+            false
+        }
+        .failed
 }
 
 fun Node.collectAllNextCDGPaths(interproceduralAnalysis: Boolean): List<List<Node>> {
     // We make everything fail to reach the end of the CDG. Then, we use the stuff collected in the
     // failed paths (everything)
-    return this.followNextCDGUntilHit(true, true, interproceduralAnalysis) { false }.failed
+    return this.followNextCDGUntilHit(
+            collectFailedPaths = true,
+            findAllPossiblePaths = true,
+            interproceduralAnalysis = interproceduralAnalysis
+        ) {
+            false
+        }
+        .failed
 }
 
 /**
@@ -231,16 +250,16 @@ fun Node.followNextCDGUntilHit(
     predicate: (Node) -> Boolean
 ): FulfilledAndFailedPaths {
     return followXUntilHit(
-        { currentNode ->
+        x = { currentNode ->
             val nextNodes = currentNode.nextCDG.toMutableList()
             if (interproceduralAnalysis) {
                 nextNodes.addAll((currentNode as? CallExpression)?.calls ?: listOf())
             }
             nextNodes
         },
-        collectFailedPaths,
-        findAllPossiblePaths,
-        predicate
+        collectFailedPaths = collectFailedPaths,
+        findAllPossiblePaths = findAllPossiblePaths,
+        predicate = predicate
     )
 }
 
@@ -261,7 +280,7 @@ fun Node.followPrevCDGUntilHit(
     predicate: (Node) -> Boolean
 ): FulfilledAndFailedPaths {
     return followXUntilHit(
-        { currentNode ->
+        x = { currentNode ->
             val nextNodes = currentNode.prevCDG.toMutableList()
             if (interproceduralAnalysis) {
                 nextNodes.addAll(
@@ -272,9 +291,9 @@ fun Node.followPrevCDGUntilHit(
             }
             nextNodes
         },
-        collectFailedPaths,
-        findAllPossiblePaths,
-        predicate
+        collectFailedPaths = collectFailedPaths,
+        findAllPossiblePaths = findAllPossiblePaths,
+        predicate = predicate
     )
 }
 
@@ -357,10 +376,10 @@ fun Node.followNextFullDFGEdgesUntilHit(
     predicate: (Node) -> Boolean
 ): FulfilledAndFailedPaths {
     return followXUntilHit(
-        { currentNode -> currentNode.nextFullDFG },
-        collectFailedPaths,
-        findAllPossiblePaths,
-        predicate
+        x = { currentNode -> currentNode.nextFullDFG },
+        collectFailedPaths = collectFailedPaths,
+        findAllPossiblePaths = findAllPossiblePaths,
+        predicate = predicate
     )
 }
 
@@ -376,12 +395,12 @@ fun Node.followNextFullDFGEdgesUntilHit(
  */
 fun Node.followNextEOGEdgesUntilHit(predicate: (Node) -> Boolean): FulfilledAndFailedPaths {
     return followXUntilHit(
-        { currentNode ->
+        x = { currentNode ->
             currentNode.nextEOGEdges.filter { it.unreachable != true }.map { it.end }
         },
-        true,
-        true,
-        predicate
+        collectFailedPaths = true,
+        findAllPossiblePaths = true,
+        predicate = predicate
     )
 }
 
@@ -397,12 +416,12 @@ fun Node.followNextEOGEdgesUntilHit(predicate: (Node) -> Boolean): FulfilledAndF
  */
 fun Node.followPrevEOGEdgesUntilHit(predicate: (Node) -> Boolean): FulfilledAndFailedPaths {
     return followXUntilHit(
-        { currentNode ->
+        x = { currentNode ->
             currentNode.prevEOGEdges.filter { it.unreachable != true }.map { it.start }
         },
-        true,
-        true,
-        predicate
+        collectFailedPaths = true,
+        findAllPossiblePaths = true,
+        predicate = predicate
     )
 }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -200,104 +200,7 @@ class FulfilledAndFailedPaths(val fulfilled: List<List<Node>>, val failed: List<
  * but not mandatory**. If the list "failed" is empty, the data flow is mandatory.
  */
 fun Node.followPrevFullDFGEdgesUntilHit(predicate: (Node) -> Boolean): FulfilledAndFailedPaths {
-    val fulfilledPaths = mutableListOf<List<Node>>()
-    val failedPaths = mutableListOf<List<Node>>()
-    val worklist = mutableListOf<List<Node>>()
-    worklist.add(listOf(this))
-
-    while (worklist.isNotEmpty()) {
-        val currentPath = worklist.removeFirst()
-        if (currentPath.last().prevFullDFG.isEmpty()) {
-            // No further nodes in the path and the path criteria are not satisfied.
-            failedPaths.add(currentPath)
-            continue
-        }
-
-        for (prev in currentPath.last().prevFullDFG) {
-            // Copy the path for each outgoing DFG edge and add the prev node
-            val nextPath = mutableListOf<Node>()
-            nextPath.addAll(currentPath)
-            nextPath.add(prev)
-
-            if (predicate(prev)) {
-                fulfilledPaths.add(nextPath)
-                continue // Don't add this path anymore. The requirement is satisfied.
-            }
-            // The prev node is new in the current path (i.e., there's no loop), so we add the path
-            // with the next step to the worklist.
-            if (!currentPath.contains(prev)) {
-                worklist.add(nextPath)
-            }
-        }
-    }
-
-    return FulfilledAndFailedPaths(fulfilledPaths, failedPaths)
-}
-
-/**
- * Returns an instance of [FulfilledAndFailedPaths] where [FulfilledAndFailedPaths.fulfilled]
- * contains all possible shortest data flow paths (with [ControlDependence]) between the starting
- * node [this] and the end node fulfilling [predicate]. The paths are represented as lists of nodes.
- * Paths which do not end at such a node are included in [FulfilledAndFailedPaths.failed].
- *
- * Hence, if "fulfilled" is a non-empty list, a data flow from [this] to such a node is **possible
- * but not mandatory**. If the list "failed" is empty, the data flow is mandatory.
- */
-fun Node.followNextCDGUntilHit(
-    collectFailedPaths: Boolean = true,
-    findAllPossiblePaths: Boolean = true,
-    interproceduralAnalysis: Boolean = false,
-    predicate: (Node) -> Boolean
-): FulfilledAndFailedPaths {
-    // Looks complicated but at least it's not recursive...
-    // result: List of paths (between from and to)
-    val fulfilledPaths = mutableListOf<List<Node>>()
-    // failedPaths: All the paths which do not satisfy "predicate"
-    val failedPaths = mutableListOf<List<Node>>()
-    // The list of paths where we're not done yet.
-    val worklist = mutableSetOf<List<Node>>()
-    worklist.add(listOf(this)) // We start only with the "from" node (=this)
-
-    val alreadySeenNodes = mutableSetOf<Node>()
-
-    while (worklist.isNotEmpty()) {
-        val currentPath = worklist.maxBy { it.size }
-        worklist.remove(currentPath)
-        val currentNode = currentPath.last()
-        alreadySeenNodes.add(currentNode)
-        // The last node of the path is where we continue. We get all of its outgoing CDG edges and
-        // follow them
-        var nextNodes = currentNode.nextCDG.toMutableList()
-        if (interproceduralAnalysis) {
-            nextNodes.addAll((currentNode as? CallExpression)?.calls ?: listOf())
-        }
-
-        // No further nodes in the path and the path criteria are not satisfied.
-        if (nextNodes.isEmpty() && collectFailedPaths) failedPaths.add(currentPath)
-
-        for (next in nextNodes) {
-            // Copy the path for each outgoing CDG edge and add the next node
-            val nextPath = currentPath.toMutableList()
-            nextPath.add(next)
-            if (predicate(next)) {
-                // We ended up in the node fulfilling "predicate", so we're done for this path. Add
-                // the path to the results.
-                fulfilledPaths.add(nextPath)
-                continue // Don't add this path anymore. The requirement is satisfied.
-            }
-            // The next node is new in the current path (i.e., there's no loop), so we add the path
-            // with the next step to the worklist.
-            if (
-                next !in currentPath &&
-                    (findAllPossiblePaths ||
-                        (next !in alreadySeenNodes && worklist.none { next in it }))
-            ) {
-                worklist.add(nextPath)
-            }
-        }
-    }
-
-    return FulfilledAndFailedPaths(fulfilledPaths, failedPaths)
+    return followXUntilHit({ currentNode -> currentNode.prevFullDFG }, true, true, predicate)
 }
 
 fun Node.collectAllPrevCDGPaths(interproceduralAnalysis: Boolean): List<List<Node>> {
@@ -315,17 +218,80 @@ fun Node.collectAllNextCDGPaths(interproceduralAnalysis: Boolean): List<List<Nod
 /**
  * Returns an instance of [FulfilledAndFailedPaths] where [FulfilledAndFailedPaths.fulfilled]
  * contains all possible shortest data flow paths (with [ControlDependence]) between the starting
+ * node [this] and the end node fulfilling [predicate]. The paths are represented as lists of nodes.
+ * Paths which do not end at such a node are included in [FulfilledAndFailedPaths.failed].
+ *
+ * Hence, if "fulfilled" is a non-empty list, a data flow from [this] to such a node is **possible
+ * but not mandatory**. If the list "failed" is empty, the data flow is mandatory.
+ */
+fun Node.followNextCDGUntilHit(
+    collectFailedPaths: Boolean = true,
+    findAllPossiblePaths: Boolean = true,
+    interproceduralAnalysis: Boolean = false,
+    predicate: (Node) -> Boolean
+): FulfilledAndFailedPaths {
+    return followXUntilHit(
+        { currentNode ->
+            val nextNodes = currentNode.nextCDG.toMutableList()
+            if (interproceduralAnalysis) {
+                nextNodes.addAll((currentNode as? CallExpression)?.calls ?: listOf())
+            }
+            nextNodes
+        },
+        collectFailedPaths,
+        findAllPossiblePaths,
+        predicate
+    )
+}
+
+/**
+ * Returns an instance of [FulfilledAndFailedPaths] where [FulfilledAndFailedPaths.fulfilled]
+ * contains all possible shortest data flow paths (with [ControlDependence]) between the starting
  * node [this] and the end node fulfilling [predicate] (backwards analysis). The paths are
  * represented as lists of nodes. Paths which do not end at such a node are included in
  * [FulfilledAndFailedPaths.failed].
  *
- * Hence, if "fulfilled" is a non-empty list, a data flow from [this] to such a node is **possible
+ * Hence, if "fulfilled" is a non-empty list, a CDG path from [this] to such a node is **possible
  * but not mandatory**. If the list "failed" is empty, the data flow is mandatory.
  */
 fun Node.followPrevCDGUntilHit(
     collectFailedPaths: Boolean = true,
     findAllPossiblePaths: Boolean = true,
     interproceduralAnalysis: Boolean = false,
+    predicate: (Node) -> Boolean
+): FulfilledAndFailedPaths {
+    return followXUntilHit(
+        { currentNode ->
+            val nextNodes = currentNode.prevCDG.toMutableList()
+            if (interproceduralAnalysis) {
+                nextNodes.addAll(
+                    (currentNode as? FunctionDeclaration)?.usages?.mapNotNull {
+                        it.astParent as? CallExpression
+                    } ?: listOf()
+                )
+            }
+            nextNodes
+        },
+        collectFailedPaths,
+        findAllPossiblePaths,
+        predicate
+    )
+}
+
+/**
+ * Returns an instance of [FulfilledAndFailedPaths] where [FulfilledAndFailedPaths.fulfilled]
+ * contains all possible shortest data flow paths (with [x] specifying how to fetch more nodes)
+ * between the starting node [this] and the end node fulfilling [predicate] (backwards analysis).
+ * The paths are represented as lists of nodes. Paths which do not end at such a node are included
+ * in [FulfilledAndFailedPaths.failed].
+ *
+ * Hence, if "fulfilled" is a non-empty list, a path from [this] to such a node is **possible but
+ * not mandatory**. If the list "failed" is empty, the path is mandatory.
+ */
+fun Node.followXUntilHit(
+    x: (Node) -> List<Node>,
+    collectFailedPaths: Boolean = true,
+    findAllPossiblePaths: Boolean = true,
     predicate: (Node) -> Boolean
 ): FulfilledAndFailedPaths {
     // Looks complicated but at least it's not recursive...
@@ -346,14 +312,7 @@ fun Node.followPrevCDGUntilHit(
         alreadySeenNodes.add(currentNode)
         // The last node of the path is where we continue. We get all of its outgoing CDG edges and
         // follow them
-        var nextNodes = currentNode.prevCDG.toMutableList()
-        if (interproceduralAnalysis) {
-            nextNodes.addAll(
-                (currentNode as? FunctionDeclaration)?.usages?.mapNotNull {
-                    it.astParent as? CallExpression
-                } ?: listOf()
-            )
-        }
+        var nextNodes = x(currentNode)
 
         // No further nodes in the path and the path criteria are not satisfied.
         if (nextNodes.isEmpty() && collectFailedPaths) failedPaths.add(currentPath)
@@ -397,52 +356,12 @@ fun Node.followNextFullDFGEdgesUntilHit(
     findAllPossiblePaths: Boolean = true,
     predicate: (Node) -> Boolean
 ): FulfilledAndFailedPaths {
-    // Looks complicated but at least it's not recursive...
-    // result: List of paths (between from and to)
-    val fulfilledPaths = mutableListOf<List<Node>>()
-    // failedPaths: All the paths which do not satisfy "predicate"
-    val failedPaths = mutableListOf<List<Node>>()
-    // The list of paths where we're not done yet.
-    val worklist = mutableSetOf<List<Node>>()
-    worklist.add(listOf(this)) // We start only with the "from" node (=this)
-
-    val alreadySeenNodes = mutableSetOf<Node>()
-
-    while (worklist.isNotEmpty()) {
-        val currentPath = worklist.maxBy { it.size }
-        worklist.remove(currentPath)
-        val currentNode = currentPath.last()
-        alreadySeenNodes.add(currentNode)
-        // The last node of the path is where we continue. We get all of its outgoing DFG edges and
-        // follow them
-        if (currentNode.nextFullDFG.isEmpty()) {
-            // No further nodes in the path and the path criteria are not satisfied.
-            if (collectFailedPaths) failedPaths.add(currentPath)
-        }
-
-        for (next in currentNode.nextFullDFG) {
-            // Copy the path for each outgoing DFG edge and add the next node
-            val nextPath = currentPath.toMutableList()
-            nextPath.add(next)
-            if (predicate(next)) {
-                // We ended up in the node fulfilling "predicate", so we're done for this path. Add
-                // the path to the results.
-                fulfilledPaths.add(nextPath)
-                continue // Don't add this path anymore. The requirement is satisfied.
-            }
-            // The next node is new in the current path (i.e., there's no loop), so we add the path
-            // with the next step to the worklist.
-            if (
-                next !in currentPath &&
-                    (findAllPossiblePaths ||
-                        (next !in alreadySeenNodes && worklist.none { next in it }))
-            ) {
-                worklist.add(nextPath)
-            }
-        }
-    }
-
-    return FulfilledAndFailedPaths(fulfilledPaths, failedPaths)
+    return followXUntilHit(
+        { currentNode -> currentNode.nextFullDFG },
+        collectFailedPaths,
+        findAllPossiblePaths,
+        predicate
+    )
 }
 
 /**
@@ -456,45 +375,14 @@ fun Node.followNextFullDFGEdgesUntilHit(
  * such a statement is always executed.
  */
 fun Node.followNextEOGEdgesUntilHit(predicate: (Node) -> Boolean): FulfilledAndFailedPaths {
-    // Looks complicated but at least it's not recursive...
-    // result: List of paths (between from and to)
-    val fulfilledPaths = mutableListOf<List<Node>>()
-    // failedPaths: All the paths which do not satisfy "predicate"
-    val failedPaths = mutableListOf<List<Node>>()
-    // The list of paths where we're not done yet.
-    val worklist = mutableListOf<List<Node>>()
-    worklist.add(listOf(this)) // We start only with the "from" node (=this)
-
-    while (worklist.isNotEmpty()) {
-        val currentPath = worklist.removeFirst()
-        // The last node of the path is where we continue. We get all of its outgoing DFG edges and
-        // follow them
-        if (currentPath.last().nextEOGEdges.none { it.unreachable != true }) {
-            // No further nodes in the path and the path criteria are not satisfied.
-            failedPaths.add(currentPath)
-            continue // Don't add this path anymore. The requirement is satisfied.
-        }
-
-        for (next in
-            currentPath.last().nextEOGEdges.filter { it.unreachable != true }.map { it.end }) {
-            // Copy the path for each outgoing DFG edge and add the next node
-            val nextPath = mutableListOf<Node>()
-            nextPath.addAll(currentPath)
-            nextPath.add(next)
-            if (predicate(next)) {
-                // We ended up in the node "to", so we're done. Add the path to the results.
-                fulfilledPaths.add(nextPath)
-                continue // Don't add this path anymore. The requirement is satisfied.
-            }
-            // The next node is new in the current path (i.e., there's no loop), so we add the path
-            // with the next step to the worklist.
-            if (!currentPath.contains(next)) {
-                worklist.add(nextPath)
-            }
-        }
-    }
-
-    return FulfilledAndFailedPaths(fulfilledPaths, failedPaths)
+    return followXUntilHit(
+        { currentNode ->
+            currentNode.nextEOGEdges.filter { it.unreachable != true }.map { it.end }
+        },
+        true,
+        true,
+        predicate
+    )
 }
 
 /**
@@ -508,45 +396,14 @@ fun Node.followNextEOGEdgesUntilHit(predicate: (Node) -> Boolean): FulfilledAndF
  * such a statement is always executed.
  */
 fun Node.followPrevEOGEdgesUntilHit(predicate: (Node) -> Boolean): FulfilledAndFailedPaths {
-    // Looks complicated but at least it's not recursive...
-    // result: List of paths (between from and to)
-    val fulfilledPaths = mutableListOf<List<Node>>()
-    // failedPaths: All the paths which do not satisfy "predicate"
-    val failedPaths = mutableListOf<List<Node>>()
-    // The list of paths where we're not done yet.
-    val worklist = mutableListOf<List<Node>>()
-    worklist.add(listOf(this)) // We start only with the "from" node (=this)
-
-    while (worklist.isNotEmpty()) {
-        val currentPath = worklist.removeFirst()
-        // The last node of the path is where we continue. We get all of its outgoing DFG edges and
-        // follow them
-        if (currentPath.last().prevEOGEdges.none { it.unreachable != true }) {
-            // No further nodes in the path and the path criteria are not satisfied.
-            failedPaths.add(currentPath)
-            continue // Don't add this path anymore. The requirement is satisfied.
-        }
-
-        for (next in
-            currentPath.last().prevEOGEdges.filter { it.unreachable != true }.map { it.start }) {
-            // Copy the path for each outgoing DFG edge and add the next node
-            val nextPath = mutableListOf<Node>()
-            nextPath.addAll(currentPath)
-            nextPath.add(next)
-            if (predicate(next)) {
-                // We ended up in the node "to", so we're done. Add the path to the results.
-                fulfilledPaths.add(nextPath)
-                continue // Don't add this path anymore. The requirement is satisfied.
-            }
-            // The next node is new in the current path (i.e., there's no loop), so we add the path
-            // with the next step to the worklist.
-            if (!currentPath.contains(next)) {
-                worklist.add(nextPath)
-            }
-        }
-    }
-
-    return FulfilledAndFailedPaths(fulfilledPaths, failedPaths)
+    return followXUntilHit(
+        { currentNode ->
+            currentNode.prevEOGEdges.filter { it.unreachable != true }.map { it.start }
+        },
+        true,
+        true,
+        predicate
+    )
 }
 
 /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -300,6 +300,18 @@ fun Node.followNextCDGUntilHit(
     return FulfilledAndFailedPaths(fulfilledPaths, failedPaths)
 }
 
+fun Node.collectAllPrevCDGPaths(interproceduralAnalysis: Boolean): List<List<Node>> {
+    // We make everything fail to reach the end of the CDG. Then, we use the stuff collected in the
+    // failed paths (everything)
+    return this.followPrevCDGUntilHit(true, true, interproceduralAnalysis) { false }.failed
+}
+
+fun Node.collectAllNextCDGPaths(interproceduralAnalysis: Boolean): List<List<Node>> {
+    // We make everything fail to reach the end of the CDG. Then, we use the stuff collected in the
+    // failed paths (everything)
+    return this.followNextCDGUntilHit(true, true, interproceduralAnalysis) { false }.failed
+}
+
 /**
  * Returns an instance of [FulfilledAndFailedPaths] where [FulfilledAndFailedPaths.fulfilled]
  * contains all possible shortest data flow paths (with [ControlDependence]) between the starting


### PR DESCRIPTION
Reworks extensions following prev/next DFG and EOG and also adds CDG- and PDG-following functions. Both new functions feature an optional interprocedural analysis which explores the callgraph.

Since there was a bunch of redundant code, the iteration was merged into a single method and only the way in which to collect the next step has to be provided by the respective specialized subgraph-following-methods.