### PR TITLE
Very simple version of memory tracking heuristics to understand if dataflows are split up and require following multiple paths

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/TypeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/TypeBuilder.kt
@@ -94,7 +94,14 @@ fun LanguageProvider.objectType(
 
     // Otherwise, we either need to create the type because of the generics or because we do not
     // know the type yet.
-    var type = ObjectType(name, generics, false, language)
+    var type =
+        ObjectType(
+            typeName = name,
+            generics = generics,
+            primitive = false,
+            mutable = true,
+            language = language,
+        )
     // Apply our usual metadata, such as scope, code, location, if we have any. Make sure only
     // to refer by the local name because we will treat types as sort of references when
     // creating them and resolve them later.

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ListType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ListType.kt
@@ -28,5 +28,9 @@ package de.fraunhofer.aisec.cpg.graph.types
 import de.fraunhofer.aisec.cpg.frontends.Language
 
 /** Represents a [List] type that contains multiple elements. */
-class ListType(typeName: CharSequence, override var elementType: Type, language: Language<*>) :
-    ObjectType(typeName, listOf(elementType), false, language), SecondOrderType
+class ListType(
+    typeName: CharSequence,
+    override var elementType: Type,
+    language: Language<*>,
+    primitive: Boolean = false,
+) : ObjectType(typeName, listOf(elementType), primitive, language), SecondOrderType

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/NumericType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/NumericType.kt
@@ -34,7 +34,14 @@ open class NumericType(
     val bitWidth: Int? = null,
     language: Language<*>,
     val modifier: Modifier = Modifier.SIGNED,
-) : ObjectType(typeName, listOf(), true, language) {
+) :
+    ObjectType(
+        typeName = typeName,
+        generics = listOf(),
+        primitive = true,
+        mutable = false,
+        language = language,
+    ) {
 
     init {
         // Built-in types are always resolved

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ObjectType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ObjectType.kt
@@ -60,16 +60,31 @@ open class ObjectType : Type, HasSecondaryTypeEdge {
         typeName: CharSequence,
         generics: List<Type>,
         primitive: Boolean,
+        mutable: Boolean,
         language: Language<*>,
     ) : super(typeName, language) {
         this.generics = generics
-        isPrimitive = primitive
+        this.isPrimitive = primitive
+        this.isMutable = mutable
+        this.language = language
+    }
+
+    constructor(
+        typeName: CharSequence,
+        generics: List<Type>,
+        primitive: Boolean,
+        language: Language<*>,
+    ) : super(typeName, language) {
+        this.generics = generics
+        this.isPrimitive = primitive
+        this.isMutable = true
         this.language = language
     }
 
     /** Empty default constructor for use in Neo4J persistence. */
     constructor() : super() {
-        isPrimitive = false
+        this.isPrimitive = false
+        this.isMutable = true
         this.generics = mutableListOf<Type>()
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/StringType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/StringType.kt
@@ -31,7 +31,16 @@ class StringType(
     typeName: CharSequence = "",
     language: Language<*>,
     generics: List<Type> = listOf(),
-) : ObjectType(typeName, generics, false, language) {
+    primitive: Boolean = false,
+    mutable: Boolean = false,
+) :
+    ObjectType(
+        typeName = typeName,
+        generics = generics,
+        primitive = primitive,
+        mutable = mutable,
+        language = language,
+    ) {
 
     init {
         // Built-in types are always resolved

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/Type.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/Type.kt
@@ -74,6 +74,9 @@ abstract class Type : Node {
     var isPrimitive = false
         protected set
 
+    var isMutable = true
+        protected set
+
     open var typeOrigin: Origin? = null
 
     /**

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
@@ -133,51 +133,87 @@ class PythonLanguage :
     @Transient
     override val builtInTypes =
         mapOf(
-            "bool" to BooleanType("bool", language = this),
+            "bool" to BooleanType(typeName = "bool", language = this),
             "int" to
                 IntegerType(
-                    "int",
-                    Integer.MAX_VALUE,
-                    this,
-                    NumericType.Modifier.NOT_APPLICABLE,
+                    typeName = "int",
+                    bitWidth = Integer.MAX_VALUE,
+                    language = this,
+                    modifier = NumericType.Modifier.NOT_APPLICABLE,
                 ), // Unlimited precision
             "float" to
                 FloatingPointType(
-                    "float",
-                    32,
-                    this,
-                    NumericType.Modifier.NOT_APPLICABLE,
+                    typeName = "float",
+                    bitWidth = 32,
+                    language = this,
+                    modifier = NumericType.Modifier.NOT_APPLICABLE,
                 ), // This depends on the implementation
             "complex" to
                 NumericType(
-                    "complex",
-                    null,
-                    this,
-                    NumericType.Modifier.NOT_APPLICABLE,
+                    typeName = "complex",
+                    bitWidth = null,
+                    language = this,
+                    modifier = NumericType.Modifier.NOT_APPLICABLE,
                 ), // It's two floats
-            "str" to StringType("str", this, listOf()),
+            "str" to
+                StringType(
+                    typeName = "str",
+                    language = this,
+                    generics = listOf(),
+                    primitive = false,
+                    mutable = false,
+                ),
             "list" to
                 ListType(
                     typeName = "list",
-                    elementType = ObjectType("object", listOf(), false, this),
+                    elementType =
+                        ObjectType(
+                            typeName = "object",
+                            generics = listOf(),
+                            primitive = false,
+                            mutable = true,
+                            language = this,
+                        ),
                     language = this,
                 ),
             "tuple" to
                 ListType(
                     typeName = "tuple",
-                    elementType = ObjectType("object", listOf(), false, this),
+                    elementType =
+                        ObjectType(
+                            typeName = "object",
+                            generics = listOf(),
+                            primitive = false,
+                            mutable = true,
+                            language = this,
+                        ),
                     language = this,
+                    primitive = true,
                 ),
             "dict" to
                 MapType(
                     typeName = "dict",
-                    elementType = ObjectType("object", listOf(), false, this),
+                    elementType =
+                        ObjectType(
+                            typeName = "object",
+                            generics = listOf(),
+                            primitive = false,
+                            mutable = true,
+                            language = this,
+                        ),
                     language = this,
                 ),
             "set" to
                 SetType(
                     typeName = "set",
-                    elementType = ObjectType("object", listOf(), false, this),
+                    elementType =
+                        ObjectType(
+                            typeName = "object",
+                            generics = listOf(),
+                            primitive = false,
+                            mutable = true,
+                            language = this,
+                        ),
                     language = this,
                 ),
         )

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/LoadIncludesTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/LoadIncludesTest.kt
@@ -47,7 +47,7 @@ class LoadIncludesTest {
                 )
             }
 
-        assertEquals(result.finalCtx.importedSources?.size, 3)
+        assertEquals(result.finalCtx.importedSources.size, 3)
 
         val stdlib = result.components("stdlib").flatMap { it.allChildren<Node>() }
 


### PR DESCRIPTION
We need to understand which nodes on a DFG path have to be followed separately. This is highly specific to each language, so this is only a rough approximation which uses the following heuristics:

* Is the type of a node (i.e., operation and its result, reference, declaration) mutable? If not, we typically copy the data.
* Do we call constructors? This obviously generates a new object which should be handled separately from the previous ones.
* Do we use some specific constructs which are no constructors but have the same effect of generating a new object? An example are list/set/dict comprehensions.

To implement this, the types get an additional field `isMutable` which can/should be set appropriately. Currently, it is set to some defaults (`true` for `ObjectType`s, `false` for `StringType`s and `NumericType`s) but this is also language-specific and should be appropriately handled there.