### PR TITLE
Added `calledBy` mirrored edge in `FunctionDeclaration`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/FunctionDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/FunctionDeclaration.kt
@@ -68,6 +68,7 @@ open class FunctionDeclaration : ValueDeclaration(), DeclarationHolder, EOGStart
      * The mirror property for [CallExpression.invokeEdges]. This holds all incoming [Invokes] edges
      * from [CallExpression] nodes to this function.
      */
+    @Relationship(value = "INVOKES", direction = Relationship.Direction.INCOMING)
     val calledByEdges: Invokes<FunctionDeclaration> =
         Invokes<FunctionDeclaration>(this, CallExpression::invokeEdges, outgoing = false)
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/FunctionDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/FunctionDeclaration.kt
@@ -29,9 +29,13 @@ import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astOptionalEdgeOf
+import de.fraunhofer.aisec.cpg.graph.edges.flows.Invoke
+import de.fraunhofer.aisec.cpg.graph.edges.flows.Invokes
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
+import de.fraunhofer.aisec.cpg.graph.edges.unwrappingIncoming
 import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Block
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
@@ -59,6 +63,19 @@ open class FunctionDeclaration : ValueDeclaration(), DeclarationHolder, EOGStart
 
     @Relationship(value = "OVERRIDES", direction = Relationship.Direction.OUTGOING)
     val overrides = mutableListOf<FunctionDeclaration>()
+
+    /**
+     * The mirror property for [CallExpression.invokeEdges]. This holds all incoming [Invokes] edges
+     * from [CallExpression] nodes to this function.
+     */
+    val calledByEdges: Invokes<FunctionDeclaration> =
+        Invokes<FunctionDeclaration>(this, CallExpression::invokeEdges, outgoing = false)
+
+    /** Virtual property for accessing [calledByEdges] without property edges. */
+    val calledBy by
+        unwrappingIncoming<CallExpression, FunctionDeclaration, FunctionDeclaration, Invoke>(
+            FunctionDeclaration::calledByEdges
+        )
 
     /** The list of return types. The default is an empty list. */
     var returnTypes = listOf<Type>()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/Extensions.kt
@@ -56,6 +56,21 @@ fun <PropertyType : Node, NodeType : Node, EdgeType : Edge<PropertyType>> NodeTy
     return edge.unwrap()
 }
 
