### PR TITLE
Add `argumentEdges` to ResolveCallExpressionAmbiguityPass

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.kt
@@ -35,6 +35,7 @@ import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
 import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeCollection
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.ConstructExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberCallExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberExpression
@@ -467,4 +468,11 @@ fun CallExpression.toMemberCallExpression(callee: MemberExpression): MemberCallE
     duplicateTo(call, callee)
 
     return call
+}
+
+fun CallExpression.toConstructExpression(callee: Reference): ConstructExpression {
+    val construct = ConstructExpression()
+    duplicateTo(construct, callee)
+
+    return construct
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveCallExpressionAmbiguityPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveCallExpressionAmbiguityPass.kt
@@ -151,8 +151,10 @@ fun SubgraphWalker.ScopedWalker.replaceCallWithConstruct(
     parent: Node,
     call: CallExpression,
 ) {
-    val construct = call.toConstructExpression(callee = call.callee as Reference)
-    construct.type = type
-
-    replace(parent, call, construct)
+    val callee = call.callee
+    if (callee is Reference) {
+        val construct = call.toConstructExpression(callee)
+        construct.type = type
+        replace(parent, call, construct)
+    }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveCallExpressionAmbiguityPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveCallExpressionAmbiguityPass.kt
@@ -40,6 +40,7 @@ import de.fraunhofer.aisec.cpg.graph.types.ObjectType
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.helpers.replace
+import de.fraunhofer.aisec.cpg.helpers.toConstructExpression
 import de.fraunhofer.aisec.cpg.nameIsType
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
 import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
@@ -150,14 +151,7 @@ fun SubgraphWalker.ScopedWalker.replaceCallWithConstruct(
     parent: Node,
     call: CallExpression,
 ) {
-    val construct = newConstructExpression()
-    construct.code = call.code
-    construct.language = call.language
-    construct.location = call.location
-    construct.callee = call.callee
-    (construct.callee as? Reference)?.resolutionHelper = construct
-    construct.arguments = call.arguments
-    construct.argumentEdges.addAll(call.argumentEdges)
+    val construct = call.toConstructExpression(callee = call.callee as Reference)
     construct.type = type
 
     replace(parent, call, construct)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveCallExpressionAmbiguityPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveCallExpressionAmbiguityPass.kt
@@ -157,6 +157,7 @@ fun SubgraphWalker.ScopedWalker.replaceCallWithConstruct(
     construct.callee = call.callee
     (construct.callee as? Reference)?.resolutionHelper = construct
     construct.arguments = call.arguments
+    construct.argumentEdges.addAll(call.argumentEdges)
     construct.type = type
 
     replace(parent, call, construct)


### PR DESCRIPTION
The PR adds the `argumentEdges` when replacing a `CallExpression` to a `ConstructExpression` ensuring that the names are also adopted