### PR TITLE
Fix unity build

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
@@ -221,7 +221,7 @@ private constructor(
                                         .trimIndent()
                                 )
                             }
-                                ?: {
+                                ?: run {
                                     writer.write(
                                         """
 #include "${file.absolutePath}"

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXIncludeTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXIncludeTest.kt
@@ -260,4 +260,47 @@ internal class CXXIncludeTest : BaseTest() {
         assertEquals(2, tu.methods.size)
         assertEquals(1, tu.methods.filterIsInstance<ConstructorDeclaration>().size)
     }
+
+    @Test
+    @Throws(Exception::class)
+    fun testUnityBuild() {
+        val file = File("src/test/resources/include.cpp")
+        val tus =
+            analyzeWithBuilder(
+                TranslationConfiguration.builder()
+                    .sourceLocations(listOf(file))
+                    .loadIncludes(true)
+                    .useUnityBuild(true)
+                    .debugParser(true)
+                    .registerLanguage<CPPLanguage>()
+                    .failOnError(true)
+            )
+        assertNotNull(tus)
+
+        val tu = tus.firstOrNull()
+        assertNotNull(tu)
+        assertFalse(tu.records.isEmpty())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testUnityBuildWithComponent() {
+        val file = File("src/test/resources/include.cpp")
+        val tus =
+            analyzeWithBuilder(
+                TranslationConfiguration.builder()
+                    .sourceLocations(listOf(file))
+                    .topLevel(file.parentFile)
+                    .loadIncludes(true)
+                    .useUnityBuild(true)
+                    .debugParser(true)
+                    .registerLanguage<CPPLanguage>()
+                    .failOnError(true)
+            )
+        assertNotNull(tus)
+
+        val tu = tus.firstOrNull()
+        assertNotNull(tu)
+        assertFalse(tu.records.isEmpty())
+    }
 }


### PR DESCRIPTION
#1960 introduced a bug when using the unity build mode without software components.
I'm not sure why the `run`  is need for the else case of the `let`, but it fixes the problem.
I also added a test-case for the unity build mode (with and without software components).