### PR TITLE
Rename `localNameOnly` to `doNotPrependNamespace`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
@@ -154,7 +154,7 @@ fun MetadataProvider.newParameterDeclaration(
     rawNode: Any? = null,
 ): ParameterDeclaration {
     val node = ParameterDeclaration()
-    node.applyMetadata(this, name, rawNode, localNameOnly = true)
+    node.applyMetadata(this, name, rawNode, doNotPrependNamespace = true)
 
     node.type = type
     node.isVariadic = variadic

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -159,8 +159,8 @@ fun Node.applyMetadata(
 }
 
 /**
- * Generates a [Name] object from the given [name]. If [doNotPrependNamespace] is set, only the supplied name is
- * used, otherwise the [namespace] is prepended to the name.
+ * Generates a [Name] object from the given [name]. If [doNotPrependNamespace] is set, only the
+ * supplied name is used, otherwise the [namespace] is prepended to the name.
  */
 fun LanguageProvider.newName(
     name: CharSequence,

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/TypeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/TypeBuilder.kt
@@ -119,7 +119,7 @@ fun LanguageProvider.objectType(
     // Apply our usual metadata, such as scope, code, location, if we have any. Make sure only
     // to refer by the local name because we will treat types as sort of references when
     // creating them and resolve them later.
-    type.applyMetadata(this, name, rawNode = rawNode, localNameOnly = true)
+    type.applyMetadata(this, name, rawNode = rawNode, doNotPrependNamespace = true)
 
     // Piping it through register type will ensure that we know the type and can resolve it later
     return c.typeManager.registerType(type)


### PR DESCRIPTION
This PR fixes #1963
