### PR TITLE
Adding iteration over a set of nodes in case we can have multiple entries

### DIFF
--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/ConceptPass.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/ConceptPass.kt
@@ -53,11 +53,9 @@ abstract class ConceptPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {
 
         // Gather all resolution EOG starters; and make sure they really do not have a
         // predecessor, otherwise we might analyze a node multiple times
-        val nodes = tu.allEOGStarters.filter { it.prevEOGEdges.isEmpty() }
-
-        for (node in nodes) {
-            walker.iterate(node)
-        }
+        val nodes = tu.allEOGStarters.filter { it.prevEOGEdges.isEmpty() }.toSet()
+        println("Iterate in concepts pass")
+        walker.iterateAll(nodes)
     }
 
     /**

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/file/python/PythonFileConceptPass.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/file/python/PythonFileConceptPass.kt
@@ -72,6 +72,7 @@ class PythonFileConceptPass(ctx: TranslationContext) : ConceptPass(ctx) {
     }
 
     private fun handleCall(callExpression: CallExpression) {
+        println("CallExpression handled: " + callExpression)
         val name = callExpression.name
 
         if (name.toString() == "open") {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -138,6 +138,7 @@ open class SymbolResolver(ctx: TranslationContext) : EOGStarterPass(ctx) {
         walker.registerHandler(this::handle)
 
         walker.iterate(eogStarter)
+
     }
 
     override fun cleanup() {


### PR DESCRIPTION
By iterating over a list of nodes the same seen list can be used. However, if the initial EOG path that a node was reached by is distinct, this also means we would have to see a node twice, i.e. they are visited with different "state". So this change would not be a solution.