### PR TITLE
Modelling program entrypoints as concepts

### DIFF
--- a/cpg-concepts/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/concepts/DynamicLoadingTest.kt
+++ b/cpg-concepts/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/concepts/DynamicLoadingTest.kt
@@ -28,11 +28,12 @@ package de.fraunhofer.aisec.cpg.concepts
 import de.fraunhofer.aisec.cpg.analysis.MultiValueEvaluator
 import de.fraunhofer.aisec.cpg.frontends.cxx.CLanguage
 import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.concepts.arch.POSIX
 import de.fraunhofer.aisec.cpg.graph.concepts.memory.LoadLibrary
 import de.fraunhofer.aisec.cpg.graph.concepts.memory.LoadSymbol
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
-import de.fraunhofer.aisec.cpg.passes.concepts.memory.CXXDynamicLoadingPass
+import de.fraunhofer.aisec.cpg.passes.concepts.memory.cxx.CXXDynamicLoadingPass
 import de.fraunhofer.aisec.cpg.test.analyze
 import de.fraunhofer.aisec.cpg.test.assertInvokes
 import java.io.File
@@ -44,7 +45,7 @@ import kotlin.test.assertNotNull
 
 class DynamicLoadingTest {
     @Test
-    fun testCXX() {
+    fun testCXXPOSIX() {
         val topLevel = File("src/integrationTest/resources/c")
         val result =
             analyze(listOf(), topLevel.toPath(), true) {
@@ -75,6 +76,7 @@ class DynamicLoadingTest {
         val loadLibrary =
             path.lastOrNull()?.operationNodes?.filterIsInstance<LoadLibrary>()?.singleOrNull()
         assertNotNull(loadLibrary)
+        assertIs<POSIX>(loadLibrary.os)
         assertEquals(
             libExample,
             loadLibrary.what,
@@ -91,6 +93,7 @@ class DynamicLoadingTest {
         val loadSymbol =
             dlSym.operationNodes.filterIsInstance<LoadSymbol<FunctionDeclaration>>().singleOrNull()
         assertNotNull(loadSymbol)
+        assertIs<POSIX>(loadSymbol.os)
         assertEquals(myFunc, loadSymbol.what, "\"what\" of the LoadSymbol should be myFunc")
 
         val c = result.refs["c"]
@@ -109,5 +112,44 @@ class DynamicLoadingTest {
         values = a.evaluate(MultiValueEvaluator())
         assertIs<Set<*>>(values)
         assertContains(values, 3)
+    }
+
+    @Test
+    fun testCXXWin32() {
+        val topLevel = File("src/integrationTest/resources/c")
+        val result =
+            analyze(listOf(), topLevel.toPath(), true) {
+                it.registerLanguage<CLanguage>()
+                it.registerPass<CXXDynamicLoadingPass>()
+                it.softwareComponents(
+                    mutableMapOf(
+                        "winmain" to listOf(topLevel.resolve("winmain")),
+                        "winexample" to listOf(topLevel.resolve("winexample")),
+                    )
+                )
+            }
+        assertNotNull(result)
+
+        val winexample = result.components["winexample"]
+        assertNotNull(winexample)
+
+        val dllMain = result.functions["DllMain"]
+        assertNotNull(dllMain)
+
+        val winmain = result.components["winmain"]
+        assertNotNull(winmain)
+
+        val loadLibrary = winmain.operationNodes.filterIsInstance<LoadLibrary>().singleOrNull()
+        assertNotNull(loadLibrary)
+        assertEquals(
+            winexample,
+            loadLibrary.what,
+            "\"what\" of the LoadLibrary should be the winexample component",
+        )
+        assertEquals(
+            dllMain,
+            loadLibrary.entryPoints.singleOrNull()?.underlyingNode,
+            "DllMain should be the only DLL entry point",
+        )
     }
 }

--- a/cpg-concepts/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/concepts/EntryPointTest.kt
+++ b/cpg-concepts/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/concepts/EntryPointTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.concepts
+
+import de.fraunhofer.aisec.cpg.frontends.cxx.CLanguage
+import de.fraunhofer.aisec.cpg.graph.conceptNodes
+import de.fraunhofer.aisec.cpg.graph.concepts.arch.POSIX
+import de.fraunhofer.aisec.cpg.graph.concepts.arch.Win32
+import de.fraunhofer.aisec.cpg.graph.concepts.flows.Main
+import de.fraunhofer.aisec.cpg.graph.get
+import de.fraunhofer.aisec.cpg.passes.concepts.flows.cxx.CXXEntryPointsPass
+import de.fraunhofer.aisec.cpg.test.analyze
+import java.io.File
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import org.junit.jupiter.api.Test
+
+class EntryPointTest {
+    @Test
+    fun testCXX() {
+        val topLevel = File("src/integrationTest/resources/c")
+        val result =
+            analyze(listOf(), topLevel.toPath(), true) {
+                it.registerLanguage<CLanguage>()
+                it.registerPass<CXXEntryPointsPass>()
+                it.softwareComponents(
+                    mutableMapOf(
+                        "main" to listOf(topLevel.resolve("main")),
+                        "winmain" to listOf(topLevel.resolve("winmain")),
+                    )
+                )
+            }
+        assertNotNull(result)
+
+        val main = result.components["main"]?.conceptNodes?.filterIsInstance<Main>()?.singleOrNull()
+        assertNotNull(main)
+        assertIs<POSIX>(main.os)
+
+        val winMain =
+            result.components["winmain"]?.conceptNodes?.filterIsInstance<Main>()?.singleOrNull()
+        assertNotNull(winMain)
+        assertIs<Win32>(winMain.os)
+    }
+}

--- a/cpg-concepts/src/integrationTest/resources/c/winexample/lib.c
+++ b/cpg-concepts/src/integrationTest/resources/c/winexample/lib.c
@@ -1,0 +1,9 @@
+#include <winbase.h>
+
+BOOL WINAPI DllMain(
+     HINSTANCE hinstDLL,
+     DWORD fdwReason,
+     LPVOID lpvReserved
+) {
+    return TRUE;
+}

--- a/cpg-concepts/src/integrationTest/resources/c/winmain/load.c
+++ b/cpg-concepts/src/integrationTest/resources/c/winmain/load.c
@@ -1,0 +1,12 @@
+#include <winbase.h>
+#include <libloaderapi.h>
+
+int WinMain(
+    HINSTANCE hInstance,
+    HINSTANCE hPrevInstance,
+    LPSTR lpCmdLine,
+    int nCmdShow
+) {
+    HMODULE lib = LoadLibraryA("winexample.dll");
+    return 0;
+}

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/arch/OperatingSystem.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/arch/OperatingSystem.kt
@@ -23,34 +23,24 @@
  *                    \______/ \__|       \______/
  *
  */
-package de.fraunhofer.aisec.cpg.graph.concepts.http
+package de.fraunhofer.aisec.cpg.graph.concepts.arch
 
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.concepts.Concept
-import de.fraunhofer.aisec.cpg.graph.concepts.Operation
-import de.fraunhofer.aisec.cpg.graph.concepts.flows.RemoteEntryPoint
 
-/** Represents a single [HttpEndpoint] on the server */
-class HttpEndpoint(
-    underlyingNode: Node,
-    val httpMethod: HttpMethod,
-    val path: String,
-    val arguments: List<Node>,
-    val supportedAuthentications: MutableList<String>,
-) : RemoteEntryPoint(underlyingNode = underlyingNode)
+/** Represents an architecture of an operating system. */
+abstract class OperatingSystemArchitecture(underlyingNode: Node) :
+    Concept(underlyingNode = underlyingNode)
 
-enum class HttpMethod {
-    GET,
-    POST,
-    PUT,
-    HEAD,
-    PATCH,
-    OPTIONS,
-    CONNECT,
-    TRACE,
-    DELETE,
-}
+/** Represents a Win32 architecture, commonly found on Windows systems. */
+class Win32(underlyingNode: Node) : OperatingSystemArchitecture(underlyingNode = underlyingNode)
 
-/** Base class for operations on an [HttpEndpoint]. */
-abstract class HttpEndpointOperation(underlyingNode: Node, concept: Concept) :
-    Operation(underlyingNode, concept)
+/** Represents a POSIX architecture, commonly found on Linux systems, */
+open class POSIX(underlyingNode: Node) :
+    OperatingSystemArchitecture(underlyingNode = underlyingNode)
+
+/**
+ * Represents a Darwin architecture, commonly found on macOS systems. macOS is a certified
+ * [UNIX](https://www.opengroup.org/openbrand/register/apple.htm) and is (mostly) POSIX compatible.
+ */
+class Darwin(underlyingNode: Node) : POSIX(underlyingNode = underlyingNode)

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/flows/EntryPoint.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/flows/EntryPoint.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.graph.concepts.flows
+
+import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.concepts.Concept
+import de.fraunhofer.aisec.cpg.graph.concepts.arch.OperatingSystemArchitecture
+
+/**
+ * Represents an entry point into the execution of the program. This can be a "local" entry point,
+ * such as a main function, a library initialization function or a "remote" entry point, such as a
+ * network endpoint.
+ */
+abstract class EntryPoint(underlyingNode: Node) : Concept(underlyingNode = underlyingNode)
+
+/** Represents a local entry point into the execution of the program, such as a main function. */
+abstract class LocalEntryPoint(
+    underlyingNode: Node,
+    /**
+     * If this entry point is specifically designed to be invoked on a certain
+     * [OperatingSystemArchitecture], it can be specified here.
+     */
+    var os: OperatingSystemArchitecture? = null,
+) : EntryPoint(underlyingNode = underlyingNode)
+
+/** The main function of a program. */
+class Main(underlyingNode: Node, os: OperatingSystemArchitecture? = null) :
+    LocalEntryPoint(underlyingNode = underlyingNode, os = os)
+
+/** Represents an entry point that is triggered if the code is loaded as a (dynamic) library. */
+class LibraryEntryPoint(underlyingNode: Node, os: OperatingSystemArchitecture? = null) :
+    LocalEntryPoint(underlyingNode = underlyingNode, os = os)
+
+/** Represents an entry point that can be triggered remotely, such as a network endpoint. */
+abstract class RemoteEntryPoint(underlyingNode: Node) : EntryPoint(underlyingNode = underlyingNode)

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/memory/DynamicLoading.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/memory/DynamicLoading.kt
@@ -28,6 +28,8 @@ package de.fraunhofer.aisec.cpg.graph.concepts.memory
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.concepts.Concept
+import de.fraunhofer.aisec.cpg.graph.concepts.arch.OperatingSystemArchitecture
+import de.fraunhofer.aisec.cpg.graph.concepts.flows.LibraryEntryPoint
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.scopes.Symbol
@@ -45,6 +47,11 @@ abstract class DynamicLoadingOperation<T : Node>(
     concept: Concept,
     /** Represents the entity that we load during runtime. */
     var what: T?,
+    /**
+     * If this operation is targeting a specific [OperatingSystemArchitecture], it can be specified
+     * here.
+     */
+    var os: OperatingSystemArchitecture? = null,
 ) : MemoryOperation(underlyingNode = underlyingNode, concept = concept), IsMemory
 
 /**
@@ -59,11 +66,22 @@ class LoadLibrary(
     concept: Concept,
     /** Represents the source code of library that we load in our graph. */
     what: Component?,
+    /**
+     * Some programming languages support an entry point that is called when a library is
+     * dynamically loaded. Examples include `DllMain` in the Win32 API.
+     */
+    var entryPoints: List<LibraryEntryPoint> = emptyList(),
+    /**
+     * If this operation is targeting a specific [OperatingSystemArchitecture], it can be specified
+     * here.
+     */
+    os: OperatingSystemArchitecture?,
 ) :
     DynamicLoadingOperation<Component>(
         underlyingNode = underlyingNode,
         concept = concept,
         what = what,
+        os = os,
     ) {
 
     /** Looks up symbol candidates for [symbol] in the [LoadLibrary.what]. */
@@ -98,4 +116,15 @@ class LoadSymbol<T : Declaration>(
      * operation that loaded the library.
      */
     var loader: LoadLibrary?,
-) : DynamicLoadingOperation<T>(underlyingNode = underlyingNode, concept = concept, what = what)
+    /**
+     * If this operation is targeting a specific [OperatingSystemArchitecture], it can be specified
+     * here.
+     */
+    os: OperatingSystemArchitecture? = loader?.os,
+) :
+    DynamicLoadingOperation<T>(
+        underlyingNode = underlyingNode,
+        concept = concept,
+        what = what,
+        os = os,
+    )

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/ConceptPass.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/ConceptPass.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.passes.concepts
+
+import de.fraunhofer.aisec.cpg.TranslationContext
+import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.component
+import de.fraunhofer.aisec.cpg.graph.conceptNodes
+import de.fraunhofer.aisec.cpg.graph.concepts.Concept
+import de.fraunhofer.aisec.cpg.graph.concepts.memory.DynamicLoading
+import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
+import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
+import de.fraunhofer.aisec.cpg.passes.TranslationUnitPass
+
+/** An abstract pass that is used to identify and handle concepts in the CPG. */
+abstract class ConceptPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {
+
+    lateinit var walker: SubgraphWalker.ScopedWalker
+
+    override fun accept(tu: TranslationUnitDeclaration) {
+        ctx.currentComponent = tu.component
+        walker = SubgraphWalker.ScopedWalker(ctx.scopeManager)
+        walker.registerHandler { _, _, node -> handleNode(node, tu) }
+
+        walker.iterate(tu)
+    }
+
+    /**
+     * This function is called for each node in the CPG. It needs to be overridden by subclasses to
+     * handle the specific node.
+     */
+    abstract fun handleNode(node: Node?, tu: TranslationUnitDeclaration)
+
+    /**
+     * Gets the [DynamicLoading] concept for this [TranslationUnitDeclaration] or creates a new one
+     * if it does not exist.
+     */
+    internal inline fun <reified T : Concept> TranslationUnitDeclaration.getConceptOrCreate(): T {
+        var concept = this.conceptNodes.filterIsInstance<T>().singleOrNull()
+        if (concept == null) {
+            concept = T::class.constructors.first().call(this)
+        }
+
+        return concept
+    }
+
+    override fun cleanup() {
+        // Nothing to do
+    }
+}

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/flows/cxx/CXXEntryPointsPass.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/flows/cxx/CXXEntryPointsPass.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.passes.concepts.flows.cxx
+
+import de.fraunhofer.aisec.cpg.TranslationContext
+import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.concepts.arch.POSIX
+import de.fraunhofer.aisec.cpg.graph.concepts.arch.Win32
+import de.fraunhofer.aisec.cpg.graph.concepts.flows.LibraryEntryPoint
+import de.fraunhofer.aisec.cpg.graph.concepts.flows.Main
+import de.fraunhofer.aisec.cpg.graph.concepts.memory.DynamicLoading
+import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
+import de.fraunhofer.aisec.cpg.passes.concepts.ConceptPass
+
+/** A pass that fills the [DynamicLoading] concept into the CPG. */
+class CXXEntryPointsPass(ctx: TranslationContext) : ConceptPass(ctx) {
+
+    override fun handleNode(node: Node?, tu: TranslationUnitDeclaration) {
+        when (node) {
+            is FunctionDeclaration -> handleFunctionDeclaration(node, tu)
+        }
+    }
+
+    private fun handleFunctionDeclaration(
+        func: FunctionDeclaration,
+        tu: TranslationUnitDeclaration,
+    ) {
+        val entry =
+            when (func.name.toString()) {
+                "main" -> Main(underlyingNode = func, os = tu.getConceptOrCreate<POSIX>())
+                "WinMain" -> Main(underlyingNode = func, os = tu.getConceptOrCreate<Win32>())
+                "DllMain" ->
+                    LibraryEntryPoint(underlyingNode = func, os = tu.getConceptOrCreate<Win32>())
+                else -> return
+            }
+
+        ctx.currentComponent?.incomingInteractions += entry
+    }
+}

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/memory/cxx/CXXDynamicLoadingPass.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/memory/cxx/CXXDynamicLoadingPass.kt
@@ -23,13 +23,15 @@
  *                    \______/ \__|       \______/
  *
  */
-package de.fraunhofer.aisec.cpg.passes.concepts.memory
+package de.fraunhofer.aisec.cpg.passes.concepts.memory.cxx
 
 import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.TranslationResult
-import de.fraunhofer.aisec.cpg.graph.Component
-import de.fraunhofer.aisec.cpg.graph.conceptNodes
-import de.fraunhofer.aisec.cpg.graph.concepts.Concept
+import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.concepts.arch.OperatingSystemArchitecture
+import de.fraunhofer.aisec.cpg.graph.concepts.arch.POSIX
+import de.fraunhofer.aisec.cpg.graph.concepts.arch.Win32
+import de.fraunhofer.aisec.cpg.graph.concepts.flows.LibraryEntryPoint
 import de.fraunhofer.aisec.cpg.graph.concepts.memory.DynamicLoading
 import de.fraunhofer.aisec.cpg.graph.concepts.memory.LoadLibrary
 import de.fraunhofer.aisec.cpg.graph.concepts.memory.LoadSymbol
@@ -38,17 +40,13 @@ import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.edges.flows.CallingContextOut
-import de.fraunhofer.aisec.cpg.graph.evaluate
-import de.fraunhofer.aisec.cpg.graph.followPrevDFG
-import de.fraunhofer.aisec.cpg.graph.operationNodes
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
-import de.fraunhofer.aisec.cpg.graph.translationResult
 import de.fraunhofer.aisec.cpg.graph.types.FunctionPointerType
-import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.passes.ControlFlowSensitiveDFGPass
 import de.fraunhofer.aisec.cpg.passes.DynamicInvokeResolver
-import de.fraunhofer.aisec.cpg.passes.TranslationUnitPass
+import de.fraunhofer.aisec.cpg.passes.concepts.ConceptPass
+import de.fraunhofer.aisec.cpg.passes.concepts.flows.cxx.CXXEntryPointsPass
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
 import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
 import kotlin.io.path.Path
@@ -56,37 +54,30 @@ import kotlin.io.path.nameWithoutExtension
 
 /** A pass that fills the [DynamicLoading] concept into the CPG. */
 @DependsOn(ControlFlowSensitiveDFGPass::class)
+@DependsOn(CXXEntryPointsPass::class)
 @ExecuteBefore(DynamicInvokeResolver::class)
-class CXXDynamicLoadingPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {
+class CXXDynamicLoadingPass(ctx: TranslationContext) : ConceptPass(ctx) {
 
-    lateinit var walker: SubgraphWalker.ScopedWalker
-
-    override fun accept(tu: TranslationUnitDeclaration) {
-        walker = SubgraphWalker.ScopedWalker(ctx.scopeManager)
-        walker.registerHandler { _, _, node ->
-            when (node) {
-                is CallExpression -> handleCallExpression(node, tu)
-            }
+    override fun handleNode(node: Node?, tu: TranslationUnitDeclaration) {
+        when (node) {
+            is CallExpression -> handleCallExpression(node, tu)
         }
-
-        walker.iterate(tu)
     }
 
     /** Handles a [CallExpression] node and checks if it is a dynamic loading operation. */
     private fun handleCallExpression(call: CallExpression, tu: TranslationUnitDeclaration) {
-        val concept = getConceptOrCreate<DynamicLoading>(tu)
+        val concept = tu.getConceptOrCreate<DynamicLoading>()
 
         val ops =
             when (call.name.toString()) {
-                "dlopen" -> {
-                    handleLibraryLoad(call, concept)
-                }
-                "dlsym" -> {
-                    handleLoadFunction(call, concept)
-                }
-                else -> {
-                    return
-                }
+                "dlopen" -> handleLibraryLoad(call, concept, os = tu.getConceptOrCreate<POSIX>())
+                "LoadLibraryA",
+                "LoadLibraryW",
+                "LoadLibraryExA",
+                "LoadLibraryExW" ->
+                    handleLibraryLoad(call, concept, os = tu.getConceptOrCreate<Win32>())
+                "dlsym" -> handleLoadFunction(call, concept)
+                else -> return
             }
 
         concept.ops += ops
@@ -153,6 +144,7 @@ class CXXDynamicLoadingPass(ctx: TranslationContext) : TranslationUnitPass(ctx) 
     private fun handleLibraryLoad(
         call: CallExpression,
         concept: DynamicLoading,
+        os: OperatingSystemArchitecture,
     ): List<LoadLibrary> {
         // The first argument of dlopen is the path to the library. We can try to evaluate the
         // argument to check if it's a constant string.
@@ -166,27 +158,25 @@ class CXXDynamicLoadingPass(ctx: TranslationContext) : TranslationUnitPass(ctx) 
                 )
             }
 
+        // Look for library entry points
+        val entryPoints =
+            component?.conceptNodes?.filterIsInstance<LibraryEntryPoint>() ?: emptyList()
+
         // Create the op
-        val op = LoadLibrary(underlyingNode = call, concept = concept, what = component)
+        val op =
+            LoadLibrary(
+                underlyingNode = call,
+                concept = concept,
+                what = component,
+                entryPoints = entryPoints,
+                os = os,
+            )
 
         return listOf(op)
     }
 
     fun TranslationResult.findComponentForLibrary(libraryName: String): Component? {
         return this.components.find { it.name.localName == libraryName }
-    }
-
-    /**
-     * Gets the [DynamicLoading] concept for this [TranslationUnitDeclaration] or creates a new one
-     * if it does not exist.
-     */
-    private inline fun <reified T : Concept> getConceptOrCreate(tu: TranslationUnitDeclaration): T {
-        var concept = tu.conceptNodes.filterIsInstance<T>().singleOrNull()
-        if (concept == null) {
-            concept = T::class.constructors.first().call(tu)
-        }
-
-        return concept
     }
 
     override fun cleanup() {


### PR DESCRIPTION
This includes main and library entry points and also makes an `HttpEndpoint` a remote entry point. Also adds support for an operating system concept and linking library entry points with dynamic loading operations.
