### PR TITLE
Fixed problem with `finalState` in `iterateEOG`

### DIFF
--- a/cpg-concepts/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/concepts/file/FileConceptTest.kt
+++ b/cpg-concepts/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/concepts/file/FileConceptTest.kt
@@ -414,15 +414,15 @@ class FileConceptTest : BaseTest() {
 
         val files = conceptNodes.filterIsInstance<File>()
         assertEquals(
-            listOf("a", "b"),
-            files.map { it.fileName },
+            setOf("a", "b"),
+            files.map { it.fileName }.toSet(),
             "Expected to find two `File` nodes (\"a\" and \"b\").",
         )
 
         val writes = conceptNodes.filterIsInstance<WriteFile>()
         assertEquals(
-            listOf("a", "b"),
-            writes.map { it.file.fileName },
+            setOf("a", "b"),
+            writes.map { it.file.fileName }.toSet(),
             "Expected to find two `WriteFile` nodes (to \"a\" and \"b\").",
         )
     }

--- a/cpg-concepts/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/concepts/file/FileConceptTest.kt
+++ b/cpg-concepts/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/concepts/file/FileConceptTest.kt
@@ -392,4 +392,38 @@ class FileConceptTest : BaseTest() {
             "Expected to find an execution path from remove to write.",
         )
     }
+
+    @Test
+    fun testLoop() {
+        val topLevel = Path.of("src", "integrationTest", "resources", "python", "file")
+
+        val result =
+            analyze(
+                files = listOf(topLevel.resolve("file_loop.py").toFile()),
+                topLevel = topLevel,
+                usePasses = true,
+            ) {
+                it.registerLanguage<PythonLanguage>()
+                it.registerPass<PythonFileConceptPass>()
+                it.symbols(mapOf("PYTHON_PLATFORM" to "linux"))
+            }
+        assertNotNull(result)
+
+        val conceptNodes = result.allChildrenWithOverlays<IsFile>()
+        assertTrue(conceptNodes.isNotEmpty())
+
+        val files = conceptNodes.filterIsInstance<File>()
+        assertEquals(
+            listOf("a", "b"),
+            files.map { it.fileName },
+            "Expected to find two `File` nodes (\"a\" and \"b\").",
+        )
+
+        val writes = conceptNodes.filterIsInstance<WriteFile>()
+        assertEquals(
+            listOf("a", "b"),
+            writes.map { it.file.fileName },
+            "Expected to find two `WriteFile` nodes (to \"a\" and \"b\").",
+        )
+    }
 }

--- a/cpg-concepts/src/integrationTest/resources/python/file/file_loop.py
+++ b/cpg-concepts/src/integrationTest/resources/python/file/file_loop.py
@@ -1,0 +1,5 @@
+x = ["a", "b", "c"]
+file = open("a")
+for bla in x:
+    file.write(bla)
+    file = open("b")

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/functional/BasicLatticesRedesign.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/functional/BasicLatticesRedesign.kt
@@ -149,9 +149,6 @@ interface Lattice<T : Lattice.Element> {
             // state.
             val nextGlobal = globalState[nextEdge] ?: continue
             val newState = transformation(this, nextEdge, nextGlobal)
-            if (nextEdge.end.nextEOGEdges.isEmpty()) {
-                finalState[nextEdge] = newState
-            }
             nextEdge.end.nextEOGEdges.forEach {
                 // We continue with the nextEOG edge if we haven't seen it before or if we updated
                 // the state in comparison to the previous time we were there.
@@ -161,6 +158,10 @@ interface Lattice<T : Lattice.Element> {
                 if (it !in edgesList && (oldGlobalIt == null || newGlobalIt != oldGlobalIt)) {
                     edgesList.add(0, it)
                 }
+            }
+
+            if (nextEdge.end.nextEOGEdges.isEmpty() || edgesList.isEmpty()) {
+                finalState[nextEdge] = newState
             }
         }
 


### PR DESCRIPTION
If the EOG ended in a loop, we previously "forgot" to add to the final state.