### PR TITLE
Pruning of if-branches in Python based on constant evaluation

### DIFF
--- a/cpg-language-python/build.gradle.kts
+++ b/cpg-language-python/build.gradle.kts
@@ -43,6 +43,9 @@ dependencies {
     // jep for python support
     implementation(libs.jep)
 
+    // we need the cpg-analysis project to dynamically invoke if-statements
+    implementation(projects.cpgAnalysis)
+
     // to evaluate some test cases
     testImplementation(project(":cpg-analysis"))
 }

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonValueEvaluator.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonValueEvaluator.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2025, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.frontends.python
+
+import de.fraunhofer.aisec.cpg.analysis.ValueEvaluator
+import de.fraunhofer.aisec.cpg.graph.HasOperatorCode
+import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.InitializerListExpression
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.Reference
+import de.fraunhofer.aisec.cpg.passes.reconstructedImportName
+import kotlin.math.pow
+
+/** An extended version of the [ValueEvaluator] that supports Python-specific operations. */
+class PythonValueEvaluator : ValueEvaluator() {
+    override val cannotEvaluate: (Node?, ValueEvaluator) -> Any?
+        get() = { node, evaluator ->
+            if (node is InitializerListExpression) {
+                // We can evaluate initializer lists if all elements are constant
+                val values = node.initializers.map { evaluator.evaluate(it) }
+                if (values.all { it is Number }) {
+                    values
+                } else {
+                    super.cannotEvaluate(node, evaluator)
+                }
+            } else {
+                super.cannotEvaluate(node, evaluator)
+            }
+        }
+
+    override fun handleReference(expr: Reference, depth: Int): Any? {
+        // We need to handle sys.platform and sys.version_info specially, since it is often used in
+        // a pre-processor macro-style, and we want to replace this with the actual value (if we
+        // have it). This allows us to dynamically prune if-branches based on constant evaluation.
+        return when {
+            expr.reconstructedImportName.toString() == "sys.platform" ->
+                PythonLanguageFrontend.SysInfo.platform ?: super.handleReference(expr, depth)
+            expr.reconstructedImportName.toString() == "sys.version_info" -> {
+                return PythonLanguageFrontend.SysInfo.versionInfo?.toList()
+                    ?: super.handleReference(expr, depth)
+            }
+            else -> super.handleReference(expr, depth)
+        }
+    }
+
+    override fun computeBinaryOpEffect(
+        lhsValue: Any?,
+        rhsValue: Any?,
+        has: HasOperatorCode?,
+    ): Any? {
+        return if (has?.operatorCode == "**") {
+            when {
+                lhsValue is Number && rhsValue is Number ->
+                    lhsValue.toDouble().pow(rhsValue.toDouble())
+                else -> cannotEvaluate(has as Node, this)
+            }
+        } else {
+            super.computeBinaryOpEffect(lhsValue, rhsValue, has)
+        }
+    }
+
+    override fun handleLess(lhsValue: Any?, rhsValue: Any?, expr: Expression?): Any? {
+        return handleListComparison(lhsValue, rhsValue, this::handleLess)
+            ?: super.handleLess(lhsValue, rhsValue, expr)
+    }
+
+    override fun handleGreater(lhsValue: Any?, rhsValue: Any?, expr: Expression?): Any? {
+        return handleListComparison(lhsValue, rhsValue, this::handleGreater)
+            ?: super.handleGreater(lhsValue, rhsValue, expr)
+    }
+
+    override fun handleLEq(lhsValue: Any?, rhsValue: Any?, expr: Expression?): Any? {
+        return handleListComparison(lhsValue, rhsValue, this::handleLEq)
+            ?: super.handleLEq(lhsValue, rhsValue, expr)
+    }
+
+    override fun handleGEq(lhsValue: Any?, rhsValue: Any?, expr: Expression?): Any? {
+        return handleListComparison(lhsValue, rhsValue, this::handleGEq)
+            ?: super.handleGEq(lhsValue, rhsValue, expr)
+    }
+
+    override fun handleEq(lhsValue: Any?, rhsValue: Any?, expr: Expression?): Any? {
+        return handleListComparison(lhsValue, rhsValue, this::handleEq)
+            ?: super.handleEq(lhsValue, rhsValue, expr)
+    }
+
+    override fun handleNEq(lhsValue: Any?, rhsValue: Any?, expr: Expression?): Any? {
+        return handleListComparison(lhsValue, rhsValue, this::handleNEq)
+            ?: super.handleNEq(lhsValue, rhsValue, expr)
+    }
+
+    /** See https://docs.python.org/3/reference/expressions.html#value-comparisons. */
+    private fun handleListComparison(
+        lhsValue: Any?,
+        rhsValue: Any?,
+        compare: (lhsValue: Any?, rhsValue: Any?, expr: Expression?) -> Any?,
+    ): Any? {
+        return if (lhsValue is List<*> && rhsValue is List<*>) {
+            lhsValue.zip(rhsValue).all { (lhs, rhs) ->
+                if (lhs != rhs) {
+                    compare(lhs, rhs, null) as? Boolean == true
+                } else {
+                    true
+                }
+            }
+        } else {
+            null
+        }
+    }
+}

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonUnreachableEOGPass.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonUnreachableEOGPass.kt
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2021, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.passes
+
+import de.fraunhofer.aisec.cpg.TranslationContext
+import de.fraunhofer.aisec.cpg.analysis.ValueEvaluator
+import de.fraunhofer.aisec.cpg.frontends.python.PythonValueEvaluator
+import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.allEOGStarters
+import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
+import de.fraunhofer.aisec.cpg.graph.edges.Edge
+import de.fraunhofer.aisec.cpg.graph.edges.flows.EvaluationOrder
+import de.fraunhofer.aisec.cpg.graph.statements.IfStatement
+import de.fraunhofer.aisec.cpg.graph.statements.WhileStatement
+import de.fraunhofer.aisec.cpg.helpers.*
+import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
+import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
+
+/**
+ * A [Pass] which uses a simple logic to determine constant values and mark unreachable code regions
+ * by setting the [EvaluationOrder.unreachable] property to true.
+ */
+@DependsOn(EvaluationOrderGraphPass::class)
+@ExecuteBefore(SymbolResolver::class)
+class UnreachableEOGPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {
+
+    private var evaluator = PythonValueEvaluator()
+
+    override fun cleanup() {
+        // Nothing to do
+    }
+
+    override fun accept(tu: TranslationUnitDeclaration) {
+        val walker = SubgraphWalker.IterativeGraphWalker()
+        walker.registerOnNodeVisit(::handle)
+
+        // Gather all resolution EOG starters; and make sure they really do not have a
+        // predecessor, otherwise we might analyze a node multiple times
+        val nodes = tu.allEOGStarters.filter { it.prevEOGEdges.isEmpty() }
+
+        for (node in nodes) {
+            walker.iterate(node)
+        }
+    }
+
+    /**
+     * We perform the actions for each [FunctionDeclaration].
+     *
+     * @param node every node in the TranslationResult
+     */
+    protected fun handle(node: Node, parent: Node?) {
+        val startState = UnreachabilityState()
+        for (firstEdge in node.nextEOGEdges) {
+            startState.push(firstEdge, ReachabilityLattice(Reachability.REACHABLE))
+        }
+        val finalState = iterateEOG(node.nextEOGEdges, startState, ::transfer) ?: return
+
+        for ((key, value) in finalState) {
+            if (value.elements == Reachability.UNREACHABLE) {
+                (key as? EvaluationOrder)?.unreachable = true
+            }
+        }
+    }
+
+    /**
+     * This method is executed for each EOG edge which is in the worklist. [currentEdge] is the edge
+     * to process, [currentState] contains the state which was observed before arriving here.
+     *
+     * This method modifies the state for the next eog edge as follows:
+     * - If the next node in the eog is an [IfStatement], the condition is evaluated and if it is
+     *   either always true or false, the else or then branch receives set to
+     *   [Reachability.UNREACHABLE].
+     * - If the next node in the eog is a [WhileStatement], the condition is evaluated and if it's
+     *   always true or false, either the EOG edge to the loop body or out of the loop body is set
+     *   to [Reachability.UNREACHABLE].
+     * - For all other nodes, we simply propagate the state which led us here.
+     *
+     * Returns the updated state and true because we always expect an update of the state.
+     */
+    fun transfer(
+        currentEdge: Edge<Node>,
+        currentState: State<Edge<Node>, Reachability>,
+    ): State<Edge<Node>, Reachability> {
+        when (val currentNode = currentEdge.end) {
+            is IfStatement -> {
+                handleIfStatement(currentEdge, currentNode, currentState)
+            }
+            is WhileStatement -> {
+                handleWhileStatement(currentEdge, currentNode, currentState)
+            }
+            else -> {
+                // For all other edges, we simply propagate the reachability property of the edge
+                // which made us come here.
+                currentNode.nextEOGEdges.forEach {
+                    currentState.push(it, currentState[currentEdge])
+                }
+            }
+        }
+
+        return currentState
+    }
+
+    /**
+     * Evaluates the condition of the [IfStatement] [n] (which is the end node of [enteringEdge]).
+     * If it is always true, then the else-branch receives the [state] [Reachability.UNREACHABLE].
+     * If the condition is always false, then the then-branch receives the [state]
+     * [Reachability.UNREACHABLE]. All other cases simply copy the state which led us here.
+     */
+    private fun handleIfStatement(
+        enteringEdge: Edge<Node>,
+        n: IfStatement,
+        state: State<Edge<Node>, Reachability>,
+    ) {
+        val evalResult = evaluator.evaluate(n.condition)
+
+        val (unreachableEdge, remainingEdges) =
+            when (evalResult) {
+                true ->
+                    // If the condition is always true, the "false" branch is always unreachable
+                    Pair(
+                        n.nextEOGEdges.firstOrNull { e -> e.branch == false },
+                        n.nextEOGEdges.filter { e -> e.branch != false },
+                    )
+                false ->
+                    // If the condition is always false, the "true" branch is always unreachable
+                    Pair(
+                        n.nextEOGEdges.firstOrNull { e -> e.branch == true },
+                        n.nextEOGEdges.filter { e -> e.branch != true },
+                    )
+                else -> Pair(null, n.nextEOGEdges)
+            }
+
+        if (unreachableEdge != null) {
+            // This edge is definitely unreachable
+            state.push(unreachableEdge, ReachabilityLattice(Reachability.UNREACHABLE))
+        }
+
+        // For all other edges, we simply propagate the reachability property of the edge which
+        // made us come here.
+        remainingEdges.forEach { state.push(it, state[enteringEdge]) }
+    }
+
+    /**
+     * Evaluates the condition of the [WhileStatement] [n] (which is the end node of
+     * [enteringEdge]). If it is always true, then the edge to the code after the loop receives the
+     * [state] [Reachability.UNREACHABLE]. If the condition is always false, then the edge to the
+     * loop body receives the [state] [Reachability.UNREACHABLE]. All other cases simply copy the
+     * state which led us here.
+     */
+    private fun handleWhileStatement(
+        enteringEdge: Edge<Node>,
+        n: WhileStatement,
+        state: State<Edge<Node>, Reachability>,
+    ) {
+        /*
+         * Note: It does not understand that code like
+         * x = true; while(x) {...; x = false;}
+         * makes the loop execute at least once.
+         * Apparently, the CPG does not offer the required functionality to
+         * differentiate between the first and subsequent evaluations of the
+         * condition.
+         */
+        val evalResult = ValueEvaluator().evaluate(n.condition)
+
+        val (unreachableEdge, remainingEdges) =
+            if (evalResult is Boolean && evalResult == true) {
+                Pair(
+                    n.nextEOGEdges.firstOrNull { e -> e.index == 1 },
+                    n.nextEOGEdges.filter { e -> e.index != 1 },
+                )
+            } else if (evalResult is Boolean && evalResult == false) {
+                Pair(
+                    n.nextEOGEdges.firstOrNull { e -> e.index == 0 },
+                    n.nextEOGEdges.filter { e -> e.index != 0 },
+                )
+            } else {
+                Pair(null, n.nextEOGEdges)
+            }
+
+        if (unreachableEdge != null) {
+            // This edge is definitely unreachable
+            state.push(unreachableEdge, ReachabilityLattice(Reachability.UNREACHABLE))
+        }
+
+        // For all other edges, we simply propagate the reachability property of the edge which
+        // made us come here.
+        remainingEdges.forEach { state.push(it, state[enteringEdge]) }
+    }
+}
+
+/**
+ * Implements the [LatticeElement] over reachability properties: TOP | REACHABLE | UNREACHABLE |
+ * BOTTOM
+ */
+class ReachabilityLattice(override val elements: Reachability) :
+    LatticeElement<Reachability>(elements) {
+    override fun lub(other: LatticeElement<Reachability>) =
+        ReachabilityLattice(maxOf(this.elements, other.elements))
+
+    override fun duplicate() = ReachabilityLattice(this.elements)
+
+    override fun compareTo(other: LatticeElement<Reachability>) =
+        this.elements.compareTo(other.elements)
+}
+
+/**
+ * The ordering will be as follows: BOTTOM (no information) < UNREACHABLE < REACHABLE (= Top of the
+ * lattice)
+ */
+enum class Reachability {
+    BOTTOM,
+    UNREACHABLE,
+    REACHABLE,
+}
+
+/**
+ * A state which actually holds a state for all [Edge]s, one only for declarations and one for
+ * ReturnStatements.
+ */
+class UnreachabilityState : State<Edge<Node>, Reachability>()

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/ConstEvalIfTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/ConstEvalIfTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.frontends.python
+
+import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.test.analyze
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class ConstEvalIfTest {
+    @Test
+    fun testSysPlatform() {
+        val topLevel = File("src/test/resources/python/consteval")
+        val result =
+            analyze(listOf(topLevel.resolve("platform.py")), topLevel.toPath(), true) {
+                it.registerLanguage<PythonLanguage>()
+                it.symbols(mapOf("PYTHON_PLATFORM" to "win32"))
+            }
+        assertNotNull(result)
+
+        val theFunc = result.calls["the_func"]
+        assertNotNull(theFunc)
+        assertEquals(1, theFunc.invokes.size)
+    }
+
+    @Test
+    fun testSysVersionInfo() {
+        val topLevel = File("src/test/resources/python/consteval")
+        val result =
+            analyze(listOf(topLevel.resolve("version_info.py")), topLevel.toPath(), true) {
+                it.registerLanguage<PythonLanguage>()
+                it.symbols(
+                    mapOf(
+                        "PYTHON_VERSION_MAJOR" to "3",
+                        "PYTHON_VERSION_MINOR" to "12",
+                        "PYTHON_VERSION_MICRO" to "0",
+                    )
+                )
+            }
+        assertNotNull(result)
+
+        val shouldNotBeReachable = result.functions("should_not_be_reachable")
+        val edges = shouldNotBeReachable.flatMap { it.astParent?.prevEOGEdges ?: listOf() }
+        edges.forEach { edge -> assertEquals(true, edge.unreachable) }
+    }
+}

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.frontends.python
 
 import de.fraunhofer.aisec.cpg.InferenceConfiguration
