### PR TITLE
Fix/test eog for loop

### DIFF
--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/testcases/Query.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/testcases/Query.kt
@@ -407,19 +407,20 @@ class Query {
 
                                 declare { variable("a", t("int")) { literal(0, t("int")) } }
 
-                                forStmt(
-                                    declareVar("i", t("int")) { literal(0, t("int")) },
-                                    ref("i") le literal(4, t("int")),
-                                    ref("i").incNoContext()
-                                ) {
-                                    ref("a") assign
-                                        {
-                                            ref("a") +
-                                                subscriptExpr {
-                                                    ref("c")
-                                                    ref("i")
+                                forStmt {
+                                    loopBody {
+                                        ref("a") assign
+                                                {
+                                                    ref("a") +
+                                                            subscriptExpr {
+                                                                ref("c")
+                                                                ref("i")
+                                                            }
                                                 }
-                                        }
+                                    }
+                                    forInitializer { declareVar("i", t("int")) { literal(0, t("int")) } }
+                                    forCondition { ref("i") le literal(4, t("int")) }
+                                    forIteration { ref("i").incNoContext() }
                                 }
 
                                 returnStmt { ref("a") }
@@ -466,19 +467,20 @@ class Query {
 
                                 declare { variable("a", t("int")) { literal(0, t("int")) } }
 
-                                forStmt(
-                                    declareVar("i", t("int")) { literal(0, t("int")) },
-                                    ref("i") le literal(4, t("int")),
-                                    ref("i").incNoContext()
-                                ) {
-                                    ref("a") assign
-                                        {
-                                            ref("a") +
-                                                subscriptExpr {
-                                                    ref("c")
-                                                    ref("i")
+                                forStmt {
+                                    loopBody {
+                                        ref("a") assign
+                                                {
+                                                    ref("a") +
+                                                            subscriptExpr {
+                                                                ref("c")
+                                                                ref("i")
+                                                            }
                                                 }
-                                        }
+                                    }
+                                    forInitializer { declareVar("i", t("int")) { literal(0, t("int")) } }
+                                    forCondition { ref("i") le literal(4, t("int")) }
+                                    forIteration { ref("i").incNoContext() }
                                 }
 
                                 returnStmt { ref("a") }
@@ -511,19 +513,20 @@ class Query {
 
                                 declare { variable("a", t("int")) { literal(0, t("int")) } }
 
-                                forStmt(
-                                    declareVar("i", t("int")) { literal(0, t("int")) },
-                                    ref("i") lt literal(4, t("int")),
-                                    ref("i").incNoContext()
-                                ) {
-                                    ref("a") assign
-                                        {
-                                            ref("a") +
-                                                subscriptExpr {
-                                                    ref("c")
-                                                    ref("i")
+                                forStmt {
+                                    loopBody {
+                                        ref("a") assign
+                                                {
+                                                    ref("a") +
+                                                            subscriptExpr {
+                                                                ref("c")
+                                                                ref("i")
+                                                            }
                                                 }
-                                        }
+                                    }
+                                    forInitializer { declareVar("i", t("int")) { literal(0, t("int")) } }
+                                    forCondition { ref("i") lt literal(4, t("int")) }
+                                    forIteration { ref("i").incNoContext() }
                                 }
 
                                 returnStmt { ref("a") }

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/testcases/ValueEvaluationTests.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/testcases/ValueEvaluationTests.kt
@@ -56,17 +56,20 @@ class ValueEvaluationTests {
                                             this.initializer = newExpr
                                         }
                                     }
-                                    forStmt(
-                                        declare {
-                                            variable("i", t("int")) { literal(0, t("int")) }
-                                        },
-                                        ref("i") lt member("length", ref("array")),
-                                        ref("i").inc()
-                                    ) {
-                                        subscriptExpr {
-                                            ref("array")
-                                            ref("i")
-                                        } assign ref("i")
+                                    forStmt {
+                                        loopBody {
+                                            subscriptExpr {
+                                                ref("array")
+                                                ref("i")
+                                            } assign ref("i")
+                                        }
+                                        forInitializer {
+                                            declare {
+                                                variable("i", t("int")) { literal(0, t("int")) }
+                                            }
+                                        }
+                                        forCondition { ref("i") lt member("length", ref("array")) }
+                                        forIteration { ref("i").inc() }
                                     }
                                     memberCall("println", member("out", ref("System"))) {
                                         subscriptExpr {
@@ -313,15 +316,16 @@ class ValueEvaluationTests {
                                     }
                                 }
 
-                                forStmt(
-                                    declareVar("i", t("int")) { literal(0, t("int")) },
-                                    ref("i") lt literal(6, t("int")),
-                                    ref("i").incNoContext()
-                                ) {
-                                    subscriptExpr {
-                                        ref("array")
-                                        ref("i")
-                                    } assign ref("i")
+                                forStmt{
+                                    loopBody {
+                                        subscriptExpr {
+                                            ref("array")
+                                            ref("i")
+                                        } assign ref("i")
+                                    }
+                                    forInitializer { declareVar("i", t("int")) { literal(0, t("int")) } }
+                                    forCondition { ref("i") lt literal(6, t("int")) }
+                                    forIteration { ref("i").incNoContext() }
                                 }
                                 returnStmt { literal(0, t("int")) }
                             }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
@@ -631,29 +631,59 @@ fun LanguageFrontend<*, *>.forEachStmt(init: ForEachStatement.() -> Unit): ForEa
  * used to create further sub-nodes as well as configuring the created node itself.
  */
 context(StatementHolder)
-fun LanguageFrontend<*, *>.forStmt(
-    initializer: DeclarationStatement,
-    condition: Expression,
-    iteration: Statement,
-    elseStmt: Statement? = null,
-    init: Block.() -> Unit
-): ForStatement {
+fun LanguageFrontend<*, *>.forStmt(init: ForStatement.() -> Unit): ForStatement {
     val node = newForStatement()
-    node.initializerStatement = initializer
-    if (initializer.isSingleDeclaration()) {
 
-        scopeManager.addDeclaration(initializer.singleDeclaration, false)
-    }
-    node.condition = condition
-    node.iterationStatement = iteration
-
-    val body = newBlock()
-    init(body)
-    node.statement = body
-
-    elseStmt?.let { node.elseStatement = it }
+    init(node)
 
     (this@StatementHolder) += node
+
+    return node
+}
+
+/**
+ * Configures the [ForStatement.condition] in the Fluent Node DSL of the nearest enclosing
+ * [ForStatement]. The [init] block can be used to create further sub-nodes as well as configuring
+ * the created node itself.
+ */
+context(ForStatement)
+fun LanguageFrontend<*, *>.forCondition(init: ForStatement.() -> Expression): Expression {
+
+    var node = init(this@ForStatement)
+
+    condition = node
+
+    return node
+}
+
+/**
+ * Configures the [ForStatement.condition] in the Fluent Node DSL of the nearest enclosing
+ * [ForStatement]. The [init] block can be used to create further sub-nodes as well as configuring
+ * the created node itself.
+ */
+context(ForStatement)
+fun LanguageFrontend<*, *>.forInitializer(
+    init: ForStatement.() -> DeclarationStatement
+): DeclarationStatement {
+
+    var node = init(this@ForStatement)
+
+    initializerStatement = node
+
+    return node
+}
+
+/**
+ * Configures the [ForStatement.iterationStatement] in the Fluent Node DSL of the nearest enclosing
+ * [ForStatement]. The [init] block can be used to create further sub-nodes as well as configuring
+ * the created node itself.
+ */
+context(ForStatement)
+fun LanguageFrontend<*, *>.forIteration(init: ForStatement.() -> Statement): Statement {
+
+    var node = init(this@ForStatement)
+
+    iterationStatement = node
 
     return node
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/ForStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/ForStatement.kt
@@ -27,6 +27,9 @@ package de.fraunhofer.aisec.cpg.graph.statements
 
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
+import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
+import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdges
+import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astOptionalEdgeOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
@@ -39,7 +42,7 @@ import org.neo4j.ogm.annotation.Relationship
  * that declares variables, can change them in an iteration statement and is executed until the
  * condition evaluates to false.
  */
-class ForStatement : LoopStatement(), BranchingNode {
+class ForStatement : LoopStatement(), BranchingNode, StatementHolder {
 
     @Relationship("INITIALIZER_STATEMENT")
     var initializerStatementEdge = astOptionalEdgeOf<Statement>()
@@ -57,6 +60,21 @@ class ForStatement : LoopStatement(), BranchingNode {
 
     override val branchedBy: Node?
         get() = condition ?: conditionDeclaration
+
+    override var statementEdges: AstEdges<Statement, AstEdge<Statement>>
+        get() {
+            val statements = astEdgesOf<Statement>()
+            statements += initializerStatementEdge
+            statements += iterationStatementEdge
+            statements += statementEdge
+            statements += elseStatementEdge
+            return statements
+        }
+        set(_) {
+            // Nothing to do here
+        }
+
+    override var statements by unwrapping(ForStatement::statementEdges)
 
     override fun toString() =
         ToStringBuilder(this, TO_STRING_STYLE)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
@@ -341,6 +341,7 @@ open class EvaluationOrderGraphPass(ctx: TranslationContext) : TranslationUnitPa
      * e.g. [LoopStatement]s or [BreakStatement].
      */
     protected fun handleEOG(node: Node?) {
+        println(node?.javaClass?.simpleName + ": " + node?.name)
         if (node == null) {
             return
         }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/GraphExamples.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/GraphExamples.kt
@@ -165,19 +165,37 @@ class GraphExamples {
                         record("someRecord") {
                             method("func") {
                                 body {
-                                    forStmt(
-                                        initializer = declare { variable("a") },
-                                        condition = literal(true, t("bool")),
-                                        iteration = ref("a").inc(),
-                                        elseStmt = call("elseCall")
-                                    ) {
-                                        ifStmt {
-                                            condition { literal(true, t("bool")) }
-                                            thenStmt { breakStmt() }
+                                    forStmt {
+                                        loopBody {
+                                            ifStmt {
+                                                condition { literal(true, t("bool")) }
+                                                thenStmt { breakStmt() }
+                                            }
+                                            call("postIf")
                                         }
-                                        call("postIf")
+                                        forInitializer {
+                                            declareVar("a", t("int")) { literal(0, t("int")) }
+                                        }
+                                        forCondition { literal(true, t("bool")) }
+                                        forIteration { ref("a").inc() }
+                                        loopElseStmt { call("elseCall") }
                                     }
                                     call("postFor")
+                                    forStmt {
+                                        loopBody {
+                                            ifStmt {
+                                                condition { literal(true, t("bool")) }
+                                                thenStmt { breakStmt() }
+                                            }
+                                            call("postIf")
+                                        }
+                                        forInitializer {
+                                            declareVar("a", t("int")) { literal(0, t("int")) }
+                                        }
+                                        forCondition { literal(true, t("bool")) }
+                                        forIteration { ref("a").inc() }
+                                        loopElseStmt { call("elseCall") }
+                                    }
                                 }
                             }
                         }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/GraphExamples.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/GraphExamples.kt
@@ -31,7 +31,6 @@ import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.autoType
 import de.fraunhofer.aisec.cpg.graph.builder.*
 import de.fraunhofer.aisec.cpg.graph.newInitializerListExpression
-import de.fraunhofer.aisec.cpg.graph.newUnaryOperator
 import de.fraunhofer.aisec.cpg.graph.newVariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.types.PointerType.PointerOrigin.POINTER
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
@@ -169,7 +168,7 @@ class GraphExamples {
                                     forStmt(
                                         initializer = declare { variable("a") },
                                         condition = literal(true, t("bool")),
-                                        iteration = newUnaryOperator("++", true, false),
+                                        iteration = ref("a").inc(),
                                         elseStmt = call("elseCall")
                                     ) {
                                         ifStmt {
@@ -179,18 +178,6 @@ class GraphExamples {
                                         call("postIf")
                                     }
                                     call("postFor")
-                                    forStmt(
-                                        initializer = declare { variable("a") },
-                                        condition = literal(true, t("bool")),
-                                        iteration = newUnaryOperator("++", true, false),
-                                        elseStmt = call("elseCall")
-                                    ) {
-                                        ifStmt {
-                                            condition { literal(true, t("bool")) }
-                                            thenStmt { breakStmt() }
-                                        }
-                                        call("postIf")
-                                    }
                                 }
                             }
                         }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPassTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPassTest.kt
@@ -151,29 +151,37 @@ class EvaluationOrderGraphPassTest {
         val postFor = forTest.calls["postFor"]
         assertNotNull(postFor)
 
-        Util.eogConnect(
-            en = Util.Edge.ENTRIES,
-            n = elseCall,
-            refs = listOf(forStmt),
-            cr = Util.Connect.NODE
+        assertTrue(
+            Util.eogConnect(
+                en = Util.Edge.ENTRIES,
+                n = elseCall,
+                refs = listOf(forStmt),
+                cr = Util.Connect.NODE
+            )
         )
-        Util.eogConnect(
-            en = Util.Edge.ENTRIES,
-            n = postFor,
-            refs = listOf(forStmt.elseStatement, breakStmt),
-            cr = Util.Connect.NODE
+        assertTrue(
+            Util.eogConnect(
+                en = Util.Edge.ENTRIES,
+                n = postFor,
+                refs = listOf(forStmt.elseStatement, breakStmt),
+                cr = Util.Connect.NODE
+            )
         )
-        Util.eogConnect(
-            en = Util.Edge.EXITS,
-            n = forStmt.elseStatement,
-            refs = listOf(postFor),
-            cr = Util.Connect.SUBTREE
+        assertTrue(
+            Util.eogConnect(
+                en = Util.Edge.EXITS,
+                n = forStmt.elseStatement,
+                refs = listOf(postFor),
+                cr = Util.Connect.SUBTREE
+            )
         )
-        Util.eogConnect(
-            en = Util.Edge.EXITS,
-            n = breakStmt,
-            refs = listOf(postFor),
-            cr = Util.Connect.SUBTREE
+        assertTrue(
+            Util.eogConnect(
+                en = Util.Edge.EXITS,
+                n = breakStmt,
+                refs = listOf(postFor),
+                cr = Util.Connect.SUBTREE
+            )
         )
     }
 
@@ -193,29 +201,37 @@ class EvaluationOrderGraphPassTest {
         val postForEach = forTest.calls["postForEach"]
         assertNotNull(postForEach)
 
-        Util.eogConnect(
-            en = Util.Edge.ENTRIES,
-            n = elseCall,
-            refs = listOf(forEachStmt),
-            cr = Util.Connect.NODE
+        assertTrue(
+            Util.eogConnect(
+                en = Util.Edge.ENTRIES,
+                n = elseCall,
+                refs = listOf(forEachStmt),
+                cr = Util.Connect.NODE
+            )
         )
-        Util.eogConnect(
-            en = Util.Edge.ENTRIES,
-            n = postForEach,
-            refs = listOf(forEachStmt.elseStatement, breakStmt),
-            cr = Util.Connect.NODE
+        assertTrue(
+            Util.eogConnect(
+                en = Util.Edge.ENTRIES,
+                n = postForEach,
+                refs = listOf(forEachStmt.elseStatement, breakStmt),
+                cr = Util.Connect.NODE
+            )
         )
-        Util.eogConnect(
-            en = Util.Edge.EXITS,
-            n = forEachStmt.elseStatement,
-            refs = listOf(postForEach),
-            cr = Util.Connect.SUBTREE
+        assertTrue(
+            Util.eogConnect(
+                en = Util.Edge.EXITS,
+                n = forEachStmt.elseStatement,
+                refs = listOf(postForEach),
+                cr = Util.Connect.SUBTREE
+            )
         )
-        Util.eogConnect(
-            en = Util.Edge.EXITS,
-            n = breakStmt,
-            refs = listOf(postForEach),
-            cr = Util.Connect.SUBTREE
+        assertTrue(
+            Util.eogConnect(
+                en = Util.Edge.EXITS,
+                n = breakStmt,
+                refs = listOf(postForEach),
+                cr = Util.Connect.SUBTREE
+            )
         )
     }
 


### PR DESCRIPTION
The missing context when creating nodes in the parameter list of the fluent dsl nodes caused them to be added at the wrong statement holders. 