### PR TITLE
Concepts/Operations remove not needed duplicate check

### DIFF
--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/file/python/PythonFileConceptPass.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/file/python/PythonFileConceptPass.kt
@@ -121,11 +121,17 @@ class PythonFileConceptPass(ctx: TranslationContext) : ConceptPass(ctx) {
                                 )
                                 return
                             }
-                            newFileWrite(
-                                underlyingNode = callExpression,
-                                file = fileNode,
-                                what = arg,
-                            )
+                            if (
+                                callExpression.overlays.none {
+                                    it is WriteFile && it.file == fileNode && it.what == arg
+                                }
+                            ) {
+                                newFileWrite(
+                                    underlyingNode = callExpression,
+                                    file = fileNode,
+                                    what = arg,
+                                )
+                            }
                         }
                         else ->
                             Util.warnWithFileLocation(

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/file/python/PythonFileConceptPass.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/file/python/PythonFileConceptPass.kt
@@ -121,17 +121,11 @@ class PythonFileConceptPass(ctx: TranslationContext) : ConceptPass(ctx) {
                                 )
                                 return
                             }
-                            if (
-                                callExpression.overlays.none {
-                                    it is WriteFile && it.file == fileNode && it.what == arg
-                                }
-                            ) {
-                                newFileWrite(
-                                    underlyingNode = callExpression,
-                                    file = fileNode,
-                                    what = arg,
-                                )
-                            }
+                            newFileWrite(
+                                underlyingNode = callExpression,
+                                file = fileNode,
+                                what = arg,
+                            )
                         }
                         else ->
                             Util.warnWithFileLocation(


### PR DESCRIPTION
This PR partially reverts a previous change that added a check to see if a `WriteFile` node already exists before creating a new one. Such a check is unnecessary unless the `ConceptPass` mistakenly processes the same `CallExpression` multiple times, which would indicate another bug. If this check were required, it should be applied generally to all Operation nodes, not just `WriteFile`, and handled in a more systematic way.