### PR TITLE
Promote Neo4J driver to API dependency for cpg-neo4j

### DIFF
--- a/cpg-neo4j/build.gradle.kts
+++ b/cpg-neo4j/build.gradle.kts
@@ -50,7 +50,7 @@ publishing {
 dependencies {
     // neo4j
     implementation(libs.bundles.neo4j)
-    implementation(libs.neo4j.driver)
+    api(libs.neo4j.driver)
 
     // Command line interface support
     implementation(libs.picocli)


### PR DESCRIPTION
We switched it to an implementation dependency, but if I use it as an external person, I would expect it as an API dependency, because otherwise I have to add the neo4j driver manually as a dependency. It is more convenient to have it as a transitive dependency.