### PR TITLE
Fix EOG starters for Namespace declarations

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/NamespaceDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/NamespaceDeclaration.kt
@@ -80,10 +80,12 @@ class NamespaceDeclaration : Declaration(), DeclarationHolder, StatementHolder, 
     override val eogStarters: List<Node>
         get() {
             val list = mutableListOf<Node>()
-            // Add all top-level declarations
-            list += declarations
-            // Add all top-level statements
-            list += statements
+
+            // The Namespace Declaration itself is the start of an eog itself, all statements and
+            // declarations
+            // that are directly a child of the declaration, are evaluated as static nodes  when the
+            // namespace is created.
+            list += this
 
             return list
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
@@ -248,8 +248,8 @@ open class EvaluationOrderGraphPass(ctx: TranslationContext) : TranslationUnitPa
         // although they can be placed in the same enclosing declaration.
         val code = statementHolder.statements
 
-        val nonStaticCode = code.filter { (it as? Block)?.isStaticBlock == false }
-        val staticCode = code.filter { it !in nonStaticCode }
+        val staticCode = code.filter { (it as? Block)?.isStaticBlock == true }
+        val nonStaticCode = code.filter { it !in staticCode }
 
         attachToEOG(statementHolder as Node)
         for (staticStatement in staticCode) {
@@ -1366,7 +1366,7 @@ open class EvaluationOrderGraphPass(ctx: TranslationContext) : TranslationUnitPa
                 val toProcess = workList[0]
                 workList.remove(toProcess)
                 passedBy.add(toProcess)
-                if (toProcess is FunctionDeclaration) {
+                if (toProcess is EOGStarterHolder) {
                     return true
                 }
                 for (pred in toProcess.prevEOG) {

--- a/cpg-language-python/src/test/resources/python/toplevel_code.py
+++ b/cpg-language-python/src/test/resources/python/toplevel_code.py
@@ -1,0 +1,4 @@
+with open('foo.txt') as file:
+    file.read()
+
+print("Done")

--- a/cpg-language-python/src/test/resources/python/toplevel_withDeclaration.py
+++ b/cpg-language-python/src/test/resources/python/toplevel_withDeclaration.py
@@ -1,0 +1,6 @@
+print("a")
+b=1
+print("c")
+
+def some():
+    print("InSome")


### PR DESCRIPTION
This PR replicates some of the changes attempted in #2122 and correcting an issue that appeared then.

The issue was that we split the EOG creation in the not static statements and the static statements. But we also made them default static, which was not correct in this case as we assumed them to be static if they were no block with a isStatic field.
Closes #2121 

In this PR make the namespace declaration the only eog starter inside of the namespace declaration. All statements and declarations contained that are part of the statement holders statements are added to the same EOG path, the contained functions are the start of their own EOG path.