### PR TITLE
Added functions to insert a node in an existing EOG path

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/EvaluationOrder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/EvaluationOrder.kt
@@ -99,7 +99,7 @@ class EvaluationOrders<NodeType : Node>(
  * Before:
  * ```
  * <node1> -- EOG -->
- *                    <node3>
+ *                    <this>
  * <node2> -- EOG -->
  * ```
  *
@@ -108,28 +108,28 @@ class EvaluationOrders<NodeType : Node>(
  * Afterward:
  * ```
  * <node1> -- EOG -->
- *                    <new node> -- EOG --> <node3>
+ *                    <new node> -- EOG --> <this>
  * <node2> -- EOG -->
  * ```
  */
 fun Node.insertNodeBeforeInEOGPath(
     newNode: Node,
-    builder: ((EvaluationOrder) -> Unit)? = null,
+    builder: ((EvaluationOrder) -> Unit) = {},
 ): Boolean {
     // Construct a new edge from the given node to the current node
-    val edge = EvaluationOrder(newNode, this).also(builder ?: {})
+    val edge = EvaluationOrder(newNode, this).also(builder)
 
     // Make a copy of the incoming edges of the current node and set the start of the new edge as
     // the end
     val copy = this.prevEOGEdges.toList()
-    copy.forEach { it.end = edge.start }
+    copy.forEach { it.end = newNode }
 
     // Clear the incoming edges of the current node
     this.prevEOGEdges.clear()
 
     // Add the old edges as the previous edges of the new edge's start. We cannot use "addAll"
     // because otherwise our mirroring will not be triggered.
-    copy.forEach { edge.start.prevEOGEdges += it }
+    copy.forEach { newNode.prevEOGEdges += it }
 
     // Add the new edge as a previous edge of the current node
     return this.prevEOGEdges.add(edge)
@@ -142,37 +142,37 @@ fun Node.insertNodeBeforeInEOGPath(
  * Before:
  * ```
  *         -- EOG --> <node1>
- * <node3>
+ * <this>
  *         -- EOG --> <node2>
  * ```
  *
- * We want to insert a new [EvaluationOrder] edge between all outgoing edges of [this] (node3).
+ * We want to insert a new [EvaluationOrder] edge between all outgoing edges of [this].
  *
  * Afterward:
  * ```
- *                               -- EOG --> <node1>
- * <node3> -- EOG --> <new node>
- *                               -- EOG --> <node2>
+ *                              -- EOG --> <node1>
+ * <this> -- EOG --> <new node>
+ *                              -- EOG --> <node2>
  * ```
  */
 fun Node.insertNodeAfterwardInEOGPath(
     newNode: Node,
-    builder: ((EvaluationOrder) -> Unit)? = null,
+    builder: ((EvaluationOrder) -> Unit) = {},
 ): Boolean {
     // Construct a new edge from the current node to the given node
-    val edge = EvaluationOrder(this, newNode).also(builder ?: {})
+    val edge = EvaluationOrder(this, newNode).also(builder)
 
     // Make a copy of the outgoing edges of the current node and set the end of the new edge as
     // the start
     val copy = this.nextEOGEdges.toList()
-    copy.forEach { it.start = edge.end }
+    copy.forEach { it.start = newNode }
 
     // Clear the outgoing edges of the current node
     this.nextEOGEdges.clear()
 
     // Add the old edges as the next edges of the new edge's end. We cannot use "addAll" because
     // otherwise our mirroring will not be triggered.
-    copy.forEach { edge.end.nextEOGEdges += it }
+    copy.forEach { newNode.nextEOGEdges += it }
 
     // Add the new edge as a next edge of the current node
     return this.nextEOGEdges.add(edge)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/EvaluationOrder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/EvaluationOrder.kt
@@ -91,3 +91,89 @@ class EvaluationOrders<NodeType : Node>(
         outgoing = outgoing,
     ),
     MirroredEdgeCollection<Node, EvaluationOrder>
+
+/**
+ * This function inserts the given [newNode] before the current node ([this]) in its existing EOG
+ * path.
+ *
+ * Before:
+ * ```
+ * <node1> -- EOG -->
+ *                    <node3>
+ * <node2> -- EOG -->
+ * ```
+ *
+ * We want to insert a new [EvaluationOrder] edge between all incoming edges of [this] (node3).
+ *
+ * Afterward:
+ * ```
+ * <node1> -- EOG -->
+ *                    <new node> -- EOG --> <node3>
+ * <node2> -- EOG -->
+ * ```
+ */
+fun Node.insertNodeBeforeInEOGPath(
+    newNode: Node,
+    builder: ((EvaluationOrder) -> Unit)? = null,
+): Boolean {
+    // Construct a new edge from the given node to the current node
+    val edge = EvaluationOrder(newNode, this).also(builder ?: {})
+
+    // Make a copy of the incoming edges of the current node and set the start of the new edge as
+    // the end
+    val copy = this.prevEOGEdges.toList()
+    copy.forEach { it.end = edge.start }
+
+    // Clear the incoming edges of the current node
+    this.prevEOGEdges.clear()
+
+    // Add the old edges as the previous edges of the new edge's start. We cannot use "addAll"
+    // because otherwise our mirroring will not be triggered.
+    copy.forEach { edge.start.prevEOGEdges += it }
+
+    // Add the new edge as a previous edge of the current node
+    return this.prevEOGEdges.add(edge)
+}
+
+/**
+ * This function inserts the given [newNode] after the current node ([this]) in its existing EOG
+ * path.
+ *
+ * Before:
+ * ```
+ *         -- EOG --> <node1>
+ * <node3>
+ *         -- EOG --> <node2>
+ * ```
+ *
+ * We want to insert a new [EvaluationOrder] edge between all outgoing edges of [this] (node3).
+ *
+ * Afterward:
+ * ```
+ *                               -- EOG --> <node1>
+ * <node3> -- EOG --> <new node>
+ *                               -- EOG --> <node2>
+ * ```
+ */
+fun Node.insertNodeAfterwardInEOGPath(
+    newNode: Node,
+    builder: ((EvaluationOrder) -> Unit)? = null,
+): Boolean {
+    // Construct a new edge from the current node to the given node
+    val edge = EvaluationOrder(this, newNode).also(builder ?: {})
+
+    // Make a copy of the outgoing edges of the current node and set the end of the new edge as
+    // the start
+    val copy = this.nextEOGEdges.toList()
+    copy.forEach { it.start = edge.end }
+
+    // Clear the outgoing edges of the current node
+    this.nextEOGEdges.clear()
+
+    // Add the old edges as the next edges of the new edge's end. We cannot use "addAll" because
+    // otherwise our mirroring will not be triggered.
+    copy.forEach { edge.end.nextEOGEdges += it }
+
+    // Add the new edge as a next edge of the current node
+    return this.nextEOGEdges.add(edge)
+}

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/EvaluationOrderTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/EvaluationOrderTest.kt
@@ -34,18 +34,18 @@ class EvaluationOrderTest {
     fun testEvaluationOrders() {
         with(TestLanguageFrontend()) {
             // <node1> -- EOG --> <node2>
-            // this should be 1 nextDFG for node1 and 1 prevDFG for node2
-            var node1 = newLiteral(value = 1)
-            var node2 = newLiteral(value = 1)
-
+            // this should be 1 nextEOG for node1 and 1 prevEOG for node2
+            val node1 = newLiteral(value = 1)
+            val node2 = newLiteral(value = 2)
             node1.nextEOGEdges.add(node2)
-            // should contain 1 prevDFG edge now
+
+            // should contain 1 prevEOG edge now
             assertEquals(1, node2.prevEOGEdges.size)
-            // and it should be the same as the nextDFG of node1
+            // and it should be the same as the nextEOG of node1
             assertSame(node1.nextEOGEdges.firstOrNull(), node2.prevEOGEdges.firstOrNull())
 
             node1.nextEOGEdges.removeAt(0)
-            // should contain 0 prevDFG edge now
+            // should contain 0 prevEOG edge now
             assertEquals(0, node2.prevEOGEdges.size)
         }
     }
@@ -54,9 +54,9 @@ class EvaluationOrderTest {
     fun testClear() {
         with(TestLanguageFrontend()) {
             // <node1> -- EOG --> <node2>
-            // this should be 1 nextDFG for node1 and 1 prevDFG for node2
-            var node1 = newLiteral(value = 1)
-            var node2 = newLiteral(value = 1)
+            // this should be 1 nextEOG for node1 and 1 prevEOG for node2
+            val node1 = newLiteral(value = 1)
+            val node2 = newLiteral(value = 2)
 
             node1.nextEOGEdges.add(node2)
             assertEquals(1, node2.prevEOGEdges.size)
@@ -64,6 +64,105 @@ class EvaluationOrderTest {
             node1.nextEOGEdges.clear()
             // should contain 0 prevEOG edge now
             assertEquals(0, node2.prevEOGEdges.size)
+        }
+    }
+
+    @Test
+    fun testInsertBefore() {
+        with(TestLanguageFrontend()) {
+            val node1 = newLiteral(value = 1)
+            val node2 = newLiteral(value = 2)
+            val node3 = newLiteral(value = 3)
+
+            // <node1> -- EOG -->
+            //                    <node3>
+            // <node2> -- EOG -->
+            node1.nextEOGEdges += node3
+            node2.nextEOGEdges += node3
+            assertEquals(2, node3.prevEOGEdges.size, "node3 should contain 2 prevEOG edges now")
+            assertEquals(
+                setOf(node1, node2),
+                node3.prevEOG.toSet(),
+                "node3 should have node1 and node2 as prevEOG",
+            )
+
+            // Now let's insert an edge from node4 to node3 "before" node3
+            // <node1> -- EOG -->
+            //                    <node4> -- EOG --> <node3>
+            // <node2> -- EOG -->
+            val node4 = newLiteral(value = 4)
+            assertTrue(node3.insertNodeBeforeInEOGPath(node4))
+            assertEquals(1, node3.prevEOGEdges.size, "node3 should contain 1 prevEOG edge now")
+            assertSame(
+                node4,
+                node3.prevEOGEdges.singleOrNull()?.start,
+                "node4 should be the start of the single prevEOG edge of node3",
+            )
+            assertEquals(2, node4.prevEOGEdges.size, "node4 should contain 2 prevEOG edges now")
+            assertEquals(
+                setOf(node1, node2),
+                node4.prevEOG.toSet(),
+                "node4 should have node1 and node2 as prevEOG",
+            )
+            assertEquals(1, node1.nextEOGEdges.size, "node1 should contain 1 nextEOG edge now")
+            assertSame(
+                node4,
+                node1.nextEOGEdges.singleOrNull()?.end,
+                "node4 should be the end of the single nextEOG edge of node1",
+            )
+        }
+    }
+
+    @Test
+    fun testInsertAfterward() {
+        with(TestLanguageFrontend()) {
+            val node1 = newLiteral(value = 1)
+            val node2 = newLiteral(value = 2)
+            val node3 = newLiteral(value = 3)
+
+            //         -- EOG --> <node1>
+            // <node3>
+            //         -- EOG --> <node2>
+            //
+            node3.nextEOGEdges += node1
+            node3.nextEOGEdges += node2
+            assertEquals(2, node3.nextEOGEdges.size, "node3 should contain 2 nextEOG edges now")
+            assertEquals(
+                setOf(node1, node2),
+                node3.nextEOG.toSet(),
+                "node3 should have node1 and node2 as nextEOG",
+            )
+
+            // Now let's insert an edge from node3 to node4 "after" node3
+            //                               -- EOG --> <node1>
+            // <node3> -- EOG --> <node4>
+            //                               -- EOG --> <node2>
+            val node4 = newLiteral(value = 4)
+            assertTrue(node3.insertNodeAfterwardInEOGPath(node4))
+            assertEquals(1, node3.nextEOGEdges.size, "node3 should contain 1 nextEOG edge now")
+            assertSame(
+                node4,
+                node3.nextEOGEdges.singleOrNull()?.end,
+                "node4 should be the end of the single nextEOG edge of node3",
+            )
+            assertEquals(2, node4.nextEOGEdges.size, "node4 should contain 2 nextEOG edges now")
+            assertEquals(
+                setOf(node1, node2),
+                node4.nextEOG.toSet(),
+                "node4 should have node1 and node2 as nextEOG",
+            )
+            assertEquals(1, node1.prevEOGEdges.size, "node1 should contain 1 prevEOG edge now")
+            assertSame(
+                node4,
+                node1.prevEOGEdges.singleOrNull()?.start,
+                "node4 should be the start of the single prevEOG edge of node1",
+            )
+            assertEquals(1, node2.prevEOGEdges.size, "node2 should contain 1 prevEOG edge now")
+            assertSame(
+                node4,
+                node2.prevEOGEdges.singleOrNull()?.start,
+                "node4 should be the start of the single prevEOG edge of node2",
+            )
         }
     }
 }


### PR DESCRIPTION
This adds two new extension functions `insertNodeBeforeInEOGPath` and `insertNodeAfterwardInEOGPath` that insert a new node into an existing EOG path either before or after the node of reference.
