### PR TITLE
Maven publish with new plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,14 +98,25 @@ jobs:
         with:
           name: reports
           path: reports.zip
-      - name: Publish to Maven Central
-        if: startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'publish-to-github-packages')
+      - name: Publish to Maven Central (release)
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           export ORG_GRADLE_PROJECT_signingInMemoryKey=`echo ${{ secrets.GPG_PRIVATE_KEY }} | base64 -d`
           ./gradlew --no-daemon --parallel publishAllPublicationsToMavenCentralRepository
         env:
           ORG_GRADLE_PROJECT_version: ${{ env.version }}
           ORG_GRADLE_PROJECT_includeJavadoc: true
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+      - name: Publish to Maven Central (snapshot)
+        if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'publish-to-github-packages')
+        run: |
+          export ORG_GRADLE_PROJECT_signingInMemoryKey=`echo ${{ secrets.GPG_PRIVATE_KEY }} | base64 -d`
+          ./gradlew --no-daemon --parallel publishAllPublicationsToMavenCentralRepository
+        env:
+          ORG_GRADLE_PROJECT_version: ${{ env.version }}
+          ORG_GRADLE_PROJECT_includeJavadoc: false
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSWORD }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,11 +101,11 @@ jobs:
       - name: Publish to Maven Central
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          export ORG_GRADLE_PROJECT_signingKey=`echo ${{ secrets.GPG_PRIVATE_KEY }} | base64 -d`
-          ./gradlew --no-daemon -Dorg.gradle.internal.publish.checksums.insecure=true --parallel -Pversion=$VERSION -PenableJavaFrontend=true  -PenableCXXFrontend=true -PenableGoFrontend=true -PenablePythonFrontend=true -PenableLLVMFrontend=true -PenableTypeScriptFrontend=true -PenableRubyFrontend=true publishToSonatype closeSonatypeStagingRepository
+          export ORG_GRADLE_PROJECT_signingInMemoryKey=`echo ${{ secrets.GPG_PRIVATE_KEY }} | base64 -d`
+          ./gradlew --no-daemon --parallel -Pversion=$VERSION -PenableJavaFrontend=true -PRELEASE_SIGNING_ENABLED=true -PenableCXXFrontend=true -PenableGoFrontend=true -PenablePythonFrontend=true -PenableLLVMFrontend=true -PenableTypeScriptFrontend=true -PenableRubyFrontend=true publishAllPublicationsToMavenCentralRepository
         env:
           VERSION: ${{ env.version }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSWORD }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
       - name: Download old dokka versions (version)
@@ -151,10 +151,11 @@ jobs:
       - name: Publish to GitHub Packages (as snapshot)
         if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'publish-to-github-packages')
         run: |
-          ./gradlew --parallel -Pversion=$VERSION publishAllPublicationsToGitHubPackagesRepository
+          ./gradlew --parallel -Pversion=$VERSION publishAllPublicationsToGithubPackagesRepository
         env:
           VERSION: ${{ env.version }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_GRADLE_PROJECT_githubPackagesUsername: ${{ env.GITHUB_ACTOR }}
+          ORG_GRADLE_PROJECT_githubPackagesPassword: ${{ secrets.GITHUB_TOKEN }}
       #- name: Publish to GitHub Packages (as commit SHA)
       #  if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'publish-to-github-packages')
       #  run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,7 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_version: ${{ env.version }}
           ORG_GRADLE_PROJECT_includeJavadoc: true
+          ORG_GRADLE_PROJECT_signingRequired: true
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSWORD }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
@@ -113,10 +114,11 @@ jobs:
         if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'publish-to-github-packages')
         run: |
           export ORG_GRADLE_PROJECT_signingInMemoryKey=`echo ${{ secrets.GPG_PRIVATE_KEY }} | base64 -d`
-          ./gradlew --no-daemon --parallel publishAllPublicationsToMavenCentralRepository
+          ./gradlew --no-daemon --parallel publishAllPublicationsToMavenCentralRepository -x npmInstall
         env:
           ORG_GRADLE_PROJECT_version: ${{ env.version }}
           ORG_GRADLE_PROJECT_includeJavadoc: false
+          ORG_GRADLE_PROJECT_signingRequired: false
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSWORD }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
@@ -160,21 +162,6 @@ jobs:
         with:
           folder: build/dokkaCustomMultiModuleOutput/main-SNAPSHOT
           target-folder: dokka/main
-      - name: Publish to GitHub Packages (as snapshot)
-        if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'publish-to-github-packages')
-        run: |
-          ./gradlew --parallel publishAllPublicationsToGithubPackagesRepository
-        env:
-          ORG_GRADLE_PROJECT_version: ${{ env.version }}
-          ORG_GRADLE_PROJECT_includeJavadoc: false
-          ORG_GRADLE_PROJECT_githubPackagesUsername: ${{ env.GITHUB_ACTOR }}
-          ORG_GRADLE_PROJECT_githubPackagesPassword: ${{ secrets.GITHUB_TOKEN }}
-      #- name: Publish to GitHub Packages (as commit SHA)
-      #  if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'publish-to-github-packages')
-      #  run: |
-      #    ./gradlew --parallel -Pversion=${GITHUB_SHA::7} publishAllPublicationsToGitHubPackagesRepository
-      #  env:
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/v')
         id: create_release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,10 +63,10 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
       - name: Build ${{ env.version }}
         run: |
-          ./gradlew --parallel -Pversion=$VERSION spotlessCheck -x spotlessApply build -x distZip -x distTar koverXmlReport koverHtmlReport performanceTest integrationTest
+          ./gradlew --parallel spotlessCheck -x spotlessApply build -x distZip -x distTar koverXmlReport koverHtmlReport performanceTest integrationTest
         id: build
         env:
-          VERSION: ${{ env.version }}
+          ORG_GRADLE_PROJECT_version: ${{ env.version }}
       - name: Prepare report.xml for Codecov
         run: |
           # this is needed because codecov incorrectly reports lines that have no coverage information (good or bad) as a miss
