### PR TITLE
Execute `ComponentPass` passes according to the dependencies between components

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
@@ -34,11 +34,14 @@ import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import de.fraunhofer.aisec.cpg.helpers.MeasurementHolder
 import de.fraunhofer.aisec.cpg.helpers.StatisticsHolder
+import de.fraunhofer.aisec.cpg.passes.ImportDependencies
+import de.fraunhofer.aisec.cpg.passes.ImportResolver
 import de.fraunhofer.aisec.cpg.passes.Pass
 import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import org.neo4j.ogm.annotation.Relationship
+import org.neo4j.ogm.annotation.Transient
 
 /**
  * The global (intermediate) result of the translation. A [LanguageFrontend] will initially populate
@@ -61,6 +64,11 @@ class TranslationResult(
      * of software.
      */
     val components by unwrapping(TranslationResult::componentEdges)
+
+    /** The import dependencies of [Component] nodes of this translation result. */
+    @Transient
+    @PopulatedByPass(ImportResolver::class)
+    var componentDependencies: ImportDependencies<Component>? = null
 
     /**
      * Scratch storage that can be used by passes to store additional information in this result.

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
@@ -38,6 +38,7 @@ import de.fraunhofer.aisec.cpg.passes.ImportDependencies
 import de.fraunhofer.aisec.cpg.passes.ImportResolver
 import de.fraunhofer.aisec.cpg.passes.Pass
 import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
+import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import org.neo4j.ogm.annotation.Relationship
@@ -65,7 +66,10 @@ class TranslationResult(
      */
     val components by unwrapping(TranslationResult::componentEdges)
 
