### PR TITLE
Fixed bug in `translationUnitForInference`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
@@ -37,6 +37,7 @@ import de.fraunhofer.aisec.cpg.ancestors
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.OverlayNode
+import de.fraunhofer.aisec.cpg.graph.component
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.NamespaceDeclaration
@@ -405,8 +406,8 @@ abstract class Language<T : LanguageFrontend<*, *>> : Node() {
      *
      * Therefore, we give the language a chance to return a [TranslationUnitDeclaration] where the
      * declaration should be placed. If the language does not override this function, the default
-     * implementation will return the first [TranslationUnitDeclaration] in
-     * [TranslationContext.currentComponent].
+     * implementation will return the first [TranslationUnitDeclaration] in the component of
+     * [source].
      *
      * But languages might choose to take the information of [TypeToInfer] and [source] and create a
      * specific [TranslationUnitDeclaration], e.g., for each namespace that is inferred globally or
@@ -416,10 +417,21 @@ abstract class Language<T : LanguageFrontend<*, *>> : Node() {
      * @param source the source that was responsible for the inference
      */
     fun <TypeToInfer : Node> translationUnitForInference(source: Node): TranslationUnitDeclaration {
-        val tu = source.ctx?.currentComponent?.translationUnits?.firstOrNull()
+        // The easiest way for the current component would be the traversing the AST, but that does
+        // not work for types. But types have a scope and the scope (should) have the connection to
+        // the AST
+        val component =
+            if (source is Type) {
+                source.scope?.astNode?.component
+            } else {
+                source.component
+            }
+        // We should also make sure that the language matches
+        val tu = component?.translationUnits?.firstOrNull { it.language == this }
+
         if (tu == null) {
             throw TranslationException(
-                "No translation unit found that should be used for inference"
+                "No suitable translation unit found that should be used for inference"
             )
         }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
@@ -420,12 +420,8 @@ abstract class Language<T : LanguageFrontend<*, *>> : Node() {
         // The easiest way for the current component would be the traversing the AST, but that does
         // not work for types. But types have a scope and the scope (should) have the connection to
         // the AST
-        val component =
-            if (source is Type) {
-                source.scope?.astNode?.component
-            } else {
-                source.component
-            }
+        val component = source.scope?.astNode?.component
+
         // We should also make sure that the language matches
         val tu = component?.translationUnits?.firstOrNull { it.language == this }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
@@ -417,7 +417,7 @@ abstract class Language<T : LanguageFrontend<*, *>> : Node() {
      * @param source the source that was responsible for the inference
      */
     fun <TypeToInfer : Node> translationUnitForInference(source: Node): TranslationUnitDeclaration {
-        // The easiest way for the current component would be the traversing the AST, but that does
+        // The easiest way to identify the current component would be traversing the AST, but that does
         // not work for types. But types have a scope and the scope (should) have the connection to
         // the AST
         val component = source.scope?.astNode?.component

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
@@ -406,7 +406,7 @@ abstract class Language<T : LanguageFrontend<*, *>> : Node() {
      *
      * Therefore, we give the language a chance to return a [TranslationUnitDeclaration] where the
      * declaration should be placed. If the language does not override this function, the default
-     * implementation will return the first [TranslationUnitDeclaration] in the component of
+     * implementation will return the first [TranslationUnitDeclaration] in the [Component] of
      * [source].
      *
      * But languages might choose to take the information of [TypeToInfer] and [source] and create a

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
@@ -34,6 +34,7 @@ import de.fraunhofer.aisec.cpg.CallResolutionResult
 import de.fraunhofer.aisec.cpg.SignatureResult
 import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.ancestors
+import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.OverlayNode
@@ -417,7 +418,8 @@ abstract class Language<T : LanguageFrontend<*, *>> : Node() {
      * @param source the source that was responsible for the inference
      */
     fun <TypeToInfer : Node> translationUnitForInference(source: Node): TranslationUnitDeclaration {
-        // The easiest way to identify the current component would be traversing the AST, but that does
+        // The easiest way to identify the current component would be traversing the AST, but that
+        // does
         // not work for types. But types have a scope and the scope (should) have the connection to
         // the AST
         val component = source.scope?.astNode?.component

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.kt
@@ -383,9 +383,11 @@ fun SubgraphWalker.ScopedWalker.replace(parent: Node?, old: Expression, new: Exp
                     // the whole call expression instead.
                     if (parent is MemberCallExpression && new is Reference) {
                         val newCall = parent.toCallExpression(new)
+                        newCall.arguments.forEach { it.astParent = newCall }
                         return replace(parent.astParent, parent, newCall)
                     } else if (new is MemberExpression) {
                         val newCall = parent.toMemberCallExpression(new)
+                        newCall.arguments.forEach { it.astParent = newCall }
                         return replace(parent.astParent, parent, newCall)
                     } else {
                         parent.callee = new

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
@@ -1923,4 +1923,22 @@ class PythonFrontendTest : BaseTest() {
         assertNotNull(myClass)
         assertNotNull(myClass.ancestors)
     }
+
+    @Test
+    fun testNestedReplace() {
+        val topLevel = Path.of("src", "test", "resources", "python")
+        val result =
+            analyze(listOf(topLevel.resolve("nested_replace.py").toFile()), topLevel, true) {
+                it.registerLanguage<PythonLanguage>()
+            }
+        assertNotNull(result)
+
+        val functionCall = result.calls["function"]
+        assertNotNull(functionCall)
+
+        val anotherFunctionCall = result.mcalls["another_function"]
+        assertNotNull(anotherFunctionCall)
+        assertNotNull(anotherFunctionCall.astParent)
+        assertSame(functionCall, anotherFunctionCall.astParent)
+    }
 }

--- a/cpg-language-python/src/test/resources/python/nested_replace.py
+++ b/cpg-language-python/src/test/resources/python/nested_replace.py
@@ -1,0 +1,4 @@
+import mypackage
+
+def func(value):
+    mypackage.function(value.another_function()).do_something()


### PR DESCRIPTION
There was a bug in `translationUnitForInference` where we returned an incorrect translation result.
