### PR TITLE
Choosing "corretto" JVM distribution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           cp gradle.properties.example gradle.properties
       - uses: actions/setup-java@v4
         with:
-          distribution: "zulu"
+          distribution: "corretto"
           java-version: "21"
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Seems to be the only one compatible with our Mac mini cluster.