### PR TITLE
Update ProgramDependenceGraph (PDG) and enable tracking implicit dataflows

### DIFF
--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/query/DataflowQueriesTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/query/DataflowQueriesTest.kt
@@ -754,4 +754,58 @@ class DataflowQueriesTest {
             "Both paths go from the variable through print to baz.",
         )
     }
+
+    @Test
+    fun testImplicitFlows() {
+        val resultVerySimple = FlowQueriesTest.verySimpleDataflow()
+
+        val bazCall = resultVerySimple.calls["baz"]
+        assertNotNull(bazCall, "We expect a call to the function \"baz\".")
+        val bazArg = bazCall.arguments.singleOrNull()
+        assertIs<BinaryOperator>(
+            bazArg,
+            "The argument of the call to \"baz\" is expected to be the binary operator \"a +  b\".",
+        )
+        val bazArgA = bazArg.lhs
+        assertIs<Reference>(
+            bazArgA,
+            "The lhs of the argument is expected to be a Reference with name \"a\".",
+        )
+        assertLocalName(
+            "a",
+            bazArgA,
+            "The lhs of the argument is expected to be a Reference with name \"a\".",
+        )
+        val explicitFlowResult =
+            dataFlow(
+                startNode = bazArgA,
+                direction = Backward(GraphToFollow.DFG),
+                type = May,
+                sensitivities = FieldSensitive + ContextSensitive,
+                scope = Interprocedural(),
+                verbose = true,
+                earlyTermination = null,
+                predicate = { (it as? Literal<*>)?.value == "bla" },
+            )
+        assertFalse(
+            explicitFlowResult.value,
+            "We expect that there is no explicit data flow between the reference \"a\" and the string literal \"bla\".",
+        )
+
+        val implicitFlowResult =
+            dataFlow(
+                startNode = bazArgA,
+                direction = Backward(GraphToFollow.DFG),
+                type = May,
+                sensitivities = FieldSensitive + ContextSensitive + Implicit,
+                scope = Interprocedural(),
+                verbose = true,
+                earlyTermination = null,
+                predicate = { (it as? Literal<*>)?.value == "bla" },
+            )
+        assertTrue(
+            implicitFlowResult.value,
+            "We expect that there is an implicit data flow between the reference \"a\" and the string literal \"bla\".",
+        )
+    }
 }

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/testcases/FlowQueriesTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/testcases/FlowQueriesTest.kt
@@ -49,6 +49,8 @@ import de.fraunhofer.aisec.cpg.graph.builder.translationResult
 import de.fraunhofer.aisec.cpg.graph.builder.translationUnit
 import de.fraunhofer.aisec.cpg.graph.builder.variable
 import de.fraunhofer.aisec.cpg.graph.builder.void
