### PR TITLE
Adding options to handle unreachable EOG branches in the `SymbolResolver`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -133,7 +133,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
         walker.strategy =
             if (passConfig?.skipUnreachableEOG == true) {
-                Strategy::nextReachableEOG
+                Strategy::REACHABLE_EOG_FORWARD
             } else {
                 Strategy::EOG_FORWARD
             }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/processing/strategy/Strategy.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/processing/strategy/Strategy.kt
@@ -51,7 +51,7 @@ object Strategy {
     }
 
     /** A strategy to traverse the EOG in forward direction, but only if the edge is reachable. */
-    fun nextReachableEOG(x: Node): Iterator<Node> {
+    fun REACHABLE_EOG_FORWARD(x: Node): Iterator<Node> {
         return x.nextEOGEdges.filter { !it.unreachable }.map { it.end }.iterator()
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/processing/strategy/Strategy.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/processing/strategy/Strategy.kt
@@ -50,6 +50,11 @@ object Strategy {
         return x.nextEOG.iterator()
     }
 
+    /** A strategy to traverse the EOG in forward direction, but only if the edge is reachable. */
+    fun nextReachableEOG(x: Node): Iterator<Node> {
+        return x.nextEOGEdges.filter { !it.unreachable }.map { it.end }.iterator()
+    }
+
     /**
      * Traverse Evaluation Order Graph in backward direction.
      *


### PR DESCRIPTION
This PR adds two configuration option to the `SymbolResolver`:
    - `skipUnreachableEOG` skips unreachable EOG paths when iterating the EOG. This means that symbols on unreachable EOG paths are not resolved. This can speed up resolution when large parts of a file are not reachable (e.g., because they are guarded by a platform switch)
    - `ignoreUnreachableDeclarations` will check, whether a declaration that is a candidate for a symbol is on an EOG path that is unreachable. This is useful in dynamically invoked languages, where symbols are declared differently on different paths.