### PR TITLE
Improvements to the symbol resolution

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
@@ -173,7 +173,7 @@ class TranslationResult(
         }
 
     override val resolutionCacheResults: Int
-        get() = finalCtx.scopeManager.symbolCache.results.size
+        get() = finalCtx.scopeManager.symbolCache.symbolMap.values.flatMap { it }.size
 
     override val config: TranslationConfiguration
         get() = finalCtx.config

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
@@ -172,6 +172,9 @@ class TranslationResult(
             return result
         }
 
+    override val resolutionCacheResults: Int
+        get() = finalCtx.scopeManager.symbolCache.results.size
+
     override val config: TranslationConfiguration
         get() = finalCtx.config
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.graph.scopes
 
 import com.fasterxml.jackson.annotation.JsonBackReference
+import de.fraunhofer.aisec.cpg.SymbolCache
 import de.fraunhofer.aisec.cpg.SymbolResolutionResult
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.Node
@@ -140,6 +141,10 @@ sealed class Scope(
         var scope: Scope? = modifiedScoped ?: this
 
         while (scope != null) {
+            // Add scope to path
+            result.path.add(scope)
+
+            // Fetch declarations with a matching symbol from the current scope
             scope.symbols[symbol]?.let { result.candidates += it }
 
             // Also add any wildcard imports that we have to the list
@@ -252,6 +257,14 @@ private fun MutableList<Declaration>.replaceImports(symbol: Symbol) {
 fun SymbolMap.mergeFrom(symbolMap: SymbolMap) {
     for (entry in symbolMap) {
         val list = this.computeIfAbsent(entry.key) { mutableListOf() }
+        list += entry.value
+    }
+}
+
+/** This function merges in all entries from the [symbolCache] into the current [SymbolCache]. */
+fun SymbolCache.mergeFrom(symbolCache: SymbolCache) {
+    for (entry in symbolCache.symbolMap) {
+        val list = this.symbolMap.computeIfAbsent(entry.key) { mutableListOf() }
         list += entry.value
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/MeasurementHolder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/MeasurementHolder.kt
@@ -58,6 +58,7 @@ class BenchmarkResults(val entries: List<List<Any>>) {
 /** Interface definition to hold different statistics about the translation process. */
 interface StatisticsHolder {
     val translatedFiles: List<String>
+    val resolutionCacheResults: Int
     val benchmarks: Set<MeasurementHolder>
     val config: TranslationConfiguration
 
@@ -73,6 +74,7 @@ interface StatisticsHolder {
                         "Translated file(s)",
                         translatedFiles.map { relativeOrAbsolute(Path.of(it), config.topLevel) },
                     ),
+                    listOf("Resolution cache results", resolutionCacheResults),
                 )
 
             benchmarks.forEach {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveMemberExpressionAmbiguityPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveMemberExpressionAmbiguityPass.kt
@@ -38,7 +38,6 @@ import de.fraunhofer.aisec.cpg.graph.newReference
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberExpression
 import de.fraunhofer.aisec.cpg.graph.translationUnit
-import de.fraunhofer.aisec.cpg.graph.types.UnknownType
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.helpers.replace
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
@@ -81,11 +80,6 @@ class ResolveMemberExpressionAmbiguityPass(ctx: TranslationContext) : Translatio
      * @param me The member expression to disambiguate and potentially replace.
      */
     private fun resolveAmbiguity(me: MemberExpression) {
-        // If our base type is an unknown type, we cannot resolve the ambiguity
-        if (me.base.type is UnknownType) {
-            return
-        }
-
         // We need to check, if our "base" (or our expression) is really a name that refers to an
         // import, because in this case we do not have a member expression, but a reference with a
         // qualified name

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveMemberExpressionAmbiguityPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveMemberExpressionAmbiguityPass.kt
@@ -38,6 +38,7 @@ import de.fraunhofer.aisec.cpg.graph.newReference
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberExpression
 import de.fraunhofer.aisec.cpg.graph.translationUnit
+import de.fraunhofer.aisec.cpg.graph.types.UnknownType
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.helpers.replace
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
@@ -80,6 +81,11 @@ class ResolveMemberExpressionAmbiguityPass(ctx: TranslationContext) : Translatio
      * @param me The member expression to disambiguate and potentially replace.
      */
     private fun resolveAmbiguity(me: MemberExpression) {
+        // If our base type is an unknown type, we cannot resolve the ambiguity
+        if (me.base.type is UnknownType) {
+            return
+        }
+
         // We need to check, if our "base" (or our expression) is really a name that refers to an
         // import, because in this case we do not have a member expression, but a reference with a
         // qualified name

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -503,8 +503,8 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
             )
         val language = source.language
 
-        if (language == null) {
-            result.success = PROBLEMATIC
+        // If there are no candidates, we can stop here
+        if (candidates.isEmpty()) {
             return result
         }
 

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/ScopeTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/ScopeTest.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.graph.scopes
 
 import de.fraunhofer.aisec.cpg.graph.Name
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.LookupScopeStatement
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Block
@@ -51,7 +52,7 @@ class ScopeTest {
         // if we try to resolve "a" now, this should point to the local A since we start there and
         // move upwards
         var result = scope.lookupSymbol("a")
-        assertEquals(listOf(localA), result)
+        assertEquals(mutableListOf<Declaration>(localA), result.candidates)
 
         // now, we pretend to have a lookup scope modifier for a symbol, e.g. through "global" in
         // Python
@@ -62,6 +63,6 @@ class ScopeTest {
 
         // let's try the lookup again, this time it should point to the global A
         result = scope.lookupSymbol("a")
-        assertEquals(listOf(globalA), result)
+        assertEquals(mutableListOf<Declaration>(globalA), result.candidates)
     }
 }

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
@@ -40,6 +40,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.AssignExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Reference
 import de.fraunhofer.aisec.cpg.graph.types.InitializerTypePropagation
+import de.fraunhofer.aisec.cpg.graph.types.UnknownType
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
 import de.fraunhofer.aisec.cpg.passes.configuration.RequiredFrontend
@@ -88,6 +89,12 @@ class PythonAddDeclarationsPass(ctx: TranslationContext) : ComponentPass(ctx), L
      */
     private fun handleWriteToReference(ref: Reference): VariableDeclaration? {
         if (ref.access != AccessValues.WRITE) {
+            return null
+        }
+
+        // If this is a member expression, and we do not know the base's type, we cannot create a
+        // declaration
+        if (ref is MemberExpression && ref.base.type is UnknownType) {
             return null
         }
 


### PR DESCRIPTION
- Avoid symbol resolution of member expression where the base has an unknown type, this can never succeed and is unncessary
- Adding (back) caching of symbol resolution. This was part of the legacy symbol resolver and never made it back