### PR TITLE
Removing `equalWithoutUnderlying`

### DIFF
--- a/cpg-concepts/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/concepts/file/FileConceptTest.kt
+++ b/cpg-concepts/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/concepts/file/FileConceptTest.kt
@@ -369,7 +369,7 @@ class FileConceptTest : BaseTest() {
         assertNotNull(file, "Expected to find exactly one `File` node (\"example.txt\").")
 
         val fileRead = conceptNodes.filterIsInstance<ReadFile>().singleOrNull()
-        assertNotNull(fileRead, "Expected to find a file read operation.")
+        assertNotNull(fileRead, "Expected to find a single file read operation.")
 
         val fileDelete = conceptNodes.filterIsInstance<DeleteFile>().singleOrNull()
         assertNotNull(fileDelete, "Expected to find a file delete operation.")

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/Concept.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/Concept.kt
@@ -41,7 +41,7 @@ abstract class Concept(underlyingNode: Node?) : OverlayNode() {
     }
 
     /** All [Operation]s belonging to this concept. */
-    val ops: MutableSet<Operation> = mutableSetOf()
+    val ops: MutableList<Operation> = mutableListOf()
 
     /**
      * This method can be overridden to set the data flow graph (DFG) for this [Concept]. Note that

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/Concept.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/Concept.kt
@@ -41,7 +41,7 @@ abstract class Concept(underlyingNode: Node?) : OverlayNode() {
     }
 
     /** All [Operation]s belonging to this concept. */
-    val ops: MutableList<Operation> = mutableListOf()
+    val ops: MutableSet<Operation> = mutableSetOf()
 
     /**
      * This method can be overridden to set the data flow graph (DFG) for this [Concept]. Note that

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/Operation.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/Operation.kt
@@ -45,10 +45,8 @@ abstract class Operation(
         this::class.simpleName?.let { name = Name(it) }
     }
 
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is Operation &&
-            super.equalWithoutUnderlying(other) &&
-            other.concept == this.concept
+    override fun equals(other: Any?): Boolean {
+        return other is Operation && other.concept == this.concept
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), concept)

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/Operation.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/Operation.kt
@@ -46,7 +46,7 @@ abstract class Operation(
     }
 
     override fun equals(other: Any?): Boolean {
-        return other is Operation && other.concept == this.concept
+        return other is Operation && super.equals(other) && other.concept == this.concept
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), concept)

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/arch/OperatingSystem.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/arch/OperatingSystem.kt
@@ -26,17 +26,12 @@
 package de.fraunhofer.aisec.cpg.graph.concepts.arch
 
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.OverlayNode
 import de.fraunhofer.aisec.cpg.graph.concepts.Concept
 import kotlin.reflect.full.isSubclassOf
 
 /** Represents an architecture of an operating system. */
 abstract class OperatingSystemArchitecture(underlyingNode: Node?) :
     Concept(underlyingNode = underlyingNode) {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other::class.isSubclassOf(this::class)
-    }
-
     override fun equals(other: Any?): Boolean {
         return other != null && other::class.isSubclassOf(this::class)
     }

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/auth/Authentication.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/auth/Authentication.kt
@@ -41,7 +41,7 @@ abstract class Authentication(underlyingNode: Node?) : Concept(underlyingNode)
 open class TokenBasedAuth(underlyingNode: Node? = null, val token: Node) :
     Authentication(underlyingNode) {
     override fun equals(other: Any?): Boolean {
-        return other is TokenBasedAuth && other.token == this.token
+        return other is TokenBasedAuth && super.equals(other) && other.token == this.token
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), token)
@@ -56,7 +56,10 @@ open class TokenBasedAuth(underlyingNode: Node? = null, val token: Node) :
 class JwtAuth(underlyingNode: Node? = null, val jwt: Node, val payload: Node) :
     TokenBasedAuth(underlyingNode, jwt) {
     override fun equals(other: Any?): Boolean {
-        return other is JwtAuth && other.jwt == this.jwt && other.payload == this.payload
+        return other is JwtAuth &&
+            super.equals(other) &&
+            other.jwt == this.jwt &&
+            other.payload == this.payload
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), jwt, payload)
@@ -75,7 +78,7 @@ abstract class AuthenticationOperation(underlyingNode: Node? = null, concept: Au
 class Authenticate(underlyingNode: Node? = null, concept: Authentication, val credential: Node) :
     AuthenticationOperation(underlyingNode, concept) {
     override fun equals(other: Any?): Boolean {
-        return other is Authenticate && other.credential == this.credential
+        return other is Authenticate && super.equals(other) && other.credential == this.credential
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), credential)

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/auth/Authentication.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/auth/Authentication.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.graph.concepts.auth
 
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.OverlayNode
 import de.fraunhofer.aisec.cpg.graph.concepts.Concept
 import de.fraunhofer.aisec.cpg.graph.concepts.Operation
 import java.util.Objects
@@ -41,10 +40,8 @@ abstract class Authentication(underlyingNode: Node?) : Concept(underlyingNode)
  */
 open class TokenBasedAuth(underlyingNode: Node? = null, val token: Node) :
     Authentication(underlyingNode) {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is TokenBasedAuth &&
-            super.equalWithoutUnderlying(other) &&
-            other.token == this.token
+    override fun equals(other: Any?): Boolean {
+        return other is TokenBasedAuth && other.token == this.token
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), token)
@@ -58,11 +55,8 @@ open class TokenBasedAuth(underlyingNode: Node? = null, val token: Node) :
  */
 class JwtAuth(underlyingNode: Node? = null, val jwt: Node, val payload: Node) :
     TokenBasedAuth(underlyingNode, jwt) {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is JwtAuth &&
-            super.equalWithoutUnderlying(other) &&
-            other.jwt == this.jwt &&
-            other.payload == this.payload
+    override fun equals(other: Any?): Boolean {
+        return other is JwtAuth && other.jwt == this.jwt && other.payload == this.payload
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), jwt, payload)
@@ -80,10 +74,8 @@ abstract class AuthenticationOperation(underlyingNode: Node? = null, concept: Au
  */
 class Authenticate(underlyingNode: Node? = null, concept: Authentication, val credential: Node) :
     AuthenticationOperation(underlyingNode, concept) {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is Authenticate &&
-            super.equalWithoutUnderlying(other) &&
-            other.credential == this.credential
+    override fun equals(other: Any?): Boolean {
+        return other is Authenticate && other.credential == this.credential
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), credential)

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/config/Configuration.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/config/Configuration.kt
@@ -73,7 +73,7 @@ class ConfigurationGroup(underlyingNode: Node? = null, var conf: Configuration) 
     var options: MutableList<ConfigurationOption> = mutableListOf()
 
     override fun equals(other: Any?): Boolean {
-        return other is ConfigurationGroup && other.conf == this.conf
+        return other is ConfigurationGroup && super.equals(other) && other.conf == this.conf
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), conf)
@@ -102,6 +102,7 @@ class ConfigurationOption(
 
     override fun equals(other: Any?): Boolean {
         return other is ConfigurationOption &&
+            super.equals(other) &&
             other.group == this.group &&
             other.key == this.key &&
             other.value == this.value
@@ -124,7 +125,9 @@ class LoadConfiguration(
     val fileExpression: Expression,
 ) : ConfigurationOperation(underlyingNode = underlyingNode, concept = conf) {
     override fun equals(other: Any?): Boolean {
-        return other is LoadConfiguration && other.fileExpression == this.fileExpression
+        return other is LoadConfiguration &&
+            super.equals(other) &&
+            other.fileExpression == this.fileExpression
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), fileExpression)
@@ -185,7 +188,9 @@ class RegisterConfigurationOption(
     var defaultValue: Node? = null,
 ) : ConfigurationOperation(underlyingNode = underlyingNode, concept = option) {
     override fun equals(other: Any?): Boolean {
-        return other is RegisterConfigurationOption && other.defaultValue == this.defaultValue
+        return other is RegisterConfigurationOption &&
+            super.equals(other) &&
+            other.defaultValue == this.defaultValue
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), defaultValue)
@@ -211,7 +216,7 @@ class ProvideConfiguration(
     var conf: Configuration,
 ) : ConfigurationOperation(underlyingNode = underlyingNode, concept = source) {
     override fun equals(other: Any?): Boolean {
-        return other is ProvideConfiguration && other.conf == this.conf
+        return other is ProvideConfiguration && super.equals(other) && other.conf == this.conf
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), conf)
@@ -227,7 +232,9 @@ class ProvideConfigurationGroup(
     var group: ConfigurationGroup,
 ) : ConfigurationOperation(underlyingNode = underlyingNode, concept = source) {
     override fun equals(other: Any?): Boolean {
-        return other is ProvideConfigurationGroup && other.group == this.group
+        return other is ProvideConfigurationGroup &&
+            super.equals(other) &&
+            other.group == this.group
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), group)
@@ -245,6 +252,7 @@ class ProvideConfigurationOption(
 ) : ConfigurationOperation(underlyingNode = underlyingNode, concept = source) {
     override fun equals(other: Any?): Boolean {
         return other is ProvideConfigurationOption &&
+            super.equals(other) &&
             other.option == this.option &&
             other.value == this.value
     }
@@ -290,7 +298,9 @@ class ConfigurationGroupSource(underlyingNode: Node? = null) :
 class ConfigurationOptionSource(underlyingNode: Node? = null, var group: ConfigurationGroupSource) :
     Concept(underlyingNode = underlyingNode) {
     override fun equals(other: Any?): Boolean {
-        return other is ConfigurationOptionSource && other.group == this.group
+        return other is ConfigurationOptionSource &&
+            super.equals(other) &&
+            other.group == this.group
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), group)

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/config/Configuration.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/config/Configuration.kt
@@ -53,7 +53,7 @@ class Configuration(underlyingNode: Node? = null) : Concept(underlyingNode = und
      * the [ConfigurationGroup]'s ops. This property returns all operations of all groups and
      * options as well as the ones targeting the complete configuration.
      */
-    val allOps: Set<Operation>
+    val allOps: List<Operation>
         get() {
             return ops + groups.flatMap { it.ops + it.options.flatMap { option -> option.ops } }
         }
@@ -266,7 +266,7 @@ class ConfigurationSource(underlyingNode: Node? = null) : Concept(underlyingNode
      * the [ConfigurationGroup]'s ops. This property returns all operations of all groups and
      * options as well as the ones targeting the complete configuration.
      */
-    val allOps: Set<Operation>
+    val allOps: List<Operation>
         get() {
             return ops + groups.flatMap { it.ops + it.options.flatMap { option -> option.ops } }
         }

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/config/Configuration.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/config/Configuration.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.graph.concepts.config
 
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.OverlayNode
 import de.fraunhofer.aisec.cpg.graph.concepts.Concept
 import de.fraunhofer.aisec.cpg.graph.concepts.Operation
 import de.fraunhofer.aisec.cpg.graph.declarations.FieldDeclaration
@@ -73,10 +72,8 @@ class ConfigurationGroup(underlyingNode: Node? = null, var conf: Configuration) 
     Concept(underlyingNode = underlyingNode) {
     var options: MutableList<ConfigurationOption> = mutableListOf()
 
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is ConfigurationGroup &&
-            super.equalWithoutUnderlying(other) &&
-            other.conf == this.conf
+    override fun equals(other: Any?): Boolean {
+        return other is ConfigurationGroup && other.conf == this.conf
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), conf)
@@ -103,9 +100,8 @@ class ConfigurationOption(
     var value: Node? = null,
 ) : Concept(underlyingNode = underlyingNode) {
 
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
+    override fun equals(other: Any?): Boolean {
         return other is ConfigurationOption &&
-            super.equalWithoutUnderlying(other) &&
             other.group == this.group &&
             other.key == this.key &&
             other.value == this.value
@@ -127,10 +123,8 @@ class LoadConfiguration(
     /** The expression that holds the file that is loaded. */
     val fileExpression: Expression,
 ) : ConfigurationOperation(underlyingNode = underlyingNode, concept = conf) {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is LoadConfiguration &&
-            super.equalWithoutUnderlying(other) &&
-            other.fileExpression == this.fileExpression
+    override fun equals(other: Any?): Boolean {
+        return other is LoadConfiguration && other.fileExpression == this.fileExpression
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), fileExpression)
@@ -190,10 +184,8 @@ class RegisterConfigurationOption(
     /** An optional default value of the option. */
     var defaultValue: Node? = null,
 ) : ConfigurationOperation(underlyingNode = underlyingNode, concept = option) {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is RegisterConfigurationOption &&
-            super.equalWithoutUnderlying(other) &&
-            other.defaultValue == this.defaultValue
+    override fun equals(other: Any?): Boolean {
+        return other is RegisterConfigurationOption && other.defaultValue == this.defaultValue
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), defaultValue)
@@ -218,10 +210,8 @@ class ProvideConfiguration(
     var source: ConfigurationSource,
     var conf: Configuration,
 ) : ConfigurationOperation(underlyingNode = underlyingNode, concept = source) {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is ProvideConfiguration &&
-            super.equalWithoutUnderlying(other) &&
-            other.conf == this.conf
+    override fun equals(other: Any?): Boolean {
+        return other is ProvideConfiguration && other.conf == this.conf
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), conf)
@@ -236,10 +226,8 @@ class ProvideConfigurationGroup(
     var source: ConfigurationGroupSource,
     var group: ConfigurationGroup,
 ) : ConfigurationOperation(underlyingNode = underlyingNode, concept = source) {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is ProvideConfigurationGroup &&
-            super.equalWithoutUnderlying(other) &&
-            other.group == this.group
+    override fun equals(other: Any?): Boolean {
+        return other is ProvideConfigurationGroup && other.group == this.group
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), group)
@@ -255,9 +243,8 @@ class ProvideConfigurationOption(
     var option: ConfigurationOption,
     var value: Node?,
 ) : ConfigurationOperation(underlyingNode = underlyingNode, concept = source) {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
+    override fun equals(other: Any?): Boolean {
         return other is ProvideConfigurationOption &&
-            super.equalWithoutUnderlying(other) &&
             other.option == this.option &&
             other.value == this.value
     }
@@ -302,10 +289,8 @@ class ConfigurationGroupSource(underlyingNode: Node? = null) :
  */
 class ConfigurationOptionSource(underlyingNode: Node? = null, var group: ConfigurationGroupSource) :
     Concept(underlyingNode = underlyingNode) {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is ConfigurationOptionSource &&
-            super.equalWithoutUnderlying(other) &&
-            other.group == this.group
+    override fun equals(other: Any?): Boolean {
+        return other is ConfigurationOptionSource && other.group == this.group
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), group)

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/config/Configuration.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/config/Configuration.kt
@@ -53,7 +53,7 @@ class Configuration(underlyingNode: Node? = null) : Concept(underlyingNode = und
      * the [ConfigurationGroup]'s ops. This property returns all operations of all groups and
      * options as well as the ones targeting the complete configuration.
      */
-    val allOps: List<Operation>
+    val allOps: Set<Operation>
         get() {
             return ops + groups.flatMap { it.ops + it.options.flatMap { option -> option.ops } }
         }
@@ -274,7 +274,7 @@ class ConfigurationSource(underlyingNode: Node? = null) : Concept(underlyingNode
      * the [ConfigurationGroup]'s ops. This property returns all operations of all groups and
      * options as well as the ones targeting the complete configuration.
      */
-    val allOps: List<Operation>
+    val allOps: Set<Operation>
         get() {
             return ops + groups.flatMap { it.ops + it.options.flatMap { option -> option.ops } }
         }

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/diskEncryption/Cipher.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/diskEncryption/Cipher.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.graph.concepts.diskEncryption
 
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.OverlayNode
 import de.fraunhofer.aisec.cpg.graph.concepts.Concept
 import java.util.Objects
 
@@ -42,9 +41,8 @@ class Cipher(underlyingNode: Node? = null) :
     /** Key size. */
     var keySize: Int? = null
 
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
+    override fun equals(other: Any?): Boolean {
         return other is Cipher &&
-            super.equalWithoutUnderlying(other) &&
             other.cipherName == this.cipherName &&
             other.blockSize == this.blockSize &&
             other.keySize == this.keySize

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/diskEncryption/Cipher.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/diskEncryption/Cipher.kt
@@ -43,6 +43,7 @@ class Cipher(underlyingNode: Node? = null) :
 
     override fun equals(other: Any?): Boolean {
         return other is Cipher &&
+            super.equals(other) &&
             other.cipherName == this.cipherName &&
             other.blockSize == this.blockSize &&
             other.keySize == this.keySize

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/diskEncryption/CipherOperation.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/diskEncryption/CipherOperation.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.graph.concepts.diskEncryption
 
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.OverlayNode
 import de.fraunhofer.aisec.cpg.graph.concepts.Operation
 import java.util.Objects
 
@@ -40,8 +39,8 @@ class Encrypt(
     val key: Secret,
 ) : CipherOperation(underlyingNode = underlyingNode, concept = concept) {
 
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is Encrypt && super.equalWithoutUnderlying(other) && other.key == this.key
+    override fun equals(other: Any?): Boolean {
+        return other is Encrypt && super.equals(other) && other.key == this.key
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), key)

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/diskEncryption/DiskEncryption.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/diskEncryption/DiskEncryption.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.graph.concepts.diskEncryption
 
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.OverlayNode
 import de.fraunhofer.aisec.cpg.graph.concepts.Concept
 import java.util.Objects
 
@@ -42,9 +41,8 @@ class DiskEncryption(underlyingNode: Node? = null) :
     /** The encryption key used for disk encryption */
     var key: Secret? = null
 
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
+    override fun equals(other: Any?): Boolean {
         return other is DiskEncryption &&
-            super.equalWithoutUnderlying(other) &&
             other.target == this.cipher &&
             other.cipher == this.cipher &&
             other.key == this.key

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/diskEncryption/DiskEncryption.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/diskEncryption/DiskEncryption.kt
@@ -43,6 +43,7 @@ class DiskEncryption(underlyingNode: Node? = null) :
 
     override fun equals(other: Any?): Boolean {
         return other is DiskEncryption &&
+            super.equals(other) &&
             other.target == this.cipher &&
             other.cipher == this.cipher &&
             other.key == this.key

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/file/File.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/file/File.kt
@@ -71,7 +71,7 @@ const val O_ACCMODE_MODE_MASK = 3L
 class File(underlyingNode: Node? = null, val fileName: String) :
     Concept(underlyingNode = underlyingNode), IsFile {
     override fun equals(other: Any?): Boolean {
-        return other is File && other.fileName == this.fileName
+        return other is File && super.equals(other) && other.fileName == this.fileName
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), fileName)
@@ -90,7 +90,7 @@ class SetFileFlags(
     val flags: Set<FileAccessModeFlags>,
 ) : FileOperation(underlyingNode = underlyingNode, file = concept), IsFile {
     override fun equals(other: Any?): Boolean {
-        return other is SetFileFlags && other.flags == this.flags
+        return other is SetFileFlags && super.equals(other) && other.flags == this.flags
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), flags)
@@ -107,7 +107,7 @@ class SetFileFlags(
 class SetFileMask(underlyingNode: Node? = null, concept: File, val mask: Long) :
     FileOperation(underlyingNode = underlyingNode, file = concept), IsFile {
     override fun equals(other: Any?): Boolean {
-        return other is SetFileMask && other.mask == this.mask
+        return other is SetFileMask && super.equals(other) && other.mask == this.mask
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), mask)

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/file/File.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/file/File.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.graph.concepts.file
 
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.OverlayNode
 import de.fraunhofer.aisec.cpg.graph.concepts.Concept
 import de.fraunhofer.aisec.cpg.graph.concepts.Operation
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
@@ -71,10 +70,8 @@ const val O_ACCMODE_MODE_MASK = 3L
  */
 class File(underlyingNode: Node? = null, val fileName: String) :
     Concept(underlyingNode = underlyingNode), IsFile {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is File &&
-            super.equalWithoutUnderlying(other) &&
-            other.fileName == this.fileName
+    override fun equals(other: Any?): Boolean {
+        return other is File && other.fileName == this.fileName
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), fileName)
@@ -92,10 +89,8 @@ class SetFileFlags(
     concept: File,
     val flags: Set<FileAccessModeFlags>,
 ) : FileOperation(underlyingNode = underlyingNode, file = concept), IsFile {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is SetFileFlags &&
-            super.equalWithoutUnderlying(other) &&
-            other.flags == this.flags
+    override fun equals(other: Any?): Boolean {
+        return other is SetFileFlags && other.flags == this.flags
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), flags)
@@ -111,10 +106,8 @@ class SetFileFlags(
  */
 class SetFileMask(underlyingNode: Node? = null, concept: File, val mask: Long) :
     FileOperation(underlyingNode = underlyingNode, file = concept), IsFile {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is SetFileMask &&
-            super.equalWithoutUnderlying(other) &&
-            other.mask == this.mask
+    override fun equals(other: Any?): Boolean {
+        return other is SetFileMask && other.mask == this.mask
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), mask)
@@ -127,11 +120,7 @@ class SetFileMask(underlyingNode: Node? = null, concept: File, val mask: Long) :
  * @param concept The corresponding [File] node.
  */
 class CloseFile(underlyingNode: Node? = null, concept: File) :
-    FileOperation(underlyingNode = underlyingNode, file = concept), IsFile {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is CloseFile && super.equalWithoutUnderlying(other)
-    }
-}
+    FileOperation(underlyingNode = underlyingNode, file = concept), IsFile {}
 
 /**
  * Represents deleting a file.
@@ -140,11 +129,7 @@ class CloseFile(underlyingNode: Node? = null, concept: File) :
  * @param concept The corresponding [File] node.
  */
 class DeleteFile(underlyingNode: Node? = null, concept: File) :
-    FileOperation(underlyingNode = underlyingNode, file = concept), IsFile {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is DeleteFile && super.equalWithoutUnderlying(other)
-    }
-}
+    FileOperation(underlyingNode = underlyingNode, file = concept), IsFile {}
 
 /**
  * Represents opening a file. This is usually done with the same underlying node the [concept] field
@@ -154,11 +139,7 @@ class DeleteFile(underlyingNode: Node? = null, concept: File) :
  * @param concept The corresponding [File] node.
  */
 class OpenFile(underlyingNode: Node? = null, concept: File) :
-    FileOperation(underlyingNode = underlyingNode, file = concept), IsFile {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is OpenFile && super.equalWithoutUnderlying(other)
-    }
-}
+    FileOperation(underlyingNode = underlyingNode, file = concept), IsFile {}
 
 /**
  * Represents reading from a file.
@@ -172,10 +153,6 @@ class ReadFile(underlyingNode: Node? = null, concept: File) :
         this.file.nextDFG += this
         this.underlyingNode?.let { underlyingNode -> this.nextDFG += underlyingNode }
     }
-
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is ReadFile && super.equalWithoutUnderlying(other)
-    }
 }
 
 /**
@@ -187,8 +164,8 @@ class ReadFile(underlyingNode: Node? = null, concept: File) :
  */
 class WriteFile(underlyingNode: Node? = null, concept: File, val what: Node) :
     FileOperation(underlyingNode = underlyingNode, file = concept), IsFile {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is WriteFile && super.equalWithoutUnderlying(other) && other.what == this.what
+    override fun equals(other: Any?): Boolean {
+        return other is WriteFile && super.equals(other) && other.what == this.what
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), what)

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/flows/EntryPoint.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/flows/EntryPoint.kt
@@ -48,7 +48,7 @@ abstract class LocalEntryPoint(
     var os: OperatingSystemArchitecture,
 ) : EntryPoint(underlyingNode = underlyingNode) {
     override fun equals(other: Any?): Boolean {
-        return other is LocalEntryPoint && other.os == this.os
+        return other is LocalEntryPoint && super.equals(other) && other.os == this.os
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), os)

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/flows/EntryPoint.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/flows/EntryPoint.kt
@@ -25,7 +25,6 @@
  */
 package de.fraunhofer.aisec.cpg.graph.concepts.flows
 
-import de.fraunhofer.aisec.cpg.graph.OverlayNode
 import de.fraunhofer.aisec.cpg.graph.concepts.Concept
 import de.fraunhofer.aisec.cpg.graph.concepts.arch.OperatingSystemArchitecture
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
@@ -48,10 +47,8 @@ abstract class LocalEntryPoint(
      */
     var os: OperatingSystemArchitecture,
 ) : EntryPoint(underlyingNode = underlyingNode) {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is LocalEntryPoint &&
-            super.equalWithoutUnderlying(other) &&
-            other.os == this.os
+    override fun equals(other: Any?): Boolean {
+        return other is LocalEntryPoint && other.os == this.os
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), os)

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/http/HttpClient.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/http/HttpClient.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.graph.concepts.http
 
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.OverlayNode
 import de.fraunhofer.aisec.cpg.graph.concepts.Concept
 import de.fraunhofer.aisec.cpg.graph.concepts.Operation
 import de.fraunhofer.aisec.cpg.graph.concepts.auth.Authentication
@@ -38,9 +37,8 @@ class HttpClient(
     val isTLS: Boolean? = false,
     val authentication: Authentication? = null,
 ) : Concept(underlyingNode = underlyingNode) {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
+    override fun equals(other: Any?): Boolean {
         return other is HttpClient &&
-            super.equalWithoutUnderlying(other) &&
             other.isTLS == this.isTLS &&
             other.authentication == this.authentication
     }

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/http/HttpClient.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/http/HttpClient.kt
@@ -39,6 +39,7 @@ class HttpClient(
 ) : Concept(underlyingNode = underlyingNode) {
     override fun equals(other: Any?): Boolean {
         return other is HttpClient &&
+            super.equals(other) &&
             other.isTLS == this.isTLS &&
             other.authentication == this.authentication
     }

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/http/HttpEndpoint.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/http/HttpEndpoint.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.graph.concepts.http
 
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.OverlayNode
 import de.fraunhofer.aisec.cpg.graph.concepts.Concept
 import de.fraunhofer.aisec.cpg.graph.concepts.Operation
 import de.fraunhofer.aisec.cpg.graph.concepts.auth.Authentication
@@ -42,9 +41,8 @@ class HttpEndpoint(
     val arguments: List<Node>,
     var authentication: Authentication?,
 ) : RemoteEntryPoint(underlyingNode = underlyingNode) {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
+    override fun equals(other: Any?): Boolean {
         return other is HttpEndpoint &&
-            super.equalWithoutUnderlying(other) &&
             other.httpMethod == this.httpMethod &&
             other.path == this.path &&
             other.arguments == this.arguments &&

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/http/HttpEndpoint.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/http/HttpEndpoint.kt
@@ -43,6 +43,7 @@ class HttpEndpoint(
 ) : RemoteEntryPoint(underlyingNode = underlyingNode) {
     override fun equals(other: Any?): Boolean {
         return other is HttpEndpoint &&
+            super.equals(other) &&
             other.httpMethod == this.httpMethod &&
             other.path == this.path &&
             other.arguments == this.arguments &&

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/logging/Log.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/logging/Log.kt
@@ -26,8 +26,8 @@
 package de.fraunhofer.aisec.cpg.graph.concepts.logging
 
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.OverlayNode
 import de.fraunhofer.aisec.cpg.graph.concepts.Concept
+import java.util.Objects
 
 /**
  * A logging node, i.e. a node corresponding to a log where [LogWrite] can write to.
@@ -37,7 +37,9 @@ import de.fraunhofer.aisec.cpg.graph.concepts.Concept
 class Log(underlyingNode: Node? = null) : Concept(underlyingNode = underlyingNode), IsLogging {
     var logName: String? = null
 
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is Log && super.equalWithoutUnderlying(other) && other.logName == this.logName
+    override fun equals(other: Any?): Boolean {
+        return other is Log && super.equals(other) && other.logName == this.logName
     }
+
+    override fun hashCode() = Objects.hash(super.hashCode(), logName)
 }

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/logging/LogWrite.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/logging/LogWrite.kt
@@ -58,6 +58,7 @@ class LogWrite(
 ) : Operation(underlyingNode = underlyingNode, concept = concept), IsLogging {
     override fun equals(other: Any?): Boolean {
         return other is LogWrite &&
+            super.equals(other) &&
             other.logLevel == this.logLevel &&
             other.logArguments == this.logArguments
     }

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/logging/LogWrite.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/logging/LogWrite.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.graph.concepts.logging
 
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.OverlayNode
 import de.fraunhofer.aisec.cpg.graph.concepts.Operation
 import java.util.Objects
 
@@ -57,9 +56,8 @@ class LogWrite(
     val logLevel: LogLevel,
     val logArguments: List<Node>,
 ) : Operation(underlyingNode = underlyingNode, concept = concept), IsLogging {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
+    override fun equals(other: Any?): Boolean {
         return other is LogWrite &&
-            super.equalWithoutUnderlying(other) &&
             other.logLevel == this.logLevel &&
             other.logArguments == this.logArguments
     }

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/memory/Memory.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/memory/Memory.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.graph.concepts.memory
 
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.OverlayNode
 import de.fraunhofer.aisec.cpg.graph.concepts.Concept
 import de.fraunhofer.aisec.cpg.graph.concepts.Operation
 import java.util.Objects
@@ -73,8 +72,8 @@ class Allocate(
     /** A reference to [what] is allocated, e.g., a variable. */
     var what: Node?,
 ) : MemoryOperation(underlyingNode = underlyingNode, concept = concept) {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is Allocate && super.equalWithoutUnderlying(other) && other.what == this.what
+    override fun equals(other: Any?): Boolean {
+        return other is Allocate && super.equals(other) && other.what == this.what
     }
 
     override fun hashCode(): Int {
@@ -92,8 +91,8 @@ class DeAllocate(
     /** A reference to [what] is de-allocated, e.g., a variable. */
     var what: Node?,
 ) : MemoryOperation(underlyingNode = underlyingNode, concept = concept) {
-    override fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return other is Allocate && super.equalWithoutUnderlying(other) && other.what == this.what
+    override fun equals(other: Any?): Boolean {
+        return other is Allocate && super.equals(other) && other.what == this.what
     }
 
     override fun hashCode(): Int {

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/EOGConceptPass.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/EOGConceptPass.kt
@@ -210,7 +210,7 @@ open class EOGConceptPass(ctx: TranslationContext) :
             addedOverlays.filter { added ->
                 currentState[currentNode]?.none { existing -> added == existing } != false &&
                     currentNode.overlays.none { existing ->
-                        (existing as? OverlayNode)?.equalWithoutUnderlying(added) == true
+                        (existing as? OverlayNode)?.equals(added) == true
                     }
             }
 

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/EOGConceptPass.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/EOGConceptPass.kt
@@ -93,8 +93,7 @@ open class EOGConceptPass(ctx: TranslationContext) :
         val nextEog = node.nextEOGEdges.toList()
         val finalState = lattice.iterateEOG(nextEog, startState, ::transfer)
 
-        // We do not need to use the finalState here as generating the new objects in the iteration
-        // already connects them to the underlying nodes.
+        // We set the underlying node based on the final state
         for ((underlyingNode, overlayNodes) in finalState) {
             overlayNodes.forEach {
                 it.underlyingNode = underlyingNode
@@ -204,7 +203,8 @@ open class EOGConceptPass(ctx: TranslationContext) :
 
         // This is some magic to filter out overlays that are already in the state (equal but not
         // identical) for the same Node. It also filters the nodes if they have already been created
-        // by a previous pass over the same code block. This happens if multiple EOG starters reach
+        // by a previous iteration over the same code block. This happens if multiple EOG starters
+        // reach
         // a certain piece of code (frequently happens with the code after catch clauses).
         val filteredAddedOverlays =
             addedOverlays.filter { added ->

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/file/python/PythonFileConceptPass.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/file/python/PythonFileConceptPass.kt
@@ -426,6 +426,7 @@ class PythonFileConceptPass(ctx: TranslationContext) : EOGConceptPass(ctx) {
     }
 
     override fun finalCleanup() {
+        super.finalCleanup()
         fileCache.clear()
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -746,8 +746,8 @@ fun Node.followPrevCDGUntilHit(
  * Hence, if "fulfilled" is a non-empty list, a path from [this] to such a node is **possible but
  * not mandatory**. If the list "failed" is empty, the path is mandatory.
  */
-inline fun Node.followXUntilHit(
-    noinline x: (Node, Context, List<Node>) -> Collection<Pair<Node, Context>>,
+fun Node.followXUntilHit(
+    x: (Node, Context, List<Node>) -> Collection<Pair<Node, Context>>,
     collectFailedPaths: Boolean = true,
     findAllPossiblePaths: Boolean = true,
     context: Context = Context(steps = 0),

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/OverlayNode.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/OverlayNode.kt
@@ -49,14 +49,8 @@ abstract class OverlayNode() : Node() {
     var underlyingNode by unwrapping(OverlayNode::underlyingNodeEdge)
 
     override fun equals(other: Any?): Boolean {
-        return other is OverlayNode &&
-            this.equalWithoutUnderlying(other) &&
-            other.underlyingNode == this.underlyingNode
+        return other is OverlayNode && super.equals(other)
     }
 
-    override fun hashCode() = Objects.hash(super.hashCode(), underlyingNode)
-
-    open fun equalWithoutUnderlying(other: OverlayNode): Boolean {
-        return super.equals(other)
-    }
+    override fun hashCode() = Objects.hash(super.hashCode())
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/OverlayNode.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/OverlayNode.kt
@@ -49,8 +49,10 @@ abstract class OverlayNode() : Node() {
     var underlyingNode by unwrapping(OverlayNode::underlyingNodeEdge)
 
     override fun equals(other: Any?): Boolean {
-        return other is OverlayNode && super.equals(other)
+        return other is OverlayNode &&
+            // this.underlyingNode == other.underlyingNode &&
+            super.equals(other)
     }
 
-    override fun hashCode() = Objects.hash(super.hashCode())
+    override fun hashCode() = Objects.hash(super.hashCode() /*, this.underlyingNode*/)
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/OverlayNode.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/OverlayNode.kt
@@ -52,15 +52,18 @@ abstract class OverlayNode() : Node() {
     /**
      * Compares this [OverlayNode] to another object.
      *
-     * Note: We intentionally exclude the underlying node from the equality check. The main reason
-     * for this is that the [EOGStarterPass] needs to compare overlay nodes independently of their
-     * underlying node. It does so to avoid duplicate overlay nodes that can exist by multiple EOG
-     * iterations over the same node. When comparing, the [other] overlay node does not have its
-     * [OverlayNode.underlyingNode] set yet and therefore a comparison would fail if we include it.
-     * Instead, we only want to know if the values of the overlay node are the same.
+     * Note: We intentionally exclude the underlying node from the equality check, unless it is set
+     * on both "this" and [other]. The main reason for this is that the [EOGStarterPass] needs to
+     * compare overlay nodes independently of their underlying node. It does so to avoid duplicate
+     * overlay nodes that can exist by multiple EOG iterations over the same node. When comparing,
+     * the [other] overlay node does not have its [OverlayNode.underlyingNode] set yet and therefore
+     * a comparison would fail if we include it. Instead, we only want to know if the values of the
+     * overlay node are the same.
      */
     override fun equals(other: Any?): Boolean {
-        return other is OverlayNode && super.equals(other)
+        return other is OverlayNode &&
+            super.equals(other) &&
+            this.underlyingNode == other.underlyingNode
     }
 
     /**
@@ -69,5 +72,7 @@ abstract class OverlayNode() : Node() {
      * Note: We intentionally exclude the underlying node from the hash code calculation, see
      * [equals].
      */
-    override fun hashCode() = Objects.hash(super.hashCode())
+    override fun hashCode(): Int {
+        return Objects.hash(super.hashCode(), underlyingNode)
+    }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/OverlayNode.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/OverlayNode.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.graph
 import de.fraunhofer.aisec.cpg.frontends.NoLanguage
 import de.fraunhofer.aisec.cpg.graph.edges.overlay.OverlaySingleEdge
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
+import de.fraunhofer.aisec.cpg.passes.EOGStarterPass
 import java.util.Objects
 import org.neo4j.ogm.annotation.Relationship
 
@@ -48,11 +49,25 @@ abstract class OverlayNode() : Node() {
 
     var underlyingNode by unwrapping(OverlayNode::underlyingNodeEdge)
 
+    /**
+     * Compares this [OverlayNode] to another object.
+     *
+     * Note: We intentionally exclude the underlying node from the equality check. The main reason
+     * for this is that the [EOGStarterPass] needs to compare overlay nodes independently of their
+     * underlying node. It does so to avoid duplicate overlay nodes that can exist by multiple EOG
+     * iterations over the same node. When comparing, the [other] overlay node does not have its
+     * [OverlayNode.underlyingNode] set yet and therefore a comparison would fail if we include it.
+     * Instead, we only want to know if the values of the overlay node are the same.
+     */
     override fun equals(other: Any?): Boolean {
-        return other is OverlayNode &&
-            // this.underlyingNode == other.underlyingNode &&
-            super.equals(other)
+        return other is OverlayNode && super.equals(other)
     }
 
-    override fun hashCode() = Objects.hash(super.hashCode() /*, this.underlyingNode*/)
+    /**
+     * Returns the hash code of this [OverlayNode].
+     *
+     * Note: We intentionally exclude the underlying node from the hash code calculation, see
+     * [equals].
+     */
+    override fun hashCode() = Objects.hash(super.hashCode())
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/OverlayNode.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/OverlayNode.kt
@@ -28,7 +28,6 @@ package de.fraunhofer.aisec.cpg.graph
 import de.fraunhofer.aisec.cpg.frontends.NoLanguage
 import de.fraunhofer.aisec.cpg.graph.edges.overlay.OverlaySingleEdge
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
-import de.fraunhofer.aisec.cpg.passes.EOGStarterPass
 import java.util.Objects
 import org.neo4j.ogm.annotation.Relationship
 
@@ -50,15 +49,9 @@ abstract class OverlayNode() : Node() {
     var underlyingNode by unwrapping(OverlayNode::underlyingNodeEdge)
 
     /**
-     * Compares this [OverlayNode] to another object.
-     *
-     * Note: We intentionally exclude the underlying node from the equality check, unless it is set
-     * on both "this" and [other]. The main reason for this is that the [EOGStarterPass] needs to
-     * compare overlay nodes independently of their underlying node. It does so to avoid duplicate
-     * overlay nodes that can exist by multiple EOG iterations over the same node. When comparing,
-     * the [other] overlay node does not have its [OverlayNode.underlyingNode] set yet and therefore
-     * a comparison would fail if we include it. Instead, we only want to know if the values of the
-     * overlay node are the same.
+     * Compares this [OverlayNode] to another object. We also include the [underlyingNode] in this
+     * process, meaning that two overlay nodes with the equal properties will not be equal if they
+     * have different underlying nodes.
      */
     override fun equals(other: Any?): Boolean {
         return other is OverlayNode &&
@@ -69,8 +62,7 @@ abstract class OverlayNode() : Node() {
     /**
      * Returns the hash code of this [OverlayNode].
      *
-     * Note: We intentionally exclude the underlying node from the hash code calculation, see
-     * [equals].
+     * See [equals] for the properties that are included in this process.
      */
     override fun hashCode(): Int {
         return Objects.hash(super.hashCode(), underlyingNode)


### PR DESCRIPTION
Instead `equals` now excludes the `underylingNode` and the EOGConceptPass collects intermediate states which are then merged into a final state and then uses `finalCleanup` to set the underlying node based on the state.
