### PR TITLE
Set AST parent to new node when replacing a node

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.kt
@@ -455,6 +455,7 @@ private fun CallExpression.duplicateTo(call: CallExpression, callee: Reference) 
 fun MemberCallExpression.toCallExpression(callee: Reference): CallExpression {
     val call = CallExpression()
     duplicateTo(call, callee)
+    call.arguments.forEach { it.astParent = call }
 
     return call
 }
@@ -462,6 +463,7 @@ fun MemberCallExpression.toCallExpression(callee: Reference): CallExpression {
 fun CallExpression.toMemberCallExpression(callee: MemberExpression): MemberCallExpression {
     val call = MemberCallExpression()
     duplicateTo(call, callee)
+    call.arguments.forEach { it.astParent = call }
 
     return call
 }
@@ -469,6 +471,7 @@ fun CallExpression.toMemberCallExpression(callee: MemberExpression): MemberCallE
 fun CallExpression.toConstructExpression(callee: Reference): ConstructExpression {
     val construct = ConstructExpression()
     duplicateTo(construct, callee)
+    construct.arguments.forEach { it.astParent = construct }
 
     return construct
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.kt
@@ -438,7 +438,9 @@ private fun CallExpression.duplicateTo(call: CallExpression, callee: Reference) 
     call.language = this.language
     call.scope = this.scope
     call.argumentEdges.clear()
-    call.argumentEdges += this.argumentEdges
+    this.argumentEdges.forEach { existingEdge ->
+        call.argumentEdges.add(existingEdge.end) { name = existingEdge.name }
+    }
     call.type = this.type
     call.assignedTypes = this.assignedTypes
     call.code = this.code
@@ -455,7 +457,6 @@ private fun CallExpression.duplicateTo(call: CallExpression, callee: Reference) 
 fun MemberCallExpression.toCallExpression(callee: Reference): CallExpression {
     val call = CallExpression()
     duplicateTo(call, callee)
-    call.arguments.forEach { it.astParent = call }
 
     return call
 }
@@ -463,7 +464,6 @@ fun MemberCallExpression.toCallExpression(callee: Reference): CallExpression {
 fun CallExpression.toMemberCallExpression(callee: MemberExpression): MemberCallExpression {
     val call = MemberCallExpression()
     duplicateTo(call, callee)
-    call.arguments.forEach { it.astParent = call }
 
     return call
 }
@@ -471,7 +471,6 @@ fun CallExpression.toMemberCallExpression(callee: MemberExpression): MemberCallE
 fun CallExpression.toConstructExpression(callee: Reference): ConstructExpression {
     val construct = ConstructExpression()
     duplicateTo(construct, callee)
-    construct.arguments.forEach { it.astParent = construct }
 
     return construct
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.kt
@@ -458,6 +458,10 @@ private fun CallExpression.duplicateTo(call: CallExpression, callee: Reference) 
     call.isInferred = this.isInferred
 }
 
+/**
+ * Creates a new [CallExpression] with the same properties (e.g. ast childre, etc.) except from DFG
+ * and EOG edges as [this]. It sets the [CallExpression.callee] to [callee].
+ */
 fun MemberCallExpression.toCallExpression(callee: Reference): CallExpression {
     val call = CallExpression()
     duplicateTo(call, callee)
@@ -465,6 +469,10 @@ fun MemberCallExpression.toCallExpression(callee: Reference): CallExpression {
     return call
 }
 
+/**
+ * Creates a new [MemberCallExpression] with the same properties (e.g. ast children, etc.) except
+ * from DFG and EOG edges as [this]. It sets the [MemberCallExpression.callee] to [callee].
+ */
 fun CallExpression.toMemberCallExpression(callee: MemberExpression): MemberCallExpression {
     val call = MemberCallExpression()
     duplicateTo(call, callee)
@@ -472,6 +480,10 @@ fun CallExpression.toMemberCallExpression(callee: MemberExpression): MemberCallE
     return call
 }
 
+/**
+ * Creates a new [ConstructExpression] with the same properties (e.g. ast children, etc.) except
+ * from DFG and EOG edges as [this]. It sets the [ConstructExpression.callee] to [callee].
+ */
 fun CallExpression.toConstructExpression(callee: Reference): ConstructExpression {
     val construct = ConstructExpression()
     duplicateTo(construct, callee)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.kt
@@ -381,11 +381,9 @@ fun SubgraphWalker.ScopedWalker.replace(parent: Node?, old: Expression, new: Exp
                     // the whole call expression instead.
                     if (parent is MemberCallExpression && new is Reference) {
                         val newCall = parent.toCallExpression(new)
-                        newCall.arguments.forEach { it.astParent = newCall }
                         return replace(parent.astParent, parent, newCall)
                     } else if (new is MemberExpression) {
                         val newCall = parent.toMemberCallExpression(new)
-                        newCall.arguments.forEach { it.astParent = newCall }
                         return replace(parent.astParent, parent, newCall)
                     } else {
                         parent.callee = new
@@ -434,10 +432,16 @@ fun SubgraphWalker.ScopedWalker.replace(parent: Node?, old: Expression, new: Exp
     return success
 }
 
+/**
+ * Copies the properties of this [CallExpression] to the given [call] and sets the `call.callee` to
+ * [callee]. Note that the ast children are not duplicated. This means that their `astParent` will
+ * now point to [call].
+ */
 private fun CallExpression.duplicateTo(call: CallExpression, callee: Reference) {
     call.language = this.language
     call.scope = this.scope
     call.argumentEdges.clear()
+    // This is required to set the astParent of the arguments to the new edge.
     this.argumentEdges.forEach { existingEdge ->
         call.argumentEdges.add(existingEdge.end) { name = existingEdge.name }
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveCallExpressionAmbiguityPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveCallExpressionAmbiguityPass.kt
@@ -144,7 +144,6 @@ fun SubgraphWalker.ScopedWalker.replaceCallWithCast(
             type
         }
     cast.expression = call.arguments.single()
-    cast.expression.astParent = cast
     cast.name = cast.castType.name
 
     replace(parent, call, cast)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveCallExpressionAmbiguityPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveCallExpressionAmbiguityPass.kt
@@ -144,6 +144,7 @@ fun SubgraphWalker.ScopedWalker.replaceCallWithCast(
             type
         }
     cast.expression = call.arguments.single()
+    cast.expression.astParent = cast
     cast.name = cast.castType.name
 
     replace(parent, call, cast)

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXExpressionTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXExpressionTest.kt
@@ -46,5 +46,9 @@ class CXXExpressionTest {
         val casts = tu.casts
         assertEquals(2, casts.size)
         assertEquals(listOf("int", "long long int"), casts.map { it.name.localName })
+
+        val cast = tu.casts.firstOrNull()
+        assertNotNull(cast)
+        assertEquals(cast, cast.expression.astParent)
     }
 }

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
@@ -325,6 +325,7 @@ class PythonFrontendTest : BaseTest() {
         assertIs<AssignExpression>(s1)
         val s2 = body.statements[1]
         assertIs<MemberCallExpression>(s2)
+        s2.arguments.forEach { assertEquals(s2, it.astParent) }
 
         val c1 = s1.declarations.firstOrNull()
         assertNotNull(c1)
@@ -333,6 +334,7 @@ class PythonFrontendTest : BaseTest() {
         assertIs<ConstructExpression>(ctor)
         assertEquals(ctor.constructor, cls.constructors.firstOrNull())
         assertFullName("simple_class.SomeClass", c1.type)
+        ctor.arguments.forEach { assertEquals(ctor, it.astParent) }
 
         assertRefersTo(s2.base, c1)
         assertEquals(1, s2.invokes.size)


### PR DESCRIPTION
Somehow, replacing a node (here: `CallExpression`s) results in the ast children still pointing to the old parent even if they are now part of the new node. This PR sets this relationship manually. However, in the long-term, I'd encourage a different solution.