### PR TITLE
Provide a function for languages to influence reference resolution out of candidates

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
@@ -379,7 +379,8 @@ abstract class Language<T : LanguageFrontend<*, *>> : Node() {
             Util.warnWithFileLocation(
                 ref,
                 log,
-                "Resolution of reference {} was ambiguous, cannot set refersTo correctly.",
+                "Resolution of reference {} was ambiguous, cannot set refersTo correctly, " +
+                    "will be set to null.",
                 ref.name
             )
             null


### PR DESCRIPTION
This adds a new function `Language.bestViableReferenceCandidate` which takes the old implementation as a default behaviour.