@@ -102,9 +102,10 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           export ORG_GRADLE_PROJECT_signingInMemoryKey=`echo ${{ secrets.GPG_PRIVATE_KEY }} | base64 -d`
-          ./gradlew --no-daemon --parallel -Pversion=$VERSION -PenableJavaFrontend=true -PRELEASE_SIGNING_ENABLED=true -PenableCXXFrontend=true -PenableGoFrontend=true -PenablePythonFrontend=true -PenableLLVMFrontend=true -PenableTypeScriptFrontend=true -PenableRubyFrontend=true publishAllPublicationsToMavenCentralRepository
+          ./gradlew --no-daemon --parallel publishAllPublicationsToMavenCentralRepository
         env:
-          VERSION: ${{ env.version }}
+          ORG_GRADLE_PROJECT_version: ${{ env.version }}
+          ORG_GRADLE_PROJECT_includeJavadoc: true
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSWORD }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
@@ -153,7 +154,8 @@ jobs:
         run: |
           ./gradlew --parallel -Pversion=$VERSION publishAllPublicationsToGithubPackagesRepository
         env:
-          VERSION: ${{ env.version }}
+          ORG_GRADLE_PROJECT_version: ${{ env.version }}
+          ORG_GRADLE_PROJECT_includeJavadoc: false
           ORG_GRADLE_PROJECT_githubPackagesUsername: ${{ env.GITHUB_ACTOR }}
           ORG_GRADLE_PROJECT_githubPackagesPassword: ${{ secrets.GITHUB_TOKEN }}
       #- name: Publish to GitHub Packages (as commit SHA)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Publish to GitHub Packages (as snapshot)
         if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'publish-to-github-packages')
         run: |
-          ./gradlew --parallel -Pversion=$VERSION publishAllPublicationsToGithubPackagesRepository
+          ./gradlew --parallel publishAllPublicationsToGithubPackagesRepository
         env:
           ORG_GRADLE_PROJECT_version: ${{ env.version }}
           ORG_GRADLE_PROJECT_includeJavadoc: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
           name: reports
           path: reports.zip
       - name: Publish to Maven Central
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'publish-to-github-packages')
         run: |
           export ORG_GRADLE_PROJECT_signingInMemoryKey=`echo ${{ secrets.GPG_PRIVATE_KEY }} | base64 -d`
           ./gradlew --no-daemon --parallel publishAllPublicationsToMavenCentralRepository

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,6 @@
 //
 plugins {
     id("org.jetbrains.dokka")
-    id("io.github.gradle-nexus.publish-plugin")
     id("test-report-aggregation")
 }
 
@@ -76,34 +75,9 @@ fun generateDokkaWithVersionTag(dokkaMultiModuleTask: org.jetbrains.dokka.gradle
     dokkaMultiModuleTask.pluginsMapConfiguration.set(mapOf)
 }
 
-
-/**
- * Publishing to maven central
- */
-nexusPublishing {
-    repositories {
-        sonatype {
-            val mavenCentralUsername: String? by project
-            val mavenCentralPassword: String? by project
-
-            username.set(mavenCentralUsername)
-            password.set(mavenCentralPassword)
-        }
-    }
-}
-
 dependencies {
     testReportAggregation(project(":cpg-core"))
 }
-
-reporting {
-    reports {
-        @Suppress("UnstableApiUsage") val testAggregateTestReport by creating(AggregateTestReport::class) {
-            testSuiteName = "test"
-        }
-    }
-}
-
 
 //
 // Load the properties that define which frontends to include

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,6 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+
 /*
  * Copyright (c) 2019-2021, Fraunhofer AISEC. All rights reserved.
  *

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,6 +12,6 @@ dependencies {
     implementation(libs.dokka.gradle)
     implementation(libs.kover.gradle)
     implementation(libs.spotless.gradle)
-    implementation(libs.nexus.publish.gradle)
+    implementation(libs.publish.central)
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))  // this is only there to be able to import 'LibrariesForLibs' in the convention plugins to access the version catalog in buildSrc
 }

--- a/buildSrc/src/main/kotlin/codyze.module-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/codyze.module-conventions.gradle.kts
@@ -3,6 +3,7 @@ import org.gradle.accessors.dm.LibrariesForLibs
 plugins {
     id("cpg.common-conventions")
     id("cpg.frontend-conventions")
+    id("cpg.publishing-conventions")
 }
 
 val libs = the<LibrariesForLibs>()  // necessary to be able to use the version catalog in buildSrc

--- a/buildSrc/src/main/kotlin/cpg.application-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cpg.application-conventions.gradle.kts
@@ -2,6 +2,7 @@ import org.gradle.accessors.dm.LibrariesForLibs
 
 plugins {
     id("cpg.common-conventions")
+    id("cpg.publishing-conventions")
     application
 }
 

--- a/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts
@@ -10,7 +10,6 @@ plugins {
     `jvm-test-suite`
     jacoco
     signing
-    `maven-publish`
     kotlin("jvm")
     kotlin("plugin.serialization")
     id("org.jetbrains.dokka")
@@ -51,61 +50,6 @@ val javadocJar by tasks.registering(Jar::class) {
     dependsOn(dokkaHtml)
     archiveClassifier.set("javadoc")
     from(dokkaHtml.outputDirectory)
-}
-
-publishing {
-    publications {
-        create<MavenPublication>(name) {
-            artifact(javadocJar)
-            from(components["java"])
-
-            pom {
-                url.set("https://github.com/Fraunhofer-AISEC/cpg")
-                licenses {
-                    license {
-                        name.set("The Apache License, Version 2.0")
-                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                    }
-                }
-                developers {
-                    developer {
-                        id.set("oxisto")
-                        organization.set("Fraunhofer AISEC")
-                        organizationUrl.set("https://www.aisec.fraunhofer.de")
-                    }
-                }
-                scm {
-                    connection.set("scm:git:git://github.com:Fraunhofer-AISEC/cpg.git")
-                    developerConnection.set("scm:git:ssh://github.com:Fraunhofer-AISEC/cpg.git")
-                    url.set("https://github.com/Fraunhofer-AISEC/cpg")
-                }
-            }
-        }
-    }
-
-    repositories {
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/Fraunhofer-AISEC/cpg")
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
-    }
-}
-
-signing {
-    val signingKey: String? by project
-    val signingPassword: String? by project
-
-    useInMemoryPgpKeys(signingKey, signingPassword)
-
-    setRequired({
-        gradle.taskGraph.hasTask("publish")
-    })
-
-    sign(publishing.publications[name])
 }
 
 //

--- a/buildSrc/src/main/kotlin/cpg.formatting-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cpg.formatting-conventions.gradle.kts
@@ -122,6 +122,9 @@ spotless {
         ktfmt().kotlinlangStyle()
         licenseHeader(headerWithStars).yearSeparator(" - ")
     }
+    kotlinGradle {
+        ktfmt().kotlinlangStyle()
+    }
 
     format("golang") {
         target("src/main/golang/**/*.go")

