### PR TITLE
Do not enter local scopes in python

### DIFF
--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CLanguage.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CLanguage.kt
@@ -114,6 +114,7 @@ open class CLanguage :
         hint: HasType?,
         targetHint: HasType?,
     ): CastResult {
+        return DirectMatch
         val match = super.tryCast(type, targetType, hint, targetHint)
         if (match != CastNotPossible) {
             return match

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
@@ -891,11 +891,7 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
         handleArguments(s.args, result, recordDeclaration)
 
         if (s.body.isNotEmpty()) {
-            // Make sure we open a new (block) scope for the function body. This is not a 1:1
-            // mapping to python scopes, since python only has a "function scope", but in the CPG
-            // the function scope only comprises the function arguments, and we need a block scope
-            // to hold all local variables within the function body.
-            result.body = makeBlock(s.body, parentNode = s, enterScope = true)
+            result.body = makeBlock(s.body, parentNode = s)
         }
 
         frontend.scopeManager.leaveScope(result)
@@ -1154,27 +1150,15 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
      * This function "wraps" a list of [Python.AST.BaseStmt] nodes into a [Block]. Since the list
      * itself does not have a code/location, we need to employ [codeAndLocationFromChildren] on the
      * [parentNode].
-     *
-     * Optionally, a new scope will be opened when [enterScope] is specified. This should be done
-     * VERY carefully, as Python has a very limited set of scopes and is most likely only to be used
-     * by [handleFunctionDef].
      */
     private fun makeBlock(
         stmts: List<Python.AST.BaseStmt>,
         parentNode: Python.AST.WithLocation,
-        enterScope: Boolean = false,
     ): Block {
         val result = newBlock()
-        if (enterScope) {
-            frontend.scopeManager.enterScope(result)
-        }
 
         for (stmt in stmts) {
             result.statements += handle(stmt)
-        }
-
-        if (enterScope) {
-            frontend.scopeManager.leaveScope(result)
         }
 
         // Try to retrieve the code and location from the parent node, if it is a base stmt

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
@@ -1750,5 +1750,10 @@ class PythonFrontendTest : BaseTest() {
 
         // There is no field called "b" in the result.
         assertNull(tu.fields["b"])
+
+        val foo = tu.functions["foo"]
+        assertNotNull(foo)
+        val refersTo = foo.refs("fooA").map { it.refersTo }
+        refersTo.forEach { refersTo -> assertIs<ParameterDeclaration>(refersTo) }
     }
 }

--- a/cpg-language-python/src/test/resources/python/variable_inference.py
+++ b/cpg-language-python/src/test/resources/python/variable_inference.py
@@ -4,3 +4,7 @@ class SomeClass:
         x = a
         b = x
         return b
+
+def foo(fooA, b):
+    fooA = bar(fooA)
+    return fooA


### PR DESCRIPTION
Python function declarations somehow enter a `LocalScope` which doesn't make sense. This feature is no longer needed by the graph and was there for legacy reasons. Also lead to incorrect lookups of variables. After this PR, python does no longer enter these `LocalScope`s . Since the feature was error-prone and only used in a single place (no not at all any more), it's removed completely.

Fixes #1978 