### PR TITLE
Lookup for matching `ParameterDeclaration`s before generating new variables

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -78,7 +78,11 @@ class ScopeManager : ScopeProvider {
 
     /** True, if the scope manager is currently in a [FunctionScope]. */
     val isInFunction: Boolean
-        get() = this.firstScopeOrNull { it is FunctionScope } != null
+        get() = currentFunctionScope != null
+
+    /** Gets the closest [FunctionScope]. */
+    val currentFunctionScope: FunctionScope?
+        get() = this.firstScopeOrNull { it is FunctionScope } as? FunctionScope
 
     /** True, if the scope manager is currently in a [RecordScope], e.g. a class. */
     val isInRecord: Boolean

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
@@ -1750,5 +1750,10 @@ class PythonFrontendTest : BaseTest() {
 
         // There is no field called "b" in the result.
         assertNull(tu.fields["b"])
+
+        val foo = tu.functions["foo"]
+        assertNotNull(foo)
+        val refersTo = foo.refs("fooA").map { it.refersTo }
+        refersTo.forEach { refersTo -> assertIs<ParameterDeclaration>(refersTo) }
     }
 }

--- a/cpg-language-python/src/test/resources/python/variable_inference.py
+++ b/cpg-language-python/src/test/resources/python/variable_inference.py
@@ -4,3 +4,7 @@ class SomeClass:
         x = a
         b = x
         return b
+
+def foo(fooA, b):
+    fooA = bar(fooA)
+    return fooA


### PR DESCRIPTION
Fixes #1978 

We could also split the big when-statement up into multiple parts.