### PR TITLE
Make `printGraph` configurable with a `Strategy`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/MermaidPrinter.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/MermaidPrinter.kt
@@ -104,23 +104,10 @@ fun <EdgeType : Edge<Node>> Node.printGraph(
         )
         conns++
 
-        // Add next and prev edges to the work-list. We sort the entries by name to have this
-        // somewhat consistent across multiple invocations of this function
+        // Add start and edges to the work-list.
         strategies.forEach { strategy ->
-            when (strategy) {
-                Strategy::DFG_FORWARD_EDGES,
-                Strategy::EOG_FORWARD_EDGES -> {
-                    worklist += strategy(end).asSequence().sortedBy { it.end.name }
-                    worklist += strategy(start).asSequence().sortedBy { it.end.name }
-                }
-
-                Strategy::DFG_BACKWARD_EDGES,
-                Strategy::EOG_BACKWARD_EDGES -> {
-                    worklist += strategy(end).asSequence().sortedBy { it.start.name }
-                    worklist += strategy(start).asSequence().sortedBy { it.start.name }
-                }
-                else -> TODO("Unknown strategy received.")
-            }
+            worklist += strategy(end).asSequence().sortedBy { it.end.name }
+            worklist += strategy(start).asSequence().sortedBy { it.end.name }
         }
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/MermaidPrinter.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/MermaidPrinter.kt
@@ -25,15 +25,40 @@
  */
 package de.fraunhofer.aisec.cpg.graph
 
+import de.fraunhofer.aisec.cpg.graph.PrintDFGDirection.*
 import de.fraunhofer.aisec.cpg.graph.edges.Edge
 import de.fraunhofer.aisec.cpg.graph.edges.flows.Dataflow
 import de.fraunhofer.aisec.cpg.graph.edges.flows.PartialDataflowGranularity
 import de.fraunhofer.aisec.cpg.helpers.identitySetOf
 import kotlin.reflect.KProperty1
 
+/**
+ * Indicates the direction when building the DFG.
+ * - [FORWARD] build the DFG starting from the given node.
+ * - [BACKWARD] build the DFG ending at the given node.
+ * - [BOTH] build the DFG from and to the given node.
+ */
+enum class PrintDFGDirection {
+    FORWARD,
+    BACKWARD,
+    BOTH,
+}
+
 /** Utility function to print the DFG using [printGraph]. */
