### PR TITLE
Replace UnaryOperator("throw") with ThrowStatement for java

### DIFF
--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
@@ -79,9 +79,8 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
         stmt: Statement
     ): de.fraunhofer.aisec.cpg.graph.statements.Statement {
         val throwStmt = stmt as ThrowStmt
-        val throwOperation =
-            this.newUnaryOperator("throw", postfix = false, prefix = true, rawNode = stmt)
-        throwOperation.input =
+        val throwOperation = newThrowStatement(rawNode = stmt)
+        throwOperation.exception =
             frontend.expressionHandler.handle(throwStmt.expression)
                 as de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
         return throwOperation


### PR DESCRIPTION
Replaces the usage of a `UnaryOperator` with operatorCode "throw" with the new node `ThrowStatement` in the java frontend.