### PR TITLE
Changing renovate updates from `daily` to `weekly`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "config:base",
-    "schedule:daily",
+    "schedule:weekly",
     ":enableVulnerabilityAlerts"
   ],
   "patch": {


### PR DESCRIPTION
Weekly dependency updates should be more than enough, otherwise we will get spammed by npm updates.