-import de.fraunhofer.aisec.cpg.analysis.ValueEvaluator
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.Annotation
 import de.fraunhofer.aisec.cpg.graph.declarations.FieldDeclaration
@@ -44,7 +43,6 @@ import de.fraunhofer.aisec.cpg.passes.ControlDependenceGraphPass
 import de.fraunhofer.aisec.cpg.sarif.Region
 import de.fraunhofer.aisec.cpg.test.*
 import java.nio.file.Path
-import kotlin.math.pow
 import kotlin.test.*
 
 class PythonFrontendTest : BaseTest() {
@@ -1640,23 +1638,5 @@ class PythonFrontendTest : BaseTest() {
 
         val refs = tu.refs
         refs.forEach { assertIsNot<MemberExpression>(it) }
-    }
-
-    class PythonValueEvaluator : ValueEvaluator() {
-        override fun computeBinaryOpEffect(
-            lhsValue: Any?,
-            rhsValue: Any?,
-            has: HasOperatorCode?,
-        ): Any? {
-            return if (has?.operatorCode == "**") {
-                when {
-                    lhsValue is Number && rhsValue is Number ->
-                        lhsValue.toDouble().pow(rhsValue.toDouble())
-                    else -> cannotEvaluate(has as Node, this)
-                }
-            } else {
-                super.computeBinaryOpEffect(lhsValue, rhsValue, has)
-            }
-        }
     }
 }

