### PR TITLE
Removing `verbose` of `dataFlow` and `executionPath`

### DIFF
--- a/codyze-core/build.gradle.kts
+++ b/codyze-core/build.gradle.kts
@@ -59,4 +59,5 @@ dependencies {
     findProject(":cpg-language-python")?.also {
         integrationTestImplementation(it)
     }
+    integrationTestImplementation(projects.cpgAnalysis)
 }

--- a/codyze-core/src/integrationTest/kotlin/codyze/SarifTest.kt
+++ b/codyze-core/src/integrationTest/kotlin/codyze/SarifTest.kt
@@ -76,9 +76,13 @@ class SarifTest {
 
         val paths = dataFlow(lit) { it is FunctionDeclaration }
         assertNotNull(paths)
-        assertEquals(2, paths.children.size, "Expected two paths")
+        assertEquals(
+            1,
+            paths.children.size,
+            "Expected one path (since it is a May analyis and verbose is false)",
+        )
 
-        val goodPath = paths.children.firstOrNull { it.value == true }
+        val goodPath = paths.children.singleOrNull()
         assertNotNull(goodPath)
 
         val sarif = paths.toSarif("my-rule")

--- a/codyze-core/src/integrationTest/kotlin/codyze/SarifTest.kt
+++ b/codyze-core/src/integrationTest/kotlin/codyze/SarifTest.kt
@@ -79,7 +79,7 @@ class SarifTest {
         assertEquals(
             1,
             paths.children.size,
-            "Expected one path (since it is a May analyis and verbose is false)",
+            "Expected one path (since it is a May analysis and verbose is false)",
         )
 
         val goodPath = paths.children.singleOrNull()

--- a/codyze-core/src/integrationTest/resources/simple.py
+++ b/codyze-core/src/integrationTest/resources/simple.py
@@ -1,3 +1,7 @@
 def foo() -> int:
     bar = 42
+
+    if bar < 20:
+        raise "bar is too small"
+
     return bar

--- a/codyze-core/src/main/kotlin/de/fraunhofer/aisec/codyze/Sarif.kt
+++ b/codyze-core/src/main/kotlin/de/fraunhofer/aisec/codyze/Sarif.kt
@@ -43,54 +43,50 @@ import io.github.detekt.sarif4k.*
  * [Boolean] and that the [QueryTree.children] represent the individual findings.
  */
 fun QueryTree<Boolean>.toSarif(ruleID: String): List<Result> {
-    // Our children contain all the results (good and bad), but we only are interested in the one
-    // matching our overall result
-    return this.children
-        .filter { it.value == true }
-        .map {
-            Result(
-                ruleID = ruleID,
-                message =
-                    if (this.value) {
-                        Message(text = "Query was successful")
-                    } else {
-                        Message(text = "Query failed")
-                    },
-                level =
-                    if (this.value) {
-                        Level.None
-                    } else {
-                        Level.Error
-                    },
-                kind =
-                    if (this.value) {
-                        ResultKind.Pass
-                    } else {
-                        ResultKind.Fail
-                    },
-                locations = listOfNotNull(it.node?.toSarifLocation()),
-                stacks = it.node?.toSarifCallStack(),
-                codeFlows =
-                    it.children.mapNotNull { child ->
-                        if (child.value is List<*>) {
-                            CodeFlow(
-                                threadFlows =
-                                    listOf(
-                                        ThreadFlow(
-                                            message = Message(text = "Thread flow"),
-                                            locations =
-                                                (child.value as List<*>)
-                                                    .filterIsInstance<Node>()
-                                                    .toSarifThreadFlowLocation(),
-                                        )
+    return this.children.map {
+        Result(
+            ruleID = ruleID,
+            message =
+                if (this.value) {
+                    Message(text = "Query was successful")
+                } else {
+                    Message(text = "Query failed")
+                },
+            level =
+                if (this.value) {
+                    Level.None
+                } else {
+                    Level.Error
+                },
+            kind =
+                if (this.value) {
+                    ResultKind.Pass
+                } else {
+                    ResultKind.Fail
+                },
+            locations = listOfNotNull(it.node?.toSarifLocation()),
+            stacks = it.node?.toSarifCallStack(),
+            codeFlows =
+                it.children.mapNotNull { child ->
+                    if (child.value is List<*>) {
+                        CodeFlow(
+                            threadFlows =
+                                listOf(
+                                    ThreadFlow(
+                                        message = Message(text = "Thread flow"),
+                                        locations =
+                                            (child.value as List<*>)
+                                                .filterIsInstance<Node>()
+                                                .toSarifThreadFlowLocation(),
                                     )
-                            )
-                        } else {
-                            null
-                        }
-                    },
-            )
-        }
+                                )
+                        )
+                    } else {
+                        null
+                    }
+                },
+        )
+    }
 }
 
 /**

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/FlowQueries.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/FlowQueries.kt
@@ -131,7 +131,7 @@ fun dataFlow(
     type: AnalysisType = May,
     vararg sensitivities: AnalysisSensitivity = FieldSensitive + ContextSensitive,
     scope: AnalysisScope = Interprocedural(),
-    verbose: Boolean = true,
+    verbose: Boolean = false,
     earlyTermination: ((Node) -> Boolean)? = null,
     predicate: (Node) -> Boolean,
 ): QueryTree<Boolean> {
@@ -178,7 +178,7 @@ fun executionPath(
     direction: AnalysisDirection = Forward(GraphToFollow.EOG),
     type: AnalysisType = May,
     scope: AnalysisScope = Interprocedural(),
-    verbose: Boolean = true,
+    verbose: Boolean = false,
     earlyTermination: ((Node) -> Boolean)? = null,
     predicate: (Node) -> Boolean,
 ): QueryTree<Boolean> {

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/FlowQueries.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/FlowQueries.kt
@@ -131,12 +131,11 @@ fun dataFlow(
     type: AnalysisType = May,
     vararg sensitivities: AnalysisSensitivity = FieldSensitive + ContextSensitive,
     scope: AnalysisScope = Interprocedural(),
-    verbose: Boolean = false,
     earlyTermination: ((Node) -> Boolean)? = null,
     predicate: (Node) -> Boolean,
 ): QueryTree<Boolean> {
-    val collectFailedPaths = type == Must || verbose
-    val findAllPossiblePaths = type == Must || verbose
+    val collectFailedPaths = type == Must
+    val findAllPossiblePaths = type == Must
     val earlyTermination = { n: Node, ctx: Context -> earlyTermination?.let { it(n) } == true }
 
     val evalRes =
@@ -178,12 +177,11 @@ fun executionPath(
     direction: AnalysisDirection = Forward(GraphToFollow.EOG),
     type: AnalysisType = May,
     scope: AnalysisScope = Interprocedural(),
-    verbose: Boolean = false,
     earlyTermination: ((Node) -> Boolean)? = null,
     predicate: (Node) -> Boolean,
 ): QueryTree<Boolean> {
-    val collectFailedPaths = type == Must || verbose
-    val findAllPossiblePaths = type == Must || verbose
+    val collectFailedPaths = type == Must
+    val findAllPossiblePaths = type == Must
     val earlyTermination = { n: Node, ctx: Context -> earlyTermination?.let { it(n) } == true }
 
     val evalRes =

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/query/DataflowQueriesTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/query/DataflowQueriesTest.kt
@@ -783,7 +783,6 @@ class DataflowQueriesTest {
                 type = May,
                 sensitivities = FieldSensitive + ContextSensitive,
                 scope = Interprocedural(),
-                verbose = true,
                 earlyTermination = null,
                 predicate = { (it as? Literal<*>)?.value == "bla" },
             )
@@ -799,7 +798,6 @@ class DataflowQueriesTest {
                 type = May,
                 sensitivities = FieldSensitive + ContextSensitive + Implicit,
                 scope = Interprocedural(),
-                verbose = true,
                 earlyTermination = null,
                 predicate = { (it as? Literal<*>)?.value == "bla" },
             )

--- a/cpg-concepts/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/concepts/MemoryTest.kt
+++ b/cpg-concepts/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/concepts/MemoryTest.kt
@@ -117,7 +117,6 @@ class MemoryTest {
                     direction = Forward(GraphToFollow.EOG),
                     type = Must,
                     scope = Interprocedural(),
-                    verbose = true,
                 )
             }
         assertNotNull(tree)


### PR DESCRIPTION
It seems that the verbose flag in the DFG and EOG analysis functions was true per default so the analysis type (MAY or MUST) had no effect. This cluttered the SARIF output.