### PR TITLE
Major rework of `ScopeManager::extractScope`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory
  *
  * Language frontends MUST call [enterScope] and [leaveScope] when they encounter nodes that modify
  * the scope and [resetToGlobal] when they first handle a new [TranslationUnitDeclaration].
- * Afterwards the currently valid "stack" of scopes within the tree can be accessed.
+ * Afterward the currently valid "stack" of scopes within the tree can be accessed.
  *
  * If a language frontend encounters a [Declaration] node, it MUST call [addDeclaration], rather
  * than adding the declaration to the node itself. This ensures that all declarations are properly
@@ -153,9 +153,8 @@ class ScopeManager : ScopeProvider {
                     existing.astNode = entry.value.astNode
 
                     // now it gets more tricky. we also need to "redirect" the AST nodes in the sub
-                    // scope manager to our
-                    // existing NameScope (currently, they point to their own, invalid copy of the
-                    // NameScope).
+                    // scope manager to our existing NameScope (currently, they point to their own,
+                    // invalid copy of the NameScope).
                     //
                     // The only way to do this, is to filter for the particular
                     // scope (the value of the map) and return the keys (the nodes)
@@ -171,6 +170,8 @@ class ScopeManager : ScopeProvider {
                     nameScopeMap[entry.key] = entry.value
                 }
             }
+
+            // Update global scope for all
 
             // We need to make sure that we do not put the "null" key (aka the global scope) of the
             // individual scope manager into our map, otherwise we would overwrite our merged global
@@ -569,9 +570,9 @@ class ScopeManager : ScopeProvider {
     }
 
     /**
-     * This function looks up a [Scope] by its [name]. The reason why this is necessary is that the
-     * [name] could potentially include aliases set by an [ImportDeclaration] and therefore can not
-     * directly be found in the [nameScopeMap].
+     * This function looks up a [Scope] by its [name] relative to [startScope]. The reason why this
+     * is necessary is that the [name] could potentially include aliases set by an
+     * [ImportDeclaration] and therefore can not directly be found in the [nameScopeMap].
      *
      * It works by splitting the name into its parts and then iteratively looking up the scope for
      * each part, starting at the "beginning". For example if we have a name `A::B::C`, we first
@@ -581,10 +582,9 @@ class ScopeManager : ScopeProvider {
      * If no scope is found at any point in the chain, `null` is returned.
      *
      * @param name the name to look up
-     * @param startScope the scope to start the lookup in. If null, the current scope is used.
-     * @return the scope, if it exists
+     * @param startScope the scope to start the lookup in
      */
