### PR TITLE
Make node of registerHandler non-nullable

### DIFF
--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/ConceptPass.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/ConceptPass.kt
@@ -46,7 +46,7 @@ abstract class ConceptPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {
     override fun accept(tu: TranslationUnitDeclaration) {
         ctx.currentComponent = tu.component
         walker = SubgraphWalker.ScopedWalker(ctx.scopeManager)
-        walker.registerHandler { _, _, node -> handleNode(node, tu) }
+        walker.registerHandler { node -> handleNode(node, tu) }
 
         walker.iterate(tu)
     }
@@ -55,7 +55,7 @@ abstract class ConceptPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {
      * This function is called for each node in the graph. It needs to be overridden by subclasses
      * to handle the specific node.
      */
-    abstract fun handleNode(node: Node?, tu: TranslationUnitDeclaration)
+    abstract fun handleNode(node: Node, tu: TranslationUnitDeclaration)
 
     /**
      * Gets concept of type [T] for this [TranslationUnitDeclaration] or creates a new one if it

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/flows/cxx/CXXEntryPointsPass.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/flows/cxx/CXXEntryPointsPass.kt
@@ -39,7 +39,7 @@ import de.fraunhofer.aisec.cpg.passes.concepts.ConceptPass
 /** A pass that fills the [EntryPoint] concept into the CPG. */
 class CXXEntryPointsPass(ctx: TranslationContext) : ConceptPass(ctx) {
 
-    override fun handleNode(node: Node?, tu: TranslationUnitDeclaration) {
+    override fun handleNode(node: Node, tu: TranslationUnitDeclaration) {
         when (node) {
             is FunctionDeclaration -> handleFunctionDeclaration(node, tu)
         }

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/memory/cxx/CXXDynamicLoadingPass.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/memory/cxx/CXXDynamicLoadingPass.kt
@@ -58,7 +58,7 @@ import kotlin.io.path.nameWithoutExtension
 @ExecuteBefore(DynamicInvokeResolver::class)
 class CXXDynamicLoadingPass(ctx: TranslationContext) : ConceptPass(ctx) {
 
-    override fun handleNode(node: Node?, tu: TranslationUnitDeclaration) {
+    override fun handleNode(node: Node, tu: TranslationUnitDeclaration) {
         when (node) {
             is CallExpression -> handleCallExpression(node, tu)
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -305,8 +305,6 @@ abstract class Node :
         nextPDGEdges.clear()
         nextEOGEdges.clear()
         prevEOGEdges.clear()
-
-        astParent = null
     }
 
     override fun toString(): String {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.kt
@@ -31,7 +31,6 @@ import de.fraunhofer.aisec.cpg.graph.ArgumentHolder
 import de.fraunhofer.aisec.cpg.graph.ContextProvider
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.StatementHolder
-import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
 import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeCollection
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
@@ -46,8 +45,6 @@ import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 import java.lang.annotation.AnnotationFormatError
 import java.lang.reflect.Field
 import java.util.*
-import java.util.function.BiConsumer
-import java.util.function.Consumer
 import org.slf4j.LoggerFactory
 
 /** A type for a node visitor callback for the [SubgraphWalker]. */
@@ -289,35 +286,36 @@ object SubgraphWalker {
         }
 
         /**
-         * Callback function(s) getting three arguments: the type of the class we're currently in,
-         * the root node of the current declaration scope, the currently visited node.
+         * Callback function(s) containing two arguments: the previous node and the currently
+         * visited node.
+         *
+         * The previous node depends on the [strategy], for example for [Strategy.AST_FORWARD], the
+         * previous node is equal to [Node.astParent]. But for a strategy like
+         * [Strategy.EOG_FORWARD], the previous node was the previous EOG node.
          */
-        private val handlers = mutableListOf<TriConsumer<RecordDeclaration?, Node?, Node?>>()
+        private val handlers = mutableListOf<(node: Node, previous: Node?) -> (Unit)>()
 
         fun clearCallbacks() {
             handlers.clear()
         }
 
-        fun registerHandler(handler: TriConsumer<RecordDeclaration?, Node?, Node?>) {
+        /**
+         * Registers a handler that is called whenever a new node is visited. The handler is passed
+         * the current node.
+         */
+        fun registerHandler(handler: (node: Node) -> (Unit)) {
+            handlers.add { node, previous -> handler(node) }
+        }
+
+        /**
+         * Registers a handler that is called whenever a new node is visited. The handler is passed
+         * the current node and the previous node (if it exists).
+         */
+        fun registerHandler(handler: (node: Node, previous: Node?) -> (Unit)) {
             handlers.add(handler)
         }
 
-        fun registerHandler(handler: BiConsumer<Node?, RecordDeclaration?>) {
-            handlers.add(
-                TriConsumer { currClass: RecordDeclaration?, _: Node?, currNode: Node? ->
-                    handler.accept(currNode, currClass)
-                }
-            )
-        }
-
-        fun registerHandler(handler: Consumer<Node?>) {
-            handlers.add(
-                TriConsumer { _: RecordDeclaration?, _: Node?, currNode: Node? ->
-                    handler.accept(currNode)
-                }
-            )
-        }
-
+        /** Informs the walker that a replacement of [from] with [to] was done. */
         fun registerReplacement(from: Node, to: Node) {
             walker?.registerReplacement(from, to)
         }
@@ -339,15 +337,15 @@ object SubgraphWalker {
 
         private fun handleNode(
             current: Node,
-            parent: Node?,
-            handler: TriConsumer<RecordDeclaration?, Node?, Node?>,
+            previous: Node?,
+            handler: (node: Node, previous: Node?) -> (Unit),
         ) {
             // Jump to the node's scope, if it is different from ours.
             if (scopeManager.currentScope != current.scope) {
                 scopeManager.jumpTo(current.scope)
             }
 
-            handler.accept(scopeManager.currentRecord, parent, current)
+            handler(current, previous)
         }
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DynamicInvokeResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DynamicInvokeResolver.kt
@@ -66,7 +66,7 @@ class DynamicInvokeResolver(ctx: TranslationContext) : ComponentPass(ctx) {
     override fun accept(component: Component) {
         inferDfgForUnresolvedCalls = config.inferenceConfiguration.inferDfgForUnresolvedSymbols
         walker = ScopedWalker(scopeManager)
-        walker.registerHandler { node, _ -> handle(node) }
+        walker.registerHandler { node -> handle(node) }
 
         for (tu in component.translationUnits) {
             walker.iterate(tu)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveCallExpressionAmbiguityPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveCallExpressionAmbiguityPass.kt
@@ -62,16 +62,18 @@ class ResolveCallExpressionAmbiguityPass(ctx: TranslationContext) : TranslationU
 
     override fun accept(tu: TranslationUnitDeclaration) {
         walker = SubgraphWalker.ScopedWalker(ctx.scopeManager)
-        walker.registerHandler { _, parent, node ->
+        walker.registerHandler { node ->
             when (node) {
-                is CallExpression -> handleCall(node, parent)
+                is CallExpression -> handleCall(node)
             }
         }
 
         walker.iterate(tu)
     }
 
-    private fun handleCall(call: CallExpression, parent: Node?) {
+    private fun handleCall(call: CallExpression) {
+        val parent = call.astParent
+
         // Make sure, we are not accidentally handling construct expressions (since they also derive
         // from call expressions)
         if (call is ConstructExpression) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveMemberExpressionAmbiguityPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveMemberExpressionAmbiguityPass.kt
@@ -63,7 +63,7 @@ class ResolveMemberExpressionAmbiguityPass(ctx: TranslationContext) : Translatio
 
     override fun accept(tu: TranslationUnitDeclaration) {
         walker = SubgraphWalker.ScopedWalker(ctx.scopeManager)
-        walker.registerHandler { _, _, node ->
+        walker.registerHandler { node ->
             when (node) {
                 is MemberExpression -> resolveAmbiguity(node)
             }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/StatisticsCollectionPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/StatisticsCollectionPass.kt
@@ -29,7 +29,6 @@ import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.ProblemNode
-import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.helpers.MeasurementHolder
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker.ScopedWalker
 
@@ -44,9 +43,9 @@ class StatisticsCollectionPass(ctx: TranslationContext) : TranslationResultPass(
         var problemNodes = 0
         var nodes = 0
         val walker = ScopedWalker(ctx.scopeManager)
-        walker.registerHandler { _: RecordDeclaration?, _: Node?, currNode: Node? ->
+        walker.registerHandler { node: Node ->
             nodes++
-            if (currNode is ProblemNode) {
+            if (node is ProblemNode) {
                 problemNodes++
             }
         }

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
@@ -110,7 +110,7 @@ class GoExtraPass(ctx: TranslationContext) : ComponentPass(ctx) {
         }
 
         walker = SubgraphWalker.ScopedWalker(scopeManager)
-        walker.registerHandler { _, _, node ->
+        walker.registerHandler { node ->
             when (node) {
                 is RecordDeclaration -> handleRecordDeclaration(node)
                 is AssignExpression -> handleAssign(node)

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaExtraPass.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaExtraPass.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationContext
-import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.codeAndLocationFrom
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.graph.fqn
@@ -54,16 +53,18 @@ class JavaExtraPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {
     override fun accept(tu: TranslationUnitDeclaration) {
         // Loop through all member expressions
         walker = SubgraphWalker.ScopedWalker(ctx.scopeManager)
-        walker.registerHandler { _, parent, node ->
+        walker.registerHandler { node ->
             when (node) {
-                is MemberExpression -> handleMemberExpression(node, parent)
+                is MemberExpression -> handleMemberExpression(node)
             }
         }
 
         walker.iterate(tu)
     }
 
-    fun handleMemberExpression(me: MemberExpression, parent: Node?) {
+    fun handleMemberExpression(me: MemberExpression) {
+        val parent = me.astParent
+
         // For now, we are only interested in fields and not in calls, since this will open another
         // can of worms
         if (parent is CallExpression && parent.callee == me) return

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/WalkerTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/WalkerTest.kt
@@ -60,10 +60,8 @@ class WalkerTest {
         val visitedNodes = mutableSetOf<Node>()
 
         walker.strategy = Strategy::EOG_FORWARD
-        walker.registerHandler { _, _, node ->
-            if (node != null) {
-                assertTrue(visitedNodes.add(node), "Visited node $node multiple times")
-            }
+        walker.registerHandler { node ->
+            assertTrue(visitedNodes.add(node), "Visited node $node multiple times")
         }
 
         for (tu in result.components.flatMap { it.translationUnits }) {

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
@@ -61,7 +61,7 @@ class PythonAddDeclarationsPass(ctx: TranslationContext) : ComponentPass(ctx), L
 
     override fun accept(p0: Component) {
         walker = SubgraphWalker.ScopedWalker(ctx.scopeManager)
-        walker.registerHandler { _, _, currNode -> handle(currNode) }
+        walker.registerHandler { node -> handle(node) }
 
         for (tu in p0.translationUnits) {
             walker.iterate(tu)


### PR DESCRIPTION
This PR makes the "node" part of the `registerHandler` of the walker non-nullable, as it is non-nullable. This was leading to annoying code with unnecessary null checks. Also converted the `TriConsumer` to a Kotlin function signature that allows the identification of the individual elements of the handler.