### PR TITLE
Support different top levels for each component

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
@@ -33,6 +33,7 @@ import de.fraunhofer.aisec.cpg.frontends.CompilationDatabase
 import de.fraunhofer.aisec.cpg.frontends.KClassSerializer
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.passes.*
 import de.fraunhofer.aisec.cpg.passes.configuration.*
@@ -273,14 +274,14 @@ private constructor(
         }
 
         /**
-         * Files or directories containing the source code to analyze. Generates a dummy software
-         * component called "application".
+         * Files or directories containing the source code to analyze. Generates a [Component] with
+         * the name of [DEFAULT_APPLICATION_NAME].
          *
          * @param sourceLocations The files with the source code
          * @return this
          */
         fun sourceLocations(vararg sourceLocations: File): Builder {
-            softwareComponents["application"] = sourceLocations.toMutableList()
+            softwareComponents[DEFAULT_APPLICATION_NAME] = sourceLocations.toMutableList()
             return this
         }
 
@@ -292,7 +293,7 @@ private constructor(
          * @return this
          */
         fun sourceLocations(sourceLocations: List<File>): Builder {
-            softwareComponents["application"] = sourceLocations.toMutableList()
+            softwareComponents[DEFAULT_APPLICATION_NAME] = sourceLocations.toMutableList()
             return this
         }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import de.fraunhofer.aisec.cpg.TranslationResult.Companion.DEFAULT_APPLICATION_NAME
 import de.fraunhofer.aisec.cpg.frontends.CompilationDatabase
 import de.fraunhofer.aisec.cpg.frontends.KClassSerializer
 import de.fraunhofer.aisec.cpg.frontends.Language
@@ -59,7 +60,7 @@ private constructor(
     val symbols: Map<String, String>,
     /** Source code files to parse. */
     val softwareComponents: Map<String, List<File>>,
-    val topLevel: File?,
+    val topLevels: MutableMap<String, File?>,
     /** Set to true to generate debug output for the parser. */
     val debugParser: Boolean,
     /**
@@ -238,7 +239,7 @@ private constructor(
     class Builder {
         private var softwareComponents: MutableMap<String, List<File>> = HashMap()
         private val languages = mutableListOf<Language<*>>()
-        private var topLevel: File? = null
+        private var topLevels = mutableMapOf<String, File?>()
         private var debugParser = false
         private var failOnError = false
         private var loadIncludes = false
@@ -313,7 +314,13 @@ private constructor(
         }
 
         fun topLevel(topLevel: File?): Builder {
-            this.topLevel = topLevel
+            this.topLevels[DEFAULT_APPLICATION_NAME] = topLevel
+            return this
+        }
+
+        fun topLevels(topLevels: Map<String, File?>): Builder {
+            this.topLevels.clear()
+            this.topLevels += topLevels
             return this
         }
 
@@ -661,7 +668,7 @@ private constructor(
             return TranslationConfiguration(
                 symbols,
                 softwareComponents,
-                topLevel,
+                topLevels,
                 debugParser,
                 failOnError,
                 loadIncludes,

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
@@ -142,6 +142,7 @@ private constructor(
         val usedFrontends = mutableSetOf<LanguageFrontend<*, *>>()
         for (sc in ctx.config.softwareComponents.keys) {
             val component = Component()
+            component.ctx = ctx
             component.name = Name(sc)
             result.addComponent(component)
 
@@ -207,39 +208,37 @@ private constructor(
                 tmpFile.deleteOnExit()
 
                 PrintWriter(tmpFile).use { writer ->
-                    list.forEach {
+                    list.forEach { file ->
                         val cxxExtensions = listOf("c", "cpp", "cc", "cxx")
-                        if (cxxExtensions.contains(it.extension)) {
-                            if (ctx.config.topLevel != null) {
-                                val topLevel = ctx.config.topLevel.toPath()
+                        if (cxxExtensions.contains(file.extension)) {
+                            ctx.config.topLevels[sc]?.let {
+                                val topLevel = it.toPath()
                                 writer.write(
                                     """
-#include "${topLevel.relativize(it.toPath())}"
-
-"""
-                                        .trimIndent()
-                                )
-                            } else {
-                                writer.write(
-                                    """
-#include "${it.absolutePath}"
+#include "${topLevel.relativize(file.toPath())}"
 
 """
                                         .trimIndent()
                                 )
                             }
+                                ?: {
+                                    writer.write(
+                                        """
+#include "${file.absolutePath}"
+
+"""
+                                            .trimIndent()
+                                    )
+                                }
                         }
                     }
                 }
 
                 sourceLocations = listOf(tmpFile)
-                if (ctx.config.compilationDatabase != null) {
-                    // merge include paths from all translation units
-                    ctx.config.compilationDatabase.addIncludePath(
-                        tmpFile,
-                        ctx.config.compilationDatabase.allIncludePaths,
-                    )
-                }
+                ctx.config.compilationDatabase?.addIncludePath(
+                    tmpFile,
+                    ctx.config.compilationDatabase.allIncludePaths,
+                )
             } else {
                 sourceLocations = list
             }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
@@ -108,7 +108,7 @@ class TranslationResult(
 
     /**
      * Adds the [tu] to the component with the name of [DEFAULT_APPLICATION_NAME]. If no such
-     * component exists, it is generated.
+     * component exists, an error is displayed.
      *
      * Note: In general, it is better idea to directly add the translation unit to the specific
      * component.
@@ -123,14 +123,12 @@ class TranslationResult(
     fun addTranslationUnit(tu: TranslationUnitDeclaration) {
         var application = components[DEFAULT_APPLICATION_NAME]
         if (application == null) {
-            // No application component exists, so we create it
-            application = Component()
-            application.ctx = this.ctx
-            application.name = Name(DEFAULT_APPLICATION_NAME, null, "")
-            components.add(application)
+            // No application component exists, but it should be since it is automatically created
+            // by the configuration, so something is wrong
+            log.error("No application component found. This should not happen.")
+        } else {
+            application.addTranslationUnit(tu)
         }
-
-        application.addTranslationUnit(tu)
     }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
@@ -127,20 +127,22 @@ class TranslationResult(
         } else if (components.isEmpty()) {
             // No component exists, so we create the new dummy component.
             swc = Component()
-            swc.name = Name(APPLICATION_LOCAL_NAME, null, "")
+            swc.ctx = this.ctx
+            swc.name = Name(DEFAULT_APPLICATION_NAME, null, "")
             components.add(swc)
         } else {
             // Multiple components exist. As we don't know where to put the tu, we check if we have
             // the component we created and add it there or create a new one.
             for (component in components) {
-                if (component.name.localName == APPLICATION_LOCAL_NAME) {
+                if (component.name.localName == DEFAULT_APPLICATION_NAME) {
                     swc = component
                     break
                 }
             }
             if (swc == null) {
                 swc = Component()
-                swc.name = Name(APPLICATION_LOCAL_NAME, null, "")
+                swc.ctx = this.ctx
+                swc.name = Name(DEFAULT_APPLICATION_NAME, null, "")
                 components.add(swc)
             }
         }
@@ -183,6 +185,6 @@ class TranslationResult(
 
     companion object {
         const val SOURCE_LOCATIONS_TO_FRONTEND = "sourceLocationsToFrontend"
-        const val APPLICATION_LOCAL_NAME = "application"
+        const val DEFAULT_APPLICATION_NAME = "application"
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
@@ -28,9 +28,7 @@ package de.fraunhofer.aisec.cpg
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.frontends.multiLanguage
-import de.fraunhofer.aisec.cpg.graph.Component
-import de.fraunhofer.aisec.cpg.graph.Name
-import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
@@ -109,8 +107,11 @@ class TranslationResult(
         }
 
     /**
-     * If no component exists, it generates a [Component] called "application" and adds [tu]. If a
-     * component already exists, adds the tu to this component.
+     * Adds the [tu] to the component with the name of [DEFAULT_APPLICATION_NAME]. If no such
+     * component exists, it is generated.
+     *
+     * Note: In general, it is better idea to directly add the translation unit to the specific
+     * component.
      *
      * @param tu The translation unit to add.
      */
@@ -119,34 +120,17 @@ class TranslationResult(
         selected and the translation unit should be added there."""
     )
     @Synchronized
-    fun addTranslationUnit(tu: TranslationUnitDeclaration?) {
-        var swc: Component? = null
-        if (components.size == 1) {
-            // Only one component exists, so we take this one
-            swc = components[0]
-        } else if (components.isEmpty()) {
-            // No component exists, so we create the new dummy component.
-            swc = Component()
-            swc.ctx = this.ctx
-            swc.name = Name(DEFAULT_APPLICATION_NAME, null, "")
-            components.add(swc)
-        } else {
-            // Multiple components exist. As we don't know where to put the tu, we check if we have
-            // the component we created and add it there or create a new one.
-            for (component in components) {
-                if (component.name.localName == DEFAULT_APPLICATION_NAME) {
-                    swc = component
-                    break
-                }
-            }
-            if (swc == null) {
-                swc = Component()
-                swc.ctx = this.ctx
-                swc.name = Name(DEFAULT_APPLICATION_NAME, null, "")
-                components.add(swc)
-            }
+    fun addTranslationUnit(tu: TranslationUnitDeclaration) {
+        var application = components[DEFAULT_APPLICATION_NAME]
+        if (application == null) {
+            // No application component exists, so we create it
+            application = Component()
+            application.ctx = this.ctx
+            application.name = Name(DEFAULT_APPLICATION_NAME, null, "")
+            components.add(application)
         }
-        tu?.let { swc.addTranslationUnit(it) }
+
+        application.addTranslationUnit(tu)
     }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.graph
 
 import de.fraunhofer.aisec.cpg.PopulatedByPass
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.multiLanguage
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
@@ -33,6 +34,7 @@ import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import de.fraunhofer.aisec.cpg.passes.ImportDependencies
 import de.fraunhofer.aisec.cpg.passes.ImportResolver
+import java.io.File
 import org.neo4j.ogm.annotation.Relationship
 import org.neo4j.ogm.annotation.Transient
 
@@ -57,6 +59,15 @@ open class Component : Node() {
     fun addTranslationUnit(tu: TranslationUnitDeclaration) {
         translationUnits.add(tu)
     }
+
+    /**
+     * Returns the top-level directory of this component according to
+     * [TranslationConfiguration.topLevels]
+     */
+    val topLevel: File?
+        get() {
+            return ctx?.config?.topLevels?.get(this.name.localName)
+        }
 
     /**
      * All points where unknown data may enter this application, e.g., the main method, or other

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.graph.builder
 
 import de.fraunhofer.aisec.cpg.*
+import de.fraunhofer.aisec.cpg.TranslationResult.Companion.DEFAULT_APPLICATION_NAME
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.*
@@ -47,6 +48,7 @@ fun LanguageFrontend<*, *>.translationResult(
 ): TranslationResult {
     val node = TranslationResult(TranslationManager.builder().config(ctx.config).build(), ctx)
     val component = Component()
+    component.name = Name(DEFAULT_APPLICATION_NAME)
     component.ctx = this.ctx
     node.addComponent(component)
     init(node)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
@@ -47,6 +47,7 @@ fun LanguageFrontend<*, *>.translationResult(
 ): TranslationResult {
     val node = TranslationResult(TranslationManager.builder().config(ctx.config).build(), ctx)
     val component = Component()
+    component.ctx = this.ctx
     node.addComponent(component)
     init(node)
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/MeasurementHolder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/MeasurementHolder.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.helpers
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.TranslationResult.Companion.DEFAULT_APPLICATION_NAME
 import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
 import java.io.File
 import java.nio.file.Path
@@ -71,7 +72,12 @@ interface StatisticsHolder {
                     listOf("Number of files translated", translatedFiles.size),
                     listOf(
                         "Translated file(s)",
-                        translatedFiles.map { relativeOrAbsolute(Path.of(it), config.topLevel) },
+                        translatedFiles.map {
+                            relativeOrAbsolute(
+                                Path.of(it),
+                                config.topLevels[DEFAULT_APPLICATION_NAME],
+                            )
+                        },
                     ),
                 )
 

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageTest.kt
@@ -94,6 +94,7 @@ class LanguageTest {
             with(TestLanguageFrontend("::", language = otherLanguage)) {
                 val tu = newTranslationUnitDeclaration("tu-language-other")
                 val comp = Component()
+                comp.ctx = this.ctx
                 comp.addTranslationUnit(tu)
                 comp
             }
@@ -103,6 +104,7 @@ class LanguageTest {
             with(TestLanguageFrontend("::", language = testLanguage)) {
                 val tu = newTranslationUnitDeclaration("tu-language-test")
                 val comp = Component()
+                comp.ctx = this.ctx
                 comp.addTranslationUnit(tu)
                 comp
             }

--- a/cpg-core/src/testFixtures/kotlin/de/fraunhofer/aisec/cpg/test/TestUtils.kt
+++ b/cpg-core/src/testFixtures/kotlin/de/fraunhofer/aisec/cpg/test/TestUtils.kt
@@ -192,16 +192,17 @@ fun analyzeWithCompilationDatabase(
     filterComponents: List<String>? = null,
     configModifier: Consumer<TranslationConfiguration.Builder>? = null,
 ): TranslationResult {
-    return analyze(
-        listOf(),
-        jsonCompilationDatabase.parentFile.toPath().toAbsolutePath(),
-        usePasses,
-    ) {
+    val top = jsonCompilationDatabase.parentFile.toPath().toAbsolutePath()
+    return analyze(listOf(), top, usePasses) {
         val db = CompilationDatabase.fromFile(jsonCompilationDatabase, filterComponents)
         if (db.isNotEmpty()) {
             it.useCompilationDatabase(db)
             @Suppress("UNCHECKED_CAST")
             it.softwareComponents(db.components as MutableMap<String, List<File>>)
+            // We need to set the top level for all components as well, since the compilation
+            // database might
+            // have relative paths based on our "top" location
+            it.topLevels(db.components.map { Pair(it.key, top.toFile()) }.toMap())
             configModifier?.accept(it)
         }
         configModifier?.accept(it)

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontend.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontend.kt
@@ -156,7 +156,7 @@ open class CXXLanguageFrontend(language: Language<CXXLanguageFrontend>, ctx: Tra
 
                 // Check for relative path based on the top level and all include paths
                 val includeLocations: MutableList<Path> = ArrayList()
-                val topLevel = config.topLevel
+                val topLevel = ctx.currentComponent?.topLevel
                 if (topLevel != null) {
                     includeLocations.add(topLevel.toPath().toAbsolutePath())
                 }
@@ -205,7 +205,9 @@ open class CXXLanguageFrontend(language: Language<CXXLanguageFrontend>, ctx: Tra
 
         // include paths
         val includePaths = mutableSetOf<String>()
-        config.topLevel?.let { includePaths.add(it.toPath().toAbsolutePath().toString()) }
+        ctx.currentComponent?.topLevel?.let {
+            includePaths.add(it.toPath().toAbsolutePath().toString())
+        }
 
         val symbols: HashMap<String, String> = HashMap()
         symbols.putAll(config.symbols)

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontend.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontend.kt
@@ -147,7 +147,7 @@ class GoLanguageFrontend(language: Language<GoLanguageFrontend>, ctx: Translatio
                     isDependency = true
                     dependency.toFile()
                 }
-                config.topLevel != null -> config.topLevel
+                ctx.currentComponent?.topLevel != null -> ctx.currentComponent?.topLevel
                 else -> file.parentFile
             }!!
 

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoUtils.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoUtils.kt
@@ -260,7 +260,7 @@ internal class Project {
             files = files.filter { shouldBeBuild(it, symbols) }.toMutableList()
 
             // TODO(oxisto): look for binaries in cmd folder
-            project.components[TranslationResult.APPLICATION_LOCAL_NAME] = files
+            project.components[TranslationResult.DEFAULT_APPLICATION_NAME] = files
             project.symbols = symbols
             // TODO(oxisto): support vendor includes
             project.includePaths = listOf(stdLib, topLevel.resolve("vendor"))

--- a/cpg-language-go/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/IntegrationTest.kt
+++ b/cpg-language-go/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/IntegrationTest.kt
@@ -26,7 +26,7 @@
 package de.fraunhofer.aisec.cpg.frontends.golang
 
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
-import de.fraunhofer.aisec.cpg.TranslationResult.Companion.APPLICATION_LOCAL_NAME
+import de.fraunhofer.aisec.cpg.TranslationResult.Companion.DEFAULT_APPLICATION_NAME
 import de.fraunhofer.aisec.cpg.frontends.golang.Project.Companion.buildProject
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.test.*
@@ -42,7 +42,7 @@ class IntegrationTest {
     fun testProject() {
         val project = buildProject("src/test/resources/golang/integration", "darwin", "arm64")
 
-        val app = project.components[APPLICATION_LOCAL_NAME]
+        val app = project.components[DEFAULT_APPLICATION_NAME]
         assertNotNull(app)
         assertNotNull(app.firstOrNull { it.endsWith("main.go") })
         assertNotNull(app.firstOrNull { it.endsWith("func_darwin.go") })

--- a/cpg-language-ini/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/ini/IniFileFrontend.kt
+++ b/cpg-language-ini/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/ini/IniFileFrontend.kt
@@ -91,7 +91,7 @@ class IniFileFrontend(language: Language<IniFileFrontend>, ctx: TranslationConte
          * [de.fraunhofer.aisec.cpg.TranslationConfiguration.topLevel] using
          * [Language.namespaceDelimiter] as a separator
          */
-        val topLevel = config.topLevel?.let { file.relativeToOrNull(it) } ?: file
+        val topLevel = ctx.currentComponent?.topLevel?.let { file.relativeToOrNull(it) } ?: file
         val parentDir = topLevel.parent
 
         val namespace =

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
@@ -522,7 +522,7 @@ open class JavaLanguageFrontend(language: Language<JavaLanguageFrontend>, ctx: T
     init {
         val reflectionTypeSolver = ReflectionTypeSolver()
         nativeTypeResolver.add(reflectionTypeSolver)
-        var root = config.topLevel
+        var root = ctx.currentComponent?.topLevel
         if (root == null && config.softwareComponents.size == 1) {
             root =
                 config.softwareComponents[config.softwareComponents.keys.first()]?.let {

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaExternalTypeHierarchyResolver.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaExternalTypeHierarchyResolver.kt
@@ -55,7 +55,7 @@ class JavaExternalTypeHierarchyResolver(ctx: TranslationContext) : ComponentPass
         val resolver = CombinedTypeSolver()
 
         resolver.add(ReflectionTypeSolver())
-        var root = config.topLevel
+        var root = ctx.currentComponent?.topLevel
         if (root == null && config.softwareComponents.size == 1) {
             root =
                 config.softwareComponents[config.softwareComponents.keys.first()]?.let {

--- a/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMLanguageFrontend.kt
+++ b/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMLanguageFrontend.kt
@@ -78,7 +78,7 @@ class JVMLanguageFrontend(
                 "class" -> {
                     JavaView(
                         JavaClassPathAnalysisInputLocation(
-                            ctx.config.topLevel!!.path,
+                            ctx.currentComponent?.topLevel?.path!!,
                             SourceType.Library,
                             listOf(
                                 NopEliminator(),
@@ -114,10 +114,14 @@ class JVMLanguageFrontend(
                     )
                 }
                 "java" -> {
-                    JavaView(JavaSourcePathAnalysisInputLocation(ctx.config.topLevel!!.path))
+                    JavaView(
+                        JavaSourcePathAnalysisInputLocation(ctx.currentComponent?.topLevel?.path!!)
+                    )
                 }
                 "jimple" -> {
-                    JimpleView(JimpleAnalysisInputLocation(ctx.config.topLevel!!.toPath()))
+                    JimpleView(
+                        JimpleAnalysisInputLocation(ctx.currentComponent?.topLevel?.toPath()!!)
+                    )
                 }
                 else -> {
                     throw TranslationException("unsupported file")

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
@@ -273,7 +273,7 @@ class PythonLanguageFrontend(language: Language<PythonLanguageFrontend>, ctx: Tr
     }
 
     private fun pythonASTtoCPG(pyAST: PyObject, path: Path): TranslationUnitDeclaration {
-        var topLevel = config.topLevel ?: path.parent.toFile()
+        var topLevel = ctx.currentComponent?.topLevel ?: path.parent.toFile()
 
         val pythonASTModule =
             fromPython(pyAST) as? Python.AST.Module

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
@@ -1717,5 +1717,4 @@ class PythonFrontendTest : BaseTest() {
         assertNotNull(c)
         assertRefersTo(c.firstAssignment, a)
     }
-
 }

--- a/cpg-language-python/src/test/resources/python/big-project/component1/mypackage/module.py
+++ b/cpg-language-python/src/test/resources/python/big-project/component1/mypackage/module.py
@@ -1,0 +1,3 @@
+import os
+
+a = os.name

--- a/cpg-language-python/src/test/resources/python/big-project/component2/otherpackage/module.py
+++ b/cpg-language-python/src/test/resources/python/big-project/component2/otherpackage/module.py
@@ -1,0 +1,4 @@
+import mypackage.module
+
+b = 3
+c = mypackage.module.a

--- a/cpg-language-python/src/test/resources/python/big-project/stdlib/os.pyi
+++ b/cpg-language-python/src/test/resources/python/big-project/stdlib/os.pyi
@@ -1,0 +1,1 @@
+name: str


### PR DESCRIPTION
This PR introduces the possibility to specify *one* top level *per* component instead of just a global one. This introduces a new `topLevels` builder in the `TranslationConfiguration`. The single `topLevel` flag is still there and sets the top level of the default component ("application"). The top level can be fetched via a virtual property `topLevel` in the `Component` class.

I also added a python test that parses different components to demonstrate the API.

Fixes #1959