-fun Node.printDFG(maxConnections: Int = 25): String {
-    return this.printGraph(Node::nextDFGEdges, Node::prevDFGEdges, maxConnections)
+fun Node.printDFG(maxConnections: Int = 25, direction: PrintDFGDirection = BOTH): String {
+    return when (direction) {
+        FORWARD -> {
+            this.printGraph(Node::nextDFGEdges, null, maxConnections)
+        }
+
+        BACKWARD -> {
+            this.printGraph(null, Node::prevDFGEdges, maxConnections)
+        }
+
+        BOTH -> {
+            this.printGraph(Node::nextDFGEdges, Node::prevDFGEdges, maxConnections)
+        }
+    }
 }
 
 /*
@@ -54,8 +79,8 @@ fun Node.printEOG(maxConnections: Int = 25): String {
  * need to return a list of edges (as a [Edge]) beginning from this node.
  */
 fun <T : Edge<Node>> Node.printGraph(
-    nextEdgeGetter: KProperty1<Node, MutableCollection<T>>,
-    prevEdgeGetter: KProperty1<Node, MutableCollection<T>>,
+    nextEdgeGetter: KProperty1<Node, MutableCollection<T>>?,
+    prevEdgeGetter: KProperty1<Node, MutableCollection<T>>?,
     maxConnections: Int = 25,
 ): String {
     val builder = StringBuilder()
@@ -69,12 +94,17 @@ fun <T : Edge<Node>> Node.printGraph(
     val alreadySeen = identitySetOf<Edge<Node>>()
     var conns = 0
 
-    worklist.addAll(nextEdgeGetter.get(this))
+    nextEdgeGetter?.let { worklist.addAll(it.get(this)) }
+    prevEdgeGetter?.let { worklist.addAll(it.get(this)) }
 
     while (worklist.isNotEmpty() && conns < maxConnections) {
         // Take one edge out of the work-list
         val edge = worklist.first()
         worklist.remove(edge)
+
+        if (edge in alreadySeen) {
+            continue
+        }
 
         // Add it to the seen-list
         alreadySeen += edge
@@ -88,17 +118,19 @@ fun <T : Edge<Node>> Node.printGraph(
 
         // Add next and prev edges to the work-list (if not already seen). We sort the entries by
         // name to have this somewhat consistent across multiple invocations of this function
-        var next = nextEdgeGetter.get(end).filter { it !in alreadySeen }.sortedBy { it.end.name }
-        worklist += next
+        nextEdgeGetter?.let { nextEdgeGetter ->
+            worklist +=
+                nextEdgeGetter.get(end).filter { it !in alreadySeen }.sortedBy { it.end.name }
+            worklist +=
+                nextEdgeGetter.get(start).filter { it !in alreadySeen }.sortedBy { it.end.name }
+        }
 
-        var prev = prevEdgeGetter.get(end).filter { it !in alreadySeen }.sortedBy { it.start.name }
-        worklist += prev
-
-        next = nextEdgeGetter.get(start).filter { it !in alreadySeen }.sortedBy { it.end.name }
-        worklist += next
-
-        prev = prevEdgeGetter.get(start).filter { it !in alreadySeen }.sortedBy { it.start.name }
-        worklist += prev
+        prevEdgeGetter?.let { prevEdgeGetter ->
+            worklist +=
+                prevEdgeGetter.get(end).filter { it !in alreadySeen }.sortedBy { it.start.name }
+            worklist +=
+                prevEdgeGetter.get(start).filter { it !in alreadySeen }.sortedBy { it.start.name }
+        }
     }
 
     builder.append("```")

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/MermaidPrinter.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/MermaidPrinter.kt
@@ -25,40 +25,22 @@
  */
 package de.fraunhofer.aisec.cpg.graph
 
-import de.fraunhofer.aisec.cpg.graph.PrintDFGDirection.*
 import de.fraunhofer.aisec.cpg.graph.edges.Edge
 import de.fraunhofer.aisec.cpg.graph.edges.flows.Dataflow
 import de.fraunhofer.aisec.cpg.graph.edges.flows.PartialDataflowGranularity
 import de.fraunhofer.aisec.cpg.helpers.identitySetOf
-import kotlin.reflect.KProperty1
-
-/**
- * Indicates the direction when building the DFG.
- * - [FORWARD] build the DFG starting from the given node.
- * - [BACKWARD] build the DFG ending at the given node.
- * - [BOTH] build the DFG from and to the given node.
- */
-enum class PrintDFGDirection {
-    FORWARD,
-    BACKWARD,
-    BOTH,
-}
+import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 
 /** Utility function to print the DFG using [printGraph]. */
-fun Node.printDFG(maxConnections: Int = 25, direction: PrintDFGDirection = BOTH): String {
-    return when (direction) {
-        FORWARD -> {
-            this.printGraph(Node::nextDFGEdges, null, maxConnections)
-        }
-
-        BACKWARD -> {
-            this.printGraph(null, Node::prevDFGEdges, maxConnections)
-        }
-
-        BOTH -> {
-            this.printGraph(Node::nextDFGEdges, Node::prevDFGEdges, maxConnections)
-        }
-    }
+fun Node.printDFG(
+    maxConnections: Int = 25,
+    vararg strategies: (Node) -> Iterator<Edge<Node>> =
+        arrayOf<(Node) -> Iterator<Edge<Node>>>(
+            Strategy::DFG_FORWARD_EDGES,
+            Strategy::DFG_BACKWARD_EDGES,
+        ),
+): String {
+    return this.printGraph(maxConnections = maxConnections, *strategies)
 }
 
 /*
@@ -75,13 +57,13 @@ fun Node.printEOG(maxConnections: Int = 25): String {
  * issues, discussions or pull requests (see
  * https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/).
  *
- * The edge type can be specified with the [nextEdgeGetter] and [prevEdgeGetter] functions, that
- * need to return a list of edges (as a [Edge]) beginning from this node.
+ * @param strategies The strategies to use when iterating the graph. See [Strategy] for
+ *   implementations.
+ * @return The Mermaid graph as a string encapsulated in triple-backticks.
  */
-fun <T : Edge<Node>> Node.printGraph(
-    nextEdgeGetter: KProperty1<Node, MutableCollection<T>>?,
-    prevEdgeGetter: KProperty1<Node, MutableCollection<T>>?,
+fun Node.printGraph(
     maxConnections: Int = 25,
+    vararg strategies: (Node) -> Iterator<Edge<Node>>,
 ): String {
     val builder = StringBuilder()
 
@@ -94,8 +76,9 @@ fun <T : Edge<Node>> Node.printGraph(
     val alreadySeen = identitySetOf<Edge<Node>>()
     var conns = 0
 
-    nextEdgeGetter?.let { worklist.addAll(it.get(this)) }
-    prevEdgeGetter?.let { worklist.addAll(it.get(this)) }
+    strategies.forEach { strategy ->
+        worklist += strategy(this).asSequence().sortedBy { it.end.name }
+    }
 
     while (worklist.isNotEmpty() && conns < maxConnections) {
         // Take one edge out of the work-list
@@ -116,20 +99,22 @@ fun <T : Edge<Node>> Node.printGraph(
         )
         conns++
 
-        // Add next and prev edges to the work-list (if not already seen). We sort the entries by
-        // name to have this somewhat consistent across multiple invocations of this function
-        nextEdgeGetter?.let { nextEdgeGetter ->
-            worklist +=
-                nextEdgeGetter.get(end).filter { it !in alreadySeen }.sortedBy { it.end.name }
-            worklist +=
-                nextEdgeGetter.get(start).filter { it !in alreadySeen }.sortedBy { it.end.name }
-        }
+        // Add next and prev edges to the work-list. We sort the entries by name to have this
+        // somewhat consistent across multiple invocations of this function
+        strategies.forEach { strategy ->
+            when (strategy) {
+                Strategy::DFG_FORWARD_EDGES -> {
+                    worklist += strategy(end).asSequence().sortedBy { it.end.name }
+                    worklist += strategy(start).asSequence().sortedBy { it.end.name }
+                }
 
-        prevEdgeGetter?.let { prevEdgeGetter ->
-            worklist +=
-                prevEdgeGetter.get(end).filter { it !in alreadySeen }.sortedBy { it.start.name }
-            worklist +=
-                prevEdgeGetter.get(start).filter { it !in alreadySeen }.sortedBy { it.start.name }
+                Strategy::DFG_BACKWARD_EDGES -> {
+                    worklist += strategy(end).asSequence().sortedBy { it.start.name }
+                    worklist += strategy(start).asSequence().sortedBy { it.start.name }
+                }
+
+                else -> TODO("Unknown strategy received.")
+            }
         }
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/processing/strategy/Strategy.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/processing/strategy/Strategy.kt
@@ -29,6 +29,8 @@ import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
+import de.fraunhofer.aisec.cpg.graph.edges.ast.*
+import de.fraunhofer.aisec.cpg.graph.edges.astEdges
 import de.fraunhofer.aisec.cpg.graph.edges.flows.*
 import java.util.*
 import org.slf4j.Logger
@@ -130,7 +132,7 @@ object Strategy {
      * @param x Current node in DFG.
      * @return Iterator over successor edges.
      */
-    fun DFG_FORWARD_EDGES(x: Node): Iterator<Dataflow> {
+    fun DFG_EDGES_FORWARD(x: Node): Iterator<Dataflow> {
         return x.nextDFGEdges.iterator()
     }
 
@@ -140,7 +142,7 @@ object Strategy {
      * @param x Current node in DFG.
      * @return Iterator over predecessor edges.
      */
-    fun DFG_BACKWARD_EDGES(x: Node): Iterator<Dataflow> {
+    fun DFG_EDGES_BACKWARD(x: Node): Iterator<Dataflow> {
         return x.prevDFGEdges.iterator()
     }
 
@@ -150,7 +152,7 @@ object Strategy {
      * @param x Current node in EOG.
      * @return Iterator over successor edges.
      */
-    fun EOG_FORWARD_EDGES(x: Node): Iterator<EvaluationOrder> {
+    fun EOG_EDGES_FORWARD(x: Node): Iterator<EvaluationOrder> {
         return x.nextEOGEdges.iterator()
     }
 
@@ -160,7 +162,27 @@ object Strategy {
      * @param x Current node in EOG.
      * @return Iterator over predecessor edges.
      */
-    fun EOG_BACKWARD_EDGES(x: Node): Iterator<EvaluationOrder> {
+    fun EOG_EDGES_BACKWARD(x: Node): Iterator<EvaluationOrder> {
         return x.prevEOGEdges.iterator()
+    }
+
+    /**
+     * Traverse [AstEdge] edges in forward direction.
+     *
+     * @param x Current node in EOG.
+     * @return Iterator over successor edges.
+     */
+    fun AST_EDGES_FORWARD(x: Node): Iterator<AstEdge<out Node>> {
+        return x.astEdges.iterator()
+    }
+
+    /**
+     * Traverse [AstEdge] edges in forward direction.
+     *
+     * @param x Current node in EOG.
+     * @return Iterator over successor edges.
+     */
+    fun AST_EDGES_BACKWARD(x: Node): Iterator<AstEdge<out Node>> {
+        return (x.astParent?.astEdges?.filter { it.end == x } ?: emptyList()).iterator()
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/processing/strategy/Strategy.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/processing/strategy/Strategy.kt
@@ -29,7 +29,7 @@ import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
-import de.fraunhofer.aisec.cpg.graph.edges.Edge
+import de.fraunhofer.aisec.cpg.graph.edges.flows.*
 import java.util.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -130,7 +130,7 @@ object Strategy {
      * @param x Current node in DFG.
      * @return Iterator over successor edges.
      */
-    fun DFG_FORWARD_EDGES(x: Node): Iterator<Edge<Node>> {
+    fun DFG_FORWARD_EDGES(x: Node): Iterator<Dataflow> {
         return x.nextDFGEdges.iterator()
     }
 
@@ -140,9 +140,27 @@ object Strategy {
      * @param x Current node in DFG.
      * @return Iterator over predecessor edges.
      */
-    fun DFG_BACKWARD_EDGES(x: Node): Iterator<Edge<Node>> {
+    fun DFG_BACKWARD_EDGES(x: Node): Iterator<Dataflow> {
         return x.prevDFGEdges.iterator()
     }
 
-    // TODO: return Dataflows instead of Edge<Node>
+    /**
+     * Traverse [EvaluationOrder] edges in forward direction.
+     *
+     * @param x Current node in EOG.
+     * @return Iterator over successor edges.
+     */
+    fun EOG_FORWARD_EDGES(x: Node): Iterator<EvaluationOrder> {
+        return x.nextEOGEdges.iterator()
+    }
+
+    /**
+     * Traverse [EvaluationOrder] edges in backward direction.
+     *
+     * @param x Current node in EOG.
+     * @return Iterator over predecessor edges.
+     */
+    fun EOG_BACKWARD_EDGES(x: Node): Iterator<EvaluationOrder> {
+        return x.prevEOGEdges.iterator()
+    }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/processing/strategy/Strategy.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/processing/strategy/Strategy.kt
@@ -29,6 +29,7 @@ import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
+import de.fraunhofer.aisec.cpg.graph.edges.Edge
 import java.util.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -107,7 +108,7 @@ object Strategy {
      * Traverse Data Flow Graph in backward direction.
      *
      * @param x Current node in DFG.
-     * @return Iterator over successors.
+     * @return Iterator over predecessor.
      */
     fun DFG_BACKWARD(x: Node): Iterator<Node> {
         return x.prevDFG.iterator()
@@ -122,4 +123,26 @@ object Strategy {
     fun AST_FORWARD(x: Node): Iterator<Node> {
         return x.astChildren.iterator()
     }
+
+    /**
+     * Traverse Data Flow Graph in forward direction.
+     *
+     * @param x Current node in DFG.
+     * @return Iterator over successor edges.
+     */
+    fun DFG_FORWARD_EDGES(x: Node): Iterator<Edge<Node>> {
+        return x.nextDFGEdges.iterator()
+    }
+
+    /**
+     * Traverse Data Flow Graph in backward direction.
+     *
+     * @param x Current node in DFG.
+     * @return Iterator over predecessor edges.
+     */
+    fun DFG_BACKWARD_EDGES(x: Node): Iterator<Edge<Node>> {
+        return x.prevDFGEdges.iterator()
+    }
+
+    // TODO: return Dataflows instead of Edge<Node>
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/MermaidPrinterTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/MermaidPrinterTest.kt
@@ -26,7 +26,9 @@
 package de.fraunhofer.aisec.cpg.graph
 
 import de.fraunhofer.aisec.cpg.GraphExamples
+import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertNotNull
 
 class MermaidPrinterTest {
@@ -36,5 +38,25 @@ class MermaidPrinterTest {
         val sc = graph.functions["main"].variables["sc"]
         assertNotNull(sc)
         println(sc.printDFG())
+    }
+
+    @Test
+    fun testPrintAST() {
+        with(TestLanguageFrontend()) {
+            val ref = newReference("foo")
+            val call = newCallExpression(ref)
+            val lit = newLiteral(1)
+            call.arguments += lit
+            assertNotNull(ref.astParent)
+
+            // We cannot really assert the whole string since the ID of nodes is not static and
+            // therefore the hashcode is not static
+            val ast = ref.printAST()
+            println(ast)
+            assertContains(ast, "foo")
+            assertContains(ast, "CallExpression")
+            assertContains(ast, "Literal")
+            assertContains(ast, "1")
+        }
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/MermaidPrinterTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/MermaidPrinterTest.kt
@@ -37,7 +37,21 @@ class MermaidPrinterTest {
         val graph = GraphExamples.getDataflowClass()
         val sc = graph.functions["main"].variables["sc"]
         assertNotNull(sc)
-        println(sc.printDFG())
+
+        val p = sc.printDFG()
+        println(p)
+        assertContains(p, "DFG")
+    }
+
+    @Test
+    fun testPrintEOG() {
+        val graph = GraphExamples.getDataflowClass()
+        val sc = graph.functions["main"].variables["sc"]
+        assertNotNull(sc)
+
+        val p = sc.printEOG()
+        println(p)
+        assertContains(p, "EOG")
     }
 
     @Test


### PR DESCRIPTION
This PR adds a direction parameter to `printDFG`, enabling control over the DFG direction to follow.

It also adds back `printEOG` and adds a new `printAST` that uses the same technique