### PR TITLE
Basic implementation of following context-sensitive calls in `followNextDFGUntilHit`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -36,6 +36,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Block
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
+import kotlin.collections.firstOrNull
 import kotlin.math.absoluteValue
 
 /**
@@ -229,7 +230,7 @@ fun Node.followPrevFullDFGEdgesUntilHit(
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
     return followXUntilHit(
-        x = { currentNode, _ -> currentNode.prevFullDFG },
+        x = { currentNode, _, _ -> currentNode.prevFullDFG },
         collectFailedPaths = collectFailedPaths,
         findAllPossiblePaths = findAllPossiblePaths,
         predicate = predicate,
@@ -269,7 +270,7 @@ fun Node.followPrevDFGEdgesUntilHit(
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
     return followXUntilHit(
-        x = { currentNode, ctx ->
+        x = { currentNode, ctx, path ->
             if (
                 useIndexStack &&
                     currentNode is InitializerListExpression &&
@@ -326,10 +327,10 @@ fun Node.followPrevDFGEdgesUntilHit(
  */
 class Context(
     val indexStack: SimpleStack<IndexedDataflowGranularity> = SimpleStack(),
-    val callStack: SimpleStack<CallExpression> = SimpleStack(),
+    val callStack: ArrayDeque<CallExpression> = ArrayDeque<CallExpression>(),
 ) {
     fun clone(): Context {
-        return Context(indexStack.clone(), callStack.clone())
+        return Context(indexStack.clone(), ArrayDeque(callStack))
     }
 }
 
