### PR TITLE
Add helper functions for concept creation

### DIFF
--- a/codyze-core/src/integrationTest/kotlin/codyze/SarifTest.kt
+++ b/codyze-core/src/integrationTest/kotlin/codyze/SarifTest.kt
@@ -47,6 +47,7 @@ class SarifTest {
                 it.registerLanguage<PythonLanguage>()
             }
         val fullLoc = result.functions["foo"].toSarifLocation()
+
         assertNotNull(fullLoc)
         assertEquals(7, fullLoc.physicalLocation?.region?.endLine)
         assertEquals(15, fullLoc.physicalLocation?.region?.endColumn)

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericConceptBuilder.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericConceptBuilder.kt
@@ -70,7 +70,7 @@ fun MetadataProvider.conceptBuildHelper(
     underlyingNode: Node,
     connectDFGUnderlyingNodeToConcept: Boolean = false,
     connectDFGConceptToUnderlyingNode: Boolean = false,
-) {
+): Concept {
     val constructor: (Node) -> Concept =
         when (name) {
             "de.fraunhofer.aisec.cpg.graph.concepts.logging.Log" -> { node ->
@@ -86,7 +86,7 @@ fun MetadataProvider.conceptBuildHelper(
                 throw IllegalArgumentException("Unknown concept: \"${name}\".")
             }
         }
-    this.newConcept(constructor, underlyingNode).also { concept ->
+    return this.newConcept(constructor, underlyingNode).also { concept ->
         if (connectDFGUnderlyingNodeToConcept) {
             underlyingNode.nextDFG += concept
         }

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericConceptBuilder.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericConceptBuilder.kt
@@ -25,18 +25,14 @@
  */
 package de.fraunhofer.aisec.cpg.graph.concepts
 
-import de.fraunhofer.aisec.cpg.graph.MetadataProvider
-import de.fraunhofer.aisec.cpg.graph.Name
-import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.NodeBuilder
-import de.fraunhofer.aisec.cpg.graph.codeAndLocationFrom
+import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.edges.flows.insertNodeAfterwardInEOGPath
 
 /**
  * This function creates a new [Concept] node based on [ConceptClass]. It is neither connected by
  * the EOG nor the DFG.
  */
-internal inline fun <reified ConceptClass : Concept> MetadataProvider.newConcept(
+inline fun <reified ConceptClass : Concept> MetadataProvider.newConcept(
     constructor: (underlyingNode: Node) -> (ConceptClass),
     underlyingNode: Node,
 ): ConceptClass =
@@ -67,3 +63,23 @@ inline fun <reified OperationClass : Operation, ConceptClass : Concept> Metadata
         underlyingNode.insertNodeAfterwardInEOGPath(this)
         NodeBuilder.log(this)
     }
+
+/** TODO */
+fun MetadataProvider.conceptBuildHelper(name: String, underlyingNode: Node): Concept {
+    val constructor: (Node) -> Concept =
+        when (name) {
+            "de.fraunhofer.aisec.cpg.graph.concepts.logging.Log" -> { node ->
+                    de.fraunhofer.aisec.cpg.graph.concepts.logging.Log(node)
+                }
+            "de.fraunhofer.aisec.cpg.graph.concepts.file.File" -> { node ->
+                    de.fraunhofer.aisec.cpg.graph.concepts.file.File(node, "filename" /* TODO */)
+                }
+            "de.fraunhofer.aisec.cpg.graph.concepts.diskEncryption.Secret" -> { node ->
+                    de.fraunhofer.aisec.cpg.graph.concepts.diskEncryption.Secret(node)
+                }
+            else -> {
+                throw IllegalArgumentException("Unknown concept: \"${name}\".")
+            }
+        }
+    return newConcept(constructor, underlyingNode)
+}

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericConceptBuilder.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericConceptBuilder.kt
@@ -37,6 +37,7 @@ inline fun <reified ConceptClass : Concept> MetadataProvider.newConcept(
     underlyingNode: Node,
 ): ConceptClass =
     constructor(underlyingNode).apply {
+        // Note: Update the conceptBuildHelper if you change this.
         this.codeAndLocationFrom(underlyingNode)
         this.name = Name("${ConceptClass::class.simpleName}", underlyingNode.name)
         NodeBuilder.log(this)
@@ -64,34 +65,145 @@ inline fun <reified OperationClass : Operation, ConceptClass : Concept> Metadata
         NodeBuilder.log(this)
     }
 
-/** TODO */
+/**
+ * Generates an object of the [Concept] with the FQN [name] and the [Concept.underlyingNode]
+ * [underlyingNode]. The constructor arguments of the respective class have to be provided by the
+ * map [constructorArguments] where the key is the name of the argument and the value is the
+ * argument to pass. [connectDFGUnderlyingNodeToConcept] specifies if the created [Concept] should
+ * be in the [Node.nextDFGEdges] edges of the [underlyingNode]. [connectDFGConceptToUnderlyingNode]
+ * specifies if the created [Concept] should be in the [Node.prevDFGEdges] of the [underlyingNode].
+ *
+ * @param name The fully qualified name of the concept class to be created.
+ * @param underlyingNode The underlying node for which the concept is created.
+ * @param constructorArguments A map of constructor arguments to be passed to the concept class
+ *   (excluding the `underlyingNode`).
+ * @param connectDFGUnderlyingNodeToConcept If true, the created concept will be added to the next
+ *   DFG edges of the underlying node.
+ * @param connectDFGConceptToUnderlyingNode If true, the created concept will be added to the prev
+ *   DFG edges of the underlying node.
+ * @return The created concept with the specified DFG edges.
+ * @throws ClassNotFoundException If the class with the specified [name] does not exist
+ * @throws IllegalArgumentException If the class with the given [name] does not have exactly one
+ *   constructor or if one of the arguments in [constructorArguments] is not a valid argument name
+ *   for this constructor.
+ */
 fun MetadataProvider.conceptBuildHelper(
     name: String,
     underlyingNode: Node,
+    constructorArguments: Map<String, Any?> = emptyMap(),
     connectDFGUnderlyingNodeToConcept: Boolean = false,
     connectDFGConceptToUnderlyingNode: Boolean = false,
 ): Concept {
-    val constructor: (Node) -> Concept =
-        when (name) {
-            "de.fraunhofer.aisec.cpg.graph.concepts.logging.Log" -> { node ->
-                    de.fraunhofer.aisec.cpg.graph.concepts.logging.Log(node)
-                }
-            "de.fraunhofer.aisec.cpg.graph.concepts.file.File" -> { node ->
-                    de.fraunhofer.aisec.cpg.graph.concepts.file.File(node, "filename" /* TODO */)
-                }
-            "de.fraunhofer.aisec.cpg.graph.concepts.diskEncryption.Secret" -> { node ->
-                    de.fraunhofer.aisec.cpg.graph.concepts.diskEncryption.Secret(node)
-                }
-            else -> {
-                throw IllegalArgumentException("Unknown concept: \"${name}\".")
+    val conceptClass = Class.forName(name).kotlin
+    val constructor =
+        conceptClass.constructors.singleOrNull()
+            ?: throw IllegalArgumentException(
+                "The class with $name does not have exactly one constructor."
+            )
+    return (constructor.callBy(
+            mapOf(
+                (constructor.parameters.singleOrNull { it.name == "underlyingNode" }
+                    ?: throw IllegalArgumentException(
+                        "There is no argument with name \"underlyingNode\" which is required for the constructor of concept ${conceptClass.simpleName}"
+                    )) to underlyingNode,
+                *constructorArguments
+                    .map { (key, value) ->
+                        (constructor.parameters.singleOrNull { it.name == key }
+                            ?: throw IllegalArgumentException(
+                                "There is no argument with name \"key\" which is specified to generate the concept ${conceptClass.simpleName}"
+                            )) to value
+                    }
+                    .toTypedArray(),
+            )
+        ) as? Concept)
+        ?.also { concept ->
+            // Note: Update "newConcept" if you change this.
+            concept.codeAndLocationFrom(underlyingNode)
+            concept.name = Name("${conceptClass.simpleName}", underlyingNode.name)
+            NodeBuilder.log(concept)
+
+            if (connectDFGUnderlyingNodeToConcept) {
+                underlyingNode.nextDFG += concept
             }
-        }
-    return this.newConcept(constructor, underlyingNode).also { concept ->
-        if (connectDFGUnderlyingNodeToConcept) {
-            underlyingNode.nextDFG += concept
-        }
-        if (connectDFGConceptToUnderlyingNode) {
-            concept.nextDFG += underlyingNode
-        }
-    }
+            if (connectDFGConceptToUnderlyingNode) {
+                concept.nextDFG += underlyingNode
+            }
+        } ?: throw IllegalArgumentException("The class $name does not create a Concept.")
+}
+
+/**
+ * Generates an object of the [Operation] with the FQN [name], the [Operation.underlyingNode]
+ * [underlyingNode], and the [Operation.concept] [concept]. The constructor arguments of the
+ * respective class have to be provided by the map [constructorArguments] where the key is the name
+ * of the argument and the value is the argument to pass. [connectDFGUnderlyingNodeToConcept]
+ * specifies if the created [Operation] should be in the [Node.nextDFGEdges] edges of the
+ * [underlyingNode]. [connectDFGConceptToUnderlyingNode] specifies if the created [Operation] should
+ * be in the [Node.prevDFGEdges] of the [underlyingNode].
+ *
+ * @param name The fully qualified name of the operation class to be created.
+ * @param underlyingNode The underlying node for which the operation is created.
+ * @param concept The [Concept] the [Operation] belongs to. It also has to be explicitly stated in
+ *   the [constructorArguments] as the name of the argument often differ.
+ * @param constructorArguments A map of constructor arguments to be passed to the operation class
+ *   (excluding the `underlyingNode`).
+ * @param connectDFGUnderlyingNodeToConcept If true, the created operation will be added to the next
+ *   DFG edges of the underlying node.
+ * @param connectDFGConceptToUnderlyingNode If true, the created operation will be added to the prev
+ *   DFG edges of the underlying node.
+ * @return The created operation with the specified DFG edges.
+ * @throws ClassNotFoundException If the class with the specified [name] does not exist.
+ * @throws IllegalArgumentException If the class with the given [name] does not have exactly one
+ *   constructor or if one of the arguments in [constructorArguments] is not a valid argument name
+ *   for this constructor.
+ */
+fun MetadataProvider.operationBuildHelper(
+    name: String,
+    underlyingNode: Node,
+    concept: Concept,
+    constructorArguments: Map<String, Any?> = emptyMap(),
+    connectDFGUnderlyingNodeToConcept: Boolean = false,
+    connectDFGConceptToUnderlyingNode: Boolean = false,
+): Operation {
+    val operationClass = Class.forName(name).kotlin
+    val constructor =
+        operationClass.constructors.singleOrNull()
+            ?: throw IllegalArgumentException(
+                "The class with $name does not have exactly one constructor."
+            )
+    return (constructor.callBy(
+            mapOf(
+                (constructor.parameters.singleOrNull { it.name == "underlyingNode" }
+                    ?: throw IllegalArgumentException(
+                        "There is no argument with name \"underlyingNode\" which is required for the constructor of operation ${operationClass.simpleName}"
+                    )) to underlyingNode,
+                *constructorArguments
+                    .map { (key, value) ->
+                        (constructor.parameters.singleOrNull { it.name == key }
+                            ?: throw IllegalArgumentException(
+                                "There is no argument with name \"key\" which is specified to generate the operation ${operationClass.simpleName}"
+                            )) to value
+                    }
+                    .toTypedArray(),
+            )
+        ) as? Operation)
+        ?.also { operation ->
+            // Note: Update "newOperation" if you change this.
+            operation.codeAndLocationFrom(underlyingNode)
+            operation.name =
+                Name(
+                    "${operationClass.simpleName}".replaceFirstChar { it.lowercaseChar() },
+                    concept.name,
+                )
+            concept.ops += operation
+            NodeBuilder.log(operation)
+
+            underlyingNode.insertNodeAfterwardInEOGPath(operation)
+
+            if (connectDFGUnderlyingNodeToConcept) {
+                underlyingNode.nextDFG += operation
+            }
+            if (connectDFGConceptToUnderlyingNode) {
+                operation.nextDFG += underlyingNode
+            }
+        } ?: throw IllegalArgumentException("The class $name does not create an Operation.")
 }

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericConceptBuilder.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericConceptBuilder.kt
@@ -65,7 +65,12 @@ inline fun <reified OperationClass : Operation, ConceptClass : Concept> Metadata
     }
 
 /** TODO */
-fun MetadataProvider.conceptBuildHelper(name: String, underlyingNode: Node) {
+fun MetadataProvider.conceptBuildHelper(
+    name: String,
+    underlyingNode: Node,
+    connectDFGUnderlyingNodeToConcept: Boolean = false,
+    connectDFGConceptToUnderlyingNode: Boolean = false,
+): Concept {
     val constructor: (Node) -> Concept =
         when (name) {
             "de.fraunhofer.aisec.cpg.graph.concepts.logging.Log" -> { node ->
@@ -81,5 +86,12 @@ fun MetadataProvider.conceptBuildHelper(name: String, underlyingNode: Node) {
                 throw IllegalArgumentException("Unknown concept: \"${name}\".")
             }
         }
-    this.newConcept(constructor, underlyingNode)
+    this.newConcept(constructor, underlyingNode).also { concept ->
+        if (connectDFGUnderlyingNodeToConcept) {
+            underlyingNode.nextDFG += concept
+        }
+        if (connectDFGConceptToUnderlyingNode) {
+            concept.nextDFG += underlyingNode
+        }
+    }
 }

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericConceptBuilder.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericConceptBuilder.kt
@@ -65,7 +65,7 @@ inline fun <reified OperationClass : Operation, ConceptClass : Concept> Metadata
     }
 
 /** TODO */
-fun MetadataProvider.conceptBuildHelper(name: String, underlyingNode: Node): Concept {
+fun MetadataProvider.conceptBuildHelper(name: String, underlyingNode: Node) {
     val constructor: (Node) -> Concept =
         when (name) {
             "de.fraunhofer.aisec.cpg.graph.concepts.logging.Log" -> { node ->
@@ -81,5 +81,5 @@ fun MetadataProvider.conceptBuildHelper(name: String, underlyingNode: Node): Con
                 throw IllegalArgumentException("Unknown concept: \"${name}\".")
             }
         }
-    return newConcept(constructor, underlyingNode)
+    this.newConcept(constructor, underlyingNode)
 }

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericConceptBuilder.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericConceptBuilder.kt
@@ -70,7 +70,7 @@ fun MetadataProvider.conceptBuildHelper(
     underlyingNode: Node,
     connectDFGUnderlyingNodeToConcept: Boolean = false,
     connectDFGConceptToUnderlyingNode: Boolean = false,
-): Concept {
+) {
     val constructor: (Node) -> Concept =
         when (name) {
             "de.fraunhofer.aisec.cpg.graph.concepts.logging.Log" -> { node ->


### PR DESCRIPTION
This PR adds helper functions to easily create `Concept` nodes from string descriptions.

- [x] Consider rewriting this using reflection (as suggested by @KuechA)
- [x] Handle extra fields
- [x] Support `Operation` nodes, too.
- [x] Resolve open todos.

Required by
- #2200
- #2183