### PR TITLE
Handling `ImportDeclaration` in EOG

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
@@ -398,6 +398,7 @@ open class EvaluationOrderGraphPass(ctx: TranslationContext) : TranslationUnitPa
             is DefaultStatement -> handleDefault(node)
             is TypeIdExpression -> handleDefault(node)
             is Reference -> handleDefault(node)
+            is ImportDeclaration -> handleDefault(node)
             // These nodes are not added to the EOG
             is IncludeDeclaration -> doNothing()
             else -> LOGGER.info("Parsing of type ${node.javaClass} is not supported (yet)")


### PR DESCRIPTION
This silences a lot of warnings. We are using `handleDefault` instead, which adds it to the EOG, but does not add any children nodes.
