### PR TITLE
Extracting handling of python "declarations" into `DeclarationHandler`

### DIFF
--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DeclarationHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DeclarationHandler.kt
@@ -34,7 +34,6 @@ import de.fraunhofer.aisec.cpg.graph.Annotation
 import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.scopes.FunctionScope
 import de.fraunhofer.aisec.cpg.graph.scopes.RecordScope
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.AssignExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberExpression
 import de.fraunhofer.aisec.cpg.graph.types.FunctionType
@@ -48,32 +47,13 @@ import de.fraunhofer.aisec.cpg.helpers.Util
  * [DeclarationHandler], for others, the [StatementHandler] will forward these statements to us.
  */
 class DeclarationHandler(frontend: PythonLanguageFrontend) :
-    PythonHandler<Declaration, Python.AST.BaseStmt>(::ProblemDeclaration, frontend) {
-    override fun handleNode(node: Python.AST.BaseStmt): Declaration {
+    PythonHandler<Declaration, Python.AST.Def>(::ProblemDeclaration, frontend) {
+    override fun handleNode(node: Python.AST.Def): Declaration {
         return when (node) {
             is Python.AST.FunctionDef -> handleFunctionDef(node)
             is Python.AST.AsyncFunctionDef -> handleFunctionDef(node)
             is Python.AST.ClassDef -> handleClassDef(node)
-            else -> {
-                return handleNotSupported(node, node.javaClass.simpleName)
-            }
         }
-    }
-
-    private fun handleNotSupported(node: Python.AST.BaseStmt, name: String): Declaration {
-        Util.errorWithFileLocation(
-            frontend,
-            node,
-            log,
-            "Parsing of type $name is not supported (yet)",
-        )
-
-        val cpgNode = this.configConstructor.get()
-        if (cpgNode is ProblemNode) {
-            cpgNode.problem = "Parsing of type $name is not supported (yet)"
-        }
-
-        return cpgNode
     }
 
     /**
@@ -95,7 +75,7 @@ class DeclarationHandler(frontend: PythonLanguageFrontend) :
             when (s) {
                 // In order to be as compatible as possible with existing languages, we try to add
                 // declarations directly to the class
-                is Python.AST.WithDeclaration -> handle(s)
+                is Python.AST.Def -> handle(s)
                 // All other statements are added to the statements block of the class
                 else -> cls.statements += frontend.statementHandler.handle(s)
             }

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DeclarationHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DeclarationHandler.kt
@@ -40,7 +40,7 @@ import de.fraunhofer.aisec.cpg.graph.types.FunctionType
 import de.fraunhofer.aisec.cpg.helpers.Util
 
 /**
- * In Python, all declarations are statements. This class handles the parsing of the statements
+ * In Python, all definitions/declarations are statements. This class handles the parsing of [Python.AST.Def] nodes to be
  * represented as [Declaration] nodes in our CPG.
  *
  * For declarations encountered directly on a namespace and classes, we directly invoke the

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DeclarationHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DeclarationHandler.kt
@@ -40,8 +40,8 @@ import de.fraunhofer.aisec.cpg.graph.types.FunctionType
 import de.fraunhofer.aisec.cpg.helpers.Util
 
 /**
- * In Python, all definitions/declarations are statements. This class handles the parsing of [Python.AST.Def] nodes to be
- * represented as [Declaration] nodes in our CPG.
+ * In Python, all definitions/declarations are statements. This class handles the parsing of
+ * [Python.AST.Def] nodes to be represented as [Declaration] nodes in our CPG.
  *
  * For declarations encountered directly on a namespace and classes, we directly invoke the
  * [DeclarationHandler], for others, the [StatementHandler] will forward these statements to us.

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DeclarationHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DeclarationHandler.kt
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2025, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.frontends.python
+
+import de.fraunhofer.aisec.cpg.frontends.HasOperatorOverloading
+import de.fraunhofer.aisec.cpg.frontends.isKnownOperatorName
+import de.fraunhofer.aisec.cpg.frontends.python.PythonLanguage.Companion.MODIFIER_KEYWORD_ONLY_ARGUMENT
+import de.fraunhofer.aisec.cpg.frontends.python.PythonLanguage.Companion.MODIFIER_POSITIONAL_ONLY_ARGUMENT
+import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.declarations.*
+import de.fraunhofer.aisec.cpg.graph.scopes.FunctionScope
+import de.fraunhofer.aisec.cpg.graph.scopes.RecordScope
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
+import de.fraunhofer.aisec.cpg.graph.types.FunctionType
+import de.fraunhofer.aisec.cpg.helpers.Util
+
+/**
+ * In Python, all declarations are statements. This class handles the parsing of the statements
+ * represented as [Declaration] nodes in our CPG.
+ *
+ * For declarations encountered directly on a namespace and classes, we directly invoke the
+ * [DeclarationHandler], for others, the [StatementHandler] will forward these statements to us.
+ */
+class DeclarationHandler(frontend: PythonLanguageFrontend) :
+    PythonHandler<Declaration, Python.AST.BaseStmt>(::ProblemDeclaration, frontend) {
+    override fun handleNode(node: Python.AST.BaseStmt): Declaration {
+        return when (node) {
+            is Python.AST.FunctionDef -> handleFunctionDef(node)
+            is Python.AST.AsyncFunctionDef -> handleFunctionDef(node)
+            else -> {
+                return handleNotSupported(node, node.javaClass.simpleName)
+            }
+        }
+    }
+
+    private fun handleNotSupported(node: Python.AST.BaseStmt, name: String): Declaration {
+        Util.errorWithFileLocation(
+            frontend,
+            node,
+            log,
+            "Parsing of type $name is not supported (yet)",
+        )
+
+        val cpgNode = this.configConstructor.get()
+        if (cpgNode is ProblemNode) {
+            cpgNode.problem = "Parsing of type $name is not supported (yet)"
+        }
+
+        return cpgNode
+    }
+
+    /**
+     * We have to consider multiple things when matching Python's FunctionDef to the CPG:
+     * - A [Python.AST.FunctionDef] could be one of
+     *     - a [ConstructorDeclaration] if it appears in a record and its [name] is `__init__`
+     *     - a [MethodeDeclaration] if it appears in a record, and it isn't a
+     *       [ConstructorDeclaration]
+     *     - a [FunctionDeclaration] if neither of the above apply
+     *
+     * In case of a [ConstructorDeclaration] or[MethodDeclaration]: the first argument is the
+     * `receiver` (most often called `self`).
+     */
+    private fun handleFunctionDef(s: Python.AST.NormalOrAsyncFunctionDef): FunctionDeclaration {
+        var recordDeclaration =
+            (frontend.scopeManager.currentScope as? RecordScope)?.astNode as? RecordDeclaration
+        val language = language
+        val result =
+            if (recordDeclaration != null) {
+                if (s.name == "__init__") {
+                    newConstructorDeclaration(
+                        name = s.name,
+                        recordDeclaration = recordDeclaration,
+                        rawNode = s,
+                    )
+                } else if (language is HasOperatorOverloading && s.name.isKnownOperatorName) {
+                    var decl =
+                        newOperatorDeclaration(
+                            name = s.name,
+                            recordDeclaration = recordDeclaration,
+                            operatorCode = language.operatorCodeFor(s.name) ?: "",
+                            rawNode = s,
+                        )
+                    if (decl.operatorCode == "") {
+                        Util.warnWithFileLocation(
+                            decl,
+                            log,
+                            "Could not find operator code for operator {}. This will most likely result in a failure",
+                            s.name,
+                        )
+                    }
+                    decl
+                } else {
+                    newMethodDeclaration(
+                        name = s.name,
+                        recordDeclaration = recordDeclaration,
+                        isStatic = false,
+                        rawNode = s,
+                    )
+                }
+            } else {
+                newFunctionDeclaration(name = s.name, rawNode = s)
+            }
+        frontend.scopeManager.enterScope(result)
+
+        frontend.statementHandler.addAsyncWarning(s, result)
+
+        // Handle decorators (which are translated into CPG "annotations")
+        result.annotations += frontend.statementHandler.handleAnnotations(s)
+
+        // Handle return type and calculate function type
+        if (result is ConstructorDeclaration) {
+            // Return type of the constructor is always its record declaration type
+            result.returnTypes = listOf(recordDeclaration?.toType() ?: unknownType())
+        } else {
+            result.returnTypes = listOf(frontend.typeOf(s.returns))
+        }
+        result.type = FunctionType.computeType(result)
+
+        handleArguments(s.args, result, recordDeclaration)
+
+        if (s.body.isNotEmpty()) {
+            result.body = frontend.statementHandler.makeBlock(s.body, parentNode = s)
+        }
+
+        frontend.scopeManager.leaveScope(result)
+
+        // We want functions inside functions to be wrapped in a declaration statement, so we are
+        // not adding them to scope's AST
+        if (frontend.scopeManager.currentScope is FunctionScope) {
+            frontend.scopeManager.addDeclaration(result, addToAST = false)
+        } else {
+            // In any other cases, we add them to the "declarations", otherwise we will not
+            // correctly resolve them.
+            frontend.scopeManager.addDeclaration(result)
+        }
+
+        return result
+    }
+
+    /** Adds the arguments to [result] which might be located in a [recordDeclaration]. */
+    private fun handleArguments(
+        args: Python.AST.arguments,
+        result: FunctionDeclaration,
+        recordDeclaration: RecordDeclaration?,
+    ) {
+        // We can merge posonlyargs and args because both are positional arguments. We do not
+        // enforce that posonlyargs can ONLY be used in a positional style, whereas args can be used
+        // both in positional and keyword style.
+        var positionalArguments = args.posonlyargs + args.args
+
+        // Handle receiver if it exists and if it is not a static method
+        if (
+            recordDeclaration != null &&
+                result.annotations.none { it.name.localName == "staticmethod" }
+        ) {
+            handleReceiverArgument(positionalArguments, args, result, recordDeclaration)
+            // Skip the receiver argument for further processing
+            positionalArguments = positionalArguments.drop(1)
+        }
+
+        // Handle remaining arguments
+        handlePositionalArguments(positionalArguments, args)
+
+        args.vararg?.let { handleArgument(it, isPosOnly = false, isVariadic = true) }
+        args.kwarg?.let { handleArgument(it, isPosOnly = false, isVariadic = false) }
+
+        handleKeywordOnlyArguments(args)
+    }
+
+    /**
+     * This function creates a [newParameterDeclaration] for the argument, setting any modifiers
+     * (like positional-only or keyword-only) and [defaultValue] if applicable.
+     */
+    internal fun handleArgument(
+        node: Python.AST.arg,
+        isPosOnly: Boolean = false,
+        isVariadic: Boolean = false,
+        isKwoOnly: Boolean = false,
+        defaultValue: Expression? = null,
+    ): ParameterDeclaration {
+        val type = frontend.typeOf(node.annotation)
+        val arg =
+            newParameterDeclaration(
+                name = node.arg,
+                type = type,
+                variadic = isVariadic,
+                rawNode = node,
+            )
+        defaultValue?.let { arg.default = it }
+        if (isPosOnly) {
+            arg.modifiers += MODIFIER_POSITIONAL_ONLY_ARGUMENT
+        }
+
+        if (isKwoOnly) {
+            arg.modifiers += MODIFIER_KEYWORD_ONLY_ARGUMENT
+        }
+
+        frontend.scopeManager.addDeclaration(arg)
+
+        return arg
+    }
+
+    /**
+     * This method retrieves the first argument of the [positionalArguments], which is typically the
+     * receiver object.
+     *
+     * A receiver can also have a default value. However, this case is not handled and is therefore
+     * passed with a problem expression.
+     */
+    private fun handleReceiverArgument(
+        positionalArguments: List<Python.AST.arg>,
+        args: Python.AST.arguments,
+        result: FunctionDeclaration,
+        recordDeclaration: RecordDeclaration,
+    ) {
+        // first argument is the receiver
+        val recvPythonNode = positionalArguments.firstOrNull()
+        if (recvPythonNode == null) {
+            result.additionalProblems += newProblemExpression("Expected a receiver", rawNode = args)
+        } else {
+            val tpe = recordDeclaration.toType()
+            val recvNode =
+                newVariableDeclaration(
+                    name = recvPythonNode.arg,
+                    type = tpe,
+                    implicitInitializerAllowed = false,
+                    rawNode = recvPythonNode,
+                )
+
+            // If the number of defaults equals the number of positional arguments, the receiver has
+            // a default value
+            if (args.defaults.size == positionalArguments.size) {
+                val defaultValue =
+                    args.defaults.getOrNull(0)?.let { frontend.expressionHandler.handle(it) }
+                defaultValue?.let {
+                    frontend.scopeManager.addDeclaration(recvNode)
+                    result.additionalProblems +=
+                        newProblemExpression("Receiver with default value", rawNode = args)
+                }
+            }
+
+            when (result) {
+                is ConstructorDeclaration,
+                is MethodDeclaration -> result.receiver = recvNode
+                else ->
+                    result.additionalProblems +=
+                        newProblemExpression(
+                            problem =
+                                "Expected a constructor or method declaration. Got something else.",
+                            rawNode = result,
+                        )
+            }
+        }
+    }
+
+    /**
+     * This method extracts the [positionalArguments] including those that may have default values.
+     *
+     * In Python only the arguments with default values are stored in `args.defaults`.
+     * https://docs.python.org/3/library/ast.html#ast.arguments
+     *
+     * For example: `def my_func(a, b=1, c=2): pass`
+     *
+     * In this case, `args.defaults` contains only the defaults for `b` and `c`, while `args.args`
+     * includes all arguments (`a`, `b` and `c`). The number of arguments without defaults is
+     * determined by subtracting the size of `args.defaults` from the total number of arguments.
+     * This matches each default to its corresponding argument.
+     *
+     * From the Python docs: "If there are fewer defaults, they correspond to the last n arguments."
+     */
+    private fun handlePositionalArguments(
+        positionalArguments: List<Python.AST.arg>,
+        args: Python.AST.arguments,
+    ) {
+        val nonDefaultArgsCount = positionalArguments.size - args.defaults.size
+
+        for (idx in positionalArguments.indices) {
+            val arg = positionalArguments[idx]
+            val defaultIndex = idx - nonDefaultArgsCount
+            val defaultValue =
+                if (defaultIndex >= 0) {
+                    args.defaults.getOrNull(defaultIndex)?.let {
+                        frontend.expressionHandler.handle(it)
+                    }
+                } else {
+                    null
+                }
+            handleArgument(arg, isPosOnly = arg in args.posonlyargs, defaultValue = defaultValue)
+        }
+    }
+
+    /**
+     * This method extracts the keyword-only arguments from [args] and maps them to the
+     * corresponding function parameters.
+     */
+    private fun handleKeywordOnlyArguments(args: Python.AST.arguments) {
+        for (idx in args.kwonlyargs.indices) {
+            val arg = args.kwonlyargs[idx]
+            val default = args.kw_defaults.getOrNull(idx)
+            handleArgument(
+                arg,
+                isPosOnly = false,
+                isKwoOnly = true,
+                defaultValue = default?.let { frontend.expressionHandler.handle(it) },
+            )
+        }
+    }
+}

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/ExpressionHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/ExpressionHandler.kt
@@ -568,7 +568,7 @@ class ExpressionHandler(frontend: PythonLanguageFrontend) :
         val function = newFunctionDeclaration(name = "", rawNode = node)
         frontend.scopeManager.enterScope(function)
         for (arg in node.args.args) {
-            this.frontend.statementHandler.handleArgument(arg)
+            this.frontend.declarationHandler.handleArgument(arg)
         }
         function.body = handle(node.body)
         frontend.scopeManager.leaveScope(function)

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/Python.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/Python.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.frontends.python
 
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
+import de.fraunhofer.aisec.cpg.graph.statements.Statement
 import jep.python.PyObject
 
 /**
@@ -60,12 +61,19 @@ interface Python {
     interface AST {
 
         /**
+         * Represents a `ast.AST` node as returned by Python's `ast` parser.
+         *
+         * @param pyObject The Python object returned by jep.
+         */
+        interface AST {
+            var pyObject: PyObject
+        }
+
+        /**
          * Some nodes, such as `ast.stmt` [AST.BaseStmt] and `ast.expr` [AST.BaseExpr] nodes have
          * extra location properties as implemented here.
          */
-        interface WithLocation { // TODO make the fields accessible `by lazy`
-            val pyObject: PyObject
-
+        interface WithLocation : AST { // TODO make the fields accessible `by lazy`
             /** Maps to the `lineno` filed from Python's ast. */
             val lineno: Int
                 get() {
@@ -92,21 +100,15 @@ interface Python {
         }
 
         /**
-         * Python does not really have "declarations", but rather these are also [AST.BaseStmt]s.
-         * But in order to be compatible with the remaining languages we need to ensure that
-         * elements such as functions or classes, still turn out to be [Declaration]s.
+         * Python does not really have "declarations", but it has "definitions". Instead of having
+         * their own AST class, they are also [AST.BaseStmt]s. In order to be compatible with the
+         * remaining languages we need to ensure that elements such as functions or classes, still
+         * turn out to be [Declaration]s, not [Statement]s
          *
          * This interface should be attached to all such statements that we consider to be
-         * declarations.
+         * definitions, and thus [Declaration]s.
          */
-        sealed interface WithDeclaration
-
-        /**
-         * Represents a `ast.AST` node as returned by Python's `ast` parser.
-         *
-         * @param pyObject The Python object returned by jep.
-         */
-        abstract class AST(pyObject: PyObject) : BaseObject(pyObject)
+        sealed interface Def : AST
 
         /**
          * ```
@@ -119,7 +121,7 @@ interface Python {
          *
          * Note: We currently only support `Module`s.
          */
-        abstract class BaseMod(pyObject: PyObject) : AST(pyObject)
+        abstract class BaseMod(pyObject: PyObject) : AST, BaseObject(pyObject)
 
         /**
          * ```
@@ -127,7 +129,7 @@ interface Python {
          *  |  Module(stmt* body, type_ignore* type_ignores)
          * ```
          */
-        class Module(pyObject: PyObject) : AST(pyObject) {
+        class Module(pyObject: PyObject) : AST, BaseObject(pyObject) {
             val body: kotlin.collections.List<BaseStmt> by lazy { "body" of pyObject }
 
             val type_ignores: kotlin.collections.List<type_ignore> by lazy {
@@ -167,7 +169,7 @@ interface Python {
          *  |  | Continue
          * ```
          */
-        sealed class BaseStmt(pyObject: PyObject) : AST(pyObject), WithLocation
+        sealed class BaseStmt(pyObject: PyObject) : AST, BaseObject(pyObject), WithLocation
 
         /**
          * Several classes are duplicated in the python AST for async and non-async variants. This
@@ -183,7 +185,7 @@ interface Python {
          * However, they are so similar, that we make use of this interface to avoid a lot of
          * duplicate code.
          */
-        sealed interface NormalOrAsyncFunctionDef : AsyncOrNot, WithDeclaration {
+        sealed interface NormalOrAsyncFunctionDef : AsyncOrNot, Def {
             val name: String
             val args: arguments
             val body: kotlin.collections.List<BaseStmt>
@@ -243,7 +245,7 @@ interface Python {
          *  |  ClassDef(identifier name, expr* bases, keyword* keywords, stmt* body, expr* decorator_list)
          * ```
          */
-        class ClassDef(pyObject: PyObject) : BaseStmt(pyObject), WithDeclaration {
+        class ClassDef(pyObject: PyObject) : BaseStmt(pyObject), Def {
             val name: String by lazy { "name" of pyObject }
 
             val bases: kotlin.collections.List<BaseExpr> by lazy { "bases" of pyObject }
@@ -564,7 +566,7 @@ interface Python {
          *
          * ast.expr = class expr(AST)
          */
-        sealed class BaseExpr(pyObject: PyObject) : AST(pyObject), WithLocation
+        sealed class BaseExpr(pyObject: PyObject) : AST, BaseObject(pyObject), WithLocation
 
         /**
          * ```
@@ -883,7 +885,7 @@ interface Python {
          *  |  boolop = And | Or
          * ```
          */
-        sealed class BaseBoolOp(pyObject: PyObject) : AST(pyObject)
+        sealed class BaseBoolOp(pyObject: PyObject) : AST, BaseObject(pyObject)
 
         /**
          * ```
@@ -906,7 +908,7 @@ interface Python {
          *  |  cmpop = Eq | NotEq | Lt | LtE | Gt | GtE | Is | IsNot | In | NotIn
          * ```
          */
-        sealed class BaseCmpOp(pyObject: PyObject) : AST(pyObject)
+        sealed class BaseCmpOp(pyObject: PyObject) : AST, BaseObject(pyObject)
 
         /**
          * ```
@@ -994,7 +996,7 @@ interface Python {
          *  |  expr_context = Load | Store | Del
          * ```
          */
-        sealed class BaseExprContext(pyObject: PyObject) : AST(pyObject)
+        sealed class BaseExprContext(pyObject: PyObject) : AST, BaseObject(pyObject)
 
         /**
          * ```
@@ -1026,7 +1028,7 @@ interface Python {
          *  |  operator = Add | Sub | Mult | MatMult | Div | Mod | Pow | LShift | RShift | BitOr | BitXor | BitAnd | FloorDiv
          * ```
          */
-        sealed class BaseOperator(pyObject: PyObject) : AST(pyObject)
+        sealed class BaseOperator(pyObject: PyObject) : AST, BaseObject(pyObject)
 
         /**
          * ```
@@ -1145,7 +1147,7 @@ interface Python {
          *  |  | MatchOr(pattern* patterns)
          * ```
          */
-        abstract class BasePattern(pyObject: PyObject) : AST(pyObject), WithLocation
+        abstract class BasePattern(pyObject: PyObject) : AST, BaseObject(pyObject), WithLocation
 
         /**
          * ```
@@ -1246,7 +1248,7 @@ interface Python {
          *  |  unaryop = Invert | Not | UAdd | USub
          * ```
          */
-        sealed class BaseUnaryOp(pyObject: PyObject) : AST(pyObject)
+        sealed class BaseUnaryOp(pyObject: PyObject) : AST, BaseObject(pyObject)
 
         /**
          * ```
@@ -1286,7 +1288,7 @@ interface Python {
          *  |  alias(identifier name, identifier? asname)
          * ```
          */
-        class alias(pyObject: PyObject) : AST(pyObject), WithLocation {
+        class alias(pyObject: PyObject) : AST, BaseObject(pyObject), WithLocation {
             val name: String by lazy { "name" of pyObject }
             val asname: String? by lazy { "asname" of pyObject }
         }
@@ -1297,7 +1299,7 @@ interface Python {
          *  |  arg(identifier arg, expr? annotation, string? type_comment)
          * ```
          */
-        class arg(pyObject: PyObject) : AST(pyObject), WithLocation {
+        class arg(pyObject: PyObject) : AST, BaseObject(pyObject), WithLocation {
             val arg: String by lazy { "arg" of pyObject }
             val annotation: BaseExpr? by lazy { "annotation" of pyObject }
             val type_comment: String? by lazy { "type_comment" of pyObject }
@@ -1309,7 +1311,7 @@ interface Python {
          *  |  arguments(arg* posonlyargs, arg* args, arg? vararg, arg* kwonlyargs, expr* kw_defaults, arg? kwarg, expr* defaults)
          * ```
          */
-        class arguments(pyObject: PyObject) : AST(pyObject) {
+        class arguments(pyObject: PyObject) : AST, BaseObject(pyObject) {
             val posonlyargs: kotlin.collections.List<arg> by lazy { "posonlyargs" of pyObject }
             val args: kotlin.collections.List<arg> by lazy { "args" of pyObject }
             val vararg: arg? by lazy { "vararg" of pyObject }
@@ -1325,7 +1327,7 @@ interface Python {
          *  |  comprehension(expr target, expr iter, expr* ifs, int is_async)
          * ```
          */
-        class comprehension(pyObject: PyObject) : AST(pyObject) {
+        class comprehension(pyObject: PyObject) : AST, BaseObject(pyObject) {
             val target: BaseExpr by lazy { "target" of pyObject }
             val iter: BaseExpr by lazy { "iter" of pyObject }
             val ifs: kotlin.collections.List<BaseExpr> by lazy { "ifs" of pyObject }
@@ -1338,7 +1340,8 @@ interface Python {
          *  |  excepthandler = ExceptHandler(expr? type, identifier? name, stmt* body)
          * ```
          */
-        sealed class BaseExcepthandler(python: PyObject) : AST(python), WithLocation
+        sealed class BaseExcepthandler(pyObject: PyObject) :
+            AST, BaseObject(pyObject), WithLocation
 
         /**
          * ast.ExceptHandler = class ExceptHandler(excepthandler) | ExceptHandler(expr? type,
@@ -1356,7 +1359,7 @@ interface Python {
          *  |  keyword(identifier? arg, expr value)
          * ```
          */
-        class keyword(pyObject: PyObject) : AST(pyObject), WithLocation {
+        class keyword(pyObject: PyObject) : AST, BaseObject(pyObject), WithLocation {
             val arg: String? by lazy { "arg" of pyObject }
             val value: BaseExpr by lazy { "value" of pyObject }
         }
@@ -1367,7 +1370,7 @@ interface Python {
          *  |  match_case(pattern pattern, expr? guard, stmt* body)
          * ```
          */
-        class match_case(pyObject: PyObject) : AST(pyObject) {
+        class match_case(pyObject: PyObject) : AST, BaseObject(pyObject) {
             val pattern: BasePattern by lazy { "pattern" of pyObject }
             val guard: BaseExpr? by lazy { "guard" of pyObject }
             val body: kotlin.collections.List<BaseStmt> by lazy { "body" of pyObject }
@@ -1381,7 +1384,7 @@ interface Python {
          *
          * TODO
          */
-        class type_ignore(pyObject: PyObject) : AST(pyObject)
+        class type_ignore(pyObject: PyObject) : AST, BaseObject(pyObject)
 
         /**
          * ```
@@ -1389,7 +1392,7 @@ interface Python {
          *  |  withitem(expr context_expr, expr? optional_vars)
          * ```
          */
-        class withitem(pyObject: PyObject) : AST(pyObject) {
+        class withitem(pyObject: PyObject) : AST, BaseObject(pyObject) {
             val context_expr: BaseExpr by lazy { "context_expr" of pyObject }
             val optional_vars: BaseExpr? by lazy { "optional_vars" of pyObject }
         }

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/Python.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/Python.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.frontends.python
 
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import jep.python.PyObject
 
 /**
@@ -89,6 +90,16 @@ interface Python {
                     return (pyObject.getAttr("end_col_offset") as? Long)?.toInt() ?: TODO()
                 }
         }
+
+        /**
+         * Python does not really have "declarations", but rather these are also [AST.BaseStmt]s.
+         * But in order to be compatible with the remaining languages we need to ensure that
+         * elements such as functions or classes, still turn out to be [Declaration]s.
+         *
+         * This interface should be attached to all such statements that we consider to be
+         * declarations.
+         */
+        interface WithDeclaration {}
 
         /**
          * Represents a `ast.AST` node as returned by Python's `ast` parser.
@@ -172,7 +183,7 @@ interface Python {
          * However, they are so similar, that we make use of this interface to avoid a lot of
          * duplicate code.
          */
-        interface NormalOrAsyncFunctionDef : AsyncOrNot {
+        interface NormalOrAsyncFunctionDef : AsyncOrNot, WithDeclaration {
             val name: String
             val args: arguments
             val body: kotlin.collections.List<BaseStmt>
@@ -232,7 +243,7 @@ interface Python {
          *  |  ClassDef(identifier name, expr* bases, keyword* keywords, stmt* body, expr* decorator_list)
          * ```
          */
-        class ClassDef(pyObject: PyObject) : BaseStmt(pyObject) {
+        class ClassDef(pyObject: PyObject) : BaseStmt(pyObject), WithDeclaration {
             val name: String by lazy { "name" of pyObject }
 
             val bases: kotlin.collections.List<BaseExpr> by lazy { "bases" of pyObject }

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/Python.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/Python.kt
@@ -99,7 +99,7 @@ interface Python {
          * This interface should be attached to all such statements that we consider to be
          * declarations.
          */
-        interface WithDeclaration {}
+        sealed interface WithDeclaration
 
         /**
          * Represents a `ast.AST` node as returned by Python's `ast` parser.
@@ -173,17 +173,17 @@ interface Python {
          * Several classes are duplicated in the python AST for async and non-async variants. This
          * interface is a common interface for those AST classes.
          */
-        interface AsyncOrNot : WithLocation
+        sealed interface AsyncOrNot : WithLocation
 
         /** This interface denotes that this is an "async" node. */
-        interface IsAsync : AsyncOrNot
+        sealed interface IsAsync : AsyncOrNot
 
         /**
          * ast.FunctionDef and ast.AsyncFunctionDef are not related according to the Python syntax.
          * However, they are so similar, that we make use of this interface to avoid a lot of
          * duplicate code.
          */
-        interface NormalOrAsyncFunctionDef : AsyncOrNot, WithDeclaration {
+        sealed interface NormalOrAsyncFunctionDef : AsyncOrNot, WithDeclaration {
             val name: String
             val args: arguments
             val body: kotlin.collections.List<BaseStmt>

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
@@ -346,7 +346,14 @@ class PythonLanguageFrontend(language: Language<PythonLanguageFrontend>, ctx: Tr
 
         if (lastNamespace != null) {
             for (stmt in pythonASTModule.body) {
-                lastNamespace.statements += statementHandler.handle(stmt)
+                when (stmt) {
+                    // In order to be as compatible as possible with existing languages, we try to
+                    // add declarations directly to the class
+                    is Python.AST.WithDeclaration -> declarationHandler.handle(stmt)
+                    // All other statements are added to the (static) statements block of the
+                    // namespace.
+                    else -> lastNamespace.statements += statementHandler.handle(stmt)
+                }
             }
         }
 

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
@@ -349,7 +349,7 @@ class PythonLanguageFrontend(language: Language<PythonLanguageFrontend>, ctx: Tr
                 when (stmt) {
                     // In order to be as compatible as possible with existing languages, we try to
                     // add declarations directly to the class
-                    is Python.AST.WithDeclaration -> declarationHandler.handle(stmt)
+                    is Python.AST.Def -> declarationHandler.handle(stmt)
                     // All other statements are added to the (static) statements block of the
                     // namespace.
                     else -> lastNamespace.statements += statementHandler.handle(stmt)

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
@@ -71,13 +71,12 @@ class PythonLanguageFrontend(language: Language<PythonLanguageFrontend>, ctx: Tr
     private val tokenTypeIndex = 0
     private val jep = JepSingleton // configure Jep
 
-    // val declarationHandler = DeclarationHandler(this)
-    // val specificationHandler = SpecificationHandler(this)
+    internal val declarationHandler = DeclarationHandler(this)
     internal var statementHandler = StatementHandler(this)
     internal var expressionHandler = ExpressionHandler(this)
 
     /**
-     * fileContent contains the whole file can be stored as a class field because the CPG creates a
+     * fileContent contains the whole file ca be stored as a class field because the CPG creates a
      * new [PythonLanguageFrontend] instance per file.
      */
     private lateinit var fileContent: String

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/StatementHandler.kt
@@ -25,11 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.frontends.python
 
-import de.fraunhofer.aisec.cpg.frontends.HasOperatorOverloading
-import de.fraunhofer.aisec.cpg.frontends.isKnownOperatorName
 import de.fraunhofer.aisec.cpg.frontends.python.Python.AST.IsAsync
-import de.fraunhofer.aisec.cpg.frontends.python.PythonLanguage.Companion.MODIFIER_KEYWORD_ONLY_ARGUMENT
-import de.fraunhofer.aisec.cpg.frontends.python.PythonLanguage.Companion.MODIFIER_POSITIONAL_ONLY_ARGUMENT
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.Annotation
 import de.fraunhofer.aisec.cpg.graph.declarations.*
@@ -45,7 +41,6 @@ import de.fraunhofer.aisec.cpg.graph.statements.ForEachStatement
 import de.fraunhofer.aisec.cpg.graph.statements.Statement
 import de.fraunhofer.aisec.cpg.graph.statements.TryStatement
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
-import de.fraunhofer.aisec.cpg.graph.types.FunctionType
 import de.fraunhofer.aisec.cpg.helpers.Util
 import kotlin.collections.plusAssign
 
@@ -55,8 +50,6 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
     override fun handleNode(node: Python.AST.BaseStmt): Statement {
         return when (node) {
             is Python.AST.ClassDef -> handleClassDef(node)
-            is Python.AST.FunctionDef -> handleFunctionDef(node)
-            is Python.AST.AsyncFunctionDef -> handleFunctionDef(node)
             is Python.AST.Pass -> return newEmptyStatement(rawNode = node)
             is Python.AST.ImportFrom -> handleImportFrom(node)
             is Python.AST.Assign -> handleAssign(node)
@@ -85,6 +78,10 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
                     problem = "The statement of class ${node.javaClass} is not supported yet",
                     rawNode = node,
                 )
+            is Python.AST.AsyncFunctionDef ->
+                wrapDeclarationToStatement(frontend.declarationHandler.handleNode(node))
+            is Python.AST.FunctionDef ->
+                wrapDeclarationToStatement(frontend.declarationHandler.handleNode(node))
         }
     }
 
@@ -825,11 +822,9 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
 
         for (s in stmt.body) {
             when (s) {
-                is Python.AST.FunctionDef -> {
-                    val stmt = handleFunctionDef(s, cls)
-                    // We need to manually set the astParent because we are not assigning it to our
-                    // statements and therefore are not triggering our automagic parent setter
-                    stmt.astParent = cls
+                is Python.AST.FunctionDef,
+                is Python.AST.AsyncFunctionDef -> {
+                    frontend.declarationHandler.handleNode(s)
                 }
                 else -> cls.statements += handleNode(s)
             }
@@ -839,88 +834,6 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
         frontend.scopeManager.addDeclaration(cls)
 
         return wrapDeclarationToStatement(cls)
-    }
-
-    /**
-     * We have to consider multiple things when matching Python's FunctionDef to the CPG:
-     * - A [Python.AST.FunctionDef] is a [Statement] from Python's point of view. The CPG sees it as
-     *   a declaration -> we have to wrap the result in a [DeclarationStatement].
-     * - A [Python.AST.FunctionDef] could be one of
-     *     - a [ConstructorDeclaration] if it appears in a record and its [name] is `__init__`
-     *     - a [MethodeDeclaration] if it appears in a record, and it isn't a
-     *       [ConstructorDeclaration]
-     *     - a [FunctionDeclaration] if neither of the above apply
-     *
-     * In case of a [ConstructorDeclaration] or[MethodDeclaration]: the first argument is the
-     * `receiver` (most often called `self`).
-     */
-    private fun handleFunctionDef(
-        s: Python.AST.NormalOrAsyncFunctionDef,
-        recordDeclaration: RecordDeclaration? = null,
-    ): DeclarationStatement {
-        val language = language
-        val result =
-            if (recordDeclaration != null) {
-                if (s.name == "__init__") {
-                    newConstructorDeclaration(
-                        name = s.name,
-                        recordDeclaration = recordDeclaration,
-                        rawNode = s,
-                    )
-                } else if (language is HasOperatorOverloading && s.name.isKnownOperatorName) {
-                    var decl =
-                        newOperatorDeclaration(
-                            name = s.name,
-                            recordDeclaration = recordDeclaration,
-                            operatorCode = language.operatorCodeFor(s.name) ?: "",
-                            rawNode = s,
-                        )
-                    if (decl.operatorCode == "") {
-                        Util.warnWithFileLocation(
-                            decl,
-                            log,
-                            "Could not find operator code for operator {}. This will most likely result in a failure",
-                            s.name,
-                        )
-                    }
-                    decl
-                } else {
-                    newMethodDeclaration(
-                        name = s.name,
-                        recordDeclaration = recordDeclaration,
-                        isStatic = false,
-                        rawNode = s,
-                    )
-                }
-            } else {
-                newFunctionDeclaration(name = s.name, rawNode = s)
-            }
-        frontend.scopeManager.enterScope(result)
-
-        addAsyncWarning(s, result)
-
-        // Handle decorators (which are translated into CPG "annotations")
-        result.annotations += handleAnnotations(s)
-
-        // Handle return type and calculate function type
-        if (result is ConstructorDeclaration) {
-            // Return type of the constructor is always its record declaration type
-            result.returnTypes = listOf(recordDeclaration?.toType() ?: unknownType())
-        } else {
-            result.returnTypes = listOf(frontend.typeOf(s.returns))
-        }
-        result.type = FunctionType.computeType(result)
-
-        handleArguments(s.args, result, recordDeclaration)
-
-        if (s.body.isNotEmpty()) {
-            result.body = makeBlock(s.body, parentNode = s)
-        }
-
-        frontend.scopeManager.leaveScope(result)
-        frontend.scopeManager.addDeclaration(result)
-
-        return wrapDeclarationToStatement(result)
     }
 
     /**
@@ -959,143 +872,7 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
         )
     }
 
-    /** Adds the arguments to [result] which might be located in a [recordDeclaration]. */
-    private fun handleArguments(
-        args: Python.AST.arguments,
-        result: FunctionDeclaration,
-        recordDeclaration: RecordDeclaration?,
-    ) {
-        // We can merge posonlyargs and args because both are positional arguments. We do not
-        // enforce that posonlyargs can ONLY be used in a positional style, whereas args can be used
-        // both in positional and keyword style.
-        var positionalArguments = args.posonlyargs + args.args
-
-        // Handle receiver if it exists and if it is not a static method
-        if (
-            recordDeclaration != null &&
-                result.annotations.none { it.name.localName == "staticmethod" }
-        ) {
-            handleReceiverArgument(positionalArguments, args, result, recordDeclaration)
-            // Skip the receiver argument for further processing
-            positionalArguments = positionalArguments.drop(1)
-        }
-
-        // Handle remaining arguments
-        handlePositionalArguments(positionalArguments, args)
-
-        args.vararg?.let { handleArgument(it, isPosOnly = false, isVariadic = true) }
-        args.kwarg?.let { handleArgument(it, isPosOnly = false, isVariadic = false) }
-
-        handleKeywordOnlyArguments(args)
-    }
-
-    /**
-     * This method retrieves the first argument of the [positionalArguments], which is typically the
-     * receiver object.
-     *
-     * A receiver can also have a default value. However, this case is not handled and is therefore
-     * passed with a problem expression.
-     */
-    private fun handleReceiverArgument(
-        positionalArguments: List<Python.AST.arg>,
-        args: Python.AST.arguments,
-        result: FunctionDeclaration,
-        recordDeclaration: RecordDeclaration,
-    ) {
-        // first argument is the receiver
-        val recvPythonNode = positionalArguments.firstOrNull()
-        if (recvPythonNode == null) {
-            result.additionalProblems += newProblemExpression("Expected a receiver", rawNode = args)
-        } else {
-            val tpe = recordDeclaration.toType()
-            val recvNode =
-                newVariableDeclaration(
-                    name = recvPythonNode.arg,
-                    type = tpe,
-                    implicitInitializerAllowed = false,
-                    rawNode = recvPythonNode,
-                )
-
-            // If the number of defaults equals the number of positional arguments, the receiver has
-            // a default value
-            if (args.defaults.size == positionalArguments.size) {
-                val defaultValue =
-                    args.defaults.getOrNull(0)?.let { frontend.expressionHandler.handle(it) }
-                defaultValue?.let {
-                    frontend.scopeManager.addDeclaration(recvNode)
-                    result.additionalProblems +=
-                        newProblemExpression("Receiver with default value", rawNode = args)
-                }
-            }
-
-            when (result) {
-                is ConstructorDeclaration,
-                is MethodDeclaration -> result.receiver = recvNode
-                else ->
-                    result.additionalProblems +=
-                        newProblemExpression(
-                            problem =
-                                "Expected a constructor or method declaration. Got something else.",
-                            rawNode = result,
-                        )
-            }
-        }
-    }
-
-    /**
-     * This method extracts the [positionalArguments] including those that may have default values.
-     *
-     * In Python only the arguments with default values are stored in `args.defaults`.
-     * https://docs.python.org/3/library/ast.html#ast.arguments
-     *
-     * For example: `def my_func(a, b=1, c=2): pass`
-     *
-     * In this case, `args.defaults` contains only the defaults for `b` and `c`, while `args.args`
-     * includes all arguments (`a`, `b` and `c`). The number of arguments without defaults is
-     * determined by subtracting the size of `args.defaults` from the total number of arguments.
-     * This matches each default to its corresponding argument.
-     *
-     * From the Python docs: "If there are fewer defaults, they correspond to the last n arguments."
-     */
-    private fun handlePositionalArguments(
-        positionalArguments: List<Python.AST.arg>,
-        args: Python.AST.arguments,
-    ) {
-        val nonDefaultArgsCount = positionalArguments.size - args.defaults.size
-
-        for (idx in positionalArguments.indices) {
-            val arg = positionalArguments[idx]
-            val defaultIndex = idx - nonDefaultArgsCount
-            val defaultValue =
-                if (defaultIndex >= 0) {
-                    args.defaults.getOrNull(defaultIndex)?.let {
-                        frontend.expressionHandler.handle(it)
-                    }
-                } else {
-                    null
-                }
-            handleArgument(arg, isPosOnly = arg in args.posonlyargs, defaultValue = defaultValue)
-        }
-    }
-
-    /**
-     * This method extracts the keyword-only arguments from [args] and maps them to the
-     * corresponding function parameters.
-     */
-    private fun handleKeywordOnlyArguments(args: Python.AST.arguments) {
-        for (idx in args.kwonlyargs.indices) {
-            val arg = args.kwonlyargs[idx]
-            val default = args.kw_defaults.getOrNull(idx)
-            handleArgument(
-                arg,
-                isPosOnly = false,
-                isKwoOnly = true,
-                defaultValue = default?.let { frontend.expressionHandler.handle(it) },
-            )
-        }
-    }
-
-    private fun handleAnnotations(
+    internal fun handleAnnotations(
         node: Python.AST.NormalOrAsyncFunctionDef
     ): Collection<Annotation> {
         return handleDeclaratorList(node, node.decorator_list)
@@ -1173,7 +950,7 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
      * itself does not have a code/location, we need to employ [codeAndLocationFromChildren] on the
      * [parentNode].
      */
-    private fun makeBlock(
+    internal fun makeBlock(
         stmts: List<Python.AST.BaseStmt>,
         parentNode: Python.AST.WithLocation,
     ): Block {
@@ -1198,37 +975,6 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
     }
 
     /**
-     * This function creates a [newParameterDeclaration] for the argument, setting any modifiers
-     * (like positional-only or keyword-only) and [defaultValue] if applicable.
-     */
-    internal fun handleArgument(
-        node: Python.AST.arg,
-        isPosOnly: Boolean = false,
-        isVariadic: Boolean = false,
-        isKwoOnly: Boolean = false,
-        defaultValue: Expression? = null,
-    ) {
-        val type = frontend.typeOf(node.annotation)
-        val arg =
-            newParameterDeclaration(
-                name = node.arg,
-                type = type,
-                variadic = isVariadic,
-                rawNode = node,
-            )
-        defaultValue?.let { arg.default = it }
-        if (isPosOnly) {
-            arg.modifiers += MODIFIER_POSITIONAL_ONLY_ARGUMENT
-        }
-
-        if (isKwoOnly) {
-            arg.modifiers += MODIFIER_KEYWORD_ONLY_ARGUMENT
-        }
-
-        frontend.scopeManager.addDeclaration(arg)
-    }
-
-    /**
      * Wrap a declaration in a [DeclarationStatement]
      *
      * @param decl The [Declaration] to be wrapped
@@ -1244,7 +990,7 @@ class StatementHandler(frontend: PythonLanguageFrontend) :
      * Checks whether [mightBeAsync] implements the [IsAsync] interface and adds a warning to the
      * corresponding [parentNode] stored in [Node.additionalProblems].
      */
-    private fun addAsyncWarning(mightBeAsync: Python.AST.AsyncOrNot, parentNode: Node) {
+    internal fun addAsyncWarning(mightBeAsync: Python.AST.AsyncOrNot, parentNode: Node) {
         if (mightBeAsync is IsAsync) {
             parentNode.additionalProblems +=
                 newProblemDeclaration(


### PR DESCRIPTION
We consider some python nodes to be "declarations" and this PR splits off processing these into a dedicated `DeclarationHandler`, rather than having them in the `StatementHandler`.