--- a/cpg-language-python/src/test/resources/python/consteval/platform.py
+++ b/cpg-language-python/src/test/resources/python/consteval/platform.py
@@ -1,0 +1,10 @@
+import sys
+
+if sys.platform == "win32":
+    def the_func():
+        return 1
+else:
+    def the_func():
+        return "not win32"
+
+the_func()

--- a/cpg-language-python/src/test/resources/python/consteval/version_info.py
+++ b/cpg-language-python/src/test/resources/python/consteval/version_info.py
@@ -1,0 +1,31 @@
+import sys
+
+if sys.version_info < (3, 14):
+    def below_3_14(): pass
+else:
+    def should_not_be_reachable(): pass
+
+if sys.version_info <= (3, 14):
+    def below_or_equal_3_14(): pass
+else:
+    def should_not_be_reachable(): pass
+
+if sys.version_info > (3, 10):
+    def greater_3_10(): pass
+else:
+    def should_not_be_reachable(): pass
+
+if sys.version_info >= (3, 10):
+    def greater_or_equal_3_10(): pass
+else:
+    def should_not_be_reachable(): pass
+
+if sys.version_info == (3, 12):
+    def equal_3_12(): pass
+else:
+    def should_not_be_reachable(): pass
+
+if sys.version_info != (3, 14):
+    def not_equal_3_14(): pass
+else:
+    def should_not_be_reachable(): pass


### PR DESCRIPTION
Python is a dynamically interpreted language. This means that (function) declarations are declared dynamically when the code is actually executed rather than at compile time. That also means that it is possible to declare different versions of declarations in conditional branches, which makes analysis hard. This is frequently used in the type shed project to decide declarations based on the Python version and platform.

A typical example looks like this:

```Python
if sys.platform == "win32":
  def win32_func():
     pass

if sys.version_info < (3, 9):
  def old_python_func():
    pass
```

This PR does two things:
a) It replaces occurrences of `sys.platform` and `sys.version_info` with the actual literal value in an evaluation
b) It checks in if-statements, whether we can constantly evaluate the condition. Note that this is *very limited* to literals and operations on literals. We cannot decide this based on references, since variables are not resolved at this point.