### PR TITLE
Fixing Java field access

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -193,16 +193,6 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
     protected fun handleReference(currentClass: RecordDeclaration?, ref: Reference) {
         val language = ref.language
 
-        if (language == null) {
-            Util.warnWithFileLocation(
-                ref,
-                log,
-                "Language for reference {} is empty, we cannot resolve this reference correctly.",
-                ref.name,
-            )
-            return
-        }
-
         // Ignore references to anonymous identifiers, if the language supports it (e.g., the _
         // identifier in Go)
         if (

--- a/cpg-core/src/testFixtures/kotlin/de/fraunhofer/aisec/cpg/test/TestUtils.kt
+++ b/cpg-core/src/testFixtures/kotlin/de/fraunhofer/aisec/cpg/test/TestUtils.kt
@@ -285,7 +285,7 @@ fun assertUsageOf(usingNode: Node?, usedNode: Node?) {
 fun assertUsageOfMemberAndBase(usingNode: Node?, usedBase: Node?, usedMember: Declaration?) {
     assertNotNull(usingNode)
     if (usingNode !is MemberExpression && !ENFORCE_MEMBER_EXPRESSION) {
-        // Assumtion here is that the target of the member portion of the expression and not the
+        // Assumption here is that the target of the member portion of the expression and not the
         // base is resolved
         assertUsageOf(usingNode, usedMember)
     } else {

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
@@ -238,9 +238,12 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
         return declarationStatement
     }
 
-    private fun handleFieldAccessExpression(
-        expr: Expression
-    ): de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression {
+    /**
+     * Translates a Java
+     * [field access expression](https://docs.oracle.com/javase/specs/jls/se23/html/jls-15.html#jls-15.11)
+     * into a [MemberExpression].
+     */
+    private fun handleFieldAccessExpression(expr: Expression): MemberExpression {
         val fieldAccessExpr = expr.asFieldAccessExpr()
 
         var baseType = unknownType()
@@ -267,7 +270,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
             base,
             fieldType,
             operatorCode = ".",
-            rawNode = fieldAccessExpr
+            rawNode = fieldAccessExpr,
         )
     }
 
@@ -355,7 +358,14 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
         return superExpression
     }
 
-    // TODO: this function needs a MAJOR overhaul!
+    /**
+     * Translates a Java
+     * [expression name](https://docs.oracle.com/javase/specs/jls/se23/html/jls-6.html#jls-ExpressionName)
+     * into an [Expression].
+     *
+     * Since a name can be a multitude of different things the result can either be a [Reference] or
+     * a [MemberExpression].
+     */
     private fun handleNameExpression(
         expr: Expression
     ): de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression? {
@@ -657,6 +667,9 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
     }
 }
 
+/**
+ * Converts a [ResolvedFieldDeclaration] to a [FieldAccessExpr] with the given name (as [NameExpr]).
+ */
 fun ResolvedFieldDeclaration.toFieldAccessExpr(expr: NameExpr): FieldAccessExpr {
     // Convert to FieldAccessExpr
     val fieldAccessExpr =

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaCallResolverHelper.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaCallResolverHelper.kt
@@ -23,10 +23,9 @@
  *                    \______/ \__|       \______/
  *
  */
-package de.fraunhofer.aisec.cpg.passes
+package de.fraunhofer.aisec.cpg.frontends.java
 
 import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.frontends.java.JavaLanguage
 import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberExpression

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguage.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguage.kt
@@ -28,9 +28,14 @@ package de.fraunhofer.aisec.cpg.frontends.java
 import com.fasterxml.jackson.annotation.JsonIgnore
 import de.fraunhofer.aisec.cpg.ScopeManager
 import de.fraunhofer.aisec.cpg.frontends.*
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
+import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.BinaryOperator
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberExpression
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.Reference
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.passes.JavaCallResolverHelper
 import kotlin.reflect.KClass
@@ -114,6 +119,25 @@ open class JavaLanguage :
         curClass: RecordDeclaration,
         scopeManager: ScopeManager,
     ) = JavaCallResolverHelper.handleSuperExpression(memberExpression, curClass, scopeManager)
+
+    /**
+     * This function handles some specifics of the Java language when choosing a reference target
+     * before invoking [Language.bestViableReferenceCandidate].
+     */
+    override fun bestViableReferenceCandidate(ref: Reference): Declaration? {
+        // Java allows to have "ambiguous" symbol when importing static fields and methods.
+        // Therefore, it can be that we both import a field and a method with the same name. We
+        // therefore do some additional filtering of the candidates here, before handling it.
+        if (ref.candidates.size > 1) {
+            if (ref.resolutionHelper is CallExpression) {
+                ref.candidates = ref.candidates.filter { it is FunctionDeclaration }.toSet()
+            } else {
+                ref.candidates = ref.candidates.filter { it is VariableDeclaration }.toSet()
+            }
+        }
+
+        return super.bestViableReferenceCandidate(ref)
+    }
 
     override val startCharacter = '<'
     override val endCharacter = '>'

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguage.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguage.kt
@@ -37,7 +37,6 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Reference
 import de.fraunhofer.aisec.cpg.graph.types.*
-import de.fraunhofer.aisec.cpg.passes.JavaCallResolverHelper
 import kotlin.reflect.KClass
 import org.neo4j.ogm.annotation.Transient
 

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
@@ -63,6 +63,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import de.fraunhofer.aisec.cpg.helpers.Benchmark
 import de.fraunhofer.aisec.cpg.helpers.CommonPath
 import de.fraunhofer.aisec.cpg.passes.JavaExternalTypeHierarchyResolver
+import de.fraunhofer.aisec.cpg.passes.JavaExtraPass
 import de.fraunhofer.aisec.cpg.passes.JavaImportResolver
 import de.fraunhofer.aisec.cpg.passes.configuration.RegisterExtraPass
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
@@ -78,6 +79,7 @@ import kotlin.jvm.optionals.getOrNull
     JavaExternalTypeHierarchyResolver::class
 ) // this pass is always required for Java
 @RegisterExtraPass(JavaImportResolver::class)
+@RegisterExtraPass(JavaExtraPass::class)
 open class JavaLanguageFrontend(language: Language<JavaLanguageFrontend>, ctx: TranslationContext) :
     LanguageFrontend<Node, Type>(language, ctx) {
 
@@ -140,6 +142,12 @@ open class JavaLanguageFrontend(language: Language<JavaLanguageFrontend>, ctx: T
                 val incl = newIncludeDeclaration(anImport.nameAsString)
                 scopeManager.addDeclaration(incl)
             }
+
+            // We create an implicit import for "java.lang.*"
+            val decl =
+                newImportDeclaration(parseName("java.lang"), wildcardImport = true)
+                    .implicit("import java.lang.*")
+            scopeManager.addDeclaration(decl)
 
             if (namespaceDeclaration != null) {
                 scopeManager.leaveScope(namespaceDeclaration)

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaExtraPass.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaExtraPass.kt
@@ -40,6 +40,12 @@ import de.fraunhofer.aisec.cpg.nameIsType
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
 import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
 
+/**
+ * This pass is responsible for handling Java-specific cases that are not covered by the general CPG
+ * logic. For example, Java has static member access, which is not modeled as a member expression,
+ * but as a reference with an FQN. This pass will convert such member expressions to references with
+ * FQNs.
+ */
 @DependsOn(TypeResolver::class)
 @ExecuteBefore(SymbolResolver::class)
 class JavaExtraPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaExtraPass.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaExtraPass.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.passes
+
+import de.fraunhofer.aisec.cpg.TranslationContext
+import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.codeAndLocationFrom
+import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
+import de.fraunhofer.aisec.cpg.graph.fqn
+import de.fraunhofer.aisec.cpg.graph.newReference
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberExpression
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.Reference
+import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
+import de.fraunhofer.aisec.cpg.helpers.replace
+import de.fraunhofer.aisec.cpg.nameIsType
+import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
+import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
+
+@DependsOn(TypeResolver::class)
+@ExecuteBefore(SymbolResolver::class)
+class JavaExtraPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {
+    private lateinit var walker: SubgraphWalker.ScopedWalker
+
+    override fun accept(tu: TranslationUnitDeclaration) {
+        // Loop through all member expressions
+        walker = SubgraphWalker.ScopedWalker(ctx.scopeManager)
+        walker.registerHandler { _, parent, node ->
+            when (node) {
+                is MemberExpression -> handleMemberExpression(node, parent)
+            }
+        }
+
+        walker.iterate(tu)
+    }
+
+    fun handleMemberExpression(me: MemberExpression, parent: Node?) {
+        // For now, we are only interested in fields and not in calls, since this will open another
+        // can of worms
+        if (parent is CallExpression && parent.callee == me) return
+
+        // Look at the "base" of the member expression and check if this is referring to a type
+        var base = me.base as? Reference
+        var type = base?.nameIsType()
+        if (type != null) {
+            // Our base refers to a type, so this is actually a static reference, which we
+            // model not as a member expression, but as a reference with an FQN. Let's build that
+            // and exchange the node
+            val ref =
+                newReference(type.name.fqn(me.name.localName), type = me.type)
+                    .codeAndLocationFrom(me)
+                    .apply { isStaticAccess = true }
+            walker.replace(parent, me, ref)
+        }
+    }
+
+    override fun cleanup() {
+        // Nothing to do
+    }
+}

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaExtraPass.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaExtraPass.kt
@@ -73,6 +73,7 @@ class JavaExtraPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {
                 newReference(type.name.fqn(me.name.localName), type = me.type)
                     .codeAndLocationFrom(me)
                     .apply { isStaticAccess = true }
+            ref.language = me.language
             walker.replace(parent, me, ref)
         }
     }

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/calls/SuperCallTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/calls/SuperCallTest.kt
@@ -89,13 +89,16 @@ internal class SuperCallTest : BaseTest() {
         val methods = subClass.methods
         val field = findByUniqueName(subClass.fields, "field")
         val getField = findByUniqueName(methods, "getField")
-        var refs = getField.allChildren<MemberExpression>()
+        var refs = getField.refs
         val fieldRef = findByUniquePredicate(refs) { "field" == it.code }
         val getSuperField = findByUniqueName(methods, "getSuperField")
         refs = getSuperField.allChildren<MemberExpression>()
         val superFieldRef = findByUniquePredicate(refs) { "super.field" == it.code }
-        assertTrue(fieldRef.base is Reference)
-        assertRefersTo(fieldRef.base, getField.receiver)
+        // See https://github.com/Fraunhofer-AISEC/cpg/issues/1863.
+        // We only have a regular call expression here, if we do not resolve anything else in the
+        // frontend
+        /*assertTrue(fieldRef.base is Reference)
+        assertRefersTo(fieldRef.base, getField.receiver)*/
         assertEquals(field, fieldRef.refersTo)
         assertTrue(superFieldRef.base is Reference)
         assertRefersTo(superFieldRef.base, getSuperField.receiver)

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/calls/SuperCallTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/calls/SuperCallTest.kt
@@ -94,11 +94,6 @@ internal class SuperCallTest : BaseTest() {
         val getSuperField = findByUniqueName(methods, "getSuperField")
         refs = getSuperField.allChildren<MemberExpression>()
         val superFieldRef = findByUniquePredicate(refs) { "super.field" == it.code }
-        // See https://github.com/Fraunhofer-AISEC/cpg/issues/1863.
-        // We only have a regular call expression here, if we do not resolve anything else in the
-        // frontend
-        /*assertTrue(fieldRef.base is Reference)
-        assertRefersTo(fieldRef.base, getField.receiver)*/
         assertEquals(field, fieldRef.refersTo)
         assertTrue(superFieldRef.base is Reference)
         assertRefersTo(superFieldRef.base, getSuperField.receiver)

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StaticImportsTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StaticImportsTest.kt
@@ -112,17 +112,19 @@ internal class StaticImportsTest : BaseTest() {
             }
         }
         val testFields = a.fields
-        val staticField = findByUniqueName(testFields, "staticField")
-        val nonStaticField = findByUniqueName(testFields, "nonStaticField")
+        val staticField = a.fields["staticField"]
+        val inferredNonStaticField = b.fields["nonStaticField"]
+        assertNotNull(staticField)
+        assertNotNull(inferredNonStaticField)
         assertTrue(staticField.modifiers.contains("static"))
-        assertFalse(nonStaticField.modifiers.contains("static"))
+        assertFalse(inferredNonStaticField.modifiers.contains("static"))
 
-        val declaredReferences = main.allChildren<MemberExpression>()
+        val declaredReferences = main.refs
         val usage = findByUniqueName(declaredReferences, "staticField")
-        assertEquals(staticField, usage.refersTo)
+        assertRefersTo(usage, staticField)
 
         val nonStatic = findByUniqueName(declaredReferences, "nonStaticField")
-        assertNotEquals(nonStaticField, nonStatic.refersTo)
-        assertTrue(nonStatic.refersTo!!.isInferred)
+        assertRefersTo(nonStatic, inferredNonStaticField)
+        assertTrue(nonStatic.refersTo?.isInferred == true)
     }
 }


### PR DESCRIPTION
This PR consists of a major overhaul of Java reference and member expression parsing. It removes a LOT of old weird legacy code that was full of weird things.

It also introduces a new Java-specific pass, that takes care of deciding when a member access is actually static or not. This might be something that we could decide to adapt for other/all languages (maybe also tied to the discussion in #1863).