### PR TITLE
Replace UnaryOperator("throw") with ThrowStatement for LLVM

### DIFF
--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/StatementHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/StatementHandler.kt
@@ -175,7 +175,10 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
             LLVMResume -> {
                 // Resumes propagation of an existing (in-flight) exception whose unwinding was
                 // interrupted with a landingpad instruction.
-                return newUnaryOperator("throw", postfix = false, prefix = true, rawNode = instr)
+                return newThrowStatement(rawNode = instr).apply {
+                    exception =
+                        newProblemExpression("We don't know the exception while parsing this node.")
+                }
             }
             LLVMLandingPad -> {
                 return handleLandingpad(instr)
@@ -335,10 +338,13 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
         } else {
             // "unwind to caller". As we don't know where the control flow continues,
             // the best model would be to throw the exception again. Here, we only know
-            // that we will throw something here but we don't know what. We have to fix
+            // that we will throw something here, but we don't know what. We have to fix
             // that later once we know in which catch-block this statement is executed.
             val throwOperation =
-                newUnaryOperator("throw", postfix = false, prefix = true, rawNode = instr)
+                newThrowStatement(rawNode = instr).apply {
+                    exception =
+                        newProblemExpression("We don't know the exception while parsing this node.")
+                }
             currentIfStatement?.elseStatement = throwOperation
         }
 

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CompressLLVMPass.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CompressLLVMPass.kt
@@ -31,7 +31,6 @@ import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Block
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.ProblemExpression
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.UnaryOperator
 import de.fraunhofer.aisec.cpg.graph.types.UnknownType
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteFirst
@@ -189,10 +188,8 @@ class CompressLLVMPass(ctx: TranslationContext) : ComponentPass(ctx) {
      */
     private fun fixThrowStatementsForCatch(catch: CatchClause) {
         val reachableThrowNodes =
-            getAllChildrenRecursively(catch).filter { n ->
-                n is UnaryOperator &&
-                    n.operatorCode?.equals("throw") == true &&
-                    n.input is ProblemExpression
+            getAllChildrenRecursively(catch).filterIsInstance<ThrowStatement>().filter { n ->
+                n.exception is ProblemExpression
             }
         if (reachableThrowNodes.isNotEmpty()) {
             if (catch.parameter == null) {
@@ -212,7 +209,7 @@ class CompressLLVMPass(ctx: TranslationContext) : ComponentPass(ctx) {
                 )
             exceptionReference.language = catch.language
             exceptionReference.refersTo = catch.parameter
-            reachableThrowNodes.forEach { n -> (n as UnaryOperator).input = exceptionReference }
+            reachableThrowNodes.forEach { n -> n.exception = exceptionReference }
         }
     }
 

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -991,12 +991,11 @@ class LLVMIRLanguageFrontendTest {
 
         val innerCatchThrows =
             (innerTry.catchClauses[0].body?.statements?.get(1) as? IfStatement)?.elseStatement
-                as? UnaryOperator
-        assertNotNull(innerCatchThrows)
-        assertNotNull(innerCatchThrows.input)
+        assertIs<ThrowStatement>(innerCatchThrows)
+        assertNotNull(innerCatchThrows.exception)
         assertSame(
             innerTry.catchClauses[0].parameter,
-            (innerCatchThrows.input as? Reference)?.refersTo
+            (innerCatchThrows.exception as? Reference)?.refersTo
         )
     }
 

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -920,34 +920,29 @@ class LLVMIRLanguageFrontendTest {
         val tryStatement =
             (funcF.bodyOrNull<LabelStatement>(0)?.subStatement as? Block)
                 ?.statements
-                ?.firstOrNull { s -> s is TryStatement } as? TryStatement
-        assertNotNull(tryStatement)
+                ?.firstOrNull { s -> s is TryStatement }
+        assertIs<TryStatement>(tryStatement)
         assertEquals(2, tryStatement.tryBlock?.statements?.size)
         assertFullName(
             "_CxxThrowException",
             tryStatement.tryBlock?.statements?.get(0) as? CallExpression
         )
-        assertEquals(
+        assertLocalName(
             "end",
-            (tryStatement.tryBlock?.statements?.get(1) as? GotoStatement)
-                ?.targetLabel
-                ?.name
-                ?.localName
+            (tryStatement.tryBlock?.statements?.get(1) as? GotoStatement)?.targetLabel
         )
 
         assertEquals(1, tryStatement.catchClauses.size)
-        val catchSwitchExpr =
-            tryStatement.catchClauses[0].body?.statements?.get(0) as? DeclarationStatement
-        assertNotNull(catchSwitchExpr)
+        val catchSwitchExpr = tryStatement.catchClauses[0].body?.statements?.get(0)
+        assertIs<DeclarationStatement>(catchSwitchExpr)
         val catchswitchCall =
             (catchSwitchExpr.singleDeclaration as? VariableDeclaration)?.initializer
-                as? CallExpression
-        assertNotNull(catchswitchCall)
+        assertIs<CallExpression>(catchswitchCall)
         assertFullName("llvm.catchswitch", catchswitchCall)
-        val ifExceptionMatches =
-            tryStatement.catchClauses[0].body?.statements?.get(1) as? IfStatement
-        val matchesExceptionCall = ifExceptionMatches?.condition as? CallExpression
-        assertNotNull(matchesExceptionCall)
+        val ifExceptionMatches = tryStatement.catchClauses[0].body?.statements?.get(1)
+        assertIs<IfStatement>(ifExceptionMatches)
+        val matchesExceptionCall = ifExceptionMatches.condition
+        assertIs<CallExpression>(matchesExceptionCall)
         assertFullName("llvm.matchesCatchpad", matchesExceptionCall)
         assertEquals(
             catchSwitchExpr.singleDeclaration,
@@ -957,8 +952,8 @@ class LLVMIRLanguageFrontendTest {
         assertEquals(64L, (matchesExceptionCall.arguments[2] as Literal<*>).value as Long)
         assertEquals(null, (matchesExceptionCall.arguments[3] as Literal<*>).value)
 
-        val catchBlock = ifExceptionMatches.thenStatement as? Block
-        assertNotNull(catchBlock)
+        val catchBlock = ifExceptionMatches.thenStatement
+        assertIs<Block>(catchBlock)
         assertFullName(
             "llvm.catchpad",
             ((catchBlock.statements[0] as? DeclarationStatement)?.singleDeclaration
@@ -966,8 +961,8 @@ class LLVMIRLanguageFrontendTest {
                 ?.initializer as? CallExpression
         )
 
-        val innerTry = catchBlock.statements[1] as? TryStatement
-        assertNotNull(innerTry)
+        val innerTry = catchBlock.statements[1]
+        assertIs<TryStatement>(innerTry)
         assertFullName(
             "_CxxThrowException",
             innerTry.tryBlock?.statements?.get(0) as? CallExpression
@@ -979,13 +974,12 @@ class LLVMIRLanguageFrontendTest {
 
         val innerCatchClause =
             (innerTry.catchClauses[0].body?.statements?.get(1) as? IfStatement)?.thenStatement
-                as? Block
-        assertNotNull(innerCatchClause)
+        assertIs<Block>(innerCatchClause)
         assertFullName(
             "llvm.catchpad",
             ((innerCatchClause.statements[0] as? DeclarationStatement)?.singleDeclaration
                     as? VariableDeclaration)
-                ?.initializer as? CallExpression
+                ?.initializer
         )
         assertLocalName("try.cont", (innerCatchClause.statements[1] as? GotoStatement)?.targetLabel)
 
@@ -993,10 +987,7 @@ class LLVMIRLanguageFrontendTest {
             (innerTry.catchClauses[0].body?.statements?.get(1) as? IfStatement)?.elseStatement
         assertIs<ThrowStatement>(innerCatchThrows)
         assertNotNull(innerCatchThrows.exception)
-        assertSame(
-            innerTry.catchClauses[0].parameter,
-            (innerCatchThrows.exception as? Reference)?.refersTo
-        )
+        assertRefersTo(innerCatchThrows.exception, innerTry.catchClauses[0].parameter)
     }
 
     // TODO: Write test for calling a vararg function (e.g. printf). LLVM code snippets can already


### PR DESCRIPTION
Replaces the usage of a UnaryOperator with operatorCode "throw" with the new node ThrowStatement in the LLVM frontend.