### PR TITLE
Consistently displaying SARIF `level` and `kind` fields

### DIFF
--- a/codyze-core/src/main/kotlin/de/fraunhofer/aisec/codyze/Sarif.kt
+++ b/codyze-core/src/main/kotlin/de/fraunhofer/aisec/codyze/Sarif.kt
@@ -62,7 +62,7 @@ fun QueryTree<Boolean>.toSarif(ruleID: String): List<Result> {
                     Level.Error
                 },
             kind =
-                if (this.value) {
+                if (result) {
                     ResultKind.Pass
                 } else {
                     ResultKind.Fail


### PR DESCRIPTION
Fixes #2191 