### PR TITLE
Trying to publish to GH packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,9 @@ on:
 jobs:
   build:
     runs-on: [self-hosted, Linux, ARM64]
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -44,8 +47,8 @@ jobs:
           export VERSION=$(echo "${GITHUB_REF}" | cut -d "/" -f3)
           if [[ $VERSION != v* ]]
           then
-            export VERSION=""
-            echo "Building version-less (main or feature branch)"
+            export VERSION="${VERSION}-SNAPSHOT"
+            echo "Building as ${VERSION}"
           else
             # make version more Java-friendly by dropping the 'v'
             export VERSION=${VERSION:1:${#VERSION}}
@@ -91,6 +94,13 @@ jobs:
         with:
           name: reports
           path: reports.zip
+      - name: Publish to GitHub Packages
+        if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'publish-to-github-packages')
+        run: |
+          ./gradlew --parallel -Pversion=$VERSION publishAllPublicationsToGitHubPackagesRepository
+        env:
+          VERSION: ${{ env.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to Maven Central
         if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'beta') && !contains(github.ref, 'alpha')
         run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Code Property Graph 
 [![Actions Status](https://github.com/Fraunhofer-AISEC/cpg/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/Fraunhofer-AISEC/cpg/actions)
- [![codecov](https://codecov.io/gh/Fraunhofer-AISEC/cpg/graph/badge.svg?token=XBXZZOQIID)](https://codecov.io/gh/Fraunhofer-AISEC/cpg) [![](https://jitpack.io/v/Fraunhofer-AISEC/cpg.svg)](https://jitpack.io/#Fraunhofer-AISEC/cpg)
+ [![codecov](https://codecov.io/gh/Fraunhofer-AISEC/cpg/graph/badge.svg?token=XBXZZOQIID)](https://codecov.io/gh/Fraunhofer-AISEC/cpg)
 
 A simple library to extract a *code property graph* out of source code. It has support for multiple passes that can extend the analysis after the graph is constructed. It currently supports C/C++ (C17), Java (Java 13) and has experimental support for Golang, Python and TypeScript. Furthermore, it has support for the [LLVM IR](http://llvm.org/docs/LangRef.html) and thus, theoretically support for all languages that compile using LLVM. 
 
@@ -76,7 +76,9 @@ Beware, that the `cpg` module includes all optional features and might potential
 
 #### Development Builds
 
-A published artifact of every commit can be requested through [JitPack](https://jitpack.io/#Fraunhofer-AISEC/cpg). This is especially useful, if your external project makes use of a specific feature that is not yet merged in yet or not published as a version yet. Please follow the instructions on the JitPack page. Please be aware, that similar to release builds, the CDT repository needs to be added as well (see above).
+For all builds on the `main` branch, an artefact is published in the [GitHub Packages](https://github.com/orgs/Fraunhofer-AISEC/packages?repo_name=cpg) under the version `main-SNAPSHOT`. Additionally, selected PRs that have the `publish-to-github-packages` label will also be published there. This is useful if an important feature is not yet in main, but you want to test it. The version refers to the PR number, e.g. `1954-SNAPSHOT`.  
+
+To use the GitHub Gradle Registry, please refer to https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry#using-a-published-package
 
 ### On Command Line
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,7 +81,7 @@ fun generateDokkaWithVersionTag(dokkaMultiModuleTask: org.jetbrains.dokka.gradle
  */
 nexusPublishing {
     repositories {
-        sonatype() {
+        sonatype {
             val mavenCentralUsername: String? by project
             val mavenCentralPassword: String? by project
 

--- a/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts
@@ -82,6 +82,17 @@ publishing {
             }
         }
     }
+
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/Fraunhofer-AISEC/cpg")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
 }
 
 signing {

--- a/codyze-compliance/build.gradle.kts
+++ b/codyze-compliance/build.gradle.kts
@@ -31,7 +31,7 @@ publishing {
     publications {
         named<MavenPublication>("codyze-compliance") {
             pom {
-                artifactId = "codyze"
+                artifactId = "codyze-compliance"
                 name.set("Codyze - Compliance Module")
                 description.set("The compliance module of Codyze")
             }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,6 +1,0 @@
-jdk:
-  - openjdk17
-install:
-  - export PATH="$PATH:$HOME/go/bin"
-  - cp gradle.properties.example gradle.properties
-  - ./gradlew build -xtest -xperformanceTest -xintegrationTest -Pgroup=com.github.Fraunhofer-AISEC -PnodeDownload=true -PenableJavaFrontend=true -PenableGoFrontend=true -PenablePythonFrontend=true -PenableLLVMFrontend=true -PenableTypeScriptFrontend=false publishToMavenLocal


### PR DESCRIPTION
This PR enables automatic publishing of CPG modules as [GitHub Maven Packages](https://github.com/orgs/Fraunhofer-AISEC/packages?repo_name=cpg). This works infinitely better than using JitPack, since we are in complete control of the publishing process and we can already publish them as part of the CI build, so it is immediately available. By default, all commits on the `main` branch will be published as `main-SNAPSHOT`. If a PR has the label `publish-to-github-packages`, it will also be published. This has the added bonus, that the groupId stays the same, one only needs to add another repository, so one can freely switch back to a released version on Maven Central.

See https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry#using-a-published-package for a guide how to use the package registry.