### PR TITLE
Resolving calls to static python methods correctly

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -201,7 +201,7 @@ fun LanguageProvider.newName(
 @JvmOverloads
 fun MetadataProvider.newAnnotation(name: CharSequence?, rawNode: Any? = null): Annotation {
     val node = Annotation()
-    node.applyMetadata(this, name, rawNode)
+    node.applyMetadata(this, name, rawNode, localNameOnly = true)
 
     log(node)
     return node

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.frontends.python
 
 import de.fraunhofer.aisec.cpg.frontends.*
 import de.fraunhofer.aisec.cpg.graph.HasOverloadedOperation
+import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.autoType
 import de.fraunhofer.aisec.cpg.graph.declarations.ParameterDeclaration
 import de.fraunhofer.aisec.cpg.graph.scopes.Symbol
@@ -34,6 +35,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.BinaryOperator
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Reference
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.UnaryOperator
 import de.fraunhofer.aisec.cpg.graph.types.*
+import de.fraunhofer.aisec.cpg.helpers.Util.warnWithFileLocation
 import kotlin.reflect.KClass
 import org.neo4j.ogm.annotation.Transient
 
@@ -202,8 +204,24 @@ class PythonLanguage :
         targetHint: HasType?,
     ): CastResult {
         // Parameters in python do not have a static type. Therefore, we need to match for all types
-        // when trying to cast one type to the type of a function parameter.
+        // when trying to cast one type to the type of a function parameter at *runtime*
         if (targetHint is ParameterDeclaration) {
+            // However, if we find type hints, we at least want to issue a warning if the types
+            // would not match
+            if (hint != null && targetType !is UnknownType && targetType !is AutoType) {
+                val match = super.tryCast(type, targetType, hint, targetHint)
+                if (match == CastNotPossible) {
+                    warnWithFileLocation(
+                        hint as Node,
+                        log,
+                        "Argument type of call to {} ({}) does not match type annotation on the function parameter ({}), but since Python does have runtime checks, we ignore this",
+                        hint.astParent?.name,
+                        type.name,
+                        targetType.name,
+                    )
+                }
+            }
+
             return DirectMatch
         }
 

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
@@ -195,6 +195,21 @@ class PythonLanguage :
         return super.propagateTypeOfBinaryOperation(operation)
     }
 
+    override fun tryCast(
+        type: Type,
+        targetType: Type,
+        hint: HasType?,
+        targetHint: HasType?,
+    ): CastResult {
+        // Parameters in python do not have a static type. Therefore, we need to match for all types
+        // when trying to cast one type to the type of a function parameter.
+        if (targetHint is ParameterDeclaration) {
+            return DirectMatch
+        }
+
+        return super.tryCast(type, targetType, hint, targetHint)
+    }
+
     companion object {
         /**
          * This is a "modifier" to differentiate parameters in functions that are "positional" only.

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
@@ -951,8 +951,11 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
         // both in positional and keyword style.
         var positionalArguments = args.posonlyargs + args.args
 
-        // Handle receiver if it exists
-        if (recordDeclaration != null) {
+        // Handle receiver if it exists and if it is not a static method
+        if (
+            recordDeclaration != null &&
+                result.annotations.none { it.name.localName == "staticmethod" }
+        ) {
             handleReceiverArgument(positionalArguments, args, result, recordDeclaration)
             // Skip the receiver argument for further processing
             positionalArguments = positionalArguments.drop(1)

--- a/cpg-language-python/src/test/resources/python/foobar.py
+++ b/cpg-language-python/src/test/resources/python/foobar.py
@@ -1,0 +1,14 @@
+def foo(a):
+    return a+1
+
+def bar():
+    return foo(42)
+
+
+class Foobar:
+    def bar(self):
+        return self.foo(41, 1)
+
+    @staticmethod
+    def foo(a, b):
+        return a+b


### PR DESCRIPTION
This PR parses the `@staticmethod` annotation and does not take accidentilly put in a receiver in this case.
