### PR TITLE
Moving `ValueEvaluator` to `cpg-core`

### DIFF
--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGPass.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGPass.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationContext
-import de.fraunhofer.aisec.cpg.analysis.ValueEvaluator
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.edges.flows.EvaluationOrder
@@ -47,8 +46,6 @@ import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
  */
 @DependsOn(ControlFlowSensitiveDFGPass::class)
 open class UnreachableEOGPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
-
-    protected open val evaluator = ValueEvaluator()
 
     override fun cleanup() {
         // Nothing to do
@@ -143,7 +140,7 @@ open class UnreachableEOGPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
         n: IfStatement,
         state: UnreachabilityStateElement,
     ): UnreachabilityStateElement {
-        val evalResult = evaluator.evaluate(n.condition)
+        val evalResult = n.language.evaluator.evaluate(n.condition)
 
         val (unreachableEdges, remainingEdges) =
             if (evalResult == true) {
@@ -192,7 +189,7 @@ open class UnreachableEOGPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
                 is ForStatement -> n.condition
                 else -> return state
             }
-        val evalResult = evaluator.evaluate(condition)
+        val evalResult = n.language.evaluator.evaluate(condition)
 
         val (unreachableEdges, remainingEdges) =
             if (evalResult is Boolean && evalResult == true) {

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/Query.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/Query.kt
@@ -25,10 +25,10 @@
  */
 package de.fraunhofer.aisec.cpg.query
 
-import de.fraunhofer.aisec.cpg.analysis.MultiValueEvaluator
-import de.fraunhofer.aisec.cpg.analysis.NumberSet
-import de.fraunhofer.aisec.cpg.analysis.SizeEvaluator
-import de.fraunhofer.aisec.cpg.analysis.ValueEvaluator
+import de.fraunhofer.aisec.cpg.evaluation.MultiValueEvaluator
+import de.fraunhofer.aisec.cpg.evaluation.NumberSet
+import de.fraunhofer.aisec.cpg.evaluation.SizeEvaluator
+import de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.types.Type

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/QueryTree.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/QueryTree.kt
@@ -25,7 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.query
 
-import de.fraunhofer.aisec.cpg.analysis.compareTo
+import de.fraunhofer.aisec.cpg.evaluation.compareTo
 import de.fraunhofer.aisec.cpg.graph.Node
 
 /**

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/query/QueryTest.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/query/QueryTest.kt
@@ -25,8 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.query
 
-import de.fraunhofer.aisec.cpg.analysis.MultiValueEvaluator
-import de.fraunhofer.aisec.cpg.analysis.NumberSet
+import de.fraunhofer.aisec.cpg.evaluation.MultiValueEvaluator
+import de.fraunhofer.aisec.cpg.evaluation.NumberSet
 import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration

--- a/cpg-concepts/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/concepts/ConfigurationPassTest.kt
+++ b/cpg-concepts/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/concepts/ConfigurationPassTest.kt
@@ -25,7 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.concepts
 
-import de.fraunhofer.aisec.cpg.analysis.MultiValueEvaluator
+import de.fraunhofer.aisec.cpg.evaluation.MultiValueEvaluator
 import de.fraunhofer.aisec.cpg.frontends.ini.IniFileLanguage
 import de.fraunhofer.aisec.cpg.frontends.python.PythonLanguage
 import de.fraunhofer.aisec.cpg.graph.*

--- a/cpg-concepts/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/concepts/DynamicLoadingTest.kt
+++ b/cpg-concepts/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/concepts/DynamicLoadingTest.kt
@@ -25,7 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.concepts
 
-import de.fraunhofer.aisec.cpg.analysis.MultiValueEvaluator
+import de.fraunhofer.aisec.cpg.evaluation.MultiValueEvaluator
 import de.fraunhofer.aisec.cpg.frontends.cxx.CLanguage
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.concepts.arch.POSIX

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/config/python/PythonStdLibConfigurationPass.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/config/python/PythonStdLibConfigurationPass.kt
@@ -26,7 +26,7 @@
 package de.fraunhofer.aisec.cpg.passes.concepts.config.python
 
 import de.fraunhofer.aisec.cpg.TranslationContext
-import de.fraunhofer.aisec.cpg.analysis.MultiValueEvaluator
+import de.fraunhofer.aisec.cpg.evaluation.MultiValueEvaluator
 import de.fraunhofer.aisec.cpg.graph.Backward
 import de.fraunhofer.aisec.cpg.graph.GraphToFollow
 import de.fraunhofer.aisec.cpg.graph.Name

--- a/cpg-console/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/NullPointerCheck.kt
+++ b/cpg-console/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/NullPointerCheck.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.analysis
 import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.console.fancyCode
 import de.fraunhofer.aisec.cpg.console.fancyLocationLink
+import de.fraunhofer.aisec.cpg.evaluation.CouldNotResolve
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
@@ -72,7 +73,7 @@ class NullPointerCheck {
             // check for all incoming DFG branches
             node.base?.prevDFG?.forEach {
                 var resolved: Any? = CouldNotResolve()
-                val resolver = ValueEvaluator()
+                val resolver = node.language.evaluator
                 if (it is Expression || it is Declaration) {
                     // try to resolve them
                     resolved = resolver.evaluate(it)

--- a/cpg-console/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/OutOfBoundsCheck.kt
+++ b/cpg-console/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/OutOfBoundsCheck.kt
@@ -54,7 +54,7 @@ class OutOfBoundsCheck {
                 Strategy::AST_FORWARD,
                 object : IVisitor<Node>() {
                     fun visit(v: SubscriptExpression) {
-                        val evaluator = ValueEvaluator()
+                        val evaluator = v.language.evaluator
                         val resolvedIndex = evaluator.evaluate(v.subscriptExpression)
 
                         if (resolvedIndex !is Int) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/MultiValueEvaluator.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/MultiValueEvaluator.kt
@@ -23,7 +23,7 @@
  *                    \______/ \__|       \______/
  *
  */
-package de.fraunhofer.aisec.cpg.analysis
+package de.fraunhofer.aisec.cpg.evaluation
 
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.FieldDeclaration
@@ -45,10 +45,14 @@ class MultiValueEvaluator : ValueEvaluator() {
         get() = LoggerFactory.getLogger(MultiValueEvaluator::class.java)
 
     override fun evaluate(node: Any?): Any? {
+        clearPath()
+
         val result = evaluateInternal(node as? Node, 0)
-        return if (result is Collection<*> && result.all { r -> r is Number })
+        return if (result is Collection<*> && result.all { r -> r is Number }) {
             ConcreteNumberSet(result.map { r -> (r as Number).toLong() }.toMutableSet())
-        else result
+        } else {
+            result
+        }
     }
 
     /** Tries to evaluate this node. Anything can happen. */

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/NumberExtensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/NumberExtensions.kt
@@ -23,7 +23,7 @@
  *                    \______/ \__|       \______/
  *
  */
-package de.fraunhofer.aisec.cpg.analysis
+package de.fraunhofer.aisec.cpg.evaluation
 
 internal operator fun Number.plus(other: Number): Number =
     when (this) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/NumberSet.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/NumberSet.kt
@@ -23,7 +23,7 @@
  *                    \______/ \__|       \______/
  *
  */
-package de.fraunhofer.aisec.cpg.analysis
+package de.fraunhofer.aisec.cpg.evaluation
 
 import de.fraunhofer.aisec.cpg.graph.Node
 import org.apache.commons.lang3.builder.ToStringBuilder

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/SizeEvaluator.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/SizeEvaluator.kt
@@ -23,7 +23,7 @@
  *                    \______/ \__|       \______/
  *
  */
-package de.fraunhofer.aisec.cpg.analysis
+package de.fraunhofer.aisec.cpg.evaluation
 
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluator.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluator.kt
@@ -23,7 +23,7 @@
  *                    \______/ \__|       \______/
  *
  */
-package de.fraunhofer.aisec.cpg.analysis
+package de.fraunhofer.aisec.cpg.evaluation
 
 import de.fraunhofer.aisec.cpg.graph.AccessValues
 import de.fraunhofer.aisec.cpg.graph.HasInitializer
@@ -74,6 +74,7 @@ open class ValueEvaluator(
 
     open fun evaluate(node: Any?): Any? {
         if (node !is Node) return node
+        clearPath()
 
         return evaluateInternal(node, 0)
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
@@ -56,9 +56,11 @@ import de.fraunhofer.aisec.cpg.helpers.Util
 import de.fraunhofer.aisec.cpg.helpers.Util.errorWithFileLocation
 import de.fraunhofer.aisec.cpg.passes.SymbolResolver
 import de.fraunhofer.aisec.cpg.passes.inference.Inference
+import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
 import java.io.File
 import kotlin.reflect.KClass
 import kotlin.reflect.full.primaryConstructor
+import org.neo4j.ogm.annotation.Transient
 
 /**
  * [CastResult] is the result of the function [Language.tryCast] and describes whether a cast of one
@@ -125,7 +127,7 @@ abstract class Language<T : LanguageFrontend<*, *>> : Node {
     open val simpleAssignmentOperators: Set<String> = setOf("=")
 
     /** The standard evaluator to be used with this language. */
-    open val evaluator: ValueEvaluator = ValueEvaluator()
+    @Transient @DoNotPersist open val evaluator: ValueEvaluator = ValueEvaluator()
 
     constructor(ctx: TranslationContext? = null) : super() {
         this.ctx = ctx

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
@@ -34,6 +34,7 @@ import de.fraunhofer.aisec.cpg.CallResolutionResult
 import de.fraunhofer.aisec.cpg.SignatureResult
 import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.ancestors
+import de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.Node
@@ -122,6 +123,9 @@ abstract class Language<T : LanguageFrontend<*, *>> : Node {
 
     /** All operators which perform a simple assignment from the rhs to the lhs. */
     open val simpleAssignmentOperators: Set<String> = setOf("=")
+
+    /** The standard evaluator to be used with this language. */
+    open val evaluator: ValueEvaluator = ValueEvaluator()
 
     constructor(ctx: TranslationContext? = null) : super() {
         this.ctx = ctx

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/EvaluationExtensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/EvaluationExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Fraunhofer AISEC. All rights reserved.
+ * Copyright (c) 2025, Fraunhofer AISEC. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,12 +25,12 @@
  */
 package de.fraunhofer.aisec.cpg.graph
 
-import de.fraunhofer.aisec.cpg.analysis.ValueEvaluator
-import de.fraunhofer.aisec.cpg.graph.edges.get
+import de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator
+import de.fraunhofer.aisec.cpg.graph.edges.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.NewArrayExpression
 
-fun Node.evaluate(evaluator: ValueEvaluator = ValueEvaluator()): Any? {
+fun Node.evaluate(evaluator: ValueEvaluator = this.language.evaluator): Any? {
     return evaluator.evaluate(this)
 }
 

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/MultiValueEvaluatorTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/MultiValueEvaluatorTest.kt
@@ -23,7 +23,7 @@
  *                    \______/ \__|       \______/
  *
  */
-package de.fraunhofer.aisec.cpg.analysis
+package de.fraunhofer.aisec.cpg.evaluation
 
 import de.fraunhofer.aisec.cpg.frontends.TestHandler
 import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
@@ -31,12 +31,7 @@ import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.AssignExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Block
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
-import de.fraunhofer.aisec.cpg.testcases.ValueEvaluationTests
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 class MultiValueEvaluatorTest {
     @Test

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/SizeEvaluatorTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/SizeEvaluatorTest.kt
@@ -23,16 +23,14 @@
  *                    \______/ \__|       \______/
  *
  */
-package de.fraunhofer.aisec.cpg.analysis
+package de.fraunhofer.aisec.cpg.evaluation
 
 import de.fraunhofer.aisec.cpg.graph.*
-import de.fraunhofer.aisec.cpg.graph.bodyOrNull
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.DeclarationStatement
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.AssignExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Block
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.SubscriptExpression
-import de.fraunhofer.aisec.cpg.testcases.ValueEvaluationTests
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluationTests.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluationTests.kt
@@ -37,7 +37,7 @@ class ValueEvaluationTests {
     companion object {
         fun getSizeExample(
             config: TranslationConfiguration =
-                TranslationConfiguration.Companion.builder()
+                TranslationConfiguration.builder()
                     .defaultPasses()
                     .registerLanguage<TestLanguage>()
                     .build()
@@ -98,7 +98,7 @@ class ValueEvaluationTests {
 
         fun getComplexExample(
             config: TranslationConfiguration =
-                TranslationConfiguration.Companion.builder()
+                TranslationConfiguration.builder()
                     .defaultPasses()
                     .registerLanguage<TestLanguage>()
                     .build()
@@ -139,7 +139,7 @@ class ValueEvaluationTests {
 
         fun getExample(
             config: TranslationConfiguration =
-                TranslationConfiguration.Companion.builder()
+                TranslationConfiguration.builder()
                     .defaultPasses()
                     .registerLanguage<TestLanguage>()
                     .build()
@@ -243,7 +243,7 @@ class ValueEvaluationTests {
 
         fun getCfExample(
             config: TranslationConfiguration =
-                TranslationConfiguration.Companion.builder()
+                TranslationConfiguration.builder()
                     .defaultPasses()
                     .registerLanguage<TestLanguage>()
                     .build()

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluationTests.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluationTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Fraunhofer AISEC. All rights reserved.
+ * Copyright (c) 2025, Fraunhofer AISEC. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,23 +23,23 @@
  *                    \______/ \__|       \______/
  *
  */
-package de.fraunhofer.aisec.cpg.testcases
+package de.fraunhofer.aisec.cpg.evaluation
 
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.frontends.TestLanguage
 import de.fraunhofer.aisec.cpg.frontends.testFrontend
-import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.array
 import de.fraunhofer.aisec.cpg.graph.builder.*
-import de.fraunhofer.aisec.cpg.passes.UnreachableEOGPass
+import de.fraunhofer.aisec.cpg.graph.newConditionalExpression
+import de.fraunhofer.aisec.cpg.graph.newNewArrayExpression
 
 class ValueEvaluationTests {
     companion object {
         fun getSizeExample(
             config: TranslationConfiguration =
-                TranslationConfiguration.builder()
+                TranslationConfiguration.Companion.builder()
                     .defaultPasses()
                     .registerLanguage<TestLanguage>()
-                    .registerPass<UnreachableEOGPass>()
                     .build()
         ) =
             testFrontend(config).build {
@@ -98,10 +98,9 @@ class ValueEvaluationTests {
 
         fun getComplexExample(
             config: TranslationConfiguration =
-                TranslationConfiguration.builder()
+                TranslationConfiguration.Companion.builder()
                     .defaultPasses()
                     .registerLanguage<TestLanguage>()
-                    .registerPass<UnreachableEOGPass>()
                     .build()
         ) =
             testFrontend(config).build {
@@ -140,10 +139,9 @@ class ValueEvaluationTests {
 
         fun getExample(
             config: TranslationConfiguration =
-                TranslationConfiguration.builder()
+                TranslationConfiguration.Companion.builder()
                     .defaultPasses()
                     .registerLanguage<TestLanguage>()
-                    .registerPass<UnreachableEOGPass>()
                     .build()
         ) =
             testFrontend(config).build {
@@ -245,10 +243,9 @@ class ValueEvaluationTests {
 
         fun getCfExample(
             config: TranslationConfiguration =
-                TranslationConfiguration.builder()
+                TranslationConfiguration.Companion.builder()
                     .defaultPasses()
                     .registerLanguage<TestLanguage>()
-                    .registerPass<UnreachableEOGPass>()
                     .build()
         ) =
             testFrontend(config).build {

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluatorTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluatorTest.kt
@@ -23,12 +23,11 @@
  *                    \______/ \__|       \______/
  *
  */
-package de.fraunhofer.aisec.cpg.analysis
+package de.fraunhofer.aisec.cpg.evaluation
 
 import de.fraunhofer.aisec.cpg.frontends.TestHandler
 import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.*
-import de.fraunhofer.aisec.cpg.testcases.ValueEvaluationTests
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/MermaidPrinterTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/MermaidPrinterTest.kt
@@ -59,7 +59,7 @@ class MermaidPrinterTest {
         with(TestLanguageFrontend()) {
             val ref = newReference("foo")
             val call = newCallExpression(ref)
-            val lit = newLiteral(1)
+            val lit = newLiteral(1337).also { it.name = Name("1337") }
             call.arguments += lit
             assertNotNull(ref.astParent)
 
@@ -70,7 +70,7 @@ class MermaidPrinterTest {
             assertContains(ast, "foo")
             assertContains(ast, "CallExpression")
             assertContains(ast, "Literal")
-            assertContains(ast, "1")
+            assertContains(ast, "1337")
         }
     }
 }

--- a/cpg-language-go/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
+++ b/cpg-language-go/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontendTest.kt
@@ -25,7 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.frontends.golang
 
-import de.fraunhofer.aisec.cpg.analysis.MultiValueEvaluator
+import de.fraunhofer.aisec.cpg.evaluation.MultiValueEvaluator
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.*

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.frontends.python
 
 import de.fraunhofer.aisec.cpg.TranslationContext
+import de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator
 import de.fraunhofer.aisec.cpg.frontends.*
 import de.fraunhofer.aisec.cpg.graph.HasOverloadedOperation
 import de.fraunhofer.aisec.cpg.graph.Name
@@ -179,6 +180,9 @@ class PythonLanguage(ctx: TranslationContext) :
                     language = this,
                 ),
         )
+
+    override val evaluator: ValueEvaluator
+        get() = PythonValueEvaluator()
 
     override fun propagateTypeOfBinaryOperation(operation: BinaryOperator): Type {
         val autoType = autoType()

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
@@ -40,6 +40,7 @@ import de.fraunhofer.aisec.cpg.graph.statements.expressions.UnaryOperator
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.helpers.Util.warnWithFileLocation
 import de.fraunhofer.aisec.cpg.helpers.neo4j.SimpleNameConverter
+import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
 import java.io.File
 import kotlin.reflect.KClass
 import org.neo4j.ogm.annotation.Transient
@@ -181,6 +182,7 @@ class PythonLanguage(ctx: TranslationContext) :
                 ),
         )
 
+    @DoNotPersist
     override val evaluator: ValueEvaluator
         get() = PythonValueEvaluator()
 

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonValueEvaluator.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonValueEvaluator.kt
@@ -25,7 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.frontends.python
 
-import de.fraunhofer.aisec.cpg.analysis.ValueEvaluator
+import de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator
 import de.fraunhofer.aisec.cpg.graph.HasOperatorCode
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonUnreachableEOGPass.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonUnreachableEOGPass.kt
@@ -38,7 +38,4 @@ import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
  */
 @ExecuteBefore(SymbolResolver::class)
 @DependsOn(EvaluationOrderGraphPass::class)
-class PythonUnreachableEOGPass(ctx: TranslationContext) : UnreachableEOGPass(ctx) {
-
-    override val evaluator = PythonValueEvaluator()
-}
+class PythonUnreachableEOGPass(ctx: TranslationContext) : UnreachableEOGPass(ctx)


### PR DESCRIPTION
This PR moves `ValueEvaluator` to `cpg-core` and makes it possible for a language to override the default.
