### PR TITLE
Patching dynamic dependency to frontends out of `cpg-neo4j` POM

### DIFF
--- a/cpg-neo4j/build.gradle.kts
+++ b/cpg-neo4j/build.gradle.kts
@@ -1,3 +1,6 @@
+import groovy.util.Node
+import groovy.util.NodeList
+
 /*
  * Copyright (c) 2021, Fraunhofer AISEC. All rights reserved.
  *
@@ -42,6 +45,17 @@ publishing {
                 artifactId = "cpg-neo4j"
                 name.set("Code Property Graph - Neo4j")
                 description.set("An Application to translate and persist specified source code as a Code Property Graph to an installed instance of the Neo4j Graph Database.")
+                withXml {
+                    // Modify the XML to exclude dependencies that start with "cpg-language-".
+                    // This is necessary because we do not want to "leak" the dependency to our dynamically activated
+                    // frontends to the outside
+                    var dependenciesNode = asNode().children().filterIsInstance<Node>().firstOrNull { true && it.name().toString() == "{http://maven.apache.org/POM/4.0.0}dependencies" }
+                    dependenciesNode?.children()?.removeIf {
+                        it is Node &&
+                                (it.name().toString() == "{http://maven.apache.org/POM/4.0.0}dependency") &&
+                                ((it.get("artifactId") as? NodeList)?.text()?.startsWith("cpg-language-") == true)
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
This PR is a follow-up to #1926 (which did not work). This time we ressort to patching the dependency out of the POM.
