### PR TITLE
Providing a `Language::translationUnitForInference` function that is used for global inference

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -868,6 +868,27 @@ class ScopeManager : ScopeProvider {
 
         return symbols.singleOrNull()
     }
+
+    /**
+     * Returns the [TranslationUnitDeclaration] that should be used for inference, especially for
+     * global declarations.
+     *
+     * @param TypeToInfer the type of the node that should be inferred
+     * @param source the source that was responsible for the inference
+     */
+    fun <TypeToInfer : Node> translationUnitForInference(
+        source: Node
+    ): TranslationUnitDeclaration? {
+        // TODO(oxisto): This workaround is needed because it seems that not all types have a proper
+        //  context :(. In this case we need to fall back to the global scope's astNode, which can
+        // be
+        //  error-prone in a multi-language scenario.
+        return if (source.ctx == null) {
+            globalScope?.astNode as? TranslationUnitDeclaration
+        } else {
+            source.language.translationUnitForInference<TypeToInfer>(source)
+        }
+    }
 }
 
 /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
@@ -49,6 +49,7 @@ open class TypeResolver(ctx: TranslationContext) : ComponentPass(ctx) {
     lateinit var walker: SubgraphWalker.ScopedWalker
 
     override fun accept(component: Component) {
+        ctx.currentComponent = component
         resolveFirstOrderTypes()
         refreshNames()
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
@@ -83,7 +83,7 @@ fun Pass<*>.tryNamespaceInference(name: Name, source: Node): NamespaceDeclaratio
         holder = tryScopeInference(parentName, source)
     }
 
-    return (holder ?: source.translationUnit)
+    return (holder ?: source.translationUnit ?: scopeManager.globalScope?.astNode)
         ?.startInference(ctx)
         ?.inferNamespaceDeclaration(name, null, source)
 }
@@ -133,7 +133,7 @@ internal fun Pass<*>.tryRecordInference(type: Type, source: Node): RecordDeclara
     }
 
     val record =
-        (holder ?: source.translationUnit)
+        (holder ?: source.translationUnit ?: scopeManager.globalScope?.astNode)
             ?.startInference(ctx)
             ?.inferRecordDeclaration(type, kind, source)
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
@@ -83,7 +83,7 @@ fun Pass<*>.tryNamespaceInference(name: Name, source: Node): NamespaceDeclaratio
         holder = tryScopeInference(parentName, source)
     }
 
-    return (holder ?: scopeManager.globalScope?.astNode)
+    return (holder ?: source.translationUnit)
         ?.startInference(ctx)
         ?.inferNamespaceDeclaration(name, null, source)
 }
@@ -133,7 +133,7 @@ internal fun Pass<*>.tryRecordInference(type: Type, source: Node): RecordDeclara
     }
 
     val record =
-        (holder ?: scopeManager.globalScope?.astNode)
+        (holder ?: source.translationUnit)
             ?.startInference(ctx)
             ?.inferRecordDeclaration(type, kind, source)
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
@@ -83,7 +83,7 @@ fun Pass<*>.tryNamespaceInference(name: Name, source: Node): NamespaceDeclaratio
         holder = tryScopeInference(parentName, source)
     }
 
-    return (holder ?: source.translationUnit ?: scopeManager.globalScope?.astNode)
+    return (holder ?: scopeManager.translationUnitForInference<NamespaceDeclaration>(source))
         ?.startInference(ctx)
         ?.inferNamespaceDeclaration(name, null, source)
 }
@@ -133,7 +133,7 @@ internal fun Pass<*>.tryRecordInference(type: Type, source: Node): RecordDeclara
     }
 
     val record =
-        (holder ?: source.translationUnit ?: scopeManager.globalScope?.astNode)
+        (holder ?: scopeManager.translationUnitForInference<RecordDeclaration>(source))
             ?.startInference(ctx)
             ?.inferRecordDeclaration(type, kind, source)
 
@@ -197,7 +197,10 @@ internal fun Pass<*>.tryVariableInference(ref: Reference): VariableDeclaration? 
     } else if (ref.language is HasGlobalVariables) {
         // We can try to infer a possible global variable (at top-level), if the language
         // supports this
-        scopeManager.globalScope?.astNode?.startInference(this.ctx)?.inferVariableDeclaration(ref)
+        scopeManager
+            .translationUnitForInference<VariableDeclaration>(ref)
+            ?.startInference(this.ctx)
+            ?.inferVariableDeclaration(ref)
     } else {
         // Nothing to infer
         null


### PR DESCRIPTION
Currently, we use the global scope's `astNode` as a start node for inference of "global" things. However, this is very buggy, since the `astNode` of the global scope is assigned to the last TU we parse. If this TU was parsed in another language, we can run into situations where we infer things in the wrong language. 

This PR fixes that by introducing a new `Language::translationUnitForInference` function that defaults to the first TU in a component and can be used by a language to provide a specific TU for specific declarations.
