### PR TITLE
Update transitive dependency due to vulnerability

### DIFF
--- a/cpg-neo4j/build.gradle.kts
+++ b/cpg-neo4j/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
 
     // Neo4J Driver
     api(libs.neo4j.driver)
+    api(libs.netty.handler)
 
     // Command line interface support
     api(libs.picocli)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ slf4j = "2.0.16"
 clikt = "5.0.2"
 kaml = "0.72.0"
 sarif4k = "0.6.0"
+netty = "4.1.118.Final"
 
 [libraries]
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin"}
@@ -33,6 +34,7 @@ apache-commons-lang3 = { module = "org.apache.commons:commons-lang3", version = 
 neo4j-ogm-core = { module = "org.neo4j:neo4j-ogm-core", version.ref = "neo4j"}
 neo4j-ogm-bolt-driver = { module = "org.neo4j:neo4j-ogm-bolt-driver", version.ref = "neo4j"}
 neo4j-driver = { module = "org.neo4j.driver:neo4j-java-driver", version.ref = "neo4j5"}
+netty-handler = { module = "io.netty:netty-handler", version.ref = "netty"}
 
 javaparser = { module = "com.github.javaparser:javaparser-symbol-solver-core", version = "3.26.0"}
 jackson = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version = "2.18.0"}


### PR DESCRIPTION
The dependency netty-handler contains a Vulnerability that I would like to patch temporarily until `[neo4j-java-driver](https://github.com/neo4j/neo4j-java-driver)` updates the dependency internally. 

Netty, an asynchronous, event-driven network application framework, has a vulnerability starting in version 4.1.91.Final and prior to version 4.1.118.Final. When a special crafted packet is received via SslHandler it doesn't correctly handle validation of such a packet in all cases which can lead to a native crash. 