### PR TITLE
Adding C++ frontend as 'optional' integration test dependency to Neo4j

### DIFF
--- a/cpg-neo4j/build.gradle.kts
+++ b/cpg-neo4j/build.gradle.kts
@@ -74,4 +74,11 @@ dependencies {
     annotationProcessor(libs.picocli.codegen)
 
     integrationTestImplementation(libs.kotlin.reflect)
+
+    // We depend on the C++ frontend for the integration tests, but the frontend is only available if enabled.
+    // If it's not available, the integration tests fail (which is ok). But if we would directly reference the
+    // project here, the build system would fail any task since it will not find a non-enabled project.
+    findProject("cpg-language-cxx")?.also {
+        integrationTestImplementation(it)
+    }
 }

--- a/cpg-neo4j/build.gradle.kts
+++ b/cpg-neo4j/build.gradle.kts
@@ -78,7 +78,7 @@ dependencies {
     // We depend on the C++ frontend for the integration tests, but the frontend is only available if enabled.
     // If it's not available, the integration tests fail (which is ok). But if we would directly reference the
     // project here, the build system would fail any task since it will not find a non-enabled project.
-    findProject("cpg-language-cxx")?.also {
+    findProject(":cpg-language-cxx")?.also {
         integrationTestImplementation(it)
     }
 }


### PR DESCRIPTION
The C++ frontend is a dependency for the neo4j integration tests. However, that is never explicitly specified. The reason for that is we cannot use the regular ´project("cpg-language-cxx")` syntax because if the C++ frontend is disable, the "cpg-language-cxx" project does not exist. We therefore now use `findProject` to find it first and it if its there.