### PR TITLE
Update LLVM tests to match new styleguide

### DIFF
--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -938,7 +938,7 @@ class LLVMIRLanguageFrontendTest {
         assertNotNull(main)
 
         // Test that x is initialized correctly
-        val mainBody = main.body as Block
+        val mainBody = main.body
         assertIs<Block>(mainBody)
 
         val fenceCall = mainBody.statements[0]

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -439,38 +439,53 @@ class LLVMIRLanguageFrontendTest {
 
         // Check that the first statement is "literal_i32_i1 val_success = literal_i32_i1(*ptr, *ptr
         // == 5)"
-        val decl = (cmpxchgStatement.statements[0].declarations[0] as VariableDeclaration)
-        assertLocalName("val_success", decl)
-        assertLocalName("literal_i32_i1", decl.type)
+        val declaration = cmpxchgStatement.statements[0].declarations[0]
+        assertIs<VariableDeclaration>(declaration)
+        assertLocalName("val_success", declaration)
+        assertLocalName("literal_i32_i1", declaration.type)
 
         // Check that the first value is *ptr
-        val value1 = (decl.initializer as ConstructExpression).arguments[0] as UnaryOperator
+        val declarationInitializer = declaration.initializer
+        assertIs<ConstructExpression>(declarationInitializer)
+        val value1 = declarationInitializer.arguments[0]
+        assertIs<UnaryOperator>(value1)
         assertEquals("*", value1.operatorCode)
         assertLocalName("ptr", value1.input)
 
         // Check that the first value is *ptr == 5
-        val value2 = (decl.initializer as ConstructExpression).arguments[1] as BinaryOperator
+        val value2 = declarationInitializer.arguments[1]
+        assertIs<BinaryOperator>(value2)
         assertEquals("==", value2.operatorCode)
-        assertEquals("*", (value2.lhs as UnaryOperator).operatorCode)
-        assertLocalName("ptr", (value2.lhs as UnaryOperator).input)
-        assertEquals(5L, (value2.rhs as Literal<*>).value as Long)
+        val value2Lhs = value2.lhs
+        assertIs<UnaryOperator>(value2Lhs)
+        assertEquals("*", value2Lhs.operatorCode)
+        assertLocalName("ptr", value2Lhs.input)
+        assertLiteralValue(5L, value2.rhs)
 
-        val ifStatement = cmpxchgStatement.statements[1] as IfStatement
+        val ifStatement = cmpxchgStatement.statements[1]
+        assertIs<IfStatement>(ifStatement)
         // The condition is the same as the second value above
-        val ifExpr = ifStatement.condition as BinaryOperator
+        val ifExpr = ifStatement.condition
+        assertIs<BinaryOperator>(ifExpr)
         assertEquals("==", ifExpr.operatorCode)
-        assertEquals("*", (ifExpr.lhs as UnaryOperator).operatorCode)
-        assertLocalName("ptr", (ifExpr.lhs as UnaryOperator).input)
-        assertEquals(5L, (ifExpr.rhs as Literal<*>).value as Long)
+        val ifExprLhs = ifExpr.lhs
+        assertIs<UnaryOperator>(ifExprLhs)
+        assertEquals("*", ifExprLhs.operatorCode)
+        assertLocalName("ptr", ifExprLhs.input)
+        assertLiteralValue(5L, ifExpr.rhs)
 
-        val thenExpr = ifStatement.thenStatement as AssignExpression
+        val thenExpr = ifStatement.thenStatement
+        assertIs<AssignExpression>(thenExpr)
         assertEquals(1, thenExpr.lhs.size)
         assertEquals(1, thenExpr.rhs.size)
         assertEquals("=", thenExpr.operatorCode)
-        assertEquals("*", (thenExpr.lhs.first() as UnaryOperator).operatorCode)
-        assertLocalName("ptr", (thenExpr.lhs.first() as UnaryOperator).input)
-        assertLocalName("old", thenExpr.rhs.first() as Reference)
-        assertLocalName("old", (thenExpr.rhs.first() as Reference).refersTo)
+        val thenExprLhs = thenExpr.lhs.first()
+        assertIs<UnaryOperator>(thenExprLhs)
+        assertEquals("*", thenExprLhs.operatorCode)
+        assertLocalName("ptr", thenExprLhs.input)
+        assertIs<Reference>(thenExpr.rhs.first())
+        assertLocalName("old", thenExpr.rhs.first())
+        assertRefersTo(thenExpr.rhs.first(), tu.variables["old"])
     }
 
     @Test

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -71,15 +71,21 @@ class LLVMIRLanguageFrontendTest {
         assertNotNull(main)
         assertLocalName("i32", main.type)
 
-        val xVector =
-            (main.bodyOrNull<Block>(0)?.statements?.get(0) as? DeclarationStatement)
-                ?.singleDeclaration as? VariableDeclaration
-        val xInit = xVector?.initializer as? InitializerListExpression
-        assertNotNull(xInit)
-        assertLocalName("poison", xInit.initializers[0] as? Reference)
-        assertEquals(0L, (xInit.initializers[1] as? Literal<*>)?.value)
-        assertEquals(0L, (xInit.initializers[2] as? Literal<*>)?.value)
-        assertEquals(0L, (xInit.initializers[3] as? Literal<*>)?.value)
+        // We want to see that the declaration is the very first statement of the method body (it's
+        // wrapped inside another block).
+        val mainBody = main.bodyOrNull<Block>(0)
+        assertIs<Block>(mainBody)
+        val declarationStmt = mainBody.statements.firstOrNull()
+        assertIs<DeclarationStatement>(declarationStmt)
+        val xVector = declarationStmt.singleDeclaration
+        assertIs<VariableDeclaration>(xVector)
+        val xInit = xVector.initializer
+        assertIs<InitializerListExpression>(xInit)
+        assertIs<Reference>(xInit.initializers[0])
+        assertLocalName("poison", xInit.initializers[0])
+        assertLiteralValue(0L, xInit.initializers[1])
+        assertLiteralValue(0L, xInit.initializers[2])
+        assertLiteralValue(0L, xInit.initializers[3])
     }
 
     @Test

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -169,54 +169,53 @@ class LLVMIRLanguageFrontendTest {
         val s = foo.parameters.firstOrNull { it.name.localName == "s" }
         assertNotNull(s)
 
-        val arrayidx =
-            foo.bodyOrNull<DeclarationStatement>(0)?.singleDeclaration as? VariableDeclaration
+        val arrayidx = foo.variables["arrayidx"]
         assertNotNull(arrayidx)
 
         // arrayidx will be assigned to a chain of the following expressions:
         // &s[1].field2.field1[5][13]
         // we will check them in the reverse order (after the unary operator)
 
-        val unary = arrayidx.initializer as? UnaryOperator
-        assertNotNull(unary)
+        val unary = arrayidx.initializer
+        assertIs<UnaryOperator>(unary)
         assertEquals("&", unary.operatorCode)
 
-        var arrayExpr = unary.input as? SubscriptExpression
-        assertNotNull(arrayExpr)
+        var arrayExpr = unary.input
+        assertIs<SubscriptExpression>(arrayExpr)
         assertLocalName("13", arrayExpr)
-        assertEquals(
+        assertLiteralValue(
             13L,
-            (arrayExpr.subscriptExpression as? Literal<*>)?.value
+            arrayExpr.subscriptExpression
         ) // should this be integer instead of long?
 
-        arrayExpr = arrayExpr.arrayExpression as? SubscriptExpression
-        assertNotNull(arrayExpr)
+        arrayExpr = arrayExpr.arrayExpression
+        assertIs<SubscriptExpression>(arrayExpr)
         assertLocalName("5", arrayExpr)
-        assertEquals(
+        assertLiteralValue(
             5L,
-            (arrayExpr.subscriptExpression as? Literal<*>)?.value
+            arrayExpr.subscriptExpression
         ) // should this be integer instead of long?
 
-        var memberExpression = arrayExpr.arrayExpression as? MemberExpression
-        assertNotNull(memberExpression)
+        var memberExpression = arrayExpr.arrayExpression
+        assertIs<MemberExpression>(memberExpression)
         assertLocalName("field_1", memberExpression)
 
-        memberExpression = memberExpression.base as? MemberExpression
-        assertNotNull(memberExpression)
+        memberExpression = memberExpression.base
+        assertIs<MemberExpression>(memberExpression)
         assertLocalName("field_2", memberExpression)
 
-        arrayExpr = memberExpression.base as? SubscriptExpression
-        assertNotNull(arrayExpr)
+        arrayExpr = memberExpression.base
+        assertIs<SubscriptExpression>(arrayExpr)
         assertLocalName("1", arrayExpr)
-        assertEquals(
+        assertLiteralValue(
             1L,
-            (arrayExpr.subscriptExpression as? Literal<*>)?.value
+            arrayExpr.subscriptExpression
         ) // should this be integer instead of long?
 
-        val ref = arrayExpr.arrayExpression as? Reference
-        assertNotNull(ref)
+        val ref = arrayExpr.arrayExpression
+        assertIs<Reference>(ref)
         assertLocalName("s", ref)
-        assertSame(s, ref.refersTo)
+        assertRefersTo(ref, s)
     }
 
     @Test

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -530,28 +530,26 @@ class LLVMIRLanguageFrontendTest {
 
         val foo = tu.functions["foo"]
         assertNotNull(foo)
-        assertEquals("literal_i32_i8", foo.type.typeName)
+        val fooType = foo.type
+        assertIs<ObjectType>(fooType)
+        assertEquals("literal_i32_i8", fooType.typeName)
 
-        val record = (foo.type as? ObjectType)?.recordDeclaration
+        val record = fooType.recordDeclaration
         assertNotNull(record)
         assertEquals(2, record.fields.size)
 
-        val returnStatement = foo.bodyOrNull<ReturnStatement>(0)
+        val returnStatement = foo.returns.singleOrNull()
         assertNotNull(returnStatement)
 
-        val construct = returnStatement.returnValue as? ConstructExpression
-        assertNotNull(construct)
+        val construct = returnStatement.returnValue
+        assertIs<ConstructExpression>(construct)
         assertEquals(2, construct.arguments.size)
 
-        var arg = construct.arguments.getOrNull(0) as? Literal<*>
-        assertNotNull(arg)
-        assertEquals("i32", arg.type.typeName)
-        assertEquals(4L, arg.value)
+        assertEquals("i32", construct.arguments[0].type.typeName)
+        assertLiteralValue(4L, construct.arguments[0])
 
-        arg = construct.arguments.getOrNull(1) as? Literal<*>
-        assertNotNull(arg)
-        assertEquals("i8", arg.type.typeName)
-        assertEquals(2L, arg.value)
+        assertEquals("i8", construct.arguments[1].type.typeName)
+        assertLiteralValue(2L, construct.arguments[1])
     }
 
     @Test

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -621,11 +621,11 @@ class LLVMIRLanguageFrontendTest {
         assertNotNull(main)
 
         // %ptr = alloca i32
-        val ptr = main.bodyOrNull<DeclarationStatement>()?.singleDeclaration as? VariableDeclaration
-        assertNotNull(ptr)
+        val ptr = main.bodyOrNull<DeclarationStatement>()?.singleDeclaration
+        assertIs<VariableDeclaration>(ptr)
 
-        val alloca = ptr.initializer as? NewArrayExpression
-        assertNotNull(alloca)
+        val alloca = ptr.initializer
+        assertIs<NewArrayExpression>(alloca)
         assertEquals("i32*", alloca.type.typeName)
 
         // store i32 3, i32* %ptr
@@ -634,16 +634,16 @@ class LLVMIRLanguageFrontendTest {
         assertEquals("=", store.operatorCode)
 
         assertEquals(1, store.lhs.size)
-        val dereferencePtr = store.lhs.first() as? UnaryOperator
-        assertNotNull(dereferencePtr)
+        val dereferencePtr = store.lhs.firstOrNull()
+        assertIs<UnaryOperator>(dereferencePtr)
         assertEquals("*", dereferencePtr.operatorCode)
         assertEquals("i32", dereferencePtr.type.typeName)
-        assertSame(ptr, (dereferencePtr.input as? Reference)?.refersTo)
+        assertRefersTo(dereferencePtr.input, ptr)
 
         assertEquals(1, store.rhs.size)
-        val value = store.rhs.first() as? Literal<*>
-        assertNotNull(value)
-        assertEquals(3L, value.value)
+        val value = store.rhs.firstOrNull()
+        assertIs<Literal<*>>(value)
+        assertLiteralValue(3L, value)
         assertEquals("i32", value.type.typeName)
     }
 

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -581,26 +581,30 @@ class LLVMIRLanguageFrontendTest {
         assertNotNull(loadXStatement)
         assertLocalName("locX", loadXStatement.singleDeclaration)
 
-        val initXOp =
-            (loadXStatement.singleDeclaration as VariableDeclaration).initializer as UnaryOperator
+        val initXOpDeclaration = loadXStatement.singleDeclaration
+        assertIs<VariableDeclaration>(initXOpDeclaration)
+        val initXOp = initXOpDeclaration.initializer
+        assertIs<UnaryOperator>(initXOp)
         assertEquals("*", initXOp.operatorCode)
 
-        var ref = initXOp.input as? Reference
-        assertNotNull(ref)
+        var ref = initXOp.input
+        assertIs<Reference>(ref)
         assertLocalName("x", ref)
-        assertSame(globalX, ref.refersTo)
+        assertRefersTo(ref, globalX)
 
         val loadAStatement = main.bodyOrNull<DeclarationStatement>(2)
         assertNotNull(loadAStatement)
+        val loadADeclaration = loadAStatement.singleDeclaration
+        assertIs<VariableDeclaration>(loadADeclaration)
         assertLocalName("locA", loadAStatement.singleDeclaration)
-        val initAOp =
-            (loadAStatement.singleDeclaration as VariableDeclaration).initializer as UnaryOperator
+        val initAOp = loadADeclaration.initializer
+        assertIs<UnaryOperator>(initAOp)
         assertEquals("*", initAOp.operatorCode)
 
-        ref = initAOp.input as? Reference
-        assertNotNull(ref)
+        ref = initAOp.input
+        assertIs<Reference>(ref)
         assertLocalName("a", ref)
-        assertSame(globalA, ref.refersTo)
+        assertRefersTo(ref, globalA)
     }
 
     @Test

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -787,48 +787,52 @@ class LLVMIRLanguageFrontendTest {
         val main = tu.functions["main"]
         assertNotNull(main)
 
-        val mainBody = main.body as Block
-        val yDecl =
-            (mainBody.statements[0] as DeclarationStatement).singleDeclaration
-                as VariableDeclaration
-        assertNotNull(yDecl)
+        val mainBody = main.body
+        assertIs<Block>(mainBody)
+        val yDeclarationStatement = mainBody.statements[0]
+        assertIs<DeclarationStatement>(yDeclarationStatement)
+        val yDecl = yDeclarationStatement.singleDeclaration
+        assertIs<VariableDeclaration>(yDecl)
 
-        val ifStatement = mainBody.statements[3] as? IfStatement
-        assertNotNull(ifStatement)
+        val ifStatement = mainBody.statements[3]
+        assertIs<IfStatement>(ifStatement)
 
-        val thenStmt = ifStatement.thenStatement as? Block
-        assertNotNull(thenStmt)
+        val thenStmt = ifStatement.thenStatement
+        assertIs<Block>(thenStmt)
         assertEquals(3, thenStmt.statements.size)
-        assertNotNull(thenStmt.statements[1] as? AssignExpression)
-        val aDecl =
-            (thenStmt.statements[0] as DeclarationStatement).singleDeclaration
-                as VariableDeclaration
-        val thenY = thenStmt.statements[1] as AssignExpression
+        val aDeclarationStatement = thenStmt.statements[0]
+        assertIs<DeclarationStatement>(aDeclarationStatement)
+        val aDecl = aDeclarationStatement.singleDeclaration
+        assertIs<VariableDeclaration>(aDecl)
+        val thenY = thenStmt.statements[1]
+        assertIs<AssignExpression>(thenY)
         assertEquals(1, thenY.lhs.size)
         assertEquals(1, thenY.rhs.size)
-        assertSame(aDecl, (thenY.rhs.first() as Reference).refersTo)
-        assertSame(yDecl, (thenY.lhs.first() as Reference).refersTo)
+        assertRefersTo(thenY.rhs.first(), aDecl)
+        assertRefersTo(thenY.lhs.first(), yDecl)
 
-        val elseStmt = ifStatement.elseStatement as? Block
-        assertNotNull(elseStmt)
+        val elseStmt = ifStatement.elseStatement
+        assertIs<Block>(elseStmt)
         assertEquals(3, elseStmt.statements.size)
-        val bDecl =
-            (elseStmt.statements[0] as DeclarationStatement).singleDeclaration
-                as VariableDeclaration
-        assertNotNull(elseStmt.statements[1] as? AssignExpression)
-        val elseY = elseStmt.statements[1] as AssignExpression
+        val bDeclarationStatement = elseStmt.statements[0]
+        assertIs<DeclarationStatement>(bDeclarationStatement)
+        val bDecl = bDeclarationStatement.singleDeclaration
+        assertIs<VariableDeclaration>(bDecl)
+        val elseY = elseStmt.statements[1]
+        assertIs<AssignExpression>(elseY)
         assertEquals(1, elseY.lhs.size)
         assertEquals(1, elseY.lhs.size)
-        assertSame(bDecl, (elseY.rhs.first() as Reference).refersTo)
-        assertSame(yDecl, (elseY.lhs.first() as Reference).refersTo)
+        assertRefersTo(elseY.rhs.first(), bDecl)
+        assertRefersTo(elseY.lhs.first(), yDecl)
 
-        val continueBlock =
-            (thenStmt.statements[2] as? GotoStatement)?.targetLabel?.subStatement as? Block
-        assertNotNull(continueBlock)
-        assertEquals(
-            yDecl,
-            ((continueBlock.statements[1] as ReturnStatement).returnValue as Reference).refersTo
-        )
+        val gotoStatement = thenStmt.statements[2]
+        assertIs<GotoStatement>(gotoStatement)
+        val continueBlock = gotoStatement.targetLabel?.subStatement
+        assertIs<Block>(continueBlock)
+        val returnStatement = continueBlock.statements[1]
+        assertIs<ReturnStatement>(returnStatement)
+        assertIs<Reference>(returnStatement.returnValue)
+        assertRefersTo(returnStatement.returnValue, yDecl)
     }
 
     @Test

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -939,18 +939,19 @@ class LLVMIRLanguageFrontendTest {
 
         // Test that x is initialized correctly
         val mainBody = main.body as Block
+        assertIs<Block>(mainBody)
 
-        val fenceCall = mainBody.statements[0] as? CallExpression
-        assertNotNull(fenceCall)
+        val fenceCall = mainBody.statements[0]
+        assertIs<CallExpression>(fenceCall)
         assertEquals(1, fenceCall.arguments.size)
-        assertEquals(2, (fenceCall.arguments[0] as Literal<*>).value)
+        assertLiteralValue(2, fenceCall.arguments[0])
 
-        val fenceCallScope = mainBody.statements[2] as? CallExpression
-        assertNotNull(fenceCallScope)
+        val fenceCallScope = mainBody.statements[2]
+        assertIs<CallExpression>(fenceCallScope)
         assertEquals(2, fenceCallScope.arguments.size)
         // TODO: This doesn't match but it doesn't seem to be our mistake
         // assertEquals(5, (fenceCallScope.arguments[0] as Literal<*>).value)
-        assertEquals("scope", (fenceCallScope.arguments[1] as Literal<*>).value)
+        assertLiteralValue("scope", fenceCallScope.arguments[1])
     }
 
     @Test

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -665,17 +665,22 @@ class LLVMIRLanguageFrontendTest {
         assertNotNull(foo)
         assertEquals("literal_i32_i8", foo.type.typeName)
 
-        val record = (foo.type as? ObjectType)?.recordDeclaration
+        val fooType = foo.type
+        assertIs<ObjectType>(fooType)
+        val record = fooType.recordDeclaration
         assertNotNull(record)
         assertEquals(2, record.fields.size)
 
-        val declStatement = foo.bodyOrNull<DeclarationStatement>()
-        assertNotNull(declStatement)
+        val declarationStatement = foo.bodyOrNull<DeclarationStatement>()
+        assertNotNull(declarationStatement)
 
-        val varDecl = declStatement.singleDeclaration as VariableDeclaration
-        assertLocalName("a", varDecl)
-        assertEquals("literal_i32_i8", varDecl.type.typeName)
-        val args = (varDecl.initializer as ConstructExpression).arguments
+        val varDeclaration = declarationStatement.singleDeclaration
+        assertIs<VariableDeclaration>(varDeclaration)
+        assertLocalName("a", varDeclaration)
+        assertEquals("literal_i32_i8", varDeclaration.type.typeName)
+        val initializer = varDeclaration.initializer
+        assertIs<ConstructExpression>(initializer)
+        val args = initializer.arguments
         assertEquals(2, args.size)
         assertLiteralValue(100L, args[0])
         assertLiteralValue(null, args[1])
@@ -696,10 +701,12 @@ class LLVMIRLanguageFrontendTest {
         assertEquals("=", assign.operatorCode)
         assertEquals(1, assign.lhs.size)
         assertEquals(1, assign.rhs.size)
-        assertLocalName("b", (assign.lhs.first() as MemberExpression).base)
-        assertEquals(".", (assign.lhs.first() as MemberExpression).operatorCode)
-        assertLocalName("field_1", assign.lhs.first() as MemberExpression)
-        assertEquals(7L, (assign.rhs.first() as Literal<*>).value as Long)
+        val assignLhs = assign.lhs.first()
+        assertIs<MemberExpression>(assignLhs)
+        assertLocalName("b", assignLhs.base)
+        assertEquals(".", assignLhs.operatorCode)
+        assertLocalName("field_1", assignLhs)
+        assertLiteralValue(7L, assign.rhs.first())
     }
 
     @Test

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -388,25 +388,34 @@ class LLVMIRLanguageFrontendTest {
         assertNotNull(atomicrmwStatement)
 
         // Check that the value is assigned to
-        val decl = (atomicrmwStatement.statements[0].declarations[0] as VariableDeclaration)
-        assertLocalName("old", decl)
-        assertLocalName("i32", decl.type)
-        assertEquals("*", (decl.initializer as UnaryOperator).operatorCode)
-        assertLocalName("ptr", (decl.initializer as UnaryOperator).input)
+        val declaration = atomicrmwStatement.statements[0].declarations[0]
+        assertIs<VariableDeclaration>(declaration)
+        assertLocalName("old", declaration)
+        assertLocalName("i32", declaration.type)
+        val initializer = declaration.initializer
+        assertIs<UnaryOperator>(initializer)
+        assertEquals("*", initializer.operatorCode)
+        assertLocalName("ptr", initializer.input)
 
         // Check that the replacement equals *ptr = *ptr + 1
-        val replacement = (atomicrmwStatement.statements[1] as AssignExpression)
+        val replacement = atomicrmwStatement.statements[1]
+        assertIs<AssignExpression>(replacement)
         assertEquals(1, replacement.lhs.size)
         assertEquals(1, replacement.rhs.size)
         assertEquals("=", replacement.operatorCode)
-        assertEquals("*", (replacement.lhs.first() as UnaryOperator).operatorCode)
-        assertLocalName("ptr", (replacement.lhs.first() as UnaryOperator).input)
+        val replacementLhs = replacement.lhs.first()
+        assertIs<UnaryOperator>(replacementLhs)
+        assertEquals("*", replacementLhs.operatorCode)
+        assertLocalName("ptr", replacementLhs.input)
         // Check that the rhs is equal to *ptr + 1
-        val add = replacement.rhs.first() as BinaryOperator
+        val add = replacement.rhs.first()
+        assertIs<BinaryOperator>(add)
         assertEquals("+", add.operatorCode)
-        assertEquals("*", (add.lhs as UnaryOperator).operatorCode)
-        assertLocalName("ptr", (add.lhs as UnaryOperator).input)
-        assertEquals(1L, (add.rhs as Literal<*>).value as Long)
+        val addLhs = add.lhs
+        assertIs<UnaryOperator>(addLhs)
+        assertEquals("*", addLhs.operatorCode)
+        assertLocalName("ptr", addLhs.input)
+        assertLiteralValue(1L, add.rhs)
     }
 
     @Test

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -219,7 +219,7 @@ class LLVMIRLanguageFrontendTest {
     }
 
     @Test
-    fun testSwitchCase() { // TODO: Update the test
+    fun testSwitchCase() {
         val topLevel = Path.of("src", "test", "resources", "llvm")
         val tu =
             analyzeAndGetFirstTU(
@@ -236,17 +236,17 @@ class LLVMIRLanguageFrontendTest {
         val onzeroLabel = main.labels.getOrNull(0)
         assertNotNull(onzeroLabel)
         assertLocalName("onzero", onzeroLabel)
-        assertTrue(onzeroLabel.subStatement is Block)
+        assertIs<Block>(onzeroLabel.subStatement)
 
         val ononeLabel = main.labels.getOrNull(1)
         assertNotNull(ononeLabel)
         assertLocalName("onone", ononeLabel)
-        assertTrue(ononeLabel.subStatement is Block)
+        assertIs<Block>(ononeLabel.subStatement)
 
         val defaultLabel = main.labels.getOrNull(2)
         assertNotNull(defaultLabel)
         assertLocalName("otherwise", defaultLabel)
-        assertTrue(defaultLabel.subStatement is Block)
+        assertIs<Block>(defaultLabel.subStatement)
 
         // Check that the type of %a is i32
         val a = main.variables["a"]
@@ -259,21 +259,24 @@ class LLVMIRLanguageFrontendTest {
         assertNotNull(switchStatement)
 
         // Check that we have switch(a)
-        assertSame(a, (switchStatement.selector as Reference).refersTo)
+        assertRefersTo(switchStatement.selector, a)
 
-        val cases = switchStatement.statement as Block
+        val cases = switchStatement.statement
+        assertIs<Block>(cases)
         // Check that the first case is case 0 -> goto onzero and that the BB is inlined
-        val case1 = cases.statements[0] as CaseStatement
-        assertEquals(0L, (case1.caseExpression as Literal<*>).value as Long)
+        val case1 = cases.statements[0]
+        assertIs<CaseStatement>(case1)
+        assertLiteralValue(0L, case1.caseExpression)
         assertSame(onzeroLabel.subStatement, cases.statements[1])
         // Check that the second case is case 1 -> goto onone and that the BB is inlined
-        val case2 = cases.statements[2] as CaseStatement
-        assertEquals(1L, (case2.caseExpression as Literal<*>).value as Long)
+        val case2 = cases.statements[2]
+        assertIs<CaseStatement>(case2)
+        assertLiteralValue(1L, case2.caseExpression)
         assertSame(ononeLabel.subStatement, cases.statements[3])
 
         // Check that the default location is inlined
         val defaultStatement = cases.statements[4] as? DefaultStatement
-        assertNotNull(defaultStatement)
+        assertIs<DefaultStatement>(defaultStatement)
         assertSame(defaultLabel.subStatement, cases.statements[5])
     }
 

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -726,41 +726,44 @@ class LLVMIRLanguageFrontendTest {
         val main = tu.functions["main"]
         assertNotNull(main)
 
-        val mainBody = main.body as Block
-        val tryStatement = mainBody.statements[0] as? TryStatement
-        assertNotNull(tryStatement)
+        val mainBody = main.body
+        assertIs<Block>(mainBody)
+        val tryStatement = mainBody.statements[0]
+        assertIs<TryStatement>(tryStatement)
 
         // Check the assignment of the function call
-        val resDecl =
-            (tryStatement.tryBlock?.statements?.get(0) as? DeclarationStatement)?.singleDeclaration
-                as? VariableDeclaration
-        assertNotNull(resDecl)
-        assertLocalName("res", resDecl)
-        val call = resDecl.initializer as? CallExpression
-        assertNotNull(call)
+        val resDeclarationStatement = tryStatement.tryBlock?.statements?.get(0)
+        assertIs<DeclarationStatement>(resDeclarationStatement)
+        val resDeclaration = resDeclarationStatement.singleDeclaration
+        assertIs<VariableDeclaration>(resDeclaration)
+        assertLocalName("res", resDeclaration)
+        val call = resDeclaration.initializer
+        assertIs<CallExpression>(call)
         assertLocalName("throwingFoo", call)
-        assertTrue(call.invokes.contains(throwingFoo))
+        assertContains(call.invokes, throwingFoo)
         assertEquals(0, call.arguments.size)
 
         // Check that the second part of the try-block is inlined by the pass
-        val aDecl =
-            (tryStatement.tryBlock?.statements?.get(1) as? DeclarationStatement)?.singleDeclaration
-                as? VariableDeclaration
-        assertNotNull(aDecl)
-        assertLocalName("a", aDecl)
-        val resStatement = tryStatement.tryBlock?.statements?.get(2) as? ReturnStatement
-        assertNotNull(resStatement)
+        val aDeclarationStatement = tryStatement.tryBlock?.statements?.get(1)
+        assertIs<DeclarationStatement>(aDeclarationStatement)
+        val aDeclaration = aDeclarationStatement.singleDeclaration
+        assertIs<VariableDeclaration>(aDeclaration)
+        assertLocalName("a", aDeclaration)
+        val resStatement = tryStatement.tryBlock?.statements?.get(2)
+        assertIs<ReturnStatement>(resStatement)
 
         // Check that the catch block is inlined by the pass
         assertEquals(1, tryStatement.catchClauses.size)
         assertEquals(5, tryStatement.catchClauses[0].body?.statements?.size)
         assertLocalName("_ZTIi | ...", tryStatement.catchClauses[0])
-        val ifStatement = tryStatement.catchClauses[0].body?.statements?.get(4) as? IfStatement
-        assertNotNull(ifStatement)
-        assertTrue(ifStatement.thenStatement is Block)
-        assertEquals(4, (ifStatement.thenStatement as Block).statements.size)
-        assertTrue(ifStatement.elseStatement is Block)
-        assertEquals(1, (ifStatement.elseStatement as Block).statements.size)
+        val ifStatement = tryStatement.catchClauses[0].body?.statements?.get(4)
+        assertIs<IfStatement>(ifStatement)
+        val thenStatement = ifStatement.thenStatement
+        assertIs<Block>(thenStatement)
+        assertEquals(4, thenStatement.statements.size)
+        val elseStatement = ifStatement.elseStatement
+        assertIs<Block>(elseStatement)
+        assertEquals(1, elseStatement.statements.size)
     }
 
     @Test

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -503,13 +503,15 @@ class LLVMIRLanguageFrontendTest {
         val foo = tu.functions["foo"]
         assertNotNull(foo)
 
-        val decl = foo.variables["value_loaded"]
-        assertNotNull(decl)
-        assertLocalName("i1", decl.type)
+        val declaration = foo.variables["value_loaded"]
+        assertNotNull(declaration)
+        assertLocalName("i1", declaration.type)
 
-        assertLocalName("val_success", (decl.initializer as MemberExpression).base)
-        assertEquals(".", (decl.initializer as MemberExpression).operatorCode)
-        assertLocalName("field_1", decl.initializer as MemberExpression)
+        val initializer = declaration.initializer
+        assertIs<MemberExpression>(initializer)
+        assertLocalName("val_success", initializer.base)
+        assertEquals(".", initializer.operatorCode)
+        assertLocalName("field_1", initializer)
     }
 
     @Test

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -110,25 +110,25 @@ class LLVMIRLanguageFrontendTest {
         assertNotNull(rand)
         assertNull(rand.body)
 
-        val decl = tu.variables["x"]
-        assertNotNull(decl)
+        val xDeclaration = tu.variables["x"]
+        assertNotNull(xDeclaration)
 
-        val call = decl.initializer as? CallExpression
-        assertNotNull(call)
+        val call = xDeclaration.initializer
+        assertIs<CallExpression>(call)
         assertLocalName("rand", call)
-        assertTrue(call.invokes.contains(rand))
+        assertContains(call.invokes, rand)
         assertEquals(0, call.arguments.size)
 
         val xorStatement = main.bodyOrNull<DeclarationStatement>(3)
         assertNotNull(xorStatement)
 
-        val xorDecl = xorStatement.singleDeclaration as? VariableDeclaration
-        assertNotNull(xorDecl)
-        assertLocalName("a", xorDecl)
-        assertEquals("i32", xorDecl.type.typeName)
+        val xorDeclaration = xorStatement.singleDeclaration
+        assertIs<VariableDeclaration>(xorDeclaration)
+        assertLocalName("a", xorDeclaration)
+        assertEquals("i32", xorDeclaration.type.typeName)
 
-        val xor = xorDecl.initializer as? BinaryOperator
-        assertNotNull(xor)
+        val xor = xorDeclaration.initializer
+        assertIs<BinaryOperator>(xor)
         assertEquals("^", xor.operatorCode)
     }
 


### PR DESCRIPTION
Testing is very important but the LLVM tests do not meet the styleguides which have recently been suggested in #1743. This PR updates them to meet the requirements.