### PR TITLE
WIP! first step: import checking extensions

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -30,8 +30,8 @@ import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.edges.Edge
 import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.Block
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
+import kotlin.Throws
 import kotlin.math.absoluteValue
 
 /**
@@ -843,4 +843,21 @@ val Node.translationUnit: TranslationUnitDeclaration?
         }
 
         return null
+    }
+
+/** Checks whether the [Node] in question is imported by utilizing [getImports]. */
+val Node.isImported: Boolean
+    get() {
+        return getImports.isNotEmpty() == true
+    }
+
+/**
+ * Finds [ImportDeclaration]s matching the [Node] in question by utilizing the scope manager to look
+ * up its name.
+ */
+val Node.getImports: List<ImportDeclaration?>
+    get() {
+        return this.scope
+            ?.lookupSymbol(name.localName, replaceImports = false)
+            ?.filterIsInstance<ImportDeclaration>() ?: emptyList()
     }

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/ExpressionHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/ExpressionHandler.kt
@@ -26,10 +26,8 @@
 package de.fraunhofer.aisec.cpg.frontends.python
 
 import de.fraunhofer.aisec.cpg.graph.*
-import de.fraunhofer.aisec.cpg.graph.declarations.ImportDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.CollectionComprehension
 import jep.python.PyObject
 
 class ExpressionHandler(frontend: PythonLanguageFrontend) :
@@ -419,7 +417,7 @@ class ExpressionHandler(frontend: PythonLanguageFrontend) :
         // our current file is (more or less) complete, but we might miss some
         // additional dependencies
         var ref =
-            if (isImport(base.name)) {
+            if (base.isImported) {
                 // Yes, it's an import, so we need to construct a reference with an FQN
                 newReference(base.name.fqn(node.attr), rawNode = node)
             } else {
@@ -492,14 +490,6 @@ class ExpressionHandler(frontend: PythonLanguageFrontend) :
         }
 
         return ret
-    }
-
-    private fun isImport(name: Name): Boolean {
-        val decl =
-            frontend.scopeManager.currentScope
-                ?.lookupSymbol(name.localName, replaceImports = false)
-                ?.filterIsInstance<ImportDeclaration>()
-        return decl?.isNotEmpty() == true
     }
 
     private fun handleName(node: Python.AST.Name): Expression {


### PR DESCRIPTION
Still a lot of problems and discussions we should have:

- `someCallExpressionNode.isImported`: this should probably return whether the call is imported or not. However, if we think about `foo.bar.baz` or any other `MemberExpression`, then the current approach does not work.
- Do we want the end-user to figure out the `base` of the `MemberExpression` and be user friendly when providing `isImported`, or do we make the end-user do all the work and simply provide `isImported` on `Name`s?
- Only thinking about `MemberExpressions` is not sufficient. `Reference`s need to be considered, too.
- As well as C++ `using namespace` stuff...
- What do other languages do?

(Remember to test nested member expressions, too)