-    fun lookupScopeByName(name: Name, startScope: Scope? = currentScope): Scope? {
+    fun lookupScopeByName(name: Name, startScope: Scope?): Scope? {
         val parts = name.splitTo(mutableListOf())
         var part: Name? = name
         var scope = startScope

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TypeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TypeManager.kt
@@ -253,7 +253,6 @@ val Type.ancestors: Set<Type.Ancestor>
 internal fun Type.getAncestors(depth: Int): Set<Type.Ancestor> {
     val types = mutableSetOf<Type.Ancestor>()
 
-
     if (superTypes.contains(this))
         log.warn(
             "Removing type {} from the list of its own supertypes. This would create a type cycle that is not allowed.",

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TypeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TypeManager.kt
@@ -253,7 +253,7 @@ internal fun Type.getAncestors(depth: Int): Set<Type.Ancestor> {
     val types = mutableSetOf<Type.Ancestor>()
 
     // Recursively call ourselves on our super types.
-    types += superTypes.flatMap { it.getAncestors(depth + 1) }
+    types += superTypes.filter { it != this }.flatMap { it.getAncestors(depth + 1) }
 
     // Since the chain starts with our type, we add ourselves to it
     types += Type.Ancestor(this, depth)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TypeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TypeManager.kt
@@ -34,6 +34,7 @@ import de.fraunhofer.aisec.cpg.graph.scopes.TemplateScope
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Reference
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.passes.Pass
+import de.fraunhofer.aisec.cpg.passes.Pass.Companion.log
 import de.fraunhofer.aisec.cpg.passes.ResolveCallExpressionAmbiguityPass
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
@@ -252,6 +253,12 @@ val Type.ancestors: Set<Type.Ancestor>
 internal fun Type.getAncestors(depth: Int): Set<Type.Ancestor> {
     val types = mutableSetOf<Type.Ancestor>()
 
+
+    if (superTypes.contains(this))
+        log.warn(
+            "Removing type {} from the list of its own supertypes. This would create a type cycle that is not allowed.",
+            this,
+        )
     // Recursively call ourselves on our super types.
     types += superTypes.filter { it != this }.flatMap { it.getAncestors(depth + 1) }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Name.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Name.kt
@@ -75,18 +75,16 @@ class Name(
 
     /**
      * This function splits a fully qualified name into its parts. For example,
-     * `my::namespace::name` would be split into `["my", "my::namespace", "my::namespace::name"]`.
+     * `my::namespace::name` would be split into `["my::namespace::name", "my::namespace", "my"]`.
      */
-    fun split(): List<Name> {
-        val list = mutableListOf<Name>()
-
+    fun splitTo(out: MutableList<Name>): MutableList<Name> {
         var current: Name? = this
         while (current != null) {
-            list.add(current)
+            out += current
             current = current.parent
         }
 
-        return list
+        return out
     }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Name.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Name.kt
@@ -74,6 +74,22 @@ class Name(
     public override fun clone(): Name = Name(localName, parent?.clone(), delimiter)
 
     /**
+     * This function splits a fully qualified name into its parts. For example,
+     * `my::namespace::name` would be split into `["my", "my::namespace", "my::namespace::name"]`.
+     */
+    fun split(): List<Name> {
+        val list = mutableListOf<Name>()
+
+        var current: Name? = this
+        while (current != null) {
+            list.add(current)
+            current = current.parent
+        }
+
+        return list
+    }
+
+    /**
      * Returns the string representation of this name using a fully qualified name notation with the
      * specified [delimiter].
      */

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/GlobalScope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/GlobalScope.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.graph.scopes
 import de.fraunhofer.aisec.cpg.ScopeManager
 import de.fraunhofer.aisec.cpg.TranslationManager
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
+import de.fraunhofer.aisec.cpg.graph.nodes
 
 /**
  * This should ideally only be called once. It constructs a new global scope, which is not
@@ -61,11 +62,9 @@ class GlobalScope : StructureDeclarationScope(null) {
             symbols.mergeFrom(other.symbols)
             wildcardImports.addAll(other.wildcardImports)
 
-            for (symbolList in other.symbols) {
-                // Update the scope property of all nodes that live on the global scope to our new
-                // global scope (this)
-                for (symbol in symbolList.value) {
-                    symbol.scope = this
+            for (node in other.astNode?.nodes ?: listOf()) {
+                if (node.scope is GlobalScope) {
+                    node.scope = this
                 }
             }
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -742,10 +742,12 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
                 }
             }
             firstLevelCandidates.ifEmpty {
-                workingPossibleTypes
-                    .map { it.superTypeDeclarations }
-                    .map { getInvocationCandidatesFromParents(name, it) }
-                    .flatten()
+                workingPossibleTypes.flatMap {
+                    getInvocationCandidatesFromParents(
+                        name,
+                        it.superTypeDeclarations.filter { it !in possibleTypes }.toSet(),
+                    )
+                }
             }
         }
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
@@ -129,7 +129,12 @@ open class TypeResolver(ctx: TranslationContext) : ComponentPass(ctx) {
             type.declaredFrom = declares
             type.recordDeclaration = declares as? RecordDeclaration
             type.typeOrigin = Type.Origin.RESOLVED
-            type.superTypes.addAll(declaredType.superTypes)
+            if (declaredType.superTypes.contains(type))
+                log.warn(
+                    "Removing type {} from the list of its own supertypes. This would create a type cycle that is not allowed.",
+                    type,
+                )
+            type.superTypes.addAll(declaredType.superTypes.filter { it != type })
             return true
         }
 

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManagerTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/scopes/ScopeManagerTest.kt
@@ -55,6 +55,7 @@ internal class ScopeManagerTest : BaseTest() {
             val func1 = frontend1.newFunctionDeclaration("func1")
             s1.addDeclaration(func1)
             s1.leaveScope(namespaceA1)
+            s1.addDeclaration(namespaceA1)
 
             val s2 = ScopeManager()
             val frontend2 =
@@ -67,11 +68,10 @@ internal class ScopeManagerTest : BaseTest() {
             val func2 = frontend2.newFunctionDeclaration("func2")
             s2.addDeclaration(func2)
             s2.leaveScope(namespaceA2)
+            s2.addDeclaration(namespaceA2)
 
             // merge the two scopes. this replicates the behaviour of parseParallel
             val final = ScopeManager()
-            val frontend =
-                TestLanguageFrontend("::", TestLanguage(), TranslationContext(config, final, tm))
             final.mergeFrom(listOf(s1, s2))
 
             // in the final scope manager, there should only be one NameScope "A"
@@ -98,9 +98,14 @@ internal class ScopeManagerTest : BaseTest() {
             assertFalse(listOf(s1, s2).map { it.globalScope }.contains(final.globalScope))
 
             // resolve symbol
-            val call =
-                frontend.newCallExpression(frontend.newReference("A::func1"), "A::func1", false)
-            val func = final.lookupSymbolByNodeName(call.callee).firstOrNull()
+            val func =
+                final
+                    .lookupSymbolByName(
+                        name = parseName("A::func1"),
+                        language = language,
+                        startScope = final.globalScope,
+                    )
+                    .firstOrNull()
 
             assertEquals(func1, func)
         }

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/DeclarationHandler.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/DeclarationHandler.kt
@@ -76,7 +76,8 @@ class DeclarationHandler(frontend: GoLanguageFrontend) :
 
                     // TODO: this will only find methods within the current translation unit.
                     //  this is a limitation that we have for C++ as well
-                    val record = frontend.scopeManager.getRecordForName(recordName, language)
+                    val record =
+                        frontend.scopeManager.lookupScope(recordName)?.astNode as? RecordDeclaration
 
                     // now this gets a little bit hacky, we will add it to the record declaration
                     // this is strictly speaking not 100 % true, since the method property edge is

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/SpecificationHandler.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/SpecificationHandler.kt
@@ -347,6 +347,11 @@ class SpecificationHandler(frontend: GoLanguageFrontend) :
 
                 // Register the type with the type system
                 frontend.typeManager.registerType(record.toType())
+
+                // Make sure to add the scope to the scope manager
+                frontend.scopeManager.enterScope(record)
+                frontend.scopeManager.leaveScope(record)
+
                 record
             }
         }

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.frontends.python
 import de.fraunhofer.aisec.cpg.InferenceConfiguration
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.TranslationManager
+import de.fraunhofer.aisec.cpg.ancestors
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.Annotation
 import de.fraunhofer.aisec.cpg.graph.declarations.FieldDeclaration
@@ -1897,5 +1898,23 @@ class PythonFrontendTest : BaseTest() {
         val expectedSuper = result.records["Foobar"]
         assertNotNull(expectedSuper)
         assertEquals(expectedSuper, clsSuper.recordDeclaration)
+    }
+
+    @Test
+    fun testSuperclassIncorrect() {
+        val topLevel = Path.of("src", "test")
+        val result =
+            analyze(
+                listOf(topLevel.resolve("resources/python/superclasses/incorrect.py").toFile()),
+                topLevel,
+                true,
+            ) {
+                it.registerLanguage<PythonLanguage>()
+            }
+        assertNotNull(result)
+
+        var myClass = result.finalCtx.typeManager.firstOrderTypes["MyClass"]
+        assertNotNull(myClass)
+        assertNotNull(myClass.ancestors)
     }
 }

--- a/cpg-language-python/src/test/resources/python/superclasses/incorrect.py
+++ b/cpg-language-python/src/test/resources/python/superclasses/incorrect.py
@@ -1,0 +1,2 @@
+class MyClass(MyClass):
+    pass


### PR DESCRIPTION
This should hopefully fix all type (name) confusions. This is a major rework of the `ScopeManager::extractScope` function that should be faster and produce less overhead and is also iterative instead of recursive.

Incidentally, the new "more correct" behaviour also uncovered some already existing problems in some other language frontends.