### PR TITLE
Support tuple deconstruction and follow value flows based on index

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Dataflow.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Dataflow.kt
@@ -63,6 +63,15 @@ class PartialDataflowGranularity(
     val partialTarget: Declaration?
 ) : Granularity
 
+/**
+ * This dataflow granularity denotes that not the "whole" object is flowing from [Dataflow.start] to
+ * [Dataflow.end] but only parts of it. Common examples include tuples or array indices.
+ */
+class IndexedDataflowGranularity(
+    /** The index that is affected by this partial dataflow. */
+    val index: Int
+) : Granularity
+
 /** Creates a new [FullDataflowGranularity]. */
 fun full(): Granularity {
     return FullDataflowGranularity
@@ -78,6 +87,14 @@ fun default() = full()
  */
 fun partial(target: Declaration?): PartialDataflowGranularity {
     return PartialDataflowGranularity(target)
+}
+
+/**
+ * Creates a new [IndexedDataflowGranularity]. The [idx] is the index that is used for the partial
+ * dataflow.
+ */
+fun indexed(idx: Int): IndexedDataflowGranularity {
+    return IndexedDataflowGranularity(idx)
 }
 
 /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Dataflow.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Dataflow.kt
@@ -70,7 +70,11 @@ class PartialDataflowGranularity(
 class IndexedDataflowGranularity(
     /** The index that is affected by this partial dataflow. */
     val index: Int
-) : Granularity
+) : Granularity {
+    override fun equals(other: Any?): Boolean {
+        return this.index == (other as? IndexedDataflowGranularity)?.index
+    }
+}
 
 /** Creates a new [FullDataflowGranularity]. */
 fun full(): Granularity {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
@@ -33,7 +33,6 @@ import de.fraunhofer.aisec.cpg.graph.edges.flows.CallingContext
 import de.fraunhofer.aisec.cpg.graph.edges.flows.CallingContextOut
 import de.fraunhofer.aisec.cpg.graph.edges.flows.FullDataflowGranularity
 import de.fraunhofer.aisec.cpg.graph.edges.flows.Granularity
-import de.fraunhofer.aisec.cpg.graph.edges.flows.indexed
 import de.fraunhofer.aisec.cpg.graph.edges.flows.partial
 import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
@@ -313,11 +312,14 @@ open class ControlFlowSensitiveDFGPass(ctx: TranslationContext) : EOGStarterPass
                             ref.refersTo?.let {
                                 doubleState.declarationsState[it] =
                                     PowersetLattice(identitySetOf(ref))
+                                /*
+                                // This should not be used because the edges already exist
+                                val startOfDFG = assignment.target
                                 doubleState.generalState[ref] =
-                                    PowersetLattice(identitySetOf(assignment.value as Node))
-                                edgePropertiesMap.computeIfAbsent(Pair(assignment.value, ref)) {
+                                    PowersetLattice(identitySetOf(startOfDFG as Node))
+                                edgePropertiesMap.computeIfAbsent(Pair(startOfDFG, ref)) {
                                     mutableSetOf<Any>()
-                                } += indexed(idx)
+                                } += indexed(idx)*/
                             }
                         }
                     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
@@ -124,6 +124,9 @@ open class ControlFlowSensitiveDFGPass(ctx: TranslationContext) : EOGStarterPass
                 }
             } else {
                 value.elements.forEach {
+                    // We currently support two properties here: The calling context and the
+                    // granularity of the edge. We get the information from the edgePropertiesMap or
+                    // use the defaults (no calling context => null and FullGranularity).
                     var callingContext: CallingContext? = null
                     var granularity: Granularity = FullDataflowGranularity
                     edgePropertiesMap[Pair(it, key)]?.let {
@@ -312,14 +315,6 @@ open class ControlFlowSensitiveDFGPass(ctx: TranslationContext) : EOGStarterPass
                             ref.refersTo?.let {
                                 doubleState.declarationsState[it] =
                                     PowersetLattice(identitySetOf(ref))
-                                /*
-                                // This should not be used because the edges already exist
-                                val startOfDFG = assignment.target
-                                doubleState.generalState[ref] =
-                                    PowersetLattice(identitySetOf(startOfDFG as Node))
-                                edgePropertiesMap.computeIfAbsent(Pair(startOfDFG, ref)) {
-                                    mutableSetOf<Any>()
-                                } += indexed(idx)*/
                             }
                         }
                     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
@@ -29,6 +29,7 @@ import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.edges.flows.CallingContextOut
+import de.fraunhofer.aisec.cpg.graph.edges.flows.indexed
 import de.fraunhofer.aisec.cpg.graph.edges.flows.partial
 import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
@@ -394,7 +395,9 @@ class DFGPass(ctx: TranslationContext) : ComponentPass(ctx) {
      * this expression.
      */
     protected fun handleInitializerListExpression(node: InitializerListExpression) {
-        node.initializers.forEach { node.prevDFGEdges += it }
+        node.initializers.forEachIndexed { idx, it ->
+            node.prevDFGEdges.add(it) { granularity = indexed(idx) }
+        }
     }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
@@ -396,7 +396,16 @@ class DFGPass(ctx: TranslationContext) : ComponentPass(ctx) {
      */
     protected fun handleInitializerListExpression(node: InitializerListExpression) {
         node.initializers.forEachIndexed { idx, it ->
-            node.prevDFGEdges.add(it) { granularity = indexed(idx) }
+            if (
+                node.astParent is AssignExpression &&
+                    node in (node.astParent as AssignExpression).lhs
+            ) {
+                // If we're the target of an assignment, the DFG flows from the node to the
+                // initializers.
+                node.nextDFGEdges.add(it) { granularity = indexed(idx) }
+            } else {
+                node.prevDFGEdges.add(it) { granularity = indexed(idx) }
+            }
         }
     }
 

--- a/cpg-language-go/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
+++ b/cpg-language-go/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
@@ -87,10 +87,10 @@ class GoLanguageFrontendTest : BaseTest() {
 
         // We should be able to follow the DFG backwards from the declaration to the individual
         // key/value expressions
-        val path = data.firstAssignment?.followPrevFullDFG { it is KeyValueExpression }
+        val path = data.firstAssignment?.followPrevDFG { it is KeyValueExpression }
 
         assertNotNull(path)
-        assertEquals(2, path.size)
+        assertEquals(3, path.size)
     }
 
     @Test

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DFGTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DFGTest.kt
@@ -42,6 +42,7 @@ import java.nio.file.Path
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -62,20 +63,21 @@ class DFGTest {
 
         assertLocalName("c", cRef)
         val cRefPrevDFG = cRef.prevDFG.singleOrNull()
-        assertIs<CallExpression>(cRefPrevDFG)
-        assertLocalName(functionName, cRefPrevDFG)
+        assertIs<InitializerListExpression>(cRefPrevDFG)
         val cRefPrevDFGGranularity = cRef.prevDFGEdges.single().granularity
         assertIs<IndexedDataflowGranularity>(cRefPrevDFGGranularity)
         assertEquals(0, cRefPrevDFGGranularity.index)
 
         assertLocalName("d", dRef)
         val dRefPrevDFG = dRef.prevDFG.singleOrNull()
-        assertIs<CallExpression>(dRefPrevDFG)
-        assertLocalName(functionName, dRefPrevDFG)
+        assertSame(cRefPrevDFG, dRefPrevDFG)
         val dRefPrevDFGGranularity = dRef.prevDFGEdges.single().granularity
-        dRef.prevFullDFG
         assertIs<IndexedDataflowGranularity>(dRefPrevDFGGranularity)
         assertEquals(1, dRefPrevDFGGranularity.index)
+
+        val tuplePrevDFG = cRefPrevDFG.prevDFG.singleOrNull()
+        assertIs<CallExpression>(tuplePrevDFG)
+        assertLocalName(functionName, tuplePrevDFG)
 
         val c = body.variables["c"]
         assertNotNull(c)

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DFGTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DFGTest.kt
@@ -86,7 +86,8 @@ class DFGTest {
         val dRefPrevDFG = dRef.prevDFG.singleOrNull()
         assertIs<CallExpression>(dRefPrevDFG)
         assertLocalName("returnTuple", dRefPrevDFG)
-        val dRefPrevDFGGranularity = dRefPrevDFG.prevDFGEdges.single().granularity
+        val dRefPrevDFGGranularity = dRef.prevDFGEdges.single().granularity
+        dRef.prevFullDFG
         assertIs<IndexedDataflowGranularity>(dRefPrevDFGGranularity)
         assertEquals(1, dRefPrevDFGGranularity.index)
 

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DFGTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DFGTest.kt
@@ -95,4 +95,160 @@ class DFGTest {
         assertNotNull(d)
         assertTrue(d.prevDFG.isEmpty())
     }
+
+    @Test
+    fun testListComprehensions2() {
+        val topLevel = Path.of("src", "test", "resources", "python")
+        val result =
+            analyze(listOf(topLevel.resolve("tuple_assign.py").toFile()), topLevel, true) {
+                it.registerLanguage<PythonLanguage>()
+            }
+        assertNotNull(result)
+        val getTuple = result.functions["getTuple2"]
+        assertNotNull(getTuple)
+
+        val body = getTuple.body
+        assertIs<Block>(body)
+        val assignment = body.statements[0]
+        assertIs<AssignExpression>(assignment)
+        assertEquals(1, assignment.lhs.size)
+        assertEquals(1, assignment.rhs.size)
+        val lhsTuple = assignment.lhs[0]
+        assertIs<InitializerListExpression>(lhsTuple)
+        assertEquals(2, lhsTuple.initializers.size)
+
+        val cRef = lhsTuple.initializers[0]
+
+        assertIs<Reference>(cRef)
+        assertLocalName("c", cRef)
+        val cRefPrevDFG = cRef.prevDFG.singleOrNull()
+        assertIs<CallExpression>(cRefPrevDFG)
+        assertLocalName("returnTuple2", cRefPrevDFG)
+        val cRefPrevDFGGranularity = cRef.prevDFGEdges.single().granularity
+        assertIs<IndexedDataflowGranularity>(cRefPrevDFGGranularity)
+        assertEquals(0, cRefPrevDFGGranularity.index)
+
+        val c = body.variables["c"]
+        assertNotNull(c)
+        assertTrue(c.prevDFG.isEmpty())
+
+        val dRef = lhsTuple.initializers[1]
+        assertIs<Reference>(dRef)
+        assertLocalName("d", dRef)
+        val dRefPrevDFG = dRef.prevDFG.singleOrNull()
+        assertIs<CallExpression>(dRefPrevDFG)
+        assertLocalName("returnTuple2", dRefPrevDFG)
+        val dRefPrevDFGGranularity = dRef.prevDFGEdges.single().granularity
+        dRef.prevFullDFG
+        assertIs<IndexedDataflowGranularity>(dRefPrevDFGGranularity)
+        assertEquals(1, dRefPrevDFGGranularity.index)
+
+        val d = body.variables["d"]
+        assertNotNull(d)
+        assertTrue(d.prevDFG.isEmpty())
+    }
+
+    @Test
+    fun testListComprehensions3() {
+        val topLevel = Path.of("src", "test", "resources", "python")
+        val result =
+            analyze(listOf(topLevel.resolve("tuple_assign.py").toFile()), topLevel, true) {
+                it.registerLanguage<PythonLanguage>()
+            }
+        assertNotNull(result)
+        val getTuple = result.functions["getTuple3"]
+        assertNotNull(getTuple)
+
+        val body = getTuple.body
+        assertIs<Block>(body)
+        val assignment = body.statements[0]
+        assertIs<AssignExpression>(assignment)
+        assertEquals(1, assignment.lhs.size)
+        assertEquals(1, assignment.rhs.size)
+        val lhsTuple = assignment.lhs[0]
+        assertIs<InitializerListExpression>(lhsTuple)
+        assertEquals(2, lhsTuple.initializers.size)
+
+        val cRef = lhsTuple.initializers[0]
+
+        assertIs<Reference>(cRef)
+        assertLocalName("c", cRef)
+        val cRefPrevDFG = cRef.prevDFG.singleOrNull()
+        assertIs<CallExpression>(cRefPrevDFG)
+        assertLocalName("returnTuple2", cRefPrevDFG)
+        val cRefPrevDFGGranularity = cRef.prevDFGEdges.single().granularity
+        assertIs<IndexedDataflowGranularity>(cRefPrevDFGGranularity)
+        assertEquals(0, cRefPrevDFGGranularity.index)
+
+        val c = body.variables["c"]
+        assertNotNull(c)
+        assertTrue(c.prevDFG.isEmpty())
+
+        val dRef = lhsTuple.initializers[1]
+        assertIs<Reference>(dRef)
+        assertLocalName("d", dRef)
+        val dRefPrevDFG = dRef.prevDFG.singleOrNull()
+        assertIs<CallExpression>(dRefPrevDFG)
+        assertLocalName("returnTuple2", dRefPrevDFG)
+        val dRefPrevDFGGranularity = dRef.prevDFGEdges.single().granularity
+        dRef.prevFullDFG
+        assertIs<IndexedDataflowGranularity>(dRefPrevDFGGranularity)
+        assertEquals(1, dRefPrevDFGGranularity.index)
+
+        val d = body.variables["d"]
+        assertNotNull(d)
+        assertTrue(d.prevDFG.isEmpty())
+    }
+
+    @Test
+    fun testListComprehensions4() {
+        val topLevel = Path.of("src", "test", "resources", "python")
+        val result =
+            analyze(listOf(topLevel.resolve("tuple_assign.py").toFile()), topLevel, true) {
+                it.registerLanguage<PythonLanguage>()
+            }
+        assertNotNull(result)
+        val getTuple = result.functions["getTuple4"]
+        assertNotNull(getTuple)
+
+        val body = getTuple.body
+        assertIs<Block>(body)
+        val assignment = body.statements[0]
+        assertIs<AssignExpression>(assignment)
+        assertEquals(1, assignment.lhs.size)
+        assertEquals(1, assignment.rhs.size)
+        val lhsTuple = assignment.lhs[0]
+        assertIs<InitializerListExpression>(lhsTuple)
+        assertEquals(2, lhsTuple.initializers.size)
+
+        val cRef = lhsTuple.initializers[0]
+
+        assertIs<Reference>(cRef)
+        assertLocalName("c", cRef)
+        val cRefPrevDFG = cRef.prevDFG.singleOrNull()
+        assertIs<CallExpression>(cRefPrevDFG)
+        assertLocalName("returnTuple", cRefPrevDFG)
+        val cRefPrevDFGGranularity = cRef.prevDFGEdges.single().granularity
+        assertIs<IndexedDataflowGranularity>(cRefPrevDFGGranularity)
+        assertEquals(0, cRefPrevDFGGranularity.index)
+
+        val c = body.variables["c"]
+        assertNotNull(c)
+        assertTrue(c.prevDFG.isEmpty())
+
+        val dRef = lhsTuple.initializers[1]
+        assertIs<Reference>(dRef)
+        assertLocalName("d", dRef)
+        val dRefPrevDFG = dRef.prevDFG.singleOrNull()
+        assertIs<CallExpression>(dRefPrevDFG)
+        assertLocalName("returnTuple", dRefPrevDFG)
+        val dRefPrevDFGGranularity = dRef.prevDFGEdges.single().granularity
+        dRef.prevFullDFG
+        assertIs<IndexedDataflowGranularity>(dRefPrevDFGGranularity)
+        assertEquals(1, dRefPrevDFGGranularity.index)
+
+        val d = body.variables["d"]
+        assertNotNull(d)
+        assertTrue(d.prevDFG.isEmpty())
+    }
 }

--- a/cpg-language-python/src/test/resources/python/tuple_assign.py
+++ b/cpg-language-python/src/test/resources/python/tuple_assign.py
@@ -1,0 +1,6 @@
+def returnTuple(a, b):
+    return (a, b)
+
+def getTuple(a, b):
+    (c, d) = returnTuple(a, b)
+    print(str(c) + " " + str(d))

--- a/cpg-language-python/src/test/resources/python/tuple_assign.py
+++ b/cpg-language-python/src/test/resources/python/tuple_assign.py
@@ -4,3 +4,18 @@ def returnTuple(a, b):
 def getTuple(a, b):
     (c, d) = returnTuple(a, b)
     print(str(c) + " " + str(d))
+
+def returnTuple2(a, b):
+    return a, b
+
+def getTuple2(a, b):
+    c, d = returnTuple2(a, b)
+    print(str(c) + " " + str(d))
+
+def getTuple3(a, b):
+    (c, d) = returnTuple2(a, b)
+    print(str(c) + " " + str(d))
+
+def getTuple4(a, b):
+    c, d = returnTuple(a, b)
+    print(str(c) + " " + str(d))


### PR DESCRIPTION
* [x] Add functionality to split up the DFG of a statement like `(a, b) = ...` where the edges are labeled with a new `index` granularity.
* [x] Add test
* [x] Try with and without brackets
* [x] Use this also in other scenarios (tuples in a return value)
* [x] Special follow DFG functions which have a stack of indices and only select matching tuple elements for unpacking