### PR TITLE
Cleanup `SymbolResolver` and make it more extensible

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
@@ -287,12 +287,15 @@ internal fun Pass<*>.tryFunctionInference(
     //    the callee is not qualified, because otherwise we are in a static call like
     //    MyClass::doSomething() or in a namespace call (in case we do not want to explore the
     //    base type here yet). This will change in a future PR.
+    val callee = call.callee
     val (suitableBases, bestGuess) =
         if (
-            call.callee is MemberExpression ||
-                !call.callee.name.isQualified() && call.language is HasImplicitReceiver
+            callee is MemberExpression ||
+                callee is Reference &&
+                    !call.callee.name.isQualified() &&
+                    call.language is HasImplicitReceiver
         ) {
-            getPossibleContainingTypes(call)
+            getPossibleContainingTypes(callee)
         } else {
             Pair(setOf(), null)
         }

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
@@ -333,7 +333,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
     private fun handleThisExpression(expr: Expression): Reference {
         val thisExpr = expr.asThisExpr()
         val qualifiedName = frontend.scopeManager.currentRecord?.name.toString()
-        val type = this.objectType(qualifiedName)
+        var type = this.objectType(qualifiedName)
         var name = thisExpr.toString()
 
         // If the typeName is specified, then this a "qualified this" and we need to handle it
@@ -344,6 +344,7 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
         val typeName = thisExpr.typeName
         if (typeName.isPresent) {
             name = "this$" + typeName.get().identifier
+            type = unknownType() // will be filled later by the symbol resolver
         }
         val thisExpression = newReference(name, type, rawNode = expr)
         return thisExpression


### PR DESCRIPTION
This PR performs a clean up of the `ScopeManager` especially related to how we handle member resolution, which was still a left over from the "legacy" system. 

This makes all the necessary handle functions `open` so that someone external to this library can extend and replace this pass, if needed. Furthermore, we make all functions we do NOT wish to be overriden `private` (mostly because we consider them part of a legacy API).

Furthermore, this PR adds more documentation to this pass.