+import de.fraunhofer.aisec.cpg.passes.ControlDependenceGraphPass
+import de.fraunhofer.aisec.cpg.passes.ProgramDependenceGraphPass
 
 class FlowQueriesTest {
 
@@ -57,6 +59,8 @@ class FlowQueriesTest {
             config: TranslationConfiguration =
                 TranslationConfiguration.builder()
                     .defaultPasses()
+                    .registerPass<ControlDependenceGraphPass>()
+                    .registerPass<ProgramDependenceGraphPass>()
                     .registerLanguage(TestLanguage("."))
                     .build()
         ) =

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/AnalysisConfiguration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/AnalysisConfiguration.kt
@@ -179,7 +179,9 @@ class Forward(graphToFollow: GraphToFollow) : AnalysisDirection(graphToFollow) {
             GraphToFollow.DFG -> {
                 filterEdges(
                         currentNode = currentNode,
-                        edges = currentNode.nextDFGEdges,
+                        edges =
+                            if (Implicit in sensitivities) currentNode.nextPDGEdges
+                            else currentNode.nextDFGEdges,
                         ctx = ctx,
                         scope = scope,
                         sensitivities = sensitivities,
@@ -297,7 +299,9 @@ class Backward(graphToFollow: GraphToFollow) : AnalysisDirection(graphToFollow) 
             GraphToFollow.DFG -> {
                 filterEdges(
                         currentNode = currentNode,
-                        edges = currentNode.prevDFGEdges,
+                        edges =
+                            if (Implicit in sensitivities) currentNode.prevPDGEdges
+                            else currentNode.prevDFGEdges,
                         ctx = ctx,
                         scope = scope,
                         sensitivities = sensitivities,
@@ -549,6 +553,6 @@ object Implicit : AnalysisSensitivity() {
         ctx: Context,
         analysisDirection: AnalysisDirection,
     ): Boolean {
-        TODO("Not yet implemented. Actually requires following PDG instead of DFG edges...")
+        return true
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/ControlDependence.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/ControlDependence.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.graph.edges.flows
 
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.edges.Edge
 import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeList
 import de.fraunhofer.aisec.cpg.graph.edges.collections.MirroredEdgeCollection
 import de.fraunhofer.aisec.cpg.passes.ControlDependenceGraphPass
@@ -43,13 +42,9 @@ class ControlDependence(
     end: Node,
     /** A set of [EvaluationOrder.branch] values. */
     var branches: Set<Boolean> = setOf(),
-) : Edge<Node>(start, end) {
-    /** All control dependence edges exercise control dependence. */
-    init {
-        dependence = DependenceType.CONTROL
-    }
+) : ProgramDependence(start, end, DependenceType.CONTROL) {
 
-    override var labels = setOf("CDG")
+    override var labels = super.labels.plus("CDG")
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Dataflow.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Dataflow.kt
@@ -28,7 +28,6 @@ package de.fraunhofer.aisec.cpg.graph.edges.flows
 import com.fasterxml.jackson.annotation.JsonIgnore
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.*
-import de.fraunhofer.aisec.cpg.graph.edges.Edge
 import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeSet
 import de.fraunhofer.aisec.cpg.graph.edges.collections.MirroredEdgeCollection
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
@@ -74,6 +73,10 @@ class IndexedDataflowGranularity(
     override fun equals(other: Any?): Boolean {
         return this.index == (other as? IndexedDataflowGranularity)?.index
     }
+
+    override fun hashCode(): Int {
+        return index
+    }
 }
 
 /** Creates a new [FullDataflowGranularity]. */
@@ -113,8 +116,8 @@ open class Dataflow(
     @Convert(DataflowGranularityConverter::class)
     @JsonIgnore
     var granularity: Granularity = default(),
-) : Edge<Node>(start, end) {
-    override var labels = setOf("DFG")
+) : ProgramDependence(start, end, DependenceType.DATA) {
+    override var labels = super.labels.plus("DFG")
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -154,8 +157,6 @@ class ContextSensitiveDataflow(
     granularity: Granularity = default(),
     val callingContext: CallingContext,
 ) : Dataflow(start, end, granularity) {
-
-    override var labels = setOf("DFG")
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -200,7 +201,7 @@ class Dataflows<T : Node>(
 
     /**
      * This connects our dataflow to our "mirror" property. Meaning that if we add a node to
-     * nextDFG, we add our thisRef to the "prev" of "next" and vice-versa.
+     * nextDFG, we add our thisRef to the "prev" of "next" and vice versa.
      */
     override fun handleOnAdd(edge: Dataflow) {
         super<MirroredEdgeCollection>.handleOnAdd(edge)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/ProgramDependence.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/ProgramDependence.kt
@@ -31,6 +31,7 @@ import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeSet
 import de.fraunhofer.aisec.cpg.graph.edges.collections.MirroredEdgeCollection
 import de.fraunhofer.aisec.cpg.passes.ProgramDependenceGraphPass
 import kotlin.reflect.KProperty
+import org.neo4j.ogm.annotation.RelationshipEntity
 
 /** The types of dependences that might be represented in the CPG */
 enum class DependenceType {
@@ -45,9 +46,7 @@ enum class DependenceType {
  *
  * After population, this collection will contain a direct combination of two other edge collections
  * ([Dataflows] and [ControlDependences]). If we would only handle an in-memory graph, we could just
- * store the edges in their original collection (e.g. DFG) as well as in the PDG. But the Neo4J OGM
- * does not support this, so unfortunately, we need to clone the edges before inserting them into
- * the collection. If we ever got rid of the Neo4J OGM we could potentially also remove the cloning.
+ * store the edges in their original collection (e.g. DFG) as well as in the PDG.
  */
 class ProgramDependences<NodeType : Node> :
     EdgeSet<NodeType, Edge<NodeType>>, MirroredEdgeCollection<NodeType, Edge<NodeType>> {
@@ -70,8 +69,32 @@ class ProgramDependences<NodeType : Node> :
     }
 
     override fun add(e: Edge<NodeType>): Boolean {
-        // Clone the edge before inserting. See comment above for a detailed explanation.
-        val clonedEdge = e.clone()
-        return super<EdgeSet>.add(clonedEdge)
+        return super<EdgeSet>.add(e)
+    }
+}
+
+/**
+ * This edge class defines that there's some kind of dependency between [start] and [end]. The
+ * nature of this dependency is defined by [dependence].
+ */
+@RelationshipEntity
+open class ProgramDependence(start: Node, end: Node, dependence: DependenceType) :
+    Edge<Node>(start, end) {
+    init {
+        this.dependence = dependence
+    }
+
+    override var labels = setOf("PDG")
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ProgramDependence) return false
+        return this.dependence == other.dependence && super.equals(other)
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + dependence.hashCode()
+        return result
     }
 }


### PR DESCRIPTION
This PR aims to achieve the following things:

* [x] Introduce `ProgramDependence` edges as a common super class for the CDG and DFG edges.
* [x] Get rid of cloning edges to add them to the PDG now that OGM is gone.
* [x] Implement the new dataflow-following functionality `Implicit` which follows the PDG instead of the DFG.
* [ ] Improve the documentation of the effects of the `Sensitivities`.
* [ ] Document the difference between implicit and explicit dataflows with few examples.