### PR TITLE
Keep argument name information when converting member call expressions to call expressions

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/Extensions.kt
@@ -80,3 +80,10 @@ fun <
     val edge = edgeProperty.call(this)
     return edge.delegate()
 }
+
+/** Returns the first edge with the given [name] or `null` if no such edge exists. */
+operator fun <NodeType : Node, EdgeType : Edge<NodeType>> EdgeList<NodeType, EdgeType>.get(
+    name: String
+): EdgeType? {
+    return this.firstOrNull { it.name == name }
+}

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.kt
@@ -439,7 +439,8 @@ private fun CallExpression.duplicateTo(call: CallExpression, callee: Reference) 
     call.ctx = this.ctx
     call.language = this.language
     call.scope = this.scope
-    call.arguments = this.arguments
+    call.argumentEdges.clear()
+    call.argumentEdges += this.argumentEdges
     call.type = this.type
     call.assignedTypes = this.assignedTypes
     call.code = this.code

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
@@ -34,6 +34,7 @@ import de.fraunhofer.aisec.cpg.graph.declarations.FieldDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.ParameterDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
+import de.fraunhofer.aisec.cpg.graph.edges.*
 import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.ListType
@@ -1716,5 +1717,11 @@ class PythonFrontendTest : BaseTest() {
         val c = component2.variables["c"]
         assertNotNull(c)
         assertRefersTo(c.firstAssignment, a)
+
+        val fooCall = component2.calls["foo"]
+        assertNotNull(fooCall)
+
+        val barArgument = fooCall.argumentEdges["bar"]?.end
+        assertNotNull(barArgument)
     }
 }

--- a/cpg-language-python/src/test/resources/python/big-project/component1/mypackage/module.py
+++ b/cpg-language-python/src/test/resources/python/big-project/component1/mypackage/module.py
@@ -1,3 +1,6 @@
 import os
 
 a = os.name
+
+def foo(bar):
+    return bar+1

--- a/cpg-language-python/src/test/resources/python/big-project/component2/otherpackage/module.py
+++ b/cpg-language-python/src/test/resources/python/big-project/component2/otherpackage/module.py
@@ -2,3 +2,4 @@ import mypackage.module
 
 b = 3
 c = mypackage.module.a
+module.foo(bar=2)


### PR DESCRIPTION
Previously, this information was lost because we were only copying/moving the nodes and not the edges
