### PR TITLE
Providing an API to update the imported symbols for an `ImportDeclaration`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
@@ -265,38 +265,43 @@ class ImportResolver(ctx: TranslationContext) : ComponentPass(ctx) {
     }
 
     private fun handleImportDeclaration(import: ImportDeclaration) {
-        // We always need to search at the global scope because we are "importing" something, so by
-        // definition, this is not in the scope of the current file.
-        val scope = scopeManager.globalScope ?: return
-
-        // Let's do some importing. We need to import either a wildcard
-        if (import.wildcardImport) {
-            val list =
-                scopeManager.lookupSymbolByName(
-                    import.import,
-                    import.language,
-                    import.location,
-                    scope
-                )
-            val symbol = list.singleOrNull()
-            if (symbol != null) {
-                // In this case, the symbol must point to a name scope
-                val symbolScope = scopeManager.lookupScope(symbol)
-                if (symbolScope is NameScope) {
-                    import.importedSymbols = symbolScope.symbols
-                }
-            }
-        } else {
-            // or a symbol directly
-            val list =
-                scopeManager
-                    .lookupSymbolByName(import.import, import.language, import.location, scope)
-                    .toMutableList()
-            import.importedSymbols = mutableMapOf(import.symbol to list)
-        }
+        import.updateImportedSymbols()
     }
 
     override fun cleanup() {
         // Nothing to do
+    }
+}
+
+/**
+ * This function updates the [ImportDeclaration.importedSymbols]. This is done once at the beginning
+ * by the [ImportResolver]. However, we need to update this list once we infer new symbols in
+ * namespaces that are imported at a later stage (e.g., in the [TypeResolver]), otherwise they won't
+ * be visible to the later passes.
+ */
+context(Pass<*>)
+fun ImportDeclaration.updateImportedSymbols() {
+    // We always need to search at the global scope because we are "importing" something, so by
+    // definition, this is not in the scope of the current file.
+    val scope = scopeManager.globalScope ?: return
+
+    // Let's do some importing. We need to import either a wildcard
+    if (this.wildcardImport) {
+        val list = scopeManager.lookupSymbolByName(this.import, this.language, this.location, scope)
+        val symbol = list.singleOrNull()
+        if (symbol != null) {
+            // In this case, the symbol must point to a name scope
+            val symbolScope = scopeManager.lookupScope(symbol)
+            if (symbolScope is NameScope) {
+                this.importedSymbols = symbolScope.symbols
+            }
+        }
+    } else {
+        // or a symbol directly
+        val list =
+            scopeManager
+                .lookupSymbolByName(this.import, this.language, this.location, scope)
+                .toMutableList()
+        this.importedSymbols = mutableMapOf(this.symbol to list)
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
@@ -29,6 +29,7 @@ import de.fraunhofer.aisec.cpg.ScopeManager
 import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.TypeManager
 import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.declarations.ImportDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.types.DeclaresType
 import de.fraunhofer.aisec.cpg.graph.types.ObjectType
@@ -141,6 +142,10 @@ open class TypeResolver(ctx: TranslationContext) : ComponentPass(ctx) {
                     t.recordDeclaration = node
                 }
             }
+        } else if (node is ImportDeclaration) {
+            // Update the imports, as they might have changed because of symbols created by
+            // record/type inference
+            node.updateImportedSymbols()
         }
     }
 


### PR DESCRIPTION
This introduces a new extension function `ImportDeclaration.updateImportedSymbols`. The idea behind that is that we might need to update the `importedSymbols` of an import declaration, if the symbols that "live" in the associated namespace change. This is mainly the case once we infer records out of known `Type` nodes. Therefore, the type resolver will update all the imported symbols before executing all the remaining passes. This way, the remainder of the passes can access imported symbols that were inferred.

Needed for #1862