### PR TITLE
Harmonizing `CallExpression` name's when importing from another namespace

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -766,7 +766,7 @@ class ScopeManager : ScopeProvider {
         noinline predicate: ((T) -> Boolean)? = null,
     ): List<T> {
         return lookupSymbolByName(node.name, node.language, node.location, scope, replaceImports) {
-                it is T && predicate?.invoke(it) == true
+                it is T && (predicate?.invoke(it) != false)
             }
             .filterIsInstance<T>()
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -742,6 +742,7 @@ class ScopeManager : ScopeProvider {
     fun lookupSymbolByNodeName(
         node: Node,
         scope: Scope? = node.scope,
+        replaceImports: Boolean = true,
         predicate: ((Declaration) -> Boolean)? = null,
     ): List<Declaration> {
         return lookupSymbolByName(
@@ -749,6 +750,7 @@ class ScopeManager : ScopeProvider {
             node.language,
             node.location,
             scope,
+            replaceImports = replaceImports,
             predicate = predicate,
         )
     }
@@ -760,8 +762,11 @@ class ScopeManager : ScopeProvider {
     inline fun <reified T : Declaration> lookupSymbolByNodeNameOfType(
         node: Node,
         scope: Scope? = node.scope,
+        replaceImports: Boolean = true,
     ): List<T> {
-        return lookupSymbolByName(node.name, node.language, node.location, scope) { it is T }
+        return lookupSymbolByName(node.name, node.language, node.location, scope, replaceImports) {
+                it is T
+            }
             .filterIsInstance<T>()
     }
 
@@ -785,6 +790,7 @@ class ScopeManager : ScopeProvider {
         language: Language<*>,
         location: PhysicalLocation? = null,
         startScope: Scope? = currentScope,
+        replaceImports: Boolean = true,
         predicate: ((Declaration) -> Boolean)? = null,
     ): List<Declaration> {
         val extractedScope = extractScope(name, language, location, startScope)
@@ -808,6 +814,7 @@ class ScopeManager : ScopeProvider {
                             n.localName,
                             languageOnly = language,
                             thisScopeOnly = true,
+                            replaceImports = replaceImports,
                             predicate = predicate,
                         )
                         .toMutableList()
@@ -816,7 +823,12 @@ class ScopeManager : ScopeProvider {
                     // Otherwise, we can look up the symbol alone (without any FQN) starting from
                     // the startScope
                     startScope
-                        ?.lookupSymbol(n.localName, languageOnly = language, predicate = predicate)
+                        ?.lookupSymbol(
+                            n.localName,
+                            languageOnly = language,
+                            replaceImports = replaceImports,
+                            predicate = predicate,
+                        )
                         ?.toMutableList() ?: mutableListOf()
                 }
             }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -763,9 +763,10 @@ class ScopeManager : ScopeProvider {
         node: Node,
         scope: Scope? = node.scope,
         replaceImports: Boolean = true,
+        noinline predicate: ((T) -> Boolean)? = null,
     ): List<T> {
         return lookupSymbolByName(node.name, node.language, node.location, scope, replaceImports) {
-                it is T
+                it is T && predicate?.invoke(it) == true
             }
             .filterIsInstance<T>()
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -763,10 +763,9 @@ class ScopeManager : ScopeProvider {
         node: Node,
         scope: Scope? = node.scope,
         replaceImports: Boolean = true,
-        noinline predicate: ((T) -> Boolean)? = null,
     ): List<T> {
         return lookupSymbolByName(node.name, node.language, node.location, scope, replaceImports) {
-                it is T && (predicate?.invoke(it) != false)
+                it is T
             }
             .filterIsInstance<T>()
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveMemberExpressionAmbiguityPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveMemberExpressionAmbiguityPass.kt
@@ -78,12 +78,9 @@ class ResolveMemberExpressionAmbiguityPass(ctx: TranslationContext) : Translatio
 
     private fun resolveReference(ref: Reference) {
         val candidates =
-            scopeManager.lookupSymbolByNodeNameOfType<ImportDeclaration>(
-                ref,
-                replaceImports = false,
-            ) {
-                it.style == ImportStyle.IMPORT_SINGLE_SYMBOL_FROM_NAMESPACE
-            }
+            scopeManager
+                .lookupSymbolByNodeNameOfType<ImportDeclaration>(ref, replaceImports = false)
+                .filter { it.style == ImportStyle.IMPORT_SINGLE_SYMBOL_FROM_NAMESPACE }
 
         // We want to resolve the ambiguity of the reference, if it is a symbol directly imported
         // from a namespace

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveMemberExpressionAmbiguityPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveMemberExpressionAmbiguityPass.kt
@@ -34,6 +34,7 @@ import de.fraunhofer.aisec.cpg.graph.codeAndLocationFrom
 import de.fraunhofer.aisec.cpg.graph.declarations.ImportDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.NamespaceDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
+import de.fraunhofer.aisec.cpg.graph.edges.scopes.ImportStyle
 import de.fraunhofer.aisec.cpg.graph.fqn
 import de.fraunhofer.aisec.cpg.graph.newReference
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
@@ -76,13 +77,17 @@ class ResolveMemberExpressionAmbiguityPass(ctx: TranslationContext) : Translatio
     }
 
     private fun resolveReference(ref: Reference) {
+        val candidates =
+            scopeManager.lookupSymbolByNodeNameOfType<ImportDeclaration>(
+                ref,
+                replaceImports = false,
+            ) {
+                it.style == ImportStyle.IMPORT_SINGLE_SYMBOL_FROM_NAMESPACE
+            }
+
         // We want to resolve the ambiguity of the reference, if it is a symbol directly imported
         // from a namespace
-        val candidate =
-            scopeManager
-                .lookupSymbolByNodeNameOfType<ImportDeclaration>(ref, replaceImports = false)
-                .map { it.import }
-                .singleOrNull()
+        val candidate = candidates.map { it.import }.singleOrNull()
         if (candidate != null && candidate != ref.name) {
             ref.name = candidate
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -492,6 +492,15 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
         // We also set the callee's refersTo
         callee.refersTo = call.invokes.firstOrNull()
+        val refersToName = callee.refersTo?.name
+        if (
+            refersToName != null &&
+                refersToName != callee.name &&
+                language is HasMemberExpressionAmbiguity
+        ) {
+            // Can harmonize the name if this is a call to a namespaced function
+            callee.name = refersToName
+        }
     }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -31,7 +31,6 @@ import de.fraunhofer.aisec.cpg.frontends.*
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.edges.flows.EvaluationOrder
-import de.fraunhofer.aisec.cpg.graph.scopes.NameScope
 import de.fraunhofer.aisec.cpg.graph.scopes.Symbol
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.*
@@ -492,20 +491,7 @@ open class SymbolResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         }
 
         // We also set the callee's refersTo
-        val firstInvoke = call.invokes.firstOrNull()
-        callee.refersTo = firstInvoke
-        val refersToName = callee.refersTo?.name
-        // We harmonize the name if this is a call to a namespaced function (e.g. "foo()", when foo
-        // was imported from "bar"). But we do not want to do that for functions in our current
-        // namespace.
-        if (
-            refersToName != null &&
-                refersToName != callee.name &&
-                firstInvoke?.scope != scopeManager.firstScopeIsInstanceOrNull<NameScope>() &&
-                language is HasMemberExpressionAmbiguity
-        ) {
-            callee.name = refersToName
-        }
+        callee.refersTo = call.invokes.firstOrNull()
     }
 
     /**

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
@@ -1478,13 +1478,18 @@ class PythonFrontendTest : BaseTest() {
             }
         assertNotNull(tu)
 
-        val barCall = tu.calls["bar"]
-        assertIs<CallExpression>(barCall)
-        assertTrue(barCall.isImported)
+        val barCalls = tu.calls("bar")
+        assertEquals(2, barCalls.size)
+        barCalls.forEach { barCall ->
+            assertIs<CallExpression>(barCall)
+            assertTrue(barCall.isImported)
+        }
 
         val bazCall = tu.calls["baz"]
-        assertIs<CallExpression>(bazCall)
-        assertTrue(bazCall.isImported)
+        assertNull(
+            bazCall,
+            "We should not have a baz() call anymore, since it should be harmonized",
+        )
 
         val fooCall = tu.calls["foo"]
         assertIs<CallExpression>(fooCall)

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
@@ -1689,6 +1689,11 @@ class PythonFrontendTest : BaseTest() {
         refs.filter { it.name.localName != "field" }.forEach { assertIsNot<MemberExpression>(it) }
 
         assertEquals(
+            listOf("pkg.function", "another_pkg.function", "another_pkg.function", "pkg.function"),
+            result.calls.map { it.name.toString() },
+        )
+
+        assertEquals(
             listOf(
                 // this is the default parameter of foo
                 "pkg.some_variable",
@@ -1714,6 +1719,10 @@ class PythonFrontendTest : BaseTest() {
                 "e",
                 // rhs
                 "pkg.third_module.variable",
+                // lhs
+                "f",
+                // rhs
+                "pkg.function",
             ),
             refs.map { it.name.toString() },
         )

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
@@ -1442,21 +1442,16 @@ class PythonFrontendTest : BaseTest() {
         val cCompletelyDifferentFunc = result.functions["c.completely_different_func"]
         assertNotNull(cCompletelyDifferentFunc)
 
-        var call = result.calls["a.func"]
+        var calls = result.calls("a.func")
+        assertEquals(2, calls.size)
+
+        var call = calls.firstOrNull()
         assertNotNull(call)
         assertInvokes(call, aFunc)
 
         assertTrue(call.isImported)
 
-        call = result.calls["a_func"]
-        assertNotNull(call)
-        assertInvokes(call, aFunc)
-
-        call =
-            result.calls[
-                    { // we need to do select it this way otherwise we will also match "a.func"
-                        it.name.toString() == "func"
-                    }]
+        call = result.calls["b.func"]
         assertNotNull(call)
         assertInvokes(call, bFunc)
 

--- a/cpg-language-python/src/test/resources/python/import_vs_member.py
+++ b/cpg-language-python/src/test/resources/python/import_vs_member.py
@@ -23,5 +23,7 @@ d = alias.function()
 # and infer a namespace "pkg.third_module". This should then be a static reference to a variable in that module
 e = third_module.variable
 
+f = function()
+
 def foo(bar = pkg.some_variable):
     pass


### PR DESCRIPTION
In some some languages, we have an ambuigity when calling `a()` whether this is a local function or imported from another namespace. The symbol resolver already resolves this correctly, but leaves the call expression's name as is. This is inconsistent with what the `ResolveMemberExpressionAmbiguityPass` does, which is adjusting the name of a dotted call `a.b()` to whatever the real import name is.

This pass harmornizes the name of `CallExpression` nodes when they are imported from another package in the `SymbolResolver`.