### PR TITLE
Restrict symbol resolving to language

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -881,7 +881,7 @@ class ScopeManager : ScopeProvider {
      * arguments [scope] and [predicate] are forwarded.
      */
     fun lookupSymbolByNameOfNode(
-        node: HasScope,
+        node: Node,
         scope: Scope? = node.scope,
         predicate: ((Declaration) -> Boolean)? = null,
     ): List<Declaration> {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -876,18 +876,16 @@ class ScopeManager : ScopeProvider {
     override val scope: Scope?
         get() = currentScope
 
-    /** A convenience function to call [lookupSymbolByName] with the properties of [node]. */
-    fun lookupSymbolByNameOfNode(node: HasNameAndLocation, scope: Scope? = currentScope): List<Declaration> {
-        return lookupSymbolByName(
-            node.name,
-            node.language,
-            node.location,
-            if (node is HasScope) {
-                node.scope
-            } else {
-                currentScope
-            }
-        )
+    /**
+     * A convenience function to call [lookupSymbolByName] with the properties of [node]. The
+     * arguments [scope] and [predicate] are forwarded.
+     */
+    fun lookupSymbolByNameOfNode(
+        node: HasNameAndLocation,
+        scope: Scope? = currentScope,
+        predicate: ((Declaration) -> Boolean)? = null,
+    ): List<Declaration> {
+        return lookupSymbolByName(node.name, node.language, node.location, scope, predicate)
     }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -900,14 +900,19 @@ class ScopeManager : ScopeProvider {
         // We need to differentiate between a qualified and unqualified lookup. We have a qualified
         // lookup, if the scope is not null. In this case we need to stay within the specified scope
         val list =
-            if (scope != null) {
-                    scope.lookupSymbol(n.localName, thisScopeOnly = true, predicate = predicate)
-                } else {
+            when {
+                scope != null -> {
+                    scope
+                        .lookupSymbol(n.localName, thisScopeOnly = true, predicate = predicate)
+                        .toMutableList()
+                }
+                else -> {
                     // Otherwise, we can look up the symbol alone (without any FQN) starting from
                     // the startScope
-                    startScope?.lookupSymbol(n.localName, predicate = predicate)
+                    startScope?.lookupSymbol(n.localName, predicate = predicate)?.toMutableList()
+                        ?: mutableListOf()
                 }
-                ?.toMutableList() ?: return listOf()
+            }
 
         // If we have both the definition and the declaration of a function declaration in our list,
         // we chose only the definition

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -881,7 +881,7 @@ class ScopeManager : ScopeProvider {
      * arguments [scope] and [predicate] are forwarded.
      */
     fun lookupSymbolByNameOfNode(
-        node: HasNameAndLocation,
+        node: HasScope,
         scope: Scope? = node.scope,
         predicate: ((Declaration) -> Boolean)? = null,
     ): List<Declaration> {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -882,7 +882,7 @@ class ScopeManager : ScopeProvider {
      */
     fun lookupSymbolByNameOfNode(
         node: HasNameAndLocation,
-        scope: Scope? = currentScope,
+        scope: Scope? = node.scope,
         predicate: ((Declaration) -> Boolean)? = null,
     ): List<Declaration> {
         return lookupSymbolByName(node.name, node.language, node.location, scope, predicate)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -876,6 +876,20 @@ class ScopeManager : ScopeProvider {
     override val scope: Scope?
         get() = currentScope
 
+    /** A convenience function to call [lookupSymbolByName] with the properties of [node]. */
+    fun lookupSymbolByNameOfNode(node: HasNameAndLocation, scope: Scope? = currentScope): List<Declaration> {
+        return lookupSymbolByName(
+            node.name,
+            node.language,
+            node.location,
+            if (node is HasScope) {
+                node.scope
+            } else {
+                currentScope
+            }
+        )
+    }
+
     /**
      * This function tries to convert a [Node.name] into a [Symbol] and then performs a lookup of
      * this symbol. This can either be an "unqualified lookup" if [name] is not qualified or a
@@ -887,9 +901,9 @@ class ScopeManager : ScopeProvider {
      * function overloading. But it will only return list of declarations within the same scope; the
      * list cannot be spread across different scopes.
      *
-     * This means that as soon one or more declarations for the symbol are found in a "local" scope,
-     * these shadow all other occurrences of the same / symbol in a "higher" scope and only the ones
-     * from the lower ones will be returned.
+     * This means that as soon one or more declarations (of the matching [language]) for the symbol
+     * are found in a "local" scope, these shadow all other occurrences of the same / symbol in a
+     * "higher" scope and only the ones from the lower ones will be returned.
      */
     fun lookupSymbolByName(
         name: Name,

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TypeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TypeManager.kt
@@ -380,5 +380,5 @@ fun Reference.nameIsType(): Type? {
     }
 
     // Lastly, check if the reference contains a symbol that points to type (declaration)
-    return scopeManager.lookupUniqueTypeSymbolByName(name, scope)?.declaredType
+    return scopeManager.lookupUniqueTypeSymbolByName(name, language, scope)?.declaredType
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.graph.scopes
 
 import com.fasterxml.jackson.annotation.JsonBackReference
+import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.Node.Companion.TO_STRING_STYLE
@@ -131,6 +132,7 @@ abstract class Scope(
      */
     fun lookupSymbol(
         symbol: Symbol,
+        languageOnly: Language<*>? = null,
         thisScopeOnly: Boolean = false,
         replaceImports: Boolean = true,
         predicate: ((Declaration) -> Boolean)? = null
@@ -158,9 +160,14 @@ abstract class Scope(
                 list.replaceImports(symbol)
             }
 
+            // Filter according to the language
+            if (languageOnly != null) {
+                list.removeIf { it.language != languageOnly }
+            }
+
             // Filter the list according to the predicate, if we have any
             if (predicate != null) {
-                list = list.filter(predicate).toMutableList()
+                list.removeIf { !predicate.invoke(it) }
             }
 
             // If we have a hit, we can break the loop

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
@@ -138,12 +138,7 @@ abstract class Scope(
         // First, try to look for the symbol in the current scope (unless we have a predefined
         // search scope). In the latter case we also need to restrict the lookup to the search scope
         var modifiedScoped = this.predefinedLookupScopes[symbol]?.targetScope
-        var scope: Scope? =
-            if (modifiedScoped != null) {
-                modifiedScoped
-            } else {
-                this
-            }
+        var scope: Scope? = modifiedScoped ?: this
 
         var list: MutableList<Declaration>? = null
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
@@ -222,9 +222,7 @@ class ImportResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         for (part in parts) {
             var namespaces =
                 scopeManager
-                    .lookupSymbolByName(part, import.location, import.scope) {
-                        it.language == import.language
-                    }
+                    .lookupSymbolByName(part, import.language, import.location, import.scope)
                     .filterIsInstance<NamespaceDeclaration>()
 
             // We are only interested in "leaf" namespace declarations, meaning that they do not
@@ -274,9 +272,12 @@ class ImportResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         // Let's do some importing. We need to import either a wildcard
         if (import.wildcardImport) {
             val list =
-                scopeManager.lookupSymbolByName(import.import, import.location, scope) {
-                    it.language == import.language
-                }
+                scopeManager.lookupSymbolByName(
+                    import.import,
+                    import.language,
+                    import.location,
+                    scope
+                )
             val symbol = list.singleOrNull()
             if (symbol != null) {
                 // In this case, the symbol must point to a name scope
@@ -289,7 +290,7 @@ class ImportResolver(ctx: TranslationContext) : ComponentPass(ctx) {
             // or a symbol directly
             val list =
                 scopeManager
-                    .lookupSymbolByName(import.import, import.location, scope)
+                    .lookupSymbolByName(import.import, import.language, import.location, scope)
                     .toMutableList()
             import.importedSymbols = mutableMapOf(import.symbol to list)
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
@@ -222,7 +222,9 @@ class ImportResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         for (part in parts) {
             var namespaces =
                 scopeManager
-                    .lookupSymbolByName(part, import.location, import.scope)
+                    .lookupSymbolByName(part, import.location, import.scope) {
+                        it.language == import.language
+                    }
                     .filterIsInstance<NamespaceDeclaration>()
 
             // We are only interested in "leaf" namespace declarations, meaning that they do not
@@ -271,7 +273,10 @@ class ImportResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
         // Let's do some importing. We need to import either a wildcard
         if (import.wildcardImport) {
-            val list = scopeManager.lookupSymbolByName(import.import, import.location, scope)
+            val list =
+                scopeManager.lookupSymbolByName(import.import, import.location, scope) {
+                    it.language == import.language
+                }
             val symbol = list.singleOrNull()
             if (symbol != null) {
                 // In this case, the symbol must point to a name scope

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -591,9 +591,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         val records = possibleContainingTypes.mapNotNull { it.root.recordDeclaration }.toSet()
         for (record in records) {
             candidates.addAll(
-                ctx.scopeManager.lookupSymbolByName(record.name.fqn(symbol), record.language) {
-                    it.language == record.language
-                }
+                ctx.scopeManager.lookupSymbolByName(record.name.fqn(symbol), record.language)
             )
         }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -204,8 +204,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
         // Find a list of candidate symbols. Currently, this is only used the in the "next-gen" call
         // resolution, but in future this will also be used in resolving regular references.
-        ref.candidates =
-            scopeManager.lookupSymbolByName(ref.name, ref.language, ref.location).toSet()
+        ref.candidates = scopeManager.lookupSymbolByNameOfNode(ref).toSet()
 
         // Preparation for a future without legacy call resolving. Taking the first candidate is not
         // ideal since we are running into an issue with function pointers here (see workaround

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -205,9 +205,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         // Find a list of candidate symbols. Currently, this is only used the in the "next-gen" call
         // resolution, but in future this will also be used in resolving regular references.
         ref.candidates =
-            scopeManager
-                .lookupSymbolByName(ref.name, ref.location) { it.language == language }
-                .toSet()
+            scopeManager.lookupSymbolByName(ref.name, ref.language, ref.location).toSet()
 
         // Preparation for a future without legacy call resolving. Taking the first candidate is not
         // ideal since we are running into an issue with function pointers here (see workaround
@@ -594,7 +592,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         val records = possibleContainingTypes.mapNotNull { it.root.recordDeclaration }.toSet()
         for (record in records) {
             candidates.addAll(
-                ctx.scopeManager.lookupSymbolByName(record.name.fqn(symbol)) {
+                ctx.scopeManager.lookupSymbolByName(record.name.fqn(symbol), record.language) {
                     it.language == record.language
                 }
             )
@@ -709,9 +707,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
             val firstLevelCandidates =
                 possibleTypes
                     .map { record ->
-                        scopeManager.lookupSymbolByName(record.name.fqn(name)) {
-                            it.language == record.language
-                        }
+                        scopeManager.lookupSymbolByName(record.name.fqn(name), record.language)
                     }
                     .flatten()
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
@@ -104,7 +104,8 @@ open class TypeResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         // filter for nodes that implement DeclaresType, because otherwise we will get a lot of
         // constructor declarations and such with the same name. It seems this is ok since most
         // languages will prefer structs/classes over functions when resolving types.
-        var declares = scopeManager.lookupUniqueTypeSymbolByName(type.name, type.scope)
+        var declares =
+            scopeManager.lookupUniqueTypeSymbolByName(type.name, type.language, type.scope)
 
         // If we did not find any declaration, we can try to infer a record declaration for it
         if (declares == null) {

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManagerTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManagerTest.kt
@@ -100,7 +100,7 @@ internal class ScopeManagerTest : BaseTest() {
             // resolve symbol
             val call =
                 frontend.newCallExpression(frontend.newReference("A::func1"), "A::func1", false)
-            val func = final.lookupSymbolByName(call.callee!!.name).firstOrNull()
+            val func = final.lookupSymbolByName(call.callee.name).firstOrNull()
 
             assertEquals(func1, func)
         }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManagerTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManagerTest.kt
@@ -100,7 +100,8 @@ internal class ScopeManagerTest : BaseTest() {
             // resolve symbol
             val call =
                 frontend.newCallExpression(frontend.newReference("A::func1"), "A::func1", false)
-            val func = final.lookupSymbolByName(call.callee.name).firstOrNull()
+            val func =
+                final.lookupSymbolByName(call.callee.name, call.callee.language).firstOrNull()
 
             assertEquals(func1, func)
         }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManagerTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManagerTest.kt
@@ -100,8 +100,7 @@ internal class ScopeManagerTest : BaseTest() {
             // resolve symbol
             val call =
                 frontend.newCallExpression(frontend.newReference("A::func1"), "A::func1", false)
-            val func =
-                final.lookupSymbolByName(call.callee.name, call.callee.language).firstOrNull()
+            val func = final.lookupSymbolByNameOfNode(call.callee).firstOrNull()
 
             assertEquals(func1, func)
         }

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/DeclarationHandler.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/DeclarationHandler.kt
@@ -76,7 +76,7 @@ class DeclarationHandler(frontend: GoLanguageFrontend) :
 
                     // TODO: this will only find methods within the current translation unit.
                     //  this is a limitation that we have for C++ as well
-                    val record = frontend.scopeManager.getRecordForName(recordName)
+                    val record = frontend.scopeManager.getRecordForName(recordName, language)
 
                     // now this gets a little bit hacky, we will add it to the record declaration
                     // this is strictly speaking not 100 % true, since the method property edge is

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
@@ -390,9 +390,7 @@ class GoExtraPass(ctx: TranslationContext) : ComponentPass(ctx) {
         // Try to see if we already know about this namespace somehow
         val namespace =
             scopeManager.lookupSymbolByNameOfNode(import).filter {
-                it is NamespaceDeclaration &&
-                    it.path == import.importURL &&
-                    it.language == import.language
+                it is NamespaceDeclaration && it.path == import.importURL
             }
 
         // If not, we can infer a namespace declaration, so we can bundle all inferred function

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
@@ -389,7 +389,7 @@ class GoExtraPass(ctx: TranslationContext) : ComponentPass(ctx) {
 
         // Try to see if we already know about this namespace somehow
         val namespace =
-            scopeManager.lookupSymbolByName(import.name, null).filter {
+            scopeManager.lookupSymbolByNameOfNode(import).filter {
                 it is NamespaceDeclaration &&
                     it.path == import.importURL &&
                     it.language == import.language

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
@@ -390,7 +390,9 @@ class GoExtraPass(ctx: TranslationContext) : ComponentPass(ctx) {
         // Try to see if we already know about this namespace somehow
         val namespace =
             scopeManager.lookupSymbolByName(import.name, null).filter {
-                it is NamespaceDeclaration && it.path == import.importURL
+                it is NamespaceDeclaration &&
+                    it.path == import.importURL &&
+                    it.language == import.language
             }
 
         // If not, we can infer a namespace declaration, so we can bundle all inferred function

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/DeclarationHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/DeclarationHandler.kt
@@ -194,7 +194,7 @@ class DeclarationHandler(lang: LLVMIRLanguageFrontend) :
             }
 
         // try to see, if the struct already exists as a record declaration
-        var record = frontend.scopeManager.getRecordForName(Name(name))
+        var record = frontend.scopeManager.getRecordForName(Name(name), language)
 
         // if yes, return it
         if (record != null) {

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/ExpressionHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/ExpressionHandler.kt
@@ -441,7 +441,7 @@ class ExpressionHandler(lang: LLVMIRLanguageFrontend) :
                 var record = (baseType as? ObjectType)?.recordDeclaration
 
                 if (record == null) {
-                    record = frontend.scopeManager.getRecordForName(baseType.name)
+                    record = frontend.scopeManager.getRecordForName(baseType.name, language)
                     if (record != null) {
                         (baseType as? ObjectType)?.recordDeclaration = record
                     }

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontend.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontend.kt
@@ -245,7 +245,7 @@ class LLVMIRLanguageFrontend(language: Language<LLVMIRLanguageFrontend>, ctx: Tr
 
     /** Determines if a struct with [name] exists in the scope. */
     fun isKnownStructTypeName(name: String): Boolean {
-        return this.scopeManager.getRecordForName(Name(name)) != null
+        return this.scopeManager.getRecordForName(Name(name), language) != null
     }
 
     fun getOperandValueAtIndex(instr: LLVMValueRef, idx: Int): Expression {

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
@@ -96,10 +96,12 @@ class PythonAddDeclarationsPass(ctx: TranslationContext) : ComponentPass(ctx) {
             //   - to look for a local symbol, unless
             //   - a global keyword is present for this symbol and scope
             if (targetScope != null) {
-                scopeManager.lookupSymbolByName(ref.name, ref.location, targetScope)
+                scopeManager.lookupSymbolByName(ref.name, ref.location, targetScope) {
+                    it.language == ref.language
+                }
             } else {
                 scopeManager.lookupSymbolByName(ref.name, ref.location) {
-                    it.scope == scopeManager.currentScope
+                    it.scope == scopeManager.currentScope && it.language == ref.language
                 }
             }
 

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
@@ -26,6 +26,8 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationContext
+import de.fraunhofer.aisec.cpg.frontends.Language
+import de.fraunhofer.aisec.cpg.frontends.python.PythonLanguage
 import de.fraunhofer.aisec.cpg.frontends.python.PythonLanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
@@ -44,7 +46,7 @@ import de.fraunhofer.aisec.cpg.passes.configuration.RequiredFrontend
 @ExecuteBefore(ImportResolver::class)
 @ExecuteBefore(SymbolResolver::class)
 @RequiredFrontend(PythonLanguageFrontend::class)
-class PythonAddDeclarationsPass(ctx: TranslationContext) : ComponentPass(ctx) {
+class PythonAddDeclarationsPass(ctx: TranslationContext) : ComponentPass(ctx), LanguageProvider {
     override fun cleanup() {
         // nothing to do
     }
@@ -205,4 +207,7 @@ class PythonAddDeclarationsPass(ctx: TranslationContext) : ComponentPass(ctx) {
             }
         }
     }
+
+    override val language: Language<*>?
+        get() = ctx.config.languages.firstOrNull { it is PythonLanguage }
 }

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
@@ -98,12 +98,10 @@ class PythonAddDeclarationsPass(ctx: TranslationContext) : ComponentPass(ctx), L
             //   - to look for a local symbol, unless
             //   - a global keyword is present for this symbol and scope
             if (targetScope != null) {
-                scopeManager.lookupSymbolByName(ref.name, ref.location, targetScope) {
-                    it.language == ref.language
-                }
+                scopeManager.lookupSymbolByName(ref.name, ref.language, ref.location, targetScope)
             } else {
-                scopeManager.lookupSymbolByName(ref.name, ref.location) {
-                    it.scope == scopeManager.currentScope && it.language == ref.language
+                scopeManager.lookupSymbolByName(ref.name, ref.language, ref.location) {
+                    it.scope == scopeManager.currentScope
                 }
             }
 

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
@@ -98,11 +98,9 @@ class PythonAddDeclarationsPass(ctx: TranslationContext) : ComponentPass(ctx), L
             //   - to look for a local symbol, unless
             //   - a global keyword is present for this symbol and scope
             if (targetScope != null) {
-                scopeManager.lookupSymbolByName(ref.name, ref.language, ref.location, targetScope)
+                scopeManager.lookupSymbolByNameOfNode(ref, targetScope)
             } else {
-                scopeManager.lookupSymbolByName(ref.name, ref.language, ref.location) {
-                    it.scope == scopeManager.currentScope
-                }
+                scopeManager.lookupSymbolByNameOfNode(ref) { it.scope == scopeManager.currentScope }
             }
 
         // Nothing to create


### PR DESCRIPTION
Currently, the symbol resolver runs wild and considers all nodes of all languages. When we have more instances where we have multiple languages in the same component, this craates a problem.

This PR now only considers the same language as the ref we are looking for.