--- a/buildSrc/src/main/kotlin/cpg.frontend-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cpg.frontend-conventions.gradle.kts
@@ -2,6 +2,7 @@ import org.gradle.accessors.dm.LibrariesForLibs
 
 plugins {
     id("cpg.common-conventions")
+    id("cpg.publishing-conventions")
 }
 
 val libs = the<LibrariesForLibs>()  // necessary to be able to use the version catalog in buildSrc

--- a/buildSrc/src/main/kotlin/cpg.library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cpg.library-conventions.gradle.kts
@@ -4,6 +4,7 @@ import org.jetbrains.dokka.gradle.DokkaTask
 
 plugins {
     id("cpg.common-conventions")
+    id("cpg.publishing-conventions")
 }
 
 val libs = the<LibrariesForLibs>()  // necessary to be able to use the version catalog in buildSrc

--- a/buildSrc/src/main/kotlin/cpg.publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cpg.publishing-conventions.gradle.kts
@@ -60,11 +60,11 @@ mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
 }
 
+// Sign the artifacts if the signingRequired property is set to true
+val signingRequired: String? by project
 
 signing {
-    setRequired({
-        gradle.taskGraph.hasTask("publishAllPublicationsToMavenCentralRepository")
-    })
+    isRequired = signingRequired.toBoolean()
 
     val signingInMemoryKey: String? by project
     val signingInMemoryKeyPassword: String? by project

--- a/buildSrc/src/main/kotlin/cpg.publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cpg.publishing-conventions.gradle.kts
@@ -1,0 +1,73 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinJvm
+import com.vanniktech.maven.publish.SonatypeHost
+
+plugins {
+    id("org.jetbrains.dokka")
+    id("com.vanniktech.maven.publish")
+    id("signing")
+}
+
+tasks.whenTaskAdded {
+    if (name == "generate") {
+        dependsOn(tasks.named("jvmSourcesJar"))
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "githubPackages"
+            url = uri("https://maven.pkg.github.com/your-org/your-project")
+            // username and password (a personal Github access token) should be specified as
+            // `githubPackagesUsername` and `githubPackagesPassword` Gradle properties or alternatively
+            // as `ORG_GRADLE_PROJECT_githubPackagesUsername` and `ORG_GRADLE_PROJECT_githubPackagesPassword`
+            // environment variables
+            credentials(PasswordCredentials::class)
+        }
+    }
+}
+
+signing {
+    setRequired({
+        gradle.taskGraph.hasTask("publishAllPublicationsToMavenCentralRepository")
+    })
+
+    val signingInMemoryKey: String? by project
+    val signingInMemoryKeyPassword: String? by project
+    useInMemoryPgpKeys(signingInMemoryKey, signingInMemoryKeyPassword)
+
+    sign(publishing.publications[name])
+}
+
+// Publication settings for maven central
+mavenPublishing {
+    configure(KotlinJvm(
+        javadocJar = JavadocJar.Dokka("dokkaHtml"),
+        sourcesJar = true,
+    ))
+    coordinates(project.group.toString(), project.name, version.toString())
+
+    pom {
+        url.set("https://github.com/Fraunhofer-AISEC/cpg")
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+            }
+        }
+        developers {
+            developer {
+                organization.set("Fraunhofer AISEC")
+                organizationUrl.set("https://www.aisec.fraunhofer.de")
+            }
+        }
+        scm {
+            connection.set("scm:git:git://github.com:Fraunhofer-AISEC/cpg.git")
+            developerConnection.set("scm:git:ssh://github.com:Fraunhofer-AISEC/cpg.git")
+            url.set("https://github.com/Fraunhofer-AISEC/cpg")
+        }
+    }
+
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+}

