### PR TITLE
Demote frontend dependencies to `implementation`

### DIFF
--- a/buildSrc/src/main/kotlin/cpg.frontend-dependency-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cpg.frontend-dependency-conventions.gradle.kts
@@ -15,30 +15,30 @@ val enableINIFrontend: Boolean by rootProject.extra
 
 dependencies {
     if (enableJavaFrontend) {
-        api(project(":cpg-language-java"))
+        implementation(project(":cpg-language-java"))
     }
     if (enableJVMFrontend) {
-        api(project(":cpg-language-jvm"))
+        implementation(project(":cpg-language-jvm"))
     }
     if (enableCXXFrontend) {
-        api(project(":cpg-language-cxx"))
+        implementation(project(":cpg-language-cxx"))
     }
     if (enableGoFrontend) {
-        api(project(":cpg-language-go"))
+        implementation(project(":cpg-language-go"))
     }
     if (enablePythonFrontend) {
-        api(project(":cpg-language-python"))
+        implementation(project(":cpg-language-python"))
     }
     if (enableLLVMFrontend) {
-        api(project(":cpg-language-llvm"))
+        implementation(project(":cpg-language-llvm"))
     }
     if (enableTypeScriptFrontend) {
-        api(project(":cpg-language-typescript"))
+        implementation(project(":cpg-language-typescript"))
     }
     if (enableRubyFrontend) {
-        api(project(":cpg-language-ruby"))
+        implementation(project(":cpg-language-ruby"))
     }
     if (enableINIFrontend) {
-        api(project(":cpg-language-ini"))
+        implementation(project(":cpg-language-ini"))
     }
 }


### PR DESCRIPTION
Currently, the depenendency injected frontends are `api` dependencies. That means that published artefacts that dynamically depend on the configured frontends (such as Neo4J) publish all frontends as a dependency. That was not the intention. Instead they should contain no external dependencies to frontends and rather use the frontends that are available when the user loads them in.
