### PR TITLE
Fix C style function resolution

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -517,6 +517,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
                 source.scope,
             )
         val language = source.language
+        val sourceCall = source as? CallExpression
 
         if (language == null) {
             result.success = CallResolutionResult.SuccessKind.PROBLEMATIC
@@ -527,29 +528,43 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         val (scope, _) = ctx.scopeManager.extractScope(source, source.scope)
         result.actualStartScope = scope ?: source.scope
 
-        // If the function does not allow function overloading, and we have multiple candidate
-        // symbols, the result is "problematic"
-        if (source.language !is HasFunctionOverloading && result.candidateFunctions.size > 1) {
-            result.success = PROBLEMATIC
-        }
-
-        // Filter functions that match the signature of our call, either directly or with casts;
-        // those functions are "viable". Take default arguments into account if the language has
-        // them.
-        result.signatureResults =
-            result.candidateFunctions
-                .map {
-                    Pair(
-                        it,
-                        it.matchesSignature(
-                            arguments.map(Expression::type),
-                            arguments,
-                            source.language is HasDefaultArguments,
+        // Resolution depends on language features
+        if (source.language !is HasFunctionOverloading) {
+            // If the function does not allow function overloading, and we have multiple candidate
+            // symbols, the result is "problematic"
+            if (result.candidateFunctions.size > 1) {
+                result.success = CallResolutionResult.SuccessKind.PROBLEMATIC
+            } else
+            // If we have only one candidate function and the number of arguments match, we can take
+            // a shortcut and stop here
+            if (
+                result.candidateFunctions.size == 1 &&
+                    result.candidateFunctions.first().parameters.size == sourceCall?.arguments?.size
+            ) {
+                result.signatureResults =
+                    result.candidateFunctions.associateWith {
+                        SignatureMatches(mutableListOf(DirectMatch))
+                    }
+            }
+        } else {
+            // Filter functions that match the signature of our call, either directly or with
+            // casts; those functions are "viable". Take default arguments into account if the
+            // language has them.
+            result.signatureResults =
+                result.candidateFunctions
+                    .map {
+                        Pair(
+                            it,
+                            it.matchesSignature(
+                                arguments.map(Expression::type),
+                                arguments,
+                                source.language is HasDefaultArguments,
+                            )
                         )
-                    )
-                }
-                .filter { it.second is SignatureMatches }
-                .associate { it }
+                    }
+                    .filter { it.second is SignatureMatches }
+                    .associate { it }
+        }
         result.viableFunctions = result.signatureResults.keys
 
         // If we have a "problematic" result, we can stop here. In this case we cannot really

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXDeclarationTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXDeclarationTest.kt
@@ -104,12 +104,12 @@ class CXXDeclarationTest {
 
         declarations.forEach { assertEquals(definition, it.definition) }
 
-        // without the "std" lib, int will not match with size_t and we will infer a new function;
-        // and this will actually result in a problematic resolution, since C does not allow
-        // function overloading.
+        // As C does not support function overload, we can resolve the call to foo even if we do not
+        // know the argument type (due to missing includes), only by the name of the function and
+        // the number of arguments.
         val inferredDefinition =
             result.functions[{ it.name.localName == "foo" && !it.isDefinition && it.isInferred }]
-        assertNotNull(inferredDefinition)
+        assertNull(inferredDefinition)
     }
 
     @Test

--- a/cpg-language-cxx/src/test/resources/calls/c-function-resolution.c
+++ b/cpg-language-cxx/src/test/resources/calls/c-function-resolution.c
@@ -1,0 +1,14 @@
+//#define MY_CONST_INT 1
+
+void foo(int i) {
+}
+void bar(int i) {
+}
+
+int main() {
+    foo(MY_CONST_INT);
+    foo(1);
+    bar(1,2);
+    return 0;
+}
+


### PR DESCRIPTION
Do not use signature based symbol resolving for languages without function overloading.
Fixes: #1635