-    /** The import dependencies of [Component] nodes of this translation result. */
+    /**
+     * The import dependencies of [Component] nodes of this translation result. The preferred way to
+     * access this is via [Strategy.COMPONENTS_LEAST_IMPORTS].
+     */
     @Transient
     @PopulatedByPass(ImportResolver::class)
     var componentDependencies: ImportDependencies<Component>? = null

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
@@ -52,9 +52,10 @@ open class Component : Node() {
     /** All translation units belonging to this application. */
     val translationUnits by unwrapping(Component::translationUnitEdges)
 
+    /** The import dependencies of [TranslationUnitDeclaration] nodes of this component. */
     @Transient
     @PopulatedByPass(ImportResolver::class)
-    var importDependencies = ImportDependencies(translationUnits)
+    var translationUnitDependencies: ImportDependencies<TranslationUnitDeclaration>? = null
 
     @Synchronized
     fun addTranslationUnit(tu: TranslationUnitDeclaration) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
@@ -35,6 +35,7 @@ import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import de.fraunhofer.aisec.cpg.passes.ImportDependencies
 import de.fraunhofer.aisec.cpg.passes.ImportResolver
 import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
+import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 import java.io.File
 import org.neo4j.ogm.annotation.Relationship
 import org.neo4j.ogm.annotation.Transient
@@ -52,7 +53,10 @@ open class Component : Node() {
     /** All translation units belonging to this application. */
     val translationUnits by unwrapping(Component::translationUnitEdges)
 
-    /** The import dependencies of [TranslationUnitDeclaration] nodes of this component. */
+    /**
+     * The import dependencies of [TranslationUnitDeclaration] nodes of this component. The
+     * preferred way to access this is via [Strategy.TRANSLATION_UNITS_LEAST_IMPORTS].
+     */
     @Transient
     @PopulatedByPass(ImportResolver::class)
     var translationUnitDependencies: ImportDependencies<TranslationUnitDeclaration>? = null

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -1360,6 +1360,18 @@ val Node.translationUnit: TranslationUnitDeclaration?
         return firstParentOrNull<TranslationUnitDeclaration>()
     }
 
+/** Returns the [Component] where this node is located in. */
+val Node.component: Component?
+    get() {
+        return firstParentOrNull { it is Component } as? Component
+    }
+
+/** Returns the [Component] where this node is located in. */
+val Node.translationResult: TranslationResult?
+    get() {
+        return firstParentOrNull { it is TranslationResult } as? TranslationResult
+    }
+
 /**
  * This helper function be used to find out if a particular expression (usually a [CallExpression]
  * or a [Reference]) is imported through a [ImportDeclaration].

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -1366,12 +1366,6 @@ val Node.component: Component?
         return firstParentOrNull { it is Component } as? Component
     }
 
-/** Returns the [Component] where this node is located in. */
-val Node.translationResult: TranslationResult?
-    get() {
-        return firstParentOrNull { it is TranslationResult } as? TranslationResult
-    }
-
 /**
  * This helper function be used to find out if a particular expression (usually a [CallExpression]
  * or a [Reference]) is imported through a [ImportDeclaration].

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -1363,7 +1363,7 @@ val Node.translationUnit: TranslationUnitDeclaration?
 /** Returns the [Component] where this node is located in. */
 val Node.component: Component?
     get() {
-        return firstParentOrNull { it is Component } as? Component
+        return firstParentOrNull<Component>()
     }
 
 /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
@@ -290,7 +290,7 @@ class ImportResolver(ctx: TranslationContext) : TranslationResultPass(ctx) {
                 if (added) {
                     log.debug(
                         "Added {} as an dependency of {}",
-                        namespaceTu.component?.name,
+                        namespaceComponent.name,
                         currentComponent.name,
                     )
                 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
@@ -272,14 +272,17 @@ fun executePass(
             consumeTargets(
                 (prototype as ComponentPass)::class,
                 ctx,
-                result.components,
+                // Execute them in the "sorted" order (if available)
+                result.componentDependencies?.sorted ?: result.components,
                 executedFrontends,
             )
         is TranslationUnitPass ->
             consumeTargets(
                 (prototype as TranslationUnitPass)::class,
                 ctx,
-                result.components.flatMap { it.translationUnits },
+                // Execute them in the "sorted" order (if available)
+                result.componentDependencies?.sorted?.flatMap { it.translationUnits }
+                    ?: result.components.flatMap { it.translationUnits },
                 executedFrontends,
             )
         is EOGStarterPass -> {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
@@ -42,6 +42,8 @@ import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteLast
 import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteLate
 import de.fraunhofer.aisec.cpg.passes.configuration.RequiredFrontend
 import de.fraunhofer.aisec.cpg.passes.configuration.RequiresLanguageTrait
+import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
+import de.fraunhofer.aisec.cpg.processing.strategy.Strategy.TRANSLATION_UNITS_LEAST_IMPORTS
 import java.util.concurrent.CompletableFuture
 import java.util.function.Consumer
 import kotlin.reflect.KClass
@@ -273,7 +275,7 @@ fun executePass(
                 (prototype as ComponentPass)::class,
                 ctx,
                 // Execute them in the "sorted" order (if available)
-                result.componentDependencies?.sorted ?: result.components,
+                (Strategy::COMPONENTS_LEAST_IMPORTS)(result).asSequence().toList(),
                 executedFrontends,
             )
         is TranslationUnitPass ->
@@ -281,8 +283,10 @@ fun executePass(
                 (prototype as TranslationUnitPass)::class,
                 ctx,
                 // Execute them in the "sorted" order (if available)
-                result.componentDependencies?.sorted?.flatMap { it.translationUnits }
-                    ?: result.components.flatMap { it.translationUnits },
+                (Strategy::COMPONENTS_LEAST_IMPORTS)(result)
+                    .asSequence()
+                    .flatMap { (Strategy::TRANSLATION_UNITS_LEAST_IMPORTS)(it).asSequence() }
+                    .toList(),
                 executedFrontends,
             )
         is EOGStarterPass -> {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -139,12 +139,12 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
         // Resolve symbols in our translation units in the order depending on their import
         // dependencies
-        component.translationUnitDependencies?.sorted?.forEach {
-            log.debug("Resolving symbols of translation unit {}", it.name)
+        for (tu in (Strategy::TRANSLATION_UNITS_LEAST_IMPORTS)(component)) {
+            log.debug("Resolving symbols of translation unit {}", tu.name)
 
             // Gather all resolution EOG starters; and make sure they really do not have a
             // predecessor, otherwise we might analyze a node multiple times
-            val nodes = it.allEOGStarters.filter { it.prevEOGEdges.isEmpty() }
+            val nodes = tu.allEOGStarters.filter { it.prevEOGEdges.isEmpty() }
 
             for (node in nodes) {
                 walker.iterate(node)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -139,7 +139,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
         // Resolve symbols in our translation units in the order depending on their import
         // dependencies
-        component.importDependencies.sortedTranslationUnits.forEach {
+        component.translationUnitDependencies?.sorted?.forEach {
             log.debug("Resolving symbols of translation unit {}", it.name)
 
             // Gather all resolution EOG starters; and make sure they really do not have a

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/processing/strategy/Strategy.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/processing/strategy/Strategy.kt
@@ -25,11 +25,19 @@
  */
 package de.fraunhofer.aisec.cpg.processing.strategy
 
+import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import java.util.*
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /** Strategies (iterators) for traversing graphs to be used by visitors. */
 object Strategy {
+
+    val log: Logger = LoggerFactory.getLogger(Strategy::class.java)
+
     /**
      * Do not traverse any nodes.
      *
@@ -53,6 +61,26 @@ object Strategy {
     /** A strategy to traverse the EOG in forward direction, but only if the edge is reachable. */
     fun REACHABLE_EOG_FORWARD(x: Node): Iterator<Node> {
         return x.nextEOGEdges.filter { !it.unreachable }.map { it.end }.iterator()
+    }
+
+    fun COMPONENTS_LEAST_IMPORTS(x: TranslationResult): Iterator<Component> {
+        return x.componentDependencies?.sorted?.iterator()
+            ?: x.components.iterator().also {
+                log.warn(
+                    "Strategy for components with least import dependencies was requested, but no import dependency information is available."
+                )
+                log.warn("Please make sure that the ImportResolver pass was run successfully.")
+            }
+    }
+
+    fun TRANSLATION_UNITS_LEAST_IMPORTS(x: Component): Iterator<TranslationUnitDeclaration> {
+        return x.translationUnitDependencies?.sorted?.iterator()
+            ?: x.translationUnits.iterator().also {
+                log.warn(
+                    "Strategy for translation units with least import dependencies was requested, but no import dependency information is available."
+                )
+                log.warn("Please make sure that the ImportResolver pass was run successfully.")
+            }
     }
 
     /**

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/FluentTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/FluentTest.kt
@@ -176,7 +176,7 @@ class FluentTest {
         var app = result.components.firstOrNull()
         assertNotNull(app)
 
-        ImportResolver(result.finalCtx).accept(app)
+        ImportResolver(result.finalCtx).accept(result)
         EvaluationOrderGraphPass(result.finalCtx).accept(app.translationUnits.first())
         SymbolResolver(result.finalCtx).accept(app)
 

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolverTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolverTest.kt
@@ -113,25 +113,25 @@ class ImportResolverTest {
 
         // a has 0 dependencies
         var a =
-            app.translationUnitDependencies.entries
-                .filter { it.key.name.toString() == "file.a" }
-                .firstOrNull()
+            app.translationUnitDependencies?.entries?.firstOrNull {
+                it.key.name.toString() == "file.a"
+            }
         assertNotNull(a)
         assertEquals(0, a.value.size)
 
         // c has 0 dependencies
         var c =
-            app.translationUnitDependencies.entries
-                .filter { it.key.name.toString() == "file.c" }
-                .firstOrNull()
+            app.translationUnitDependencies?.entries?.firstOrNull {
+                it.key.name.toString() == "file.c"
+            }
         assertNotNull(c)
         assertEquals(0, c.value.size)
 
         // b has two dependencies (a, c)
         var b =
-            app.translationUnitDependencies.entries
-                .filter { it.key.name.toString() == "file.b" }
-                .firstOrNull()
+            app.translationUnitDependencies?.entries?.firstOrNull {
+                it.key.name.toString() == "file.b"
+            }
         assertNotNull(b)
         assertEquals(2, b.value.size)
         assertEquals(setOf(a.key, c.key), b.value)

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolverTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolverTest.kt
@@ -113,7 +113,7 @@ class ImportResolverTest {
 
         // a has 0 dependencies
         var a =
-            app.importDependencies.entries
+            app.translationUnitDependencies.entries
                 .filter { it.key.name.toString() == "file.a" }
                 .firstOrNull()
         assertNotNull(a)
@@ -121,7 +121,7 @@ class ImportResolverTest {
 
         // c has 0 dependencies
         var c =
-            app.importDependencies.entries
+            app.translationUnitDependencies.entries
                 .filter { it.key.name.toString() == "file.c" }
                 .firstOrNull()
         assertNotNull(c)
@@ -129,7 +129,7 @@ class ImportResolverTest {
 
         // b has two dependencies (a, c)
         var b =
-            app.importDependencies.entries
+            app.translationUnitDependencies.entries
                 .filter { it.key.name.toString() == "file.b" }
                 .firstOrNull()
         assertNotNull(b)


### PR DESCRIPTION
This PR makes the same import-dependencies object that is currently available on a `Component` (between TUs) available on the `TranslationResult` (between components). I decided to generalize the `ImportDependencies` class for this. This might sounds overkill but my feeling is that this might pay off at some point.

To access that information, I added two new "strategies" (`TRANSLATION_UNITS_LEAST_IMPORTS` and `COMPONENTS_LEAST_IMPORTS`). I do not really like the UPPERCASE naming on these strategies, but we probably want to change that for all of them at some point. So they are named like this for consistency.

Furthermore, `ComponentPass` passes are now executed according to the `COMPONENTS_LEAST_IMPORTS` strategy and a `TranslationUnitPass` is executed according to first the `COMPONENTS_LEAST_IMPORTS` and then the `TRANSLATION_UNITS_LEAST_IMPORTS` inside the component. This should make it harmonised for all passes. 

The most important pass to use that is the `SymbolResolver`, which now resolves symbols of components in the desired order as preparation needed for #2006.

Because the `ImportResolver` populates this map, it cannot use this strategy and I had to promote this to a `TranslationResultPass`, which I think is ok. It still gathers the information on a component level, just the entry point is the translation result.