### PR TITLE
Do not infer field declarations in static methods

### DIFF
--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
@@ -134,6 +134,14 @@ class PythonAddDeclarationsPass(ctx: TranslationContext) : ComponentPass(ctx), L
                     // creating fields, except if this is a receiver
                     return null
                 }
+                scopeManager.isInRecord &&
+                    scopeManager.isInFunction &&
+                    scopeManager.currentFunction?.annotations?.any {
+                        it.name.localName == "staticmethod"
+                    } == true -> {
+                    // If this is a static method, so we may need a local variable
+                    null
+                }
                 scopeManager.isInRecord -> {
                     // We end up here for fields declared directly in the class body. These are
                     // class attributes; more or less static fields.


### PR DESCRIPTION
The `PythonAddDeclarationsPass` infers a `FieldDeclaration` even if we're in a static function. This is not really correct. We now infer a `VariableDeclaration` instead.