### PR TITLE
Restricting `lookupScopeByName` to a specific `language`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -543,7 +543,7 @@ class ScopeManager : ScopeProvider {
      */
     fun extractScope(
         name: Name,
-        language: Language<*>? = null,
+        language: Language<*>,
         location: PhysicalLocation? = null,
         scope: Scope? = currentScope,
     ): ScopeExtraction? {
@@ -672,7 +672,7 @@ class ScopeManager : ScopeProvider {
      *
      * @return the declaration, or null if it does not exist
      */
-    fun getRecordForName(name: Name, language: Language<*>?): RecordDeclaration? {
+    fun getRecordForName(name: Name, language: Language<*>): RecordDeclaration? {
         return lookupSymbolByName(name, language)
             .filterIsInstance<RecordDeclaration>()
             .singleOrNull()
@@ -782,7 +782,7 @@ class ScopeManager : ScopeProvider {
      */
     fun lookupSymbolByName(
         name: Name,
-        language: Language<*>?,
+        language: Language<*>,
         location: PhysicalLocation? = null,
         startScope: Scope? = currentScope,
         predicate: ((Declaration) -> Boolean)? = null,
@@ -846,7 +846,7 @@ class ScopeManager : ScopeProvider {
      */
     fun lookupTypeSymbolByName(
         name: Name,
-        language: Language<*>?,
+        language: Language<*>,
         startScope: Scope?,
     ): DeclaresType? {
         var symbols =

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -525,7 +525,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         val language = source.language
 
         // Set the start scope. This can either be the call's scope or a scope specified in an FQN
-        val extractedScope = ctx.scopeManager.extractScope(source, source.scope)
+        val extractedScope = ctx.scopeManager.extractScope(source, language, source.scope)
 
         // If we could not extract the scope (even though one was specified), we can only return an
         // empty result

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
@@ -112,7 +112,7 @@ open class TypeResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
         // If we did not find any declaration, we can try to infer a record declaration for it
         if (declares == null) {
-            declares = tryRecordInference(type, locationHint = type)
+            declares = tryRecordInference(type, source = type)
         }
 
         // If we found the "real" declared type, we can normalize the name of our scoped type

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
@@ -66,7 +66,12 @@ import kotlin.collections.forEach
  */
 fun Pass<*>.tryNamespaceInference(name: Name, locationHint: Node?): NamespaceDeclaration? {
     // Determine the scope where we want to start our inference
-    val extractedScope = scopeManager.extractScope(name, location = locationHint?.location)
+    val extractedScope =
+        scopeManager.extractScope(
+            name,
+            language = locationHint?.language,
+            location = locationHint?.location,
+        )
     var scope = extractedScope?.scope
 
     if (scope !is NameScope) {
@@ -103,7 +108,12 @@ internal fun Pass<*>.tryRecordInference(
         }
     // Determine the scope where we want to start our inference
     val extractedScope =
-        scopeManager.extractScope(type.name, location = locationHint?.location, scope = type.scope)
+        scopeManager.extractScope(
+            type.name,
+            language = locationHint?.language,
+            location = locationHint?.location,
+            scope = type.scope,
+        )
     var scope = extractedScope?.scope
 
     if (scope !is NameScope) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
@@ -67,11 +67,7 @@ import kotlin.collections.forEach
 fun Pass<*>.tryNamespaceInference(name: Name, source: Node): NamespaceDeclaration? {
     // Determine the scope where we want to start our inference
     val extractedScope =
-        scopeManager.extractScope(
-            name,
-            language = source.language,
-            location = source.location,
-        )
+        scopeManager.extractScope(name, language = source.language, location = source.location)
     var scope = extractedScope?.scope
 
     if (scope !is NameScope) {
@@ -417,9 +413,7 @@ internal fun Pass<*>.tryMethodInference(
     // other type declarations are already inferred by the type resolver at this stage.
     if (records.isEmpty()) {
         records =
-            listOfNotNull(
-                tryRecordInference(bestGuess?.root ?: call.unknownType(), source = call)
-            )
+            listOfNotNull(tryRecordInference(bestGuess?.root ?: call.unknownType(), source = call))
     }
     records = records.distinct()
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
@@ -64,13 +64,13 @@ import kotlin.collections.forEach
  * Tries to infer a [NamespaceDeclaration] from a [Name]. This will return `null`, if inference was
  * not possible, or if it was turned off in the [InferenceConfiguration].
  */
-fun Pass<*>.tryNamespaceInference(name: Name, locationHint: Node?): NamespaceDeclaration? {
+fun Pass<*>.tryNamespaceInference(name: Name, source: Node): NamespaceDeclaration? {
     // Determine the scope where we want to start our inference
     val extractedScope =
         scopeManager.extractScope(
             name,
-            language = locationHint?.language,
-            location = locationHint?.location,
+            language = source.language,
+            location = source.location,
         )
     var scope = extractedScope?.scope
 
@@ -84,22 +84,19 @@ fun Pass<*>.tryNamespaceInference(name: Name, locationHint: Node?): NamespaceDec
     // parent record)
     var parentName = name.parent
     if (scope == null && parentName != null) {
-        holder = tryScopeInference(parentName, locationHint)
+        holder = tryScopeInference(parentName, source)
     }
 
     return (holder ?: scopeManager.globalScope?.astNode)
         ?.startInference(ctx)
-        ?.inferNamespaceDeclaration(name, null, locationHint)
+        ?.inferNamespaceDeclaration(name, null, source)
 }
 
 /**
  * Tries to infer a [RecordDeclaration] from an unresolved [Type]. This will return `null`, if
  * inference was not possible, or if it was turned off in the [InferenceConfiguration].
  */
-internal fun Pass<*>.tryRecordInference(
-    type: Type,
-    locationHint: Node? = null,
-): RecordDeclaration? {
+internal fun Pass<*>.tryRecordInference(type: Type, source: Node): RecordDeclaration? {
     val kind =
         if (type.language is HasStructs) {
             "struct"
@@ -110,8 +107,8 @@ internal fun Pass<*>.tryRecordInference(
     val extractedScope =
         scopeManager.extractScope(
             type.name,
-            language = locationHint?.language,
-            location = locationHint?.location,
+            language = source.language,
+            location = source.location,
             scope = type.scope,
         )
     var scope = extractedScope?.scope
@@ -136,13 +133,13 @@ internal fun Pass<*>.tryRecordInference(
     // parent record)
     var parentName = type.name.parent
     if (scope == null && parentName != null) {
-        holder = tryScopeInference(parentName, locationHint)
+        holder = tryScopeInference(parentName, source)
     }
 
     val record =
         (holder ?: scopeManager.globalScope?.astNode)
             ?.startInference(ctx)
-            ?.inferRecordDeclaration(type, kind, locationHint)
+            ?.inferRecordDeclaration(type, kind, source)
 
     // Update the type's record. Because types are only unique per scope, we potentially need to
     // update multiple type nodes, i.e., all type nodes whose FQN match the inferred record. We only
@@ -241,7 +238,7 @@ internal fun Pass<*>.tryFieldInference(
     // We access an unknown field of an unknown record. so we need to handle that along the
     // way as well.
     if (record == null) {
-        record = tryRecordInference(targetType, locationHint = ref)
+        record = tryRecordInference(targetType, source = ref)
     }
 
     if (record == null) {
@@ -421,7 +418,7 @@ internal fun Pass<*>.tryMethodInference(
     if (records.isEmpty()) {
         records =
             listOfNotNull(
-                tryRecordInference(bestGuess?.root ?: call.unknownType(), locationHint = call)
+                tryRecordInference(bestGuess?.root ?: call.unknownType(), source = call)
             )
     }
     records = records.distinct()
@@ -438,15 +435,15 @@ internal fun Pass<*>.tryMethodInference(
  * check will be repeated for `java.lang`, until we are finally ready to infer the
  * [RecordDeclaration] `java.lang.System`.
  */
-internal fun Pass<*>.tryScopeInference(scopeName: Name, locationHint: Node?): Declaration? {
+internal fun Pass<*>.tryScopeInference(scopeName: Name, source: Node): Declaration? {
     // At this point, we need to check whether we have any type reference to our scope
     // name. If we have (e.g. it is used in a function parameter, variable, etc.), then we
     // have a high chance that this is actually a parent record and not a namespace
     var parentType = typeManager.lookupResolvedType(scopeName)
     return if (parentType != null) {
-        tryRecordInference(parentType, locationHint = locationHint)
+        tryRecordInference(parentType, source = source)
     } else {
-        tryNamespaceInference(scopeName, locationHint = locationHint)
+        tryNamespaceInference(scopeName, source = source)
     }
 }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
@@ -176,7 +176,7 @@ internal fun Pass<*>.tryVariableInference(ref: Reference): VariableDeclaration? 
     } else if (ref.name.isQualified()) {
         // For now, we only infer globals at the top-most global level, i.e., no globals in
         // namespaces
-        val extractedScope = scopeManager.extractScope(ref, null)
+        val extractedScope = scopeManager.extractScope(ref, ref.language, null)
         when (val scope = extractedScope?.scope) {
             is NameScope -> {
                 log.warn(


### PR DESCRIPTION
Not having the restriction leads to confusion when we have a namespace in different languages. As a nice effect, I had a look at things that were for some reason nullable and made them non-nullable.