### PR TITLE
Resolving unresolved symbol in lookupScope if the lookup is unqualified.

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -255,6 +255,8 @@ class ScopeManager : ScopeProvider {
                 }
         }
 
+        newScope?.ctx = nodeToScope.ctx
+
         // push the new scope
         if (newScope != null) {
             pushScope(newScope)
@@ -813,7 +815,7 @@ class ScopeManager : ScopeProvider {
                         .lookupSymbol(
                             n.localName,
                             languageOnly = language,
-                            thisScopeOnly = true,
+                            qualifiedLookup = true,
                             replaceImports = replaceImports,
                             predicate = predicate,
                         )

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
@@ -25,10 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg
 
-import de.fraunhofer.aisec.cpg.frontends.Language
-import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
-import de.fraunhofer.aisec.cpg.frontends.SupportsParallelParsing
-import de.fraunhofer.aisec.cpg.frontends.TranslationException
+import de.fraunhofer.aisec.cpg.frontends.*
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.scopes.GlobalScope
@@ -270,6 +267,15 @@ private constructor(
 
         // Adds all languages provided as additional sources that may be relevant in the main code
         usedLanguages.addAll(ctx.additionalSources.mapNotNull { it.relative.language }.toSet())
+
+        usedLanguages.filterIsInstance<HasBuiltins>().forEach { hasBuiltins ->
+            // Includes a file in the analysis, if relative to its rootpath it matches the name of
+            // a builtins file candidate.
+            val builtinsCandidates = hasBuiltins.getBuiltinsFileCandidates()
+            ctx.additionalSources
+                .filter { builtinsCandidates.contains(it.relative) }
+                .forEach { ctx.importedSources.add(it) }
+        }
 
         // A set of processed files from [TranslationContext.additionalSources] that is used as
         // negative to the

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageTraits.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/LanguageTraits.kt
@@ -37,6 +37,7 @@ import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.graph.scopes.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.passes.*
+import java.io.File
 import kotlin.reflect.KClass
 
 /**
@@ -298,6 +299,8 @@ interface HasOperatorOverloading : LanguageTrait {
 interface HasBuiltins : LanguageTrait {
     /** Returns the namespace under which builtins exist. */
     val builtinsNamespace: Name
+
+    fun getBuiltinsFileCandidates(): Set<File>
 }
 
 /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.graph.scopes
 
 import com.fasterxml.jackson.annotation.JsonBackReference
 import de.fraunhofer.aisec.cpg.PopulatedByPass
+import de.fraunhofer.aisec.cpg.frontends.HasBuiltins
 import de.fraunhofer.aisec.cpg.frontends.HasImplicitReceiver
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.Node
@@ -134,7 +135,7 @@ sealed class Scope(
      * can be used for additional filtering.
      *
      * By default, the lookup algorithm will go to the [Scope.parent] if no match was found in the
-     * current scope. This behaviour can be turned off with [thisScopeOnly]. This is useful for
+     * current scope. This behaviour can be turned off with [qualifiedLookup]. This is useful for
      * qualified lookups, where we want to stay in our lookup-scope.
      *
      * We need to consider the language trait [HasImplicitReceiver] here as well. If the language
@@ -142,8 +143,8 @@ sealed class Scope(
      * are in a qualified lookup.
      *
      * @param symbol the symbol to lookup
-     * @param thisScopeOnly whether we should stay in the current scope for lookup or traverse to
-     *   its parents if no match was found.
+     * @param qualifiedLookup whether the lookup is looked to a specific namespace, and we therefore should stay in the
+     * current scope for lookup. If the lookup is unqualified we traverse the current scopes parents if no match was found.
      * @param replaceImports whether any symbols pointing to [ImportDeclaration.importedSymbols] or
      *   wildcards should be replaced with their actual nodes
      * @param predicate An optional predicate which should be used in the lookup.
@@ -151,7 +152,7 @@ sealed class Scope(
     fun lookupSymbol(
         symbol: Symbol,
         languageOnly: Language<*>? = null,
-        thisScopeOnly: Boolean = false,
+        qualifiedLookup: Boolean = false,
         replaceImports: Boolean = true,
         predicate: ((Declaration) -> Boolean)? = null,
     ): List<Declaration> {
@@ -193,10 +194,10 @@ sealed class Scope(
                 break
             }
 
-            // If we do not have a hit, we can go up one scope, unless thisScopeOnly is set to true
+            // If we do not have a hit, we can go up one scope, unless [qualifiedLookup] is set to true
             // (or we had a modified scope)
             scope =
-                if (thisScopeOnly || modifiedScoped != null) {
+                if (qualifiedLookup || modifiedScoped != null) {
                     break
                 } else {
                     // If our language needs explicit lookup for fields (and other class members),
@@ -208,6 +209,32 @@ sealed class Scope(
                         scope.parent
                     }
                 }
+        }
+
+        // If the symbol was still not resolved, and we are performing an unqualified resolution, we search in the
+        // languages builtin scope for the symbol
+        if (list.isNullOrEmpty() && !qualifiedLookup) {
+            list = mutableListOf()
+            // If the language has builtins we can search there for the symbol
+            (languageOnly as? HasBuiltins)?.let {
+                val builtinNamespace = it.builtinsNamespace
+                // Retrieve the builtins scope from the builtins namespace
+                (ctx ?: this.astNode?.ctx)?.scopeManager?.lookupScope(builtinNamespace)?.let {
+                    builtinScope ->
+                    // Obviously we don't want to search in the builtins scope if we already failed
+                    // finding the symbol in the builtins scope
+                    if (builtinScope != this) {
+                        list.addAll(
+                            builtinScope.lookupSymbol(
+                                symbol,
+                                languageOnly = languageOnly,
+                                replaceImports = replaceImports,
+                                predicate = predicate,
+                            )
+                        )
+                    }
+                }
+            }
         }
 
         return list ?: listOf()

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
@@ -258,6 +258,10 @@ class PythonLanguage :
         return filesForNamespace
     }
 
+    override fun getBuiltinsFileCandidates(): Set<File> {
+        return nameToLanguageFiles(builtinsNamespace)
+    }
+
     companion object {
         /**
          * This is a "modifier" to differentiate parameters in functions that are "positional" only.


### PR DESCRIPTION
The PR adds the builtin files of each parsed language to the additional nodes that should be parsed. Then, in the lookup scope function, symbols that are not resolved while performing an unqualified lookup are searched in the builtins namespace. Additionally, the `thisScopeOnly` parameter is renamed to `qualifiedLookup` as it is only a small renaming relevant in the context.