@@ -341,6 +342,9 @@ class SimpleStack<T>() {
     fun push(newElem: T) {
         deque.addFirst(newElem)
     }
+
+    val current: T?
+        get() = deque.firstOrNull()
 
     fun checkAndPop(elemToPop: T): Boolean {
         if (deque.firstOrNull() == elemToPop) {
@@ -477,7 +481,7 @@ fun Node.followNextPDGUntilHit(
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
     return followXUntilHit(
-        x = { currentNode, _ ->
+        x = { currentNode, _, _ ->
             val nextNodes = currentNode.nextPDG.toMutableList()
             if (interproceduralAnalysis) {
                 nextNodes.addAll((currentNode as? CallExpression)?.calls ?: listOf())
@@ -506,7 +510,7 @@ fun Node.followNextCDGUntilHit(
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
     return followXUntilHit(
-        x = { currentNode, _ ->
+        x = { currentNode, _, _ ->
             val nextNodes = currentNode.nextCDG.toMutableList()
             if (interproceduralAnalysis) {
                 nextNodes.addAll((currentNode as? CallExpression)?.calls ?: listOf())
@@ -536,7 +540,7 @@ fun Node.followPrevPDGUntilHit(
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
     return followXUntilHit(
-        x = { currentNode, _ ->
+        x = { currentNode, _, _ ->
             val nextNodes = currentNode.prevPDG.toMutableList()
             if (interproceduralAnalysis) {
                 nextNodes.addAll(
@@ -570,7 +574,7 @@ fun Node.followPrevCDGUntilHit(
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
     return followXUntilHit(
-        x = { currentNode, _ ->
+        x = { currentNode, _, _ ->
             val nextNodes = currentNode.prevCDG.toMutableList()
             if (interproceduralAnalysis) {
                 nextNodes.addAll(
@@ -598,7 +602,7 @@ fun Node.followPrevCDGUntilHit(
  * not mandatory**. If the list "failed" is empty, the path is mandatory.
  */
 inline fun Node.followXUntilHit(
-    noinline x: (Node, Context) -> Collection<Node>,
+    noinline x: (Node, Context, List<Node>) -> Collection<Node>,
     collectFailedPaths: Boolean = true,
     findAllPossiblePaths: Boolean = true,
     context: Context = Context(),
@@ -623,7 +627,7 @@ inline fun Node.followXUntilHit(
         alreadySeenNodes.add(currentNode)
         // The last node of the path is where we continue. We get all of its outgoing CDG edges and
         // follow them
-        var nextNodes = x(currentNode, currentContext)
+        var nextNodes = x(currentNode, currentContext, currentPath.first)
 
         // No further nodes in the path and the path criteria are not satisfied.
         if (nextNodes.isEmpty() && collectFailedPaths) failedPaths.add(currentPath.first)
@@ -674,7 +678,7 @@ fun Node.followNextFullDFGEdgesUntilHit(
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
     return followXUntilHit(
-        x = { currentNode, _ -> currentNode.nextFullDFG },
+        x = { currentNode, _, _ -> currentNode.nextFullDFG },
         collectFailedPaths = collectFailedPaths,
         findAllPossiblePaths = findAllPossiblePaths,
         predicate = predicate,
@@ -697,7 +701,7 @@ fun Node.followNextDFGEdgesUntilHit(
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
     return followXUntilHit(
-        x = { currentNode, ctx ->
+        x = { currentNode, ctx, path ->
             if (
                 useIndexStack &&
                     currentNode is InitializerListExpression &&
@@ -728,7 +732,7 @@ fun Node.followNextDFGEdgesUntilHit(
                 currentNode.nextDFGEdges.forEach {
                     if (it is ContextSensitiveDataflow && it.callingContext is CallingContextIn) {
                         // Push the call of our calling context to the stack
-                        ctx.callStack.push(it.callingContext.call)
+                        ctx.callStack.addFirst(it.callingContext.call)
                     }
                     if (
                         it.end is InitializerListExpression &&
@@ -741,21 +745,33 @@ fun Node.followNextDFGEdgesUntilHit(
                 }
 
                 // We need to filter out the edges which based on the stack
-                currentNode.nextDFGEdges
-                    .filter {
-                        if (ctx.callStack.isEmpty()) {
-                            true
-                        } else if (
-                            it is ContextSensitiveDataflow && it.callingContext is CallingContextOut
-                        ) {
-                            // We are only interested in outgoing edges from our current "call-in".
-                            // If we found it, we can pop it.
-                            ctx.callStack.checkAndPop(it.callingContext.call)
-                        } else {
-                            true
+                val selected =
+                    currentNode.nextDFGEdges
+                        .filter {
+                            if (ctx.callStack.isEmpty()) {
+                                true
+                            } else if (
+                                it is ContextSensitiveDataflow &&
+                                    it.callingContext is CallingContextOut
+                            ) {
+                                // We are only interested in outgoing edges from our current
+                                // "call-in", i.e., the call expression that is on the stack.
+                                ctx.callStack.firstOrNull() == it.callingContext.call
+                            } else {
+                                true
+                            }
                         }
+                        .map { it.end }
+
+                // Let's do any remaining pop'ing
+                currentNode.nextDFGEdges.forEach {
+                    if (it is ContextSensitiveDataflow && it.callingContext is CallingContextOut) {
+                        // Pop the current call, if it's on top
+                        ctx.callStack.removeIfFirst<CallExpression>(it.callingContext.call)
                     }
-                    .map { it.end }
+                }
+
+                selected
             }
         },
         collectFailedPaths = collectFailedPaths,
@@ -780,7 +796,7 @@ fun Node.followNextEOGEdgesUntilHit(
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
     return followXUntilHit(
-        x = { currentNode, _ ->
+        x = { currentNode, _, _ ->
             currentNode.nextEOGEdges.filter { it.unreachable != true }.map { it.end }
         },
         collectFailedPaths = collectFailedPaths,
@@ -805,7 +821,7 @@ fun Node.followPrevEOGEdgesUntilHit(
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
     return followXUntilHit(
-        x = { currentNode, _ ->
+        x = { currentNode, _, _ ->
             currentNode.prevEOGEdges.filter { it.unreachable != true }.map { it.start }
         },
         collectFailedPaths = collectFailedPaths,
@@ -1275,3 +1291,12 @@ val Expression.isImported: Boolean
     get() {
         return this.importedFrom.isNotEmpty()
     }
+
+private fun <T> ArrayDeque<T>.removeIfFirst(element: T): Boolean {
+    return if (firstOrNull() == element) {
+        removeFirst()
+        true
+    } else {
+        false
+    }
+}

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -36,7 +36,6 @@ import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Block
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
-import java.util.ArrayDeque
 import kotlin.math.absoluteValue
 
 /**
@@ -229,7 +228,7 @@ fun Node.followPrevFullDFGEdgesUntilHit(
     findAllPossiblePaths: Boolean = true,
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
-    return followXUntilHit<Any?>(
+    return followXUntilHit(
         x = { currentNode, _ -> currentNode.prevFullDFG },
         collectFailedPaths = collectFailedPaths,
         findAllPossiblePaths = findAllPossiblePaths,
@@ -270,12 +269,11 @@ fun Node.followPrevDFGEdgesUntilHit(
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
     return followXUntilHit(
-        stack = SimpleStack<IndexedDataflowGranularity>(),
-        x = { currentNode, indexStack ->
+        x = { currentNode, ctx ->
             if (
                 useIndexStack &&
                     currentNode is InitializerListExpression &&
-                    indexStack?.isEmpty() != true
+                    ctx.indexStack.isEmpty() != true
             ) {
                 // There's something on the stack. Get the relevant parts
                 currentNode.prevDFGEdges
@@ -288,8 +286,9 @@ fun Node.followPrevDFGEdgesUntilHit(
                             // from).
                             // We try to pop from the stack and only select the elements with the
                             // matching index.
-                            indexStack?.checkAndPop(it.granularity as IndexedDataflowGranularity) ==
-                                true
+                            ctx.indexStack.checkAndPop(
+                                it.granularity as IndexedDataflowGranularity
+                            ) == true
                         } else {
                             true
                         }
@@ -305,7 +304,7 @@ fun Node.followPrevDFGEdgesUntilHit(
                     ) {
                         // CurrentNode is the child and nextDFG goes to ILE => currentNode's written
                         // to. Push to stack
-                        indexStack?.push(it.granularity as IndexedDataflowGranularity)
+                        ctx.indexStack.push(it.granularity as IndexedDataflowGranularity)
                     }
                 }
                 currentNode.prevDFG
@@ -317,8 +316,25 @@ fun Node.followPrevDFGEdgesUntilHit(
     )
 }
 
+/**
+ * This class holds the context for the [followXUntilHit] function. It is used to keep track of the
+ * current index stack and call stack.
+ *
+ * This class supports copying to allow for cloning the context when needed. This is needed when we
+ * need to follow more than one path at a time, otherwise the different branches would override the
+ * stacks.
+ */
+class Context(
+    val indexStack: SimpleStack<IndexedDataflowGranularity> = SimpleStack(),
+    val callStack: SimpleStack<CallExpression> = SimpleStack(),
+) {
+    fun clone(): Context {
+        return Context(indexStack.clone(), callStack.clone())
+    }
+}
+
 class SimpleStack<T>() {
-    private val deque = kotlin.collections.ArrayDeque<T>()
+    private val deque = ArrayDeque<T>()
 
     fun isEmpty(): Boolean = deque.isEmpty()
 
@@ -460,7 +476,7 @@ fun Node.followNextPDGUntilHit(
     interproceduralAnalysis: Boolean = false,
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
-    return followXUntilHit<Any?>(
+    return followXUntilHit(
         x = { currentNode, _ ->
             val nextNodes = currentNode.nextPDG.toMutableList()
             if (interproceduralAnalysis) {
@@ -489,7 +505,7 @@ fun Node.followNextCDGUntilHit(
     interproceduralAnalysis: Boolean = false,
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
-    return followXUntilHit<Any?>(
+    return followXUntilHit(
         x = { currentNode, _ ->
             val nextNodes = currentNode.nextCDG.toMutableList()
             if (interproceduralAnalysis) {
@@ -519,7 +535,7 @@ fun Node.followPrevPDGUntilHit(
     interproceduralAnalysis: Boolean = false,
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
-    return followXUntilHit<Any?>(
+    return followXUntilHit(
         x = { currentNode, _ ->
             val nextNodes = currentNode.prevPDG.toMutableList()
             if (interproceduralAnalysis) {
@@ -553,7 +569,7 @@ fun Node.followPrevCDGUntilHit(
     interproceduralAnalysis: Boolean = false,
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
-    return followXUntilHit<Any?>(
+    return followXUntilHit(
         x = { currentNode, _ ->
             val nextNodes = currentNode.prevCDG.toMutableList()
             if (interproceduralAnalysis) {
@@ -581,11 +597,11 @@ fun Node.followPrevCDGUntilHit(
  * Hence, if "fulfilled" is a non-empty list, a path from [this] to such a node is **possible but
  * not mandatory**. If the list "failed" is empty, the path is mandatory.
  */
-inline fun <reified T> Node.followXUntilHit(
-    noinline x: (Node, SimpleStack<T>?) -> Collection<Node>,
+inline fun Node.followXUntilHit(
+    noinline x: (Node, Context) -> Collection<Node>,
     collectFailedPaths: Boolean = true,
     findAllPossiblePaths: Boolean = true,
-    stack: SimpleStack<T>? = null,
+    context: Context = Context(),
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
     // Looks complicated but at least it's not recursive...
@@ -594,8 +610,8 @@ inline fun <reified T> Node.followXUntilHit(
     // failedPaths: All the paths which do not satisfy "predicate"
     val failedPaths = mutableListOf<List<Node>>()
     // The list of paths where we're not done yet.
-    val worklist = mutableSetOf<Pair<List<Node>, SimpleStack<T>?>>()
-    worklist.add(Pair(listOf(this), stack)) // We start only with the "from" node (=this)
+    val worklist = mutableSetOf<Pair<List<Node>, Context>>()
+    worklist.add(Pair(listOf(this), context)) // We start only with the "from" node (=this)
 
     val alreadySeenNodes = mutableSetOf<Node>()
 
@@ -603,11 +619,11 @@ inline fun <reified T> Node.followXUntilHit(
         val currentPath = worklist.maxBy { it.first.size }
         worklist.remove(currentPath)
         val currentNode = currentPath.first.last()
-        val currentStack = currentPath.second
+        val currentContext = currentPath.second
         alreadySeenNodes.add(currentNode)
         // The last node of the path is where we continue. We get all of its outgoing CDG edges and
         // follow them
-        var nextNodes = x(currentNode, currentStack)
+        var nextNodes = x(currentNode, currentContext)
 
         // No further nodes in the path and the path criteria are not satisfied.
         if (nextNodes.isEmpty() && collectFailedPaths) failedPaths.add(currentPath.first)
@@ -629,7 +645,13 @@ inline fun <reified T> Node.followXUntilHit(
                     (findAllPossiblePaths ||
                         (next !in alreadySeenNodes && worklist.none { next in it.first }))
             ) {
-                worklist.add(Pair(nextPath, stack?.clone()))
+                val newContext =
+                    if (nextPath.size > 1) {
+                        currentContext.clone()
+                    } else {
+                        currentContext
+                    }
+                worklist.add(Pair(nextPath, newContext))
             }
         }
     }
@@ -651,7 +673,7 @@ fun Node.followNextFullDFGEdgesUntilHit(
     findAllPossiblePaths: Boolean = true,
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
-    return followXUntilHit<Any?>(
+    return followXUntilHit(
         x = { currentNode, _ -> currentNode.nextFullDFG },
         collectFailedPaths = collectFailedPaths,
         findAllPossiblePaths = findAllPossiblePaths,
@@ -674,14 +696,12 @@ fun Node.followNextDFGEdgesUntilHit(
     useIndexStack: Boolean = true,
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
-    val callingStack = SimpleStack<CallExpression>()
     return followXUntilHit(
-        stack = SimpleStack<IndexedDataflowGranularity>(),
-        x = { currentNode, indexStack ->
+        x = { currentNode, ctx ->
             if (
                 useIndexStack &&
                     currentNode is InitializerListExpression &&
-                    indexStack?.isEmpty() != true
+                    ctx.indexStack.isEmpty() != true
             ) {
                 // There's something on the stack. Get the relevant parts
                 currentNode.nextDFGEdges
@@ -694,8 +714,9 @@ fun Node.followNextDFGEdgesUntilHit(
                             // from).
                             // We try to pop from the stack and only select the elements with the
                             // matching index.
-                            indexStack?.checkAndPop(it.granularity as IndexedDataflowGranularity) ==
-                                true
+                            ctx.indexStack.checkAndPop(
+                                it.granularity as IndexedDataflowGranularity
+                            ) == true
                         } else {
                             true
                         }
@@ -707,7 +728,7 @@ fun Node.followNextDFGEdgesUntilHit(
                 currentNode.nextDFGEdges.forEach {
                     if (it is ContextSensitiveDataflow && it.callingContext is CallingContextIn) {
                         // Push the call of our calling context to the stack
-                        callingStack.push(it.callingContext.call)
+                        ctx.callStack.push(it.callingContext.call)
                     }
                     if (
                         it.end is InitializerListExpression &&
@@ -715,21 +736,21 @@ fun Node.followNextDFGEdgesUntilHit(
                     ) {
                         // CurrentNode is the child and nextDFG goes to ILE => currentNode's written
                         // to. Push to stack
-                        indexStack?.push(it.granularity as IndexedDataflowGranularity)
+                        ctx.indexStack.push(it.granularity as IndexedDataflowGranularity)
                     }
                 }
 
                 // We need to filter out the edges which based on the stack
                 currentNode.nextDFGEdges
                     .filter {
-                        if (callingStack.isEmpty()) {
+                        if (ctx.callStack.isEmpty()) {
                             true
                         } else if (
                             it is ContextSensitiveDataflow && it.callingContext is CallingContextOut
                         ) {
                             // We are only interested in outgoing edges from our current "call-in".
                             // If we found it, we can pop it.
-                            callingStack.checkAndPop(it.callingContext.call)
+                            ctx.callStack.checkAndPop(it.callingContext.call)
                         } else {
                             true
                         }
@@ -758,7 +779,7 @@ fun Node.followNextEOGEdgesUntilHit(
     findAllPossiblePaths: Boolean = true,
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
-    return followXUntilHit<Any?>(
+    return followXUntilHit(
         x = { currentNode, _ ->
             currentNode.nextEOGEdges.filter { it.unreachable != true }.map { it.end }
         },
@@ -783,7 +804,7 @@ fun Node.followPrevEOGEdgesUntilHit(
     findAllPossiblePaths: Boolean = true,
     predicate: (Node) -> Boolean,
 ): FulfilledAndFailedPaths {
-    return followXUntilHit<Any?>(
+    return followXUntilHit(
         x = { currentNode, _ ->
             currentNode.prevEOGEdges.filter { it.unreachable != true }.map { it.start }
         },

--- a/cpg-language-python/src/test/resources/python/context_sensitive.py
+++ b/cpg-language-python/src/test/resources/python/context_sensitive.py
@@ -11,7 +11,7 @@ class EncryptionManager:
         return (hex_key, key_id)
 
     def encryt_data(self, data):
-        (key, key_id) = setup_new_key()
+        (key, key_id) = self.setup_new_key()
 
         if some_decision():
             very_good_key = "very_good" + key

--- a/cpg-language-python/src/test/resources/python/context_sensitive.py
+++ b/cpg-language-python/src/test/resources/python/context_sensitive.py
@@ -1,0 +1,24 @@
+def cipher_operation(command, data, key):
+    return platform_cipher_operation(command, data, key)
+
+class EncryptionManager:
+    @staticmethod
+    def setup_new_key():
+        key_id = create_new_key()
+        key = retrieve_key_from_server(key_id)
+        hex_key = to_hex(key)
+
+        return (hex_key, key_id)
+
+    def encryt_data(self, data):
+        (key, key_id) = setup_new_key()
+
+        if some_decision():
+            very_good_key = "very_good" + key
+            (res, err) = cipher_operation("something_else", data.payload, very_good_key)
+            del key
+            data.key_id = key_id
+        else:
+            (res, err) = cipher_operation("encrypt", data.payload, key)
+            del key
+            data.key_id = key_id


### PR DESCRIPTION
I am not sure if this really solves *all* the problems, but at least this tries to use the information that we have in the calling context in/out so that we are properly following dataflows into functions and out of functions using the correct call (stack).
