### PR TITLE
Fixed issues with parsing additional sources

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationContext.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationContext.kt
@@ -25,9 +25,9 @@
  */
 package de.fraunhofer.aisec.cpg
 
+import de.fraunhofer.aisec.cpg.TranslationManager.AdditionalSource
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
-import java.io.File
 
 /**
  * The translation context holds all necessary managers and configurations needed during the
@@ -61,17 +61,18 @@ class TranslationContext(
     /**
      * Set of files, that are available for additional analysis. They are not the primary subjects
      * of analysis but are available to the language frontend. The files are obtained by expanding
-     * the paths in [TranslationConfiguration.includePaths].
+     * the paths in [TranslationConfiguration.includePaths]. This is done by
+     * [TranslationManager.runFrontends].
      *
      * The frontend can decide to add some of the contained files to [importedSources] which will
      * get them translated into the final graph by the [TranslationManager].
      */
-    var additionalSources: MutableSet<File> = mutableSetOf(),
+    var additionalSources: MutableSet<AdditionalSource> = mutableSetOf(),
 
     /**
      * The additional sources from the [additionalSources] chosen to be analyzed along with the code
      * under analysis. The language frontends are supposed to fill this list, e.g. by analyzing the
      * import statements of the analyzed code and deciding which sources contain relevant symbols.
      */
-    var importedSources: MutableSet<File> = mutableSetOf(),
+    var importedSources: MutableSet<AdditionalSource> = mutableSetOf(),
 )

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguageFrontend.kt
@@ -314,8 +314,10 @@ class PythonLanguageFrontend(language: Language<PythonLanguageFrontend>, ctx: Tr
 
         // We need to resolve the path relative to the top level to get the full module identifier
         // with packages. Note: in reality, only directories that have __init__.py file present are
-        // actually packages, but we skip this for now
-        var relative = path.relativeToOrNull(topLevel.toPath())
+        // actually packages, but we skip this for now. Since we are dealing with potentially
+        // relative paths, we need to canonicalize both paths.
+        var relative =
+            path.toFile().canonicalFile.relativeToOrNull(topLevel.canonicalFile)?.toPath()
         var module = path.nameWithoutExtension
         var modulePaths = (relative?.parent?.pathString?.split("/") ?: listOf()) + module
 


### PR DESCRIPTION
This PR fixes some issues with parsing of additional sources. The main problem was that if include parts are "sister" paths, e.g., ../external/lib1 and ../external/lib2, then the previous logic return an incorrect relativ path of ../lib2 instead of "lib2". This PR changes that and optimizes the implementation in a way that the additional sources are already prepared in a relative way in the translation manager (the original include path is kept to be sure). This way, a language frontend can just focus on looking at relative paths and see whether they match for example a package structure.