+/** See [UnwrappedEdgeList.IncomingDelegate]. */
+fun <
+    IncomingType : Node,
+    PropertyType : Node,
+    NodeType : Node,
+    EdgeType : Edge<PropertyType>,
+> NodeType.unwrappingIncoming(
+    edgeProperty: KProperty1<NodeType, EdgeList<PropertyType, EdgeType>>
+): UnwrappedEdgeList<PropertyType, EdgeType>.IncomingDelegate<NodeType, IncomingType> {
+    // Create an unwrapped container out of the edge property...
+    edgeProperty.isAccessible = true
+    val edge = edgeProperty.call(this)
+    return edge.unwrap().IncomingDelegate<NodeType, IncomingType>()
+}
+
 /** See [UnwrappedEdgeSet.Delegate]. */
 fun <PropertyType : Node, NodeType : Node, EdgeType : Edge<PropertyType>> NodeType.unwrapping(
     edgeProperty: KProperty1<NodeType, EdgeSet<PropertyType, EdgeType>>

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeList.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeList.kt
@@ -207,6 +207,7 @@ class UnwrappedEdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
      * parameter for the [Edge.end] property, but not for the [Edge.start] property. This is why we
      * need to cast the underlying [Edge.start] property to the incoming type.
      */
+    @Transient
     inner class IncomingDelegate<ThisType : Node, IncomingType>() {
         operator fun getValue(
             thisRef: ThisType,

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeList.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeList.kt
@@ -200,6 +200,32 @@ class UnwrappedEdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
         }
     }
 
+    /**
+     * Similar to [Delegate] but this employs dark voodoo magic to make an incoming list available
+     * as delegate. This is a little bit dangerous because we need to cast the unwrapped listed to
+     * the incoming type. The originating reason for this is that an [Edge] only has a generic type
+     * parameter for the [Edge.end] property, but not for the [Edge.start] property. This is why we
+     * need to cast the underlying [Edge.start] property to the incoming type.
+     */
+    inner class IncomingDelegate<ThisType : Node, IncomingType>() {
+        operator fun getValue(
+            thisRef: ThisType,
+            property: KProperty<*>,
+        ): MutableList<IncomingType> {
+            @Suppress("UNCHECKED_CAST")
+            return this@UnwrappedEdgeList as MutableList<IncomingType>
+        }
+
+        operator fun setValue(
+            thisRef: ThisType,
+            property: KProperty<*>,
+            value: List<IncomingType>,
+        ) {
+            @Suppress("UNCHECKED_CAST")
+            this@UnwrappedEdgeList.resetTo(value as Collection<NodeType>)
+        }
+    }
+
     operator fun <ThisType : Node> provideDelegate(
         thisRef: ThisType,
         prop: KProperty<*>,

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Invoke.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Invoke.kt
@@ -29,7 +29,9 @@ import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.edges.Edge
 import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeList
+import de.fraunhofer.aisec.cpg.graph.edges.collections.MirroredEdgeCollection
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
+import kotlin.reflect.KProperty
 import org.neo4j.ogm.annotation.RelationshipEntity
 
 /** This edge class denotes the invocation of a [FunctionDeclaration] by a [CallExpression]. */
@@ -59,10 +61,19 @@ class Invoke(
 }
 
 /** A container for [Usage] edges. [NodeType] is necessary because of the Neo4J OGM. */
-class Invokes<NodeType : FunctionDeclaration>(thisRef: CallExpression) :
-    EdgeList<FunctionDeclaration, Invoke>(thisRef = thisRef, init = ::Invoke) {
+class Invokes<NodeType : FunctionDeclaration>(
+    thisRef: Node,
+    override var mirrorProperty: KProperty<MutableCollection<Invoke>>,
+    outgoing: Boolean = true,
+) :
+    EdgeList<FunctionDeclaration, Invoke>(thisRef = thisRef, init = ::Invoke, outgoing = outgoing),
+    MirroredEdgeCollection<FunctionDeclaration, Invoke> {
     override fun handleOnAdd(edge: Invoke) {
+        super<MirroredEdgeCollection>.handleOnAdd(edge)
+
         // TODO: Make thisRef generic :(
-        edge.end.registerTypeObserver(thisRef as CallExpression)
+        if (outgoing) {
+            edge.end.registerTypeObserver(thisRef as CallExpression)
+        }
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
@@ -54,7 +54,12 @@ open class CallExpression :
      */
     @PopulatedByPass(SymbolResolver::class)
     @Relationship(value = "INVOKES", direction = Relationship.Direction.OUTGOING)
-    var invokeEdges = Invokes<FunctionDeclaration>(this)
+    var invokeEdges: Invokes<FunctionDeclaration> =
+        Invokes<FunctionDeclaration>(
+            this,
+            mirrorProperty = FunctionDeclaration::calledByEdges,
+            outgoing = true,
+        )
         protected set
 
     /**

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/InvokeTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/InvokeTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.graph.edges.flows
+
+import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.newCallExpression
+import de.fraunhofer.aisec.cpg.graph.newFunctionDeclaration
+import de.fraunhofer.aisec.cpg.graph.newReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class InvokeTest {
+    @Test
+    fun testMirror() {
+        with(TestLanguageFrontend()) {
+            val func = newFunctionDeclaration("myFunc")
+            val call = newCallExpression(newReference("myFunc"))
+            call.invokes += func
+
+            assertEquals(1, func.calledByEdges.size)
+
+            val edge = func.calledByEdges.firstOrNull()
+            assertNotNull(edge)
+            assertEquals(call, edge.start)
+            assertEquals(func, edge.end)
+
+            val test = func.calledBy
+            assertNotNull(test)
+            val test1 = test.firstOrNull()
+            assertNotNull(test1)
+        }
+    }
+}

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/InvokeTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/InvokeTest.kt
@@ -32,6 +32,7 @@ import de.fraunhofer.aisec.cpg.graph.newReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertSame
 
 class InvokeTest {
     @Test
@@ -45,13 +46,14 @@ class InvokeTest {
 
             val edge = func.calledByEdges.firstOrNull()
             assertNotNull(edge)
-            assertEquals(call, edge.start)
-            assertEquals(func, edge.end)
+            assertSame(call, edge.start)
+            assertSame(func, edge.end)
 
-            val test = func.calledBy
-            assertNotNull(test)
-            val test1 = test.firstOrNull()
-            assertNotNull(test1)
+            assertEquals(1, func.calledBy.size)
+            assertSame(call, func.calledBy.firstOrNull())
+
+            func.calledBy.clear()
+            assertEquals(0, call.invokes.size)
         }
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/persistence/TestCommon.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/persistence/TestCommon.kt
@@ -62,6 +62,7 @@ class TestCommon {
                 "ASSIGNED_TYPES",
                 "AST",
                 "BODY",
+                "CALLED_BY",
                 "CDG",
                 "DEFINES",
                 "DFG",

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/persistence/TestCommon.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/persistence/TestCommon.kt
@@ -62,7 +62,6 @@ class TestCommon {
                 "ASSIGNED_TYPES",
                 "AST",
                 "BODY",
-                "CALLED_BY",
                 "CDG",
                 "DEFINES",
                 "DFG",


### PR DESCRIPTION
This PR adds a mirrored `calledBy` edge in a `FunctionDeclaration` that mirrors the `invokes` edge of a `CallExpression`.