### PR TITLE
Resolved bug in member expression ambiguity

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/PassHelper.kt
@@ -179,7 +179,7 @@ internal fun Pass<*>.tryVariableInference(ref: Reference): VariableDeclaration? 
     } else if (ref.name.isQualified()) {
         // For now, we only infer globals at the top-most global level, i.e., no globals in
         // namespaces
-        val extractedScope = scopeManager.extractScope(ref, ref.language, null)
+        val extractedScope = scopeManager.extractScope(ref, ref.language)
         when (val scope = extractedScope?.scope) {
             is NameScope -> {
                 log.warn(

--- a/cpg-language-python/src/test/resources/python/call_confusion.py
+++ b/cpg-language-python/src/test/resources/python/call_confusion.py
@@ -1,0 +1,5 @@
+from somewhere import context
+
+class MyClass():
+    def some_func(self, context: context.SomeContext):
+        context.do_something()


### PR DESCRIPTION
There was a bug in resolving member expression ambiguities when the name of a member's base was identical to an import. This PR should resolve that issue.

Fixes #2220
