### PR TITLE
fix package name and enable ini in console and neo4j

### DIFF
--- a/cpg-console/src/main/kotlin/de/fraunhofer/aisec/cpg/console/TranslatePlugin.kt
+++ b/cpg-console/src/main/kotlin/de/fraunhofer/aisec/cpg/console/TranslatePlugin.kt
@@ -78,6 +78,7 @@ class TranslatePlugin : Plugin {
                         "                    .optionalLanguage(\"de.fraunhofer.aisec.cpg.frontends.golang.GoLanguage\")" +
                         "                    .optionalLanguage(\"de.fraunhofer.aisec.cpg.frontends.typescript.TypeScriptLanguage\")" +
                         "                    .optionalLanguage(\"de.fraunhofer.aisec.cpg.frontends.ruby.RubyLanguage\")" +
+                        "                    .optionalLanguage(\"de.fraunhofer.aisec.cpg.frontends.ini.IniFileLanguage\")" +
                         "                    .defaultPasses()\n" +
                         "                    .useParallelPasses(false)\n" +
                         "                    .configurePass<de.fraunhofer.aisec.cpg.passes.ControlFlowSensitiveDFGPass>(\n" +

--- a/cpg-language-ini/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/ini/IniFileFrontend.kt
+++ b/cpg-language-ini/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/ini/IniFileFrontend.kt
@@ -23,7 +23,7 @@
  *                    \______/ \__|       \______/
  *
  */
-package de.fraunhofer.aisec.cpg.frontend.configfiles
+package de.fraunhofer.aisec.cpg.frontends.ini
 
 import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.Language

--- a/cpg-language-ini/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/ini/IniFileLanguage.kt
+++ b/cpg-language-ini/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/ini/IniFileLanguage.kt
@@ -23,7 +23,7 @@
  *                    \______/ \__|       \______/
  *
  */
-package de.fraunhofer.aisec.cpg.frontend.configfiles
+package de.fraunhofer.aisec.cpg.frontends.ini
 
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.types.StringType

--- a/cpg-language-ini/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/ini/IniFileTest.kt
+++ b/cpg-language-ini/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/ini/IniFileTest.kt
@@ -23,7 +23,7 @@
  *                    \______/ \__|       \______/
  *
  */
-package de.fraunhofer.aisec.cpg.frontend.configfiles
+package de.fraunhofer.aisec.cpg.frontends.ini
 
 import de.fraunhofer.aisec.cpg.graph.declarations.FieldDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration

--- a/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
+++ b/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
@@ -493,6 +493,7 @@ class Application : Callable<Int> {
                 .optionalLanguage("de.fraunhofer.aisec.cpg.frontends.typescript.TypeScriptLanguage")
                 .optionalLanguage("de.fraunhofer.aisec.cpg.frontends.ruby.RubyLanguage")
                 .optionalLanguage("de.fraunhofer.aisec.cpg.frontends.jvm.JVMLanguage")
+                .optionalLanguage("de.fraunhofer.aisec.cpg.frontends.ini.IniFileLanguage")
                 .loadIncludes(loadIncludes)
                 .addIncludesToGraph(loadIncludes)
                 .debugParser(DEBUG_PARSER)


### PR DESCRIPTION
Fix the package name to align with the other frontends and enable the INI frontend in the console and neo4j modules.