### PR TITLE
Make translation context available everywhere

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -881,9 +881,8 @@ class ScopeManager : ScopeProvider {
     ): TranslationUnitDeclaration? {
         // TODO(oxisto): This workaround is needed because it seems that not all types have a proper
         //  context :(. In this case we need to fall back to the global scope's astNode, which can
-        // be
-        //  error-prone in a multi-language scenario.
-        return if (source.ctx == null) {
+        //  be error-prone in a multi-language scenario.
+        return if (!source.isInitialized) {
             globalScope?.astNode as? TranslationUnitDeclaration
         } else {
             source.language.translationUnitForInference<TypeToInfer>(source)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
@@ -93,10 +93,7 @@ class TranslationResult(
     val isCancelled: Boolean
         get() = translationManager.isCancelled()
 
-    override var ctx: TranslationContext? = null
-        get() {
-            return finalCtx
-        }
+    override var ctx: TranslationContext = finalCtx
 
     /**
      * Checks if only a single software component has been analyzed and returns its translation

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Handler.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Handler.kt
@@ -53,7 +53,6 @@ abstract class Handler<ResultNode : Node?, HandlerNode, L : LanguageFrontend<in 
     CodeAndLocationProvider<HandlerNode> by frontend,
     ScopeProvider by frontend,
     NamespaceProvider by frontend,
-    ContextProvider by frontend,
     RawNodeTypeProvider<HandlerNode> {
     protected val map = HashMap<Class<out HandlerNode>, HandlerInterface<ResultNode, HandlerNode>>()
     private val typeOfT: Class<*>?

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
@@ -340,7 +340,7 @@ abstract class Language<T : LanguageFrontend<*, *>> : Node() {
                     null,
                     source,
                     false,
-                    source.ctx!!,
+                    source.ctx,
                     null,
                     needsExactMatch = true,
                 )
@@ -416,7 +416,7 @@ abstract class Language<T : LanguageFrontend<*, *>> : Node() {
      * @param source the source that was responsible for the inference
      */
     fun <TypeToInfer : Node> translationUnitForInference(source: Node): TranslationUnitDeclaration {
-        val tu = source.ctx?.currentComponent?.translationUnits?.firstOrNull()
+        val tu = source.ctx.currentComponent?.translationUnits?.firstOrNull()
         if (tu == null) {
             throw TranslationException(
                 "No translation unit found that should be used for inference"

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageFrontend.kt
@@ -50,8 +50,8 @@ abstract class LanguageFrontend<AstNode, TypeNode>(
 
     /**
      * The translation context, which contains all necessary managers used in this frontend parsing
-     * process. Note, that different contexts could passed to frontends, e.g., in parallel parsing
-     * to supply different managers to different frontends.
+     * process. Note, that different contexts could be passed to frontends, e.g., in parallel
+     * parsing to supply different managers to different frontends.
      */
     final override var ctx: TranslationContext,
 ) :

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
@@ -73,7 +73,7 @@ open class Component : Node() {
     @DoNotPersist
     val topLevel: File?
         get() {
-            return ctx?.config?.topLevels?.get(this.name.localName)
+            return ctx.config.topLevels[this.name.localName]
         }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -378,7 +378,7 @@ private fun <AstNode> Node.setCodeAndLocation(
     provider: CodeAndLocationProvider<AstNode>,
     rawNode: AstNode,
 ) {
-    if (this.ctx?.config?.codeInNodes == true) {
+    if (this.ctx.config.codeInNodes == true) {
         // only set code, if it's not already set or empty
         val code = provider.codeOf(rawNode)
         if (code != null) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -58,7 +58,7 @@ interface MetadataProvider
  * A simple interface that everything, that supplies a language, should implement. Examples include
  * each [Node], but also transformation steps, such as [Handler].
  */
-interface LanguageProvider : MetadataProvider {
+interface LanguageProvider : ContextProvider {
     val language: Language<*>
 }
 
@@ -234,7 +234,7 @@ fun NamespaceProvider.fqn(localName: String): Name {
 }
 
 interface ContextProvider : MetadataProvider {
-    val ctx: TranslationContext?
+    val ctx: TranslationContext
 }
 
 /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/TypeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/TypeBuilder.kt
@@ -106,23 +106,17 @@ fun LanguageProvider.objectType(
         return builtIn
     }
 
-    // Otherwise, we need to create a new type and register it at the type manager
-    val c =
-        (this as? ContextProvider)?.ctx
-            ?: throw TranslationException(
-                "Could not create type: translation context not available"
-            )
-
     // Otherwise, we either need to create the type because of the generics or because we do not
     // know the type yet.
     var type = ObjectType(name, generics, false, language)
+
     // Apply our usual metadata, such as scope, code, location, if we have any. Make sure only
     // to refer by the local name because we will treat types as sort of references when
     // creating them and resolve them later.
     type.applyMetadata(this, name, rawNode = rawNode, doNotPrependNamespace = true)
 
     // Piping it through register type will ensure that we know the type and can resolve it later
-    return c.typeManager.registerType(type)
+    return this.ctx.typeManager.registerType(type)
 }
 
 /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/Builder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/Builder.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.graph.types
+
+import de.fraunhofer.aisec.cpg.frontends.Language
+import de.fraunhofer.aisec.cpg.graph.LanguageProvider
+import de.fraunhofer.aisec.cpg.graph.applyMetadata
+
+/** Creates a new [FunctionType]. */
+fun LanguageProvider.functionType(
+    typeName: String = "",
+    parameters: List<Type> = listOf(),
+    returnTypes: List<Type> = listOf(),
+    language: Language<*>,
+    rawNode: Any? = null,
+): FunctionType {
+    var type = FunctionType(typeName, parameters, returnTypes, language)
+    type.applyMetadata(this, typeName, rawNode = rawNode, doNotPrependNamespace = true)
+
+    return this.ctx.typeManager.registerType(type)
+}

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionType.kt
@@ -37,7 +37,7 @@ import de.fraunhofer.aisec.cpg.graph.unknownType
  */
 class FunctionType
 @JvmOverloads
-constructor(
+internal constructor(
     typeName: String = "",
     var parameters: List<Type> = listOf(),
     var returnTypes: List<Type> = listOf(),

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/FunctionType.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.frontends.Language
-import de.fraunhofer.aisec.cpg.frontends.TranslationException
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.unknownType
 
@@ -73,8 +72,7 @@ constructor(
                     func.language,
                 )
 
-            val c = func.ctx ?: throw TranslationException("context not available")
-            return c.typeManager.registerType(type)
+            return func.ctx.typeManager.registerType(type)
         }
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/DFGFunctionSummaries.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/DFGFunctionSummaries.kt
@@ -117,7 +117,7 @@ class DFGFunctionSummaries {
         val language = functionDecl.language
         val languageName = language.javaClass.name
         val methodName = functionDecl.name
-        val typeManager = functionDecl.ctx?.typeManager ?: return null
+        val typeManager = functionDecl.ctx.typeManager
 
         // The language and the method name have to match. If a signature is specified, it also has
         // to match to the one of the FunctionDeclaration, null indicates that we accept everything.

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/DFGFunctionSummariesTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/DFGFunctionSummariesTest.kt
@@ -88,32 +88,25 @@ class DFGFunctionSummariesTest {
                                 // We need three types with a type hierarchy.
                                 val objectType = t("test.Object")
                                 val listType = t("test.List")
-                                ctx?.let {
-                                    val recordDecl =
-                                        startInference(it)?.inferRecordDeclaration(listType)
-                                    listType.recordDeclaration = recordDecl
-                                    recordDecl?.addSuperClass(objectType)
-                                    listType.superTypes.add(objectType)
-                                }
+                                var recordDecl =
+                                    startInference(ctx)?.inferRecordDeclaration(listType)
+                                listType.recordDeclaration = recordDecl
+                                recordDecl?.addSuperClass(objectType)
+                                listType.superTypes.add(objectType)
 
                                 val specialListType = t("test.SpecialList")
-                                ctx?.let {
-                                    val recordDecl =
-                                        startInference(it)?.inferRecordDeclaration(specialListType)
-                                    specialListType.recordDeclaration = recordDecl
-                                    recordDecl?.addSuperClass(listType)
-                                    specialListType.superTypes.add(listType)
-                                }
+                                recordDecl =
+                                    startInference(ctx)?.inferRecordDeclaration(specialListType)
+                                specialListType.recordDeclaration = recordDecl
+                                recordDecl?.addSuperClass(listType)
+                                specialListType.superTypes.add(listType)
 
                                 val verySpecialListType = t("test.VerySpecialList")
-                                ctx?.let {
-                                    val recordDecl =
-                                        startInference(it)
-                                            ?.inferRecordDeclaration(verySpecialListType)
-                                    verySpecialListType.recordDeclaration = recordDecl
-                                    recordDecl?.addSuperClass(specialListType)
-                                    verySpecialListType.superTypes.add(listType)
-                                }
+                                recordDecl =
+                                    startInference(ctx)?.inferRecordDeclaration(verySpecialListType)
+                                verySpecialListType.recordDeclaration = recordDecl
+                                recordDecl?.addSuperClass(specialListType)
+                                verySpecialListType.superTypes.add(listType)
                             }
 
                             function("main", t("int")) {

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilderTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilderTest.kt
@@ -25,14 +25,13 @@
  */
 package de.fraunhofer.aisec.cpg.graph
 
+import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.builder.plus
 import de.fraunhofer.aisec.cpg.graph.declarations.FieldDeclaration
 import de.fraunhofer.aisec.cpg.graph.edges.flows.CallingContextIn
 import de.fraunhofer.aisec.cpg.graph.edges.flows.ContextSensitiveDataflow
 import de.fraunhofer.aisec.cpg.graph.edges.flows.PartialDataflowGranularity
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.Literal
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.Reference
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -40,35 +39,39 @@ import kotlin.test.assertTrue
 class ExpressionBuilderTest {
     @Test
     fun testDuplicateWithDFGProperties() {
-        val node1 = Literal<Int>()
-        val node2 = Reference()
-        val granularity = PartialDataflowGranularity(FieldDeclaration())
-        val callingContextIn = CallingContextIn(CallExpression())
-        node1.prevDFGEdges.addContextSensitive(node2, granularity, callingContextIn)
+        with(TestLanguageFrontend()) {
+            val node1 = newLiteral(42)
+            val node2 = newReference("foo")
+            val granularity = PartialDataflowGranularity(FieldDeclaration())
+            val callingContextIn = CallingContextIn(CallExpression())
+            node1.prevDFGEdges.addContextSensitive(node2, granularity, callingContextIn)
 
-        val clone = node1.duplicate(false)
-        val clonedPrevDFG = clone.prevDFGEdges.single()
-        assertTrue(clonedPrevDFG is ContextSensitiveDataflow)
-        assertEquals(callingContextIn, clonedPrevDFG.callingContext)
-        assertEquals(granularity, clonedPrevDFG.granularity)
+            val clone = node1.duplicate(false)
+            val clonedPrevDFG = clone.prevDFGEdges.single()
+            assertTrue(clonedPrevDFG is ContextSensitiveDataflow)
+            assertEquals(callingContextIn, clonedPrevDFG.callingContext)
+            assertEquals(granularity, clonedPrevDFG.granularity)
 
-        assertEquals(setOf<Node>(node1, clone), node2.nextDFG)
+            assertEquals(setOf<Node>(node1, clone), node2.nextDFG)
+        }
     }
 
     @Test
     fun testDuplicateWithDFGProperties2() {
-        val node1 = Literal<Int>()
-        val node2 = Reference()
-        val granularity = PartialDataflowGranularity(FieldDeclaration())
-        val callingContextIn = CallingContextIn(CallExpression())
-        node1.nextDFGEdges.addContextSensitive(node2, granularity, callingContextIn)
+        with(TestLanguageFrontend()) {
+            val node1 = newLiteral(42)
+            val node2 = newReference("foo")
+            val granularity = PartialDataflowGranularity(FieldDeclaration())
+            val callingContextIn = CallingContextIn(CallExpression())
+            node1.nextDFGEdges.addContextSensitive(node2, granularity, callingContextIn)
 
-        val clone = node1.duplicate(false)
-        val clonedPrevDFG = clone.nextDFGEdges.single()
-        assertTrue(clonedPrevDFG is ContextSensitiveDataflow)
-        assertEquals(callingContextIn, clonedPrevDFG.callingContext)
-        assertEquals(granularity, clonedPrevDFG.granularity)
+            val clone = node1.duplicate(false)
+            val clonedPrevDFG = clone.nextDFGEdges.single()
+            assertTrue(clonedPrevDFG is ContextSensitiveDataflow)
+            assertEquals(callingContextIn, clonedPrevDFG.callingContext)
+            assertEquals(granularity, clonedPrevDFG.granularity)
 
-        assertEquals(setOf<Node>(node1, clone), node2.prevDFG)
+            assertEquals(setOf<Node>(node1, clone), node2.prevDFG)
+        }
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/helpers/ExtensionsTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/helpers/ExtensionsTest.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.helpers
 import de.fraunhofer.aisec.cpg.GraphExamples.Companion.testFrontend
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.frontends.TestLanguage
+import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.applyWithScope
@@ -40,7 +41,6 @@ import de.fraunhofer.aisec.cpg.graph.builder.translationUnit
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.problems
 import de.fraunhofer.aisec.cpg.graph.statements.DeclarationStatement
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.CollectionComprehension
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.ProblemExpression
 import de.fraunhofer.aisec.cpg.graph.variables
 import de.fraunhofer.aisec.cpg.test.BaseTest
@@ -87,16 +87,18 @@ internal class ExtensionsTest : BaseTest() {
 
     @Test
     fun testApplyWithScopeWithoutCtxAndScopeManager() {
-        val collectionComprehension =
-            CollectionComprehension().applyWithScope {
-                val varA = VariableDeclaration()
-                varA.name = Name("a")
-                val declarationStatement = DeclarationStatement()
-                declarationStatement.addDeclaration(varA)
-                this.statement = declarationStatement
-            }
-        val varA = collectionComprehension.variables["a"]
-        assertIs<VariableDeclaration>(varA)
-        assertNull(varA.scope)
+        with(TestLanguageFrontend()) {
+            val collectionComprehension =
+                newCollectionComprehension().applyWithScope {
+                    val varA = VariableDeclaration()
+                    varA.name = Name("a")
+                    val declarationStatement = DeclarationStatement()
+                    declarationStatement.addDeclaration(varA)
+                    this.statement = declarationStatement
+                }
+            val varA = collectionComprehension.variables["a"]
+            assertIs<VariableDeclaration>(varA)
+            assertNull(varA.scope)
+        }
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/persistence/TestCommon.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/persistence/TestCommon.kt
@@ -46,6 +46,7 @@ class TestCommon {
                 "id",
                 "isImplicit",
                 "isInferred",
+                "isInitialized",
                 "location",
                 "name",
             ),

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontend.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontend.kt
@@ -772,7 +772,7 @@ open class CXXLanguageFrontend(language: Language<CXXLanguageFrontend>, ctx: Tra
                 ) {
                     it.typeName
                 } + type.typeName
-            type = FunctionType(name, paramTypes, listOf(type), language)
+            type = functionType(name, paramTypes, listOf(type), language)
         }
 
         // Lastly, there might be further nested declarators that adjust the type further.

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
@@ -396,7 +396,7 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
             constructor.returnTypes =
                 constructor.returnTypes.map { addParameterizedTypesToType(it, parameterizedTypes) }
             constructor.type =
-                FunctionType(
+                functionType(
                     constructor.type.typeName,
                     (constructor.type as? FunctionType)?.parameters ?: listOf(),
                     constructor.returnTypes,

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/types/TypedefTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/types/TypedefTest.kt
@@ -82,7 +82,7 @@ internal class TypedefTest : BaseTest() {
             assertEquals(NumericType.Modifier.UNSIGNED, returnType.modifier)
             assertEquals(uintfp1.type, uintfp2?.type)
 
-            val type = tu.ctx?.scopeManager?.typedefFor(Name("test"))
+            val type = tu.ctx.scopeManager.typedefFor(Name("test"))
             assertIs<IntegerType>(type)
             assertLocalName("uint8_t", type)
         }
@@ -161,7 +161,7 @@ internal class TypedefTest : BaseTest() {
             val fPtr2 = tu.variables["intFptr2"]
             assertEquals(fPtr1?.type, fPtr2?.type)
 
-            val type = tu.ctx?.scopeManager?.typedefFor(Name("type_B"))
+            val type = tu.ctx.scopeManager.typedefFor(Name("type_B"))
             assertLocalName("template_class_A", type)
             assertIs<ObjectType>(type)
             assertEquals(listOf(primitiveType("int"), primitiveType("int")), type.generics)

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
@@ -1408,7 +1408,7 @@ internal class CXXLanguageFrontendTest : BaseTest() {
                 it.registerLanguage<CLanguage>()
             }
         with(tu) {
-            val typedefs = tu.ctx?.scopeManager?.typedefFor(Name("MyStruct"))
+            val typedefs = tu.ctx.scopeManager.typedefFor(Name("MyStruct"))
             assertLocalName("__myStruct", typedefs)
 
             val main = tu.functions["main"]

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaCallResolverHelper.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaCallResolverHelper.kt
@@ -110,7 +110,7 @@ class JavaCallResolverHelper {
             val baseName = callee.base.name.parent ?: return null
 
             val type =
-                callee.ctx?.typeManager?.lookupResolvedType(baseName.toString())
+                callee.ctx.typeManager.lookupResolvedType(baseName.toString())
                     ?: callee.unknownType()
             if (type in curClass.implementedInterfaces) {
                 // Basename is an interface -> BaseName.super refers to BaseName itself

--- a/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
+++ b/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
@@ -490,6 +490,7 @@ class Application : Callable<Int> {
             val pieces = customPasses.split(",")
             for (pass in pieces) {
                 if (pass.contains(".")) {
+                    @Suppress("UNCHECKED_CAST")
                     translationConfiguration.registerPass(
                         Class.forName(pass).kotlin as KClass<out Pass<*>>
                     )


### PR DESCRIPTION
This PR tries to make the translation context (as `ctx`) available everywhere. Therefore we declare it as `lateinit` and if we try to access it without being set, we crash.