--- a/buildSrc/src/main/kotlin/cpg.publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cpg.publishing-conventions.gradle.kts
@@ -10,7 +10,7 @@ publishing {
     repositories {
         maven {
             name = "githubPackages"
-            url = uri("https://maven.pkg.github.com/your-org/your-project")
+            url = uri("https://maven.pkg.github.com/Fraunhofer-AISEC/cpg")
             // username and password (a personal Github access token) should be specified as
             // `githubPackagesUsername` and `githubPackagesPassword` Gradle properties or alternatively
             // as `ORG_GRADLE_PROJECT_githubPackagesUsername` and `ORG_GRADLE_PROJECT_githubPackagesPassword`

--- a/codyze-compliance/build.gradle.kts
+++ b/codyze-compliance/build.gradle.kts
@@ -23,9 +23,7 @@
  *                    \______/ \__|       \______/
  *
  */
-plugins {
-    id("codyze.module-conventions")
-}
+plugins { id("codyze.module-conventions") }
 
 mavenPublishing {
     pom {
@@ -37,11 +35,12 @@ mavenPublishing {
 dependencies {
     implementation(libs.kaml)
 
-    // We depend on the Python frontend for the integration tests, but the frontend is only available if enabled.
-    // If it's not available, the integration tests fail (which is ok). But if we would directly reference the
-    // project here, the build system would fail any task since it will not find a non-enabled project.
-    findProject(":cpg-language-python")?.also {
-        integrationTestImplementation(it)
-    }
+    // We depend on the Python frontend for the integration tests, but the frontend is only
+    // available if enabled.
+    // If it's not available, the integration tests fail (which is ok). But if we would directly
+    // reference the
+    // project here, the build system would fail any task since it will not find a non-enabled
+    // project.
+    findProject(":cpg-language-python")?.also { integrationTestImplementation(it) }
     integrationTestImplementation(libs.clikt)
 }

--- a/codyze-compliance/build.gradle.kts
+++ b/codyze-compliance/build.gradle.kts
@@ -27,15 +27,10 @@ plugins {
     id("codyze.module-conventions")
 }
 
-publishing {
-    publications {
-        named<MavenPublication>("codyze-compliance") {
-            pom {
-                artifactId = "codyze-compliance"
-                name.set("Codyze - Compliance Module")
-                description.set("The compliance module of Codyze")
-            }
-        }
+mavenPublishing {
+    pom {
+        name.set("Codyze - Compliance Module")
+        description.set("The compliance module of Codyze")
     }
 }
 

--- a/codyze-core/build.gradle.kts
+++ b/codyze-core/build.gradle.kts
@@ -49,11 +49,12 @@ dependencies {
     // Scripting host
     api("org.jetbrains.kotlin:kotlin-scripting-jvm-host")
 
-    // We depend on the Python frontend for the integration tests, but the frontend is only available if enabled.
-    // If it's not available, the integration tests fail (which is ok). But if we would directly reference the
-    // project here, the build system would fail any task since it will not find a non-enabled project.
-    findProject(":cpg-language-python")?.also {
-        integrationTestImplementation(it)
-    }
+    // We depend on the Python frontend for the integration tests, but the frontend is only
+    // available if enabled.
+    // If it's not available, the integration tests fail (which is ok). But if we would directly
+    // reference the
+    // project here, the build system would fail any task since it will not find a non-enabled
+    // project.
+    findProject(":cpg-language-python")?.also { integrationTestImplementation(it) }
     integrationTestImplementation(projects.cpgAnalysis)
 }

--- a/codyze-core/build.gradle.kts
+++ b/codyze-core/build.gradle.kts
@@ -25,17 +25,13 @@
  */
 plugins {
     id("cpg.common-conventions")
+    id("cpg.publishing-conventions")
 }
 
-publishing {
-    publications {
-        named<MavenPublication>("codyze-core") {
-            pom {
-                artifactId = "codyze-core"
-                name.set("Codyze - Core")
-                description.set("Core module of the Codyze static analysis tool.")
-            }
-        }
+mavenPublishing {
+    pom {
+        name.set("Codyze - Core")
+        description.set("Core module of the Codyze static analysis tool")
     }
 }
 

--- a/codyze/build.gradle.kts
+++ b/codyze/build.gradle.kts
@@ -31,9 +31,7 @@ plugins {
     id("cpg.frontend-dependency-conventions")
 }
 
-application {
-    mainClass.set("de.fraunhofer.aisec.codyze.ApplicationKt")
-}
+application { mainClass.set("de.fraunhofer.aisec.codyze.ApplicationKt") }
 
 mavenPublishing {
     pom {
@@ -41,13 +39,18 @@ mavenPublishing {
         description.set("The compliance module of Codyze")
         withXml {
             // Modify the XML to exclude dependencies that start with "cpg-language-".
-            // This is necessary because we do not want to "leak" the dependency to our dynamically activated
+            // This is necessary because we do not want to "leak" the dependency to our dynamically
+            // activated
             // frontends to the outside
-            val dependenciesNode = asNode().children().filterIsInstance<Node>().firstOrNull { it.name().toString() == "{http://maven.apache.org/POM/4.0.0}dependencies" }
+            val dependenciesNode =
+                asNode().children().filterIsInstance<Node>().firstOrNull {
+                    it.name().toString() == "{http://maven.apache.org/POM/4.0.0}dependencies"
+                }
             dependenciesNode?.children()?.removeIf {
                 it is Node &&
-                        (it.name().toString() == "{http://maven.apache.org/POM/4.0.0}dependency") &&
-                        ((it.get("artifactId") as? NodeList)?.text()?.startsWith("cpg-language-") == true)
+                    (it.name().toString() == "{http://maven.apache.org/POM/4.0.0}dependency") &&
+                    ((it.get("artifactId") as? NodeList)?.text()?.startsWith("cpg-language-") ==
+                        true)
             }
         }
     }

--- a/codyze/build.gradle.kts
+++ b/codyze/build.gradle.kts
@@ -35,24 +35,19 @@ application {
     mainClass.set("de.fraunhofer.aisec.codyze.ApplicationKt")
 }
 
-publishing {
-    publications {
-        named<MavenPublication>("codyze") {
-            pom {
-                artifactId = "codyze"
-                name.set("Codyze")
-                description.set("The one-stop shop to the code property graph")
-                withXml {
-                    // Modify the XML to exclude dependencies that start with "cpg-language-".
-                    // This is necessary because we do not want to "leak" the dependency to our dynamically activated
-                    // frontends to the outside
-                    val dependenciesNode = asNode().children().filterIsInstance<Node>().firstOrNull { it.name().toString() == "{http://maven.apache.org/POM/4.0.0}dependencies" }
-                    dependenciesNode?.children()?.removeIf {
-                        it is Node &&
-                                (it.name().toString() == "{http://maven.apache.org/POM/4.0.0}dependency") &&
-                                ((it.get("artifactId") as? NodeList)?.text()?.startsWith("cpg-language-") == true)
-                    }
-                }
+mavenPublishing {
+    pom {
+        name.set("Codyze - Compliance Module")
+        description.set("The compliance module of Codyze")
+        withXml {
+            // Modify the XML to exclude dependencies that start with "cpg-language-".
+            // This is necessary because we do not want to "leak" the dependency to our dynamically activated
+            // frontends to the outside
+            val dependenciesNode = asNode().children().filterIsInstance<Node>().firstOrNull { it.name().toString() == "{http://maven.apache.org/POM/4.0.0}dependencies" }
+            dependenciesNode?.children()?.removeIf {
+                it is Node &&
+                        (it.name().toString() == "{http://maven.apache.org/POM/4.0.0}dependency") &&
+                        ((it.get("artifactId") as? NodeList)?.text()?.startsWith("cpg-language-") == true)
             }
         }
     }

--- a/cpg-analysis/build.gradle.kts
+++ b/cpg-analysis/build.gradle.kts
@@ -23,9 +23,7 @@
  *                    \______/ \__|       \______/
  *
  */
-plugins {
-    id("cpg.library-conventions")
-}
+plugins { id("cpg.library-conventions") }
 
 mavenPublishing {
     pom {

--- a/cpg-analysis/build.gradle.kts
+++ b/cpg-analysis/build.gradle.kts
@@ -27,16 +27,10 @@ plugins {
     id("cpg.library-conventions")
 }
 
-
-publishing {
-    publications {
-        named<MavenPublication>("cpg-analysis") {
-            pom {
-                artifactId = "cpg-analysis"
-                name.set("Code Property Graph - Analysis Modules")
-                description.set("Analysis modules for the CPG")
-            }
-        }
+mavenPublishing {
+    pom {
+        name.set("Code Property Graph - Analysis Modules")
+        description.set("Analysis modules for the CPG")
     }
 }
 

--- a/cpg-concepts/build.gradle.kts
+++ b/cpg-concepts/build.gradle.kts
@@ -23,36 +23,26 @@
  *                    \______/ \__|       \______/
  *
  */
-plugins {
-    id("cpg.frontend-conventions")
-}
+plugins { id("cpg.frontend-conventions") }
 
-publishing {
-    publications {
-        named<MavenPublication>("cpg-concepts") {
-            pom {
-                artifactId = "cpg-concepts"
-                name.set("Code Property Graph - Concepts")
-                description.set("A 'concepts' extension for the CPG")
-            }
-        }
+mavenPublishing {
+    pom {
+        name.set("Code Property Graph - Concepts")
+        description.set("A 'concepts' extension for the CPG")
     }
 }
 
 dependencies {
     implementation(projects.cpgAnalysis)
 
-    // We depend on the Python and C/C++ frontend for the integration tests, but the frontend is only available if enabled.
-    // If it's not available, the integration tests fail (which is ok). But if we would directly reference the
-    // project here, the build system would fail any task since it will not find a non-enabled project.
-    findProject(":cpg-language-python")?.also {
-        integrationTestImplementation(it)
-    }
-    findProject(":cpg-language-cxx")?.also {
-        integrationTestImplementation(it)
-    }
-    findProject(":cpg-language-ini")?.also {
-        integrationTestImplementation(it)
-    }
+    // We depend on the Python and C/C++ frontend for the integration tests, but the frontend is
+    // only available if enabled.
+    // If it's not available, the integration tests fail (which is ok). But if we would directly
+    // reference the
+    // project here, the build system would fail any task since it will not find a non-enabled
+    // project.
+    findProject(":cpg-language-python")?.also { integrationTestImplementation(it) }
+    findProject(":cpg-language-cxx")?.also { integrationTestImplementation(it) }
+    findProject(":cpg-language-ini")?.also { integrationTestImplementation(it) }
     integrationTestImplementation(projects.cpgAnalysis)
 }

--- a/cpg-console/build.gradle.kts
+++ b/cpg-console/build.gradle.kts
@@ -28,15 +28,12 @@ plugins {
     id("cpg.frontend-dependency-conventions")
 }
 
-publishing {
-    publications {
-        named<MavenPublication>("cpg-console") {
-            pom {
-                artifactId = "cpg-console"
-                name.set("Code Property Graph - Console")
-                description.set("An Application to translate source code into a Code Property Graph and perform different types of analysis on the resulting graph.")
-            }
-        }
+mavenPublishing {
+    pom {
+        name.set("Code Property Graph - Console")
+        description.set(
+            "An Application to translate source code into a Code Property Graph and perform different types of analysis on the resulting graph."
+        )
     }
 }
 
@@ -45,11 +42,7 @@ application {
     applicationDefaultJvmArgs = listOf("-Xss515m", "-Xmx8g")
 }
 
-repositories {
-    maven {
-        setUrl("https://jitpack.io")
-    }
-}
+repositories { maven { setUrl("https://jitpack.io") } }
 
 dependencies {
     // CPG
@@ -59,7 +52,8 @@ dependencies {
 
     implementation(libs.kotlin.ki.shell)
 
-    // ki-shell dependencies, that we need to specify manually because we are using the JitPack "release"
+    // ki-shell dependencies, that we need to specify manually because we are using the JitPack
+    // "release"
     implementation(libs.kotlin.script.runtime)
     implementation(libs.bundles.kotlin.scripting)
     implementation(libs.antlr.runtime)

--- a/cpg-core/build.gradle.kts
+++ b/cpg-core/build.gradle.kts
@@ -28,18 +28,10 @@ plugins {
     id("cpg.library-conventions")
 }
 
-publishing {
-    publications {
-        named<MavenPublication>("cpg-core") {
-            pom {
-                artifactId = "cpg-core"
-                name.set("Code Property Graph - Core")
-                description.set("A simple library to extract a code property graph out of source code. It has support for multiple passes that can extend the analysis after the graph is constructed.")
-            }
-
-            suppressPomMetadataWarningsFor("testFixturesApiElements")
-            suppressPomMetadataWarningsFor("testFixturesRuntimeElements")
-        }
+mavenPublishing {
+    pom {
+        name.set("Code Property Graph - Core")
+        description.set("A simple library to extract a code property graph out of source code. It has support for multiple passes that can extend the analysis after the graph is constructed.")
     }
 }
 

--- a/cpg-core/build.gradle.kts
+++ b/cpg-core/build.gradle.kts
@@ -31,7 +31,9 @@ plugins {
 mavenPublishing {
     pom {
         name.set("Code Property Graph - Core")
-        description.set("A simple library to extract a code property graph out of source code. It has support for multiple passes that can extend the analysis after the graph is constructed.")
+        description.set(
+            "A simple library to extract a code property graph out of source code. It has support for multiple passes that can extend the analysis after the graph is constructed."
+        )
     }
 }
 
@@ -52,6 +54,8 @@ dependencies {
 
     testImplementation(libs.junit.params)
 
-    testFixturesApi(libs.kotlin.test.junit5)  // somehow just using testFixturesApi(kotlin("test")) does not work for testFixtures
+    testFixturesApi(
+        libs.kotlin.test.junit5
+    ) // somehow just using testFixturesApi(kotlin("test")) does not work for testFixtures
     testFixturesApi(libs.mockito)
 }

--- a/cpg-language-cxx/build.gradle.kts
+++ b/cpg-language-cxx/build.gradle.kts
@@ -23,19 +23,12 @@
  *                    \______/ \__|       \______/
  *
  */
-plugins {
-    id("cpg.frontend-conventions")
-}
+plugins { id("cpg.frontend-conventions") }
 
-publishing {
-    publications {
-        named<MavenPublication>("cpg-language-cxx") {
-            pom {
-                artifactId = "cpg-language-cxx"
-                name.set("Code Property Graph - C/C++ Frontend")
-                description.set("A C/C++ language frontend for the CPG")
-            }
-        }
+mavenPublishing {
+    pom {
+        name.set("Code Property Graph - C/C++ Frontend")
+        description.set("A C/C++ language frontend for the CPG")
     }
 }
 

--- a/cpg-language-go/build.gradle.kts
+++ b/cpg-language-go/build.gradle.kts
@@ -30,15 +30,10 @@ plugins {
     alias(libs.plugins.download)
 }
 
-publishing {
-    publications {
-        named<MavenPublication>("cpg-language-go") {
-            pom {
-                artifactId = "cpg-language-go"
-                name.set("Code Property Graph - Go Frontend")
-                description.set("A Go language frontend for the CPG")
-            }
-        }
+mavenPublishing {
+    pom {
+        name.set("Code Property Graph - Go Frontend")
+        description.set("A Go language frontend for the CPG")
     }
 }
 
@@ -48,25 +43,24 @@ dependencies {
 }
 
 tasks {
-    val downloadLibGoAST by registering(Download::class) {
-        val version = "v0.0.5"
+    val downloadLibGoAST by
+        registering(Download::class) {
+            val version = "v0.0.5"
 
-        src(listOf(
-            "https://github.com/Fraunhofer-AISEC/libgoast/releases/download/${version}/libgoast-arm64.dylib",
-            "https://github.com/Fraunhofer-AISEC/libgoast/releases/download/${version}/libgoast-amd64.dylib",
-            "https://github.com/Fraunhofer-AISEC/libgoast/releases/download/${version}/libgoast-arm64.so",
-            "https://github.com/Fraunhofer-AISEC/libgoast/releases/download/${version}/libgoast-amd64.so",
-            "https://github.com/Fraunhofer-AISEC/libgoast/releases/download/${version}/libgoast-amd64.dll"
-        ))
-        dest(projectDir.resolve("src/main/resources"))
-        onlyIfModified(true)
-    }
+            src(
+                listOf(
+                    "https://github.com/Fraunhofer-AISEC/libgoast/releases/download/${version}/libgoast-arm64.dylib",
+                    "https://github.com/Fraunhofer-AISEC/libgoast/releases/download/${version}/libgoast-amd64.dylib",
+                    "https://github.com/Fraunhofer-AISEC/libgoast/releases/download/${version}/libgoast-arm64.so",
+                    "https://github.com/Fraunhofer-AISEC/libgoast/releases/download/${version}/libgoast-amd64.so",
+                    "https://github.com/Fraunhofer-AISEC/libgoast/releases/download/${version}/libgoast-amd64.dll",
+                )
+            )
+            dest(projectDir.resolve("src/main/resources"))
+            onlyIfModified(true)
+        }
 
-    processResources {
-        dependsOn(downloadLibGoAST)
-    }
+    processResources { dependsOn(downloadLibGoAST) }
 
-    sourcesJar {
-        dependsOn(downloadLibGoAST)
-    }
+    sourcesJar { dependsOn(downloadLibGoAST) }
 }

--- a/cpg-language-go/src/main/resources/.gitignore
+++ b/cpg-language-go/src/main/resources/.gitignore
@@ -1,4 +1,5 @@
 *.dylib
 *.so
+*.dll
 *.h
 

--- a/cpg-language-ini/build.gradle.kts
+++ b/cpg-language-ini/build.gradle.kts
@@ -23,19 +23,12 @@
  *                    \______/ \__|       \______/
  *
  */
-plugins {
-    id("cpg.frontend-conventions")
-}
+plugins { id("cpg.frontend-conventions") }
 
-publishing {
-    publications {
-        named<MavenPublication>("cpg-language-ini") {
-            pom {
-                artifactId = "cpg-language-ini"
-                name.set("Code Property Graph - INI Frontend")
-                description.set("An INI configuration file frontend for the CPG")
-            }
-        }
+mavenPublishing {
+    pom {
+        name.set("Code Property Graph - INI Frontend")
+        description.set("An INI configuration file frontend for the CPG")
     }
 }
 

--- a/cpg-language-java/build.gradle.kts
+++ b/cpg-language-java/build.gradle.kts
@@ -23,22 +23,13 @@
  *                    \______/ \__|       \______/
  *
  */
-plugins {
-    id("cpg.frontend-conventions")
-}
+plugins { id("cpg.frontend-conventions") }
 
-publishing {
-    publications {
-        named<MavenPublication>("cpg-language-java") {
-            pom {
-                artifactId = "cpg-language-java"
-                name.set("Code Property Graph - Java Frontend")
-                description.set("A Java language frontend for the CPG")
-            }
-        }
+mavenPublishing {
+    pom {
+        name.set("Code Property Graph - Java Frontend")
+        description.set("A Java language frontend for the CPG")
     }
 }
 
-dependencies {
-    implementation(libs.javaparser)
-}
+dependencies { implementation(libs.javaparser) }

--- a/cpg-language-jvm/build.gradle.kts
+++ b/cpg-language-jvm/build.gradle.kts
@@ -23,28 +23,17 @@
  *                    \______/ \__|       \______/
  *
  */
-plugins {
-    id("cpg.frontend-conventions")
-}
+plugins { id("cpg.frontend-conventions") }
 
-publishing {
-    publications {
-        named<MavenPublication>("cpg-language-jvm") {
-            pom {
-                artifactId = "cpg-language-jvm"
-                name.set("Code Property Graph - JVM bytecode Frontend")
-                description.set("A JVM bytecode frontend for the CPG")
-            }
-        }
+mavenPublishing {
+    pom {
+        name.set("Code Property Graph - JVM bytecode Frontend")
+        description.set("A JVM bytecode frontend for the CPG")
     }
 }
 
 dependencies {
     implementation(libs.bundles.sootup)
     // needed until https://github.com/antlr/antlr4/issues/3895 is fixed
-    runtimeOnly("org.antlr:antlr4-runtime") {
-        version {
-            strictly("4.9.3")
-        }
-    }
+    runtimeOnly("org.antlr:antlr4-runtime") { version { strictly("4.9.3") } }
 }

--- a/cpg-language-llvm/build.gradle.kts
+++ b/cpg-language-llvm/build.gradle.kts
@@ -23,19 +23,12 @@
  *                    \______/ \__|       \______/
  *
  */
-plugins {
-    id("cpg.frontend-conventions")
-}
+plugins { id("cpg.frontend-conventions") }
 
-publishing {
-    publications {
-        named<MavenPublication>("cpg-language-llvm") {
-            pom {
-                artifactId = "cpg-language-llvm"
-                name.set("Code Property Graph - LLVM Frontend")
-                description.set("A LLVM language frontend for the CPG")
-            }
-        }
+mavenPublishing {
+    pom {
+        name.set("Code Property Graph - LLVM Frontend")
+        description.set("A LLVM language frontend for the CPG")
     }
 }
 

--- a/cpg-language-python/build.gradle.kts
+++ b/cpg-language-python/build.gradle.kts
@@ -23,19 +23,12 @@
  *                    \______/ \__|       \______/
  *
  */
-plugins {
-    id("cpg.frontend-conventions")
-}
+plugins { id("cpg.frontend-conventions") }
 
-publishing {
-    publications {
-        named<MavenPublication>("cpg-language-python") {
-            pom {
-                artifactId = "cpg-language-python"
-                name.set("Code Property Graph - Python Frontend")
-                description.set("A Python language frontend for the CPG")
-            }
-        }
+mavenPublishing {
+    pom {
+        name.set("Code Property Graph - Python Frontend")
+        description.set("A Python language frontend for the CPG")
     }
 }
 

--- a/cpg-language-ruby/build.gradle.kts
+++ b/cpg-language-ruby/build.gradle.kts
@@ -23,25 +23,17 @@
  *                    \______/ \__|       \______/
  *
  */
-import com.github.gradle.node.npm.task.NpmTask
 
 plugins {
     id("cpg.frontend-conventions")
     alias(libs.plugins.node)
 }
 
-publishing {
-    publications {
-        named<MavenPublication>("cpg-language-ruby") {
-            pom {
-                artifactId = "cpg-language-ruby"
-                name.set("Code Property Graph - Ruby")
-                description.set("A Ruby language frontend for the CPG")
-            }
-        }
+mavenPublishing {
+    pom {
+        name.set("Code Property Graph - Ruby")
+        description.set("A Ruby language frontend for the CPG")
     }
 }
 
-dependencies {
-    implementation(libs.jruby)
-}
+dependencies { implementation(libs.jruby) }

--- a/cpg-language-typescript/build.gradle.kts
+++ b/cpg-language-typescript/build.gradle.kts
@@ -30,15 +30,10 @@ plugins {
     alias(libs.plugins.node)
 }
 
-publishing {
-    publications {
-        named<MavenPublication>("cpg-language-typescript") {
-            pom {
-                artifactId = "cpg-language-typescript"
-                name.set("Code Property Graph - JavaScript/TypeScript Frontend")
-                description.set("A JavaScript/TypeScript language frontend for the CPG")
-            }
-        }
+mavenPublishing {
+    pom {
+        name.set("Code Property Graph - JavaScript/TypeScript Frontend")
+        description.set("A JavaScript/TypeScript language frontend for the CPG")
     }
 }
 
@@ -48,18 +43,19 @@ node {
     nodeProjectDir.set(file("${project.projectDir.resolve("src/main/nodejs")}"))
 }
 
-val npmBuild by tasks.registering(NpmTask::class) {
-    inputs.file("src/main/nodejs/package.json").withPathSensitivity(PathSensitivity.RELATIVE)
-    inputs.file("src/main/nodejs/package-lock.json").withPathSensitivity(PathSensitivity.RELATIVE)
-    inputs.dir("src/main/nodejs/src").withPathSensitivity(PathSensitivity.RELATIVE)
-    outputs.dir("build/resources/main/nodejs")
-    outputs.cacheIf { true }
+val npmBuild by
+    tasks.registering(NpmTask::class) {
+        inputs.file("src/main/nodejs/package.json").withPathSensitivity(PathSensitivity.RELATIVE)
+        inputs
+            .file("src/main/nodejs/package-lock.json")
+            .withPathSensitivity(PathSensitivity.RELATIVE)
+        inputs.dir("src/main/nodejs/src").withPathSensitivity(PathSensitivity.RELATIVE)
+        outputs.dir("build/resources/main/nodejs")
+        outputs.cacheIf { true }
 
-    workingDir.set(file("src/main/nodejs"))
-    npmCommand.set(listOf("run", "bundle"))
-    dependsOn(tasks.getByName("npmInstall"))
-}
+        workingDir.set(file("src/main/nodejs"))
+        npmCommand.set(listOf("run", "bundle"))
+        dependsOn(tasks.getByName("npmInstall"))
+    }
 
-tasks.processResources {
-    dependsOn(npmBuild)
-}
+tasks.processResources { dependsOn(npmBuild) }

--- a/cpg-language-typescript/build.gradle.kts
+++ b/cpg-language-typescript/build.gradle.kts
@@ -43,7 +43,7 @@ publishing {
 }
 
 node {
-    download.set(findProperty("nodeDownload")?.toString()?.toBoolean() ?: false)
+    download.set(true)
     version.set("20.11.1")
     nodeProjectDir.set(file("${project.projectDir.resolve("src/main/nodejs")}"))
 }

--- a/cpg-neo4j/build.gradle.kts
+++ b/cpg-neo4j/build.gradle.kts
@@ -33,29 +33,33 @@ plugins {
 
 application {
     mainClass.set("de.fraunhofer.aisec.cpg_vis_neo4j.ApplicationKt")
-    // Since we are potentially persisting deeply nested graphs, we need to increase the stack and heap size.
-    // Note, that if you are running this IntelliJ, you might need to manually specify this as VM arguments.
+    // Since we are potentially persisting deeply nested graphs, we need to increase the stack and
+    // heap size.
+    // Note, that if you are running this IntelliJ, you might need to manually specify this as VM
+    // arguments.
     applicationDefaultJvmArgs = listOf("-Xss515m", "-Xmx8g")
 }
 
-publishing {
-    publications {
-        named<MavenPublication>("cpg-neo4j") {
-            pom {
-                artifactId = "cpg-neo4j"
-                name.set("Code Property Graph - Neo4j")
-                description.set("An Application to translate and persist specified source code as a Code Property Graph to an installed instance of the Neo4j Graph Database.")
-                withXml {
-                    // Modify the XML to exclude dependencies that start with "cpg-language-".
-                    // This is necessary because we do not want to "leak" the dependency to our dynamically activated
-                    // frontends to the outside
-                    val dependenciesNode = asNode().children().filterIsInstance<Node>().firstOrNull { it.name().toString() == "{http://maven.apache.org/POM/4.0.0}dependencies" }
-                    dependenciesNode?.children()?.removeIf {
-                        it is Node &&
-                                (it.name().toString() == "{http://maven.apache.org/POM/4.0.0}dependency") &&
-                                ((it.get("artifactId") as? NodeList)?.text()?.startsWith("cpg-language-") == true)
-                    }
+mavenPublishing {
+    pom {
+        name.set("Code Property Graph - Neo4j")
+        description.set(
+            "An Application to translate and persist specified source code as a Code Property Graph to an installed instance of the Neo4j Graph Database."
+        )
+        withXml {
+            // Modify the XML to exclude dependencies that start with "cpg-language-".
+            // This is necessary because we do not want to "leak" the dependency to our dynamically
+            // activated
+            // frontends to the outside
+            val dependenciesNode =
+                asNode().children().filterIsInstance<Node>().firstOrNull {
+                    it.name().toString() == "{http://maven.apache.org/POM/4.0.0}dependencies"
                 }
+            dependenciesNode?.children()?.removeIf {
+                it is Node &&
+                    (it.name().toString() == "{http://maven.apache.org/POM/4.0.0}dependency") &&
+                    ((it.get("artifactId") as? NodeList)?.text()?.startsWith("cpg-language-") ==
+                        true)
             }
         }
     }
@@ -75,12 +79,13 @@ dependencies {
 
     integrationTestImplementation(libs.kotlin.reflect)
 
-    // We depend on the C++ frontend for the integration tests, but the frontend is only available if enabled.
-    // If it's not available, the integration tests fail (which is ok). But if we would directly reference the
-    // project here, the build system would fail any task since it will not find a non-enabled project.
-    findProject(":cpg-language-cxx")?.also {
-        integrationTestImplementation(it)
-    }
+    // We depend on the C++ frontend for the integration tests, but the frontend is only available
+    // if enabled.
+    // If it's not available, the integration tests fail (which is ok). But if we would directly
+    // reference the
+    // project here, the build system would fail any task since it will not find a non-enabled
+    // project.
+    findProject(":cpg-language-cxx")?.also { integrationTestImplementation(it) }
     integrationTestImplementation(project(":cpg-concepts"))
     implementation(project(":cpg-concepts"))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ neo4j = "4.0.10"
 neo4j5 = "5.28.2"
 log4j = "2.24.0"
 spotless = "7.0.1"
-nexus-publish = "2.0.0"
+publish = "0.31.0"
 sootup = "1.3.0"
 slf4j = "2.0.16"
 clikt = "5.0.2"
@@ -60,13 +60,13 @@ junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version = "5
 mockito = { module = "org.mockito:mockito-core", version = "5.16.0"}
 
 # plugins needed for build.gradle.kts in buildSrc
+publish-central = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "publish" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-serialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
 dokka-gradle = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "2.0.0" } # the dokka plugin is slightly behind the main Kotlin release cycle
 dokka-versioning = { module = "org.jetbrains.dokka:versioning-plugin", version = "2.0.0"}
 kover-gradle = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version = "0.9.0" }
 spotless-gradle = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
-nexus-publish-gradle = { module = "io.github.gradle-nexus:publish-plugin", version.ref = "nexus-publish" }
 
 sootup-core = { module = "org.soot-oss:sootup.core", version.ref = "sootup" }
 sootup-java-core = { module = "org.soot-oss:sootup.java.core", version.ref = "sootup" }


### PR DESCRIPTION
We migrated to the new https://central.sonatype.com portal with our namespace and we had to change the plugin to the new modern version of https://github.com/vanniktech/gradle-maven-publish-plugin

This also should now include skipping dokka/javadoc for GitHub package releases.