### PR TITLE
Faster type and symbol resolution

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -545,8 +545,8 @@ class ScopeManager : ScopeProvider {
             val scopeName = n.parent
 
             // this is a scoped call. we need to explicitly jump to that particular scope
-            val scopes = filterScopes { (it is NameScope && it.name == scopeName) }
-            if (scopes.isEmpty()) {
+            val nameScope = fqnScopeMap[scopeName.toString()]
+            if (nameScope == null) {
                 Util.warnWithFileLocation(
                     location,
                     LOGGER,
@@ -554,7 +554,7 @@ class ScopeManager : ScopeProvider {
                 )
                 return null
             }
-            s = scopes[0]
+            s = nameScope
         }
 
         return ScopeExtraction(s, n)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -61,8 +61,8 @@ class ScopeManager : ScopeProvider {
      */
     private val scopeMap: MutableMap<Node?, Scope> = IdentityHashMap()
 
-    /** A lookup map for each scope and its associated FQN. */
-    private val fqnScopeMap: MutableMap<String, NameScope> = mutableMapOf()
+    /** A lookup map for each [NameScope] and its associated FQN. */
+    private val fqnScopeMap: MutableMap<Name, NameScope> = mutableMapOf()
 
     /** The currently active scope. */
     var currentScope: Scope? = null
@@ -197,7 +197,10 @@ class ScopeManager : ScopeProvider {
         if (scope is NameScope) {
             // for this to work, it is essential that RecordDeclaration and NamespaceDeclaration
             // nodes have a FQN as their name.
-            fqnScopeMap[scope.astNode?.name.toString()] = scope
+            val name = scope.astNode?.name
+            if (name != null) {
+                fqnScopeMap[name] = scope
+            }
         }
         currentScope?.let {
             it.children.add(scope)
@@ -436,7 +439,7 @@ class ScopeManager : ScopeProvider {
     }
 
     /** This function looks up scope by its FQN. This only works for [NameScope]s */
-    fun lookupScope(fqn: String): NameScope? {
+    fun lookupScope(fqn: Name): NameScope? {
         return this.fqnScopeMap[fqn]
     }
 
@@ -545,7 +548,7 @@ class ScopeManager : ScopeProvider {
             val scopeName = n.parent
 
             // this is a scoped call. we need to explicitly jump to that particular scope
-            val nameScope = fqnScopeMap[scopeName.toString()]
+            val nameScope = fqnScopeMap[scopeName]
             if (nameScope == null) {
                 Util.warnWithFileLocation(
                     location,

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveMemberExpressionAmbiguityPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveMemberExpressionAmbiguityPass.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.passes
 import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.HasCallExpressionAmbiguity
 import de.fraunhofer.aisec.cpg.frontends.HasMemberExpressionAmbiguity
+import de.fraunhofer.aisec.cpg.graph.HasBase
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.codeAndLocationFrom
 import de.fraunhofer.aisec.cpg.graph.declarations.NamespaceDeclaration
@@ -127,8 +128,8 @@ class ResolveMemberExpressionAmbiguityPass(ctx: TranslationContext) : Translatio
  */
 val Expression.reconstructedImportName: Name
     get() {
-        return if (this is MemberExpression) {
-            this.base.reconstructedImportName.fqn(this.name.localName)
+        return if (this is HasBase) {
+            this.base?.reconstructedImportName.fqn(this.name.localName)
         } else {
             this.name
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -421,6 +421,16 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         val callee = call.callee
         val language = call.language
 
+        // If the base type is unknown, we cannot resolve the call
+        if (callee is MemberExpression && callee.base.type is UnknownType) {
+            Util.warnWithFileLocation(
+                call,
+                log,
+                "Cannot resolve call to ${callee.name} because the base type is unknown",
+            )
+            return
+        }
+
         // Handle a possible overloaded operator->
         resolveOverloadedArrowOperator(callee)
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -544,6 +544,11 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
             )
         val language = source.language
 
+        // If there are no candidates, we can stop here
+        if (candidates.isEmpty()) {
+            return result
+        }
+
         // Set the start scope. This can either be the call's scope or a scope specified in an FQN
         val extractedScope = ctx.scopeManager.extractScope(source, source.scope)
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -544,11 +544,6 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
             )
         val language = source.language
 
-        // If there are no candidates, we can stop here
-        if (candidates.isEmpty()) {
-            return result
-        }
-
         // Set the start scope. This can either be the call's scope or a scope specified in an FQN
         val extractedScope = ctx.scopeManager.extractScope(source, source.scope)
 
@@ -560,6 +555,11 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
         val scope = extractedScope.scope
         result.actualStartScope = scope ?: source.scope
+
+        // If there are no candidates, we can stop here
+        if (candidates.isEmpty()) {
+            return result
+        }
 
         // If the function does not allow function overloading, and we have multiple candidate
         // symbols, the result is "problematic"

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManagerTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManagerTest.kt
@@ -82,7 +82,7 @@ internal class ScopeManagerTest : BaseTest() {
             assertNotNull(scopeA)
 
             // should also be able to look up via the FQN
-            assertEquals(scopeA, final.lookupScope("A"))
+            assertEquals(scopeA, final.lookupScope(parseName("A")))
 
             // and it should contain both functions from the different file in the same namespace
             assertContains(scopeA.symbols["func1"] ?: listOf(), func1)
@@ -112,28 +112,29 @@ internal class ScopeManagerTest : BaseTest() {
         val frontend =
             TestLanguageFrontend("::", TestLanguage(), TranslationContext(config, s, TypeManager()))
         s.resetToGlobal(frontend.newTranslationUnitDeclaration("file.cpp", null))
+        with(frontend) {
+            assertNull(s.currentNamespace)
 
-        assertNull(s.currentNamespace)
+            val namespaceA = frontend.newNamespaceDeclaration("A", null)
+            s.enterScope(namespaceA)
 
-        val namespaceA = frontend.newNamespaceDeclaration("A", null)
-        s.enterScope(namespaceA)
+            assertEquals("A", s.currentNamespace.toString())
 
-        assertEquals("A", s.currentNamespace.toString())
+            // nested namespace A::B
+            val namespaceB = frontend.newNamespaceDeclaration("B", null)
+            s.enterScope(namespaceB)
 
-        // nested namespace A::B
-        val namespaceB = frontend.newNamespaceDeclaration("B", null)
-        s.enterScope(namespaceB)
+            assertEquals("A::B", s.currentNamespace.toString())
 
-        assertEquals("A::B", s.currentNamespace.toString())
+            val func = frontend.newFunctionDeclaration("func")
+            s.addDeclaration(func)
 
-        val func = frontend.newFunctionDeclaration("func")
-        s.addDeclaration(func)
+            s.leaveScope(namespaceB)
+            s.addDeclaration(namespaceB)
+            s.leaveScope(namespaceA)
 
-        s.leaveScope(namespaceB)
-        s.addDeclaration(namespaceB)
-        s.leaveScope(namespaceA)
-
-        val scope = s.lookupScope("A::B")
-        assertNotNull(scope)
+            val scope = s.lookupScope(parseName("A::B"))
+            assertNotNull(scope)
+        }
     }
 }

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclaratorHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclaratorHandler.kt
@@ -246,7 +246,7 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
             // into account
             parentScope =
                 frontend.scopeManager.lookupScope(
-                    frontend.scopeManager.currentNamespace.fqn(parent.toString()).toString()
+                    frontend.scopeManager.currentNamespace.fqn(parent.toString())
                 )
 
             declaration = createAppropriateFunction(name, parentScope, ctx.parent)

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclaratorHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclaratorHandler.kt
@@ -246,7 +246,11 @@ class DeclaratorHandler(lang: CXXLanguageFrontend) :
             // into account
             parentScope =
                 frontend.scopeManager.lookupScope(
-                    frontend.scopeManager.currentNamespace.fqn(parent.toString())
+                    parseName(
+                        frontend.scopeManager.currentNamespace
+                            .fqn(parent.toString(), delimiter = parent.delimiter)
+                            .toString()
+                    )
                 )
 
             declaration = createAppropriateFunction(name, parentScope, ctx.parent)

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
@@ -40,6 +40,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.AssignExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Reference
 import de.fraunhofer.aisec.cpg.graph.types.InitializerTypePropagation
+import de.fraunhofer.aisec.cpg.graph.types.UnknownType
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
 import de.fraunhofer.aisec.cpg.passes.configuration.RequiredFrontend
@@ -88,6 +89,12 @@ class PythonAddDeclarationsPass(ctx: TranslationContext) : ComponentPass(ctx), L
      */
     private fun handleWriteToReference(ref: Reference): VariableDeclaration? {
         if (ref.access != AccessValues.WRITE) {
+            return null
+        }
+
+        // If this is a member expression, and we do not know the base's type, we cannot create a
+        // declaration
+        if (ref is MemberExpression && ref.base.type is UnknownType) {
             return null
         }
 

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/statementHandler/StatementHandlerTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/statementHandler/StatementHandlerTest.kt
@@ -245,7 +245,8 @@ class StatementHandlerTest : BaseTest() {
         // Our scopes do not match 1:1 to python scopes, but rather the python "global" scope is a
         // name space with the name of the file and the function scope is a block scope of the
         // function body
-        var pythonGlobalScope = result.finalCtx.scopeManager.lookupScope(file.nameWithoutExtension)
+        var pythonGlobalScope =
+            result.finalCtx.scopeManager.lookupScope(Name(file.nameWithoutExtension))
 
         var globalC = cVariables.firstOrNull { it.scope == pythonGlobalScope }
         assertNotNull(globalC)


### PR DESCRIPTION
This PR speeds up type and symbol resolution across the whole code-base

* Optimized `extractScope` by using the `fqnScopeMap` instead of filtering ALL scopes.
* Removed unnecessary nested loop over all nodes/types again in `TypeManager`
* Faster type/scope merging in the `TranslationManager` the using parallel parsing (8ms instead of 5s)
* Do not try to resolve member expressions of an unknown base type. This will fail and will only result in a lot of spam and in the attempts to resolve the "UNKNOWN" scope (which does not exist)

This boosted my test case (parsing python type shed stdlib) from ~70s to ~~45s~~ 32s