### PR TITLE
Fix import `from .` import

### DIFF
--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
@@ -579,7 +579,12 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
                 }
             }
 
-            module = parent.fqn(module.localName)
+            module =
+                if (module.localName != "") {
+                    parent.fqn(module.localName)
+                } else {
+                    parent ?: Name("")
+                }
         }
 
         for (imp in node.names) {


### PR DESCRIPTION
`from .` import statements ended up with a double dot on the module path. This PR fixes that.
