### PR TITLE
Small improvements to `PythonFileConceptPass`

### DIFF
--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/file/python/PythonFileConceptPass.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/file/python/PythonFileConceptPass.kt
@@ -255,7 +255,7 @@ class PythonFileConceptPass(ctx: TranslationContext) : ConceptPass(ctx) {
             expression
                 .followDFGEdgesUntilHit(
                     collectFailedPaths = false,
-                    findAllPossiblePaths = true,
+                    findAllPossiblePaths = false,
                     direction = Backward(GraphToFollow.DFG),
                 ) { node ->
                     node.overlays.any { overlay -> overlay is OpenFile }

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/file/python/PythonFileConceptPass.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/file/python/PythonFileConceptPass.kt
@@ -121,11 +121,17 @@ class PythonFileConceptPass(ctx: TranslationContext) : ConceptPass(ctx) {
                                 )
                                 return
                             }
-                            newFileWrite(
-                                underlyingNode = callExpression,
-                                file = fileNode,
-                                what = arg,
-                            )
+                            if (
+                                callExpression.overlays.none {
+                                    it is WriteFile && it.file == fileNode && it.what == arg
+                                }
+                            ) {
+                                newFileWrite(
+                                    underlyingNode = callExpression,
+                                    file = fileNode,
+                                    what = arg,
+                                )
+                            }
                         }
                         else ->
                             Util.warnWithFileLocation(


### PR DESCRIPTION
The `PythonFileConceptPass` is slightly improved as follows:

* It generates an equal `ReadFile` operation only once. Somehow, there were multiple equal nodes created. Apparently, the same node is visited multiple times.
* The `followDFGEdgesUntilHit` can be configured with `findAllPossiblePaths = false` which should simply merge two paths instead of following them separately. The important part is that all end-nodes should still be collected but we will explore less paths reaching it.