### PR TITLE
Optimized region utils

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -306,7 +306,7 @@ fun <T : Node, AstNode> T.codeAndLocationFromOtherRawNode(rawNode: AstNode?): T 
 context(CodeAndLocationProvider<AstNode>)
 fun <T : Node, AstNode> T.codeAndLocationFromChildren(
     parentNode: AstNode,
-    newLineType: CharSequence = "\n"
+    lineBreakSequence: CharSequence = "\n"
 ): T {
     var first: Node? = null
     var last: Node? = null
@@ -363,7 +363,7 @@ fun <T : Node, AstNode> T.codeAndLocationFromChildren(
         val parentRegion = this@CodeAndLocationProvider.locationOf(parentNode)?.region
         if (parentCode != null && parentRegion != null) {
             // If the parent has code and region the new region is used to extract the code
-            this.code = getCodeOfSubregion(parentCode, parentRegion, newRegion, newLineType)
+            this.code = getCodeOfSubregion(parentCode, parentRegion, newRegion, lineBreakSequence)
         }
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -32,7 +32,6 @@ import de.fraunhofer.aisec.cpg.graph.NodeBuilder.LOGGER
 import de.fraunhofer.aisec.cpg.graph.NodeBuilder.log
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
-import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.helpers.getCodeOfSubregion
 import de.fraunhofer.aisec.cpg.passes.inference.IsImplicitProvider
 import de.fraunhofer.aisec.cpg.passes.inference.IsInferredProvider
@@ -299,10 +298,16 @@ fun <T : Node, AstNode> T.codeAndLocationFromOtherRawNode(rawNode: AstNode?): T 
  * code is extracted from the parent node to catch separators and auxiliary syntactic elements that
  * are between the child nodes.
  *
- * @param parentNode Used to extract the code for this node
+ * @param parentNode Used to extract the code for this node.
+ * @param newLineType The char(s) used to describe a new line, usually either "\n" or "\r\n". This
+ *   is needed because the location block spanning the children usually comprises more than one
+ *   line.
  */
 context(CodeAndLocationProvider<AstNode>)
-fun <T : Node, AstNode> T.codeAndLocationFromChildren(parentNode: AstNode): T {
+fun <T : Node, AstNode> T.codeAndLocationFromChildren(
+    parentNode: AstNode,
+    newLineType: CharSequence = "\n"
+): T {
     var first: Node? = null
     var last: Node? = null
 
@@ -358,7 +363,7 @@ fun <T : Node, AstNode> T.codeAndLocationFromChildren(parentNode: AstNode): T {
         val parentRegion = this@CodeAndLocationProvider.locationOf(parentNode)?.region
         if (parentCode != null && parentRegion != null) {
             // If the parent has code and region the new region is used to extract the code
-            this.code = getCodeOfSubregion(parentCode, parentRegion, newRegion)
+            this.code = getCodeOfSubregion(parentCode, parentRegion, newRegion, newLineType)
         }
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/RegionUtils.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/RegionUtils.kt
@@ -37,7 +37,7 @@ fun getCodeOfSubregion(
     code: String,
     nodeRegion: Region,
     subRegion: Region,
-    newLineType: CharSequence = "\n"
+    lineBreakSequence: CharSequence = "\n"
 ): String {
     val start =
         if (subRegion.startLine == nodeRegion.startLine) {
@@ -45,7 +45,7 @@ fun getCodeOfSubregion(
         } else {
             (StringUtils.ordinalIndexOf(
                 code,
-                newLineType,
+                lineBreakSequence,
                 subRegion.startLine - nodeRegion.startLine
             ) + subRegion.startColumn)
         }
@@ -55,7 +55,7 @@ fun getCodeOfSubregion(
         } else {
             (StringUtils.ordinalIndexOf(
                 code,
-                newLineType,
+                lineBreakSequence,
                 subRegion.endLine - nodeRegion.startLine
             ) + subRegion.endColumn)
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/RegionUtils.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/RegionUtils.kt
@@ -25,50 +25,39 @@
  */
 package de.fraunhofer.aisec.cpg.helpers
 
-import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.sarif.Region
 import kotlin.math.min
 import org.apache.commons.lang3.StringUtils
 
 /**
- * To prevent issues with different newline types and formatting.
- *
- * @param multilineCode The newline type is extracted from the code assuming it contains newlines
- * @return the String of the newline or \n as default
+ * Returns the part of the [code] described by [subRegion], embedded in [nodeRegion]. [newLineType]
+ * can be used to specify the type of new-line char(s) used on the platform.
  */
-fun getNewLineType(multilineCode: String, region: Region? = null): String {
-    var code = multilineCode
-    region?.let {
-        if (it.startLine != it.endLine) {
-            code = code.substring(0, code.length - it.endColumn + 1)
-        }
-    }
-
-    val nls = listOf("\n\r", "\r\n", "\n")
-    for (nl in nls) {
-        if (code.endsWith(nl)) {
-            return nl
-        }
-    }
-    LanguageFrontend.log.debug("Could not determine newline type. Assuming \\n.")
-    return "\n"
-}
-
-fun getCodeOfSubregion(code: String, nodeRegion: Region, subRegion: Region): String {
-    val nlType = getNewLineType(code, nodeRegion)
+fun getCodeOfSubregion(
+    code: String,
+    nodeRegion: Region,
+    subRegion: Region,
+    newLineType: CharSequence = "\n"
+): String {
     val start =
         if (subRegion.startLine == nodeRegion.startLine) {
             subRegion.startColumn - nodeRegion.startColumn
         } else {
-            (StringUtils.ordinalIndexOf(code, nlType, subRegion.startLine - nodeRegion.startLine) +
-                subRegion.startColumn)
+            (StringUtils.ordinalIndexOf(
+                code,
+                newLineType,
+                subRegion.startLine - nodeRegion.startLine
+            ) + subRegion.startColumn)
         }
     var end =
         if (subRegion.endLine == nodeRegion.startLine) {
             subRegion.endColumn - nodeRegion.startColumn
         } else {
-            (StringUtils.ordinalIndexOf(code, nlType, subRegion.endLine - nodeRegion.startLine) +
-                subRegion.endColumn)
+            (StringUtils.ordinalIndexOf(
+                code,
+                newLineType,
+                subRegion.endLine - nodeRegion.startLine
+            ) + subRegion.endColumn)
         }
 
     // Unfortunately, we sometimes have issues with (non)-Unicode characters in code, where the

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/ExpressionHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/ExpressionHandler.kt
@@ -270,7 +270,7 @@ class ExpressionHandler(frontend: PythonLanguageFrontend) :
                             node.keys[i]?.let { handle(it) } ?: newProblemExpression("missing key"),
                         value = handle(node.values[i]),
                     )
-                    .codeAndLocationFromChildren(node)
+                    .codeAndLocationFromChildren(node, frontend.lineSeparator)
         }
         val ile = newInitializerListExpression(rawNode = node)
         ile.type = frontend.objectType("dict")

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
@@ -51,7 +51,7 @@ import kotlin.math.min
 @RegisterExtraPass(PythonAddDeclarationsPass::class)
 class PythonLanguageFrontend(language: Language<PythonLanguageFrontend>, ctx: TranslationContext) :
     LanguageFrontend<Python.AST.AST, Python.AST.AST?>(language, ctx) {
-    private val lineSeparator = '\n' // TODO
+    val lineSeparator = "\n" // TODO
     private val tokenTypeIndex = 0
     private val jep = JepSingleton // configure Jep
 
@@ -191,7 +191,7 @@ class PythonLanguageFrontend(language: Language<PythonLanguageFrontend>, ctx: Tr
                 lines = removeExtraAtEnd(location, lines)
                 lines = fixStartColumn(location, lines)
 
-                lines.joinToString(separator = lineSeparator.toString())
+                lines.joinToString(separator = lineSeparator)
             } else {
                 null
             }

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
@@ -1056,7 +1056,7 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
             // and only Python.AST.BaseStmt nodes would be accepted. This would cause issues with
             // other nodes that are not "statements", but also handled as part of this handler,
             // e.g., the Python.AST.ExceptHandler.
-            with(frontend) { result.codeAndLocationFromChildren(ast) }
+            with(frontend) { result.codeAndLocationFromChildren(ast, frontend.lineSeparator) }
         }
 
         return result


### PR DESCRIPTION
It seems that region utils (whatever they do) checked for a potential new line character in every call of `codeAndLocationFromChildren`. But the new line char should stay constant within the file, so we are using the `lineSeperator` property (in the python frontend) instead.
