### PR TITLE
Using relative paths in SARIF file

### DIFF
--- a/codyze-core/src/integrationTest/kotlin/codyze/SarifTest.kt
+++ b/codyze-core/src/integrationTest/kotlin/codyze/SarifTest.kt
@@ -55,6 +55,8 @@ class SarifTest {
         assertNotNull(fullLoc)
         assertEquals(7, fullLoc.physicalLocation?.region?.endLine)
         assertEquals(15, fullLoc.physicalLocation?.region?.endColumn)
+        assertEquals("simple.py", fullLoc.physicalLocation?.artifactLocation?.uri)
+        assertEquals("application", fullLoc.physicalLocation?.artifactLocation?.uriBaseID)
 
         val logical = fullLoc.logicalLocations?.firstOrNull()
         assertNotNull(logical)

--- a/codyze-core/src/main/kotlin/de/fraunhofer/aisec/codyze/Project.kt
+++ b/codyze-core/src/main/kotlin/de/fraunhofer/aisec/codyze/Project.kt
@@ -141,6 +141,10 @@ class AnalysisProject(
                 tool =
                     Tool(driver = ToolComponent(name = "Codyze", version = "x.x.x", rules = rules)),
                 results = results,
+                originalURIBaseIDS =
+                    config.topLevels
+                        .mapNotNull { Pair(it.key, it.toSarifLocation()) }
+                        .associate { it },
             )
 
         return AnalysisResult(

--- a/codyze-core/src/main/kotlin/de/fraunhofer/aisec/codyze/Sarif.kt
+++ b/codyze-core/src/main/kotlin/de/fraunhofer/aisec/codyze/Sarif.kt
@@ -41,6 +41,7 @@ import de.fraunhofer.aisec.cpg.query.QueryTree
 import de.fraunhofer.aisec.cpg.query.SinglePathResult
 import io.github.detekt.sarif4k.*
 import java.io.File
+import kotlin.io.path.relativeToOrSelf
 import kotlin.io.path.toPath
 
 /**
@@ -219,7 +220,7 @@ fun de.fraunhofer.aisec.cpg.sarif.PhysicalLocation.toSarif(
     var uri = this.artifactLocation.uri.toPath()
     val uriBase = component?.location?.artifactLocation?.uri?.toPath()
     if (uriBase != null) {
-        uri = uriBase.relativize(uri)
+        uri = uri.relativeToOrSelf(uriBase)
     }
 
     return PhysicalLocation(

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
@@ -63,7 +63,7 @@ private constructor(
     val symbols: Map<String, String>,
     /** Source code files to parse. */
     val softwareComponents: Map<String, List<File>>,
-    val topLevels: MutableMap<String, File?>,
+    val topLevels: MutableMap<String, File>,
     /** Set to true to generate debug output for the parser. */
     val debugParser: Boolean,
     /**
@@ -244,7 +244,7 @@ private constructor(
     class Builder {
         private var softwareComponents: MutableMap<String, List<File>> = HashMap()
         private val languages = mutableListOf<KClass<out Language<*>>>()
-        private var topLevels = mutableMapOf<String, File?>()
+        private var topLevels = mutableMapOf<String, File>()
         private var debugParser = false
         private var failOnError = false
         private var loadIncludes = false
@@ -319,12 +319,12 @@ private constructor(
             return this
         }
 
-        fun topLevel(topLevel: File?): Builder {
+        fun topLevel(topLevel: File): Builder {
             this.topLevels[DEFAULT_APPLICATION_NAME] = topLevel
             return this
         }
 
-        fun topLevels(topLevels: Map<String, File?>): Builder {
+        fun topLevels(topLevels: Map<String, File>): Builder {
             this.topLevels.clear()
             this.topLevels += topLevels
             return this

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationContext.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationContext.kt
@@ -29,6 +29,7 @@ import de.fraunhofer.aisec.cpg.TranslationManager.AdditionalSource
 import de.fraunhofer.aisec.cpg.TranslationManager.Companion.log
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.Component
+import de.fraunhofer.aisec.cpg.graph.ContextProvider
 import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
 import java.io.File
 
@@ -52,7 +53,7 @@ open class TranslationContext(
      * the [TranslationResult.finalCtx] this may either be null or the last component analyzed.
      */
     var currentComponent: Component? = null,
-) {
+) : ContextProvider {
     /**
      * The scope manager which comprises the complete translation result. In case of sequential
      * parsing, this scope manager is passed to the individual frontends one after another. In case
@@ -125,6 +126,9 @@ open class TranslationContext(
             }
             return languages.firstOrNull()
         }
+
+    override val ctx: TranslationContext
+        get() = this
 
     /**
      * This is a special [TranslationContext] that is used when no translation context is available.

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
@@ -31,6 +31,7 @@ import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.scopes.GlobalScope
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.helpers.Benchmark
+import de.fraunhofer.aisec.cpg.passes.SymbolResolver
 import de.fraunhofer.aisec.cpg.passes.executePass
 import de.fraunhofer.aisec.cpg.passes.executePassesInParallel
 import de.fraunhofer.aisec.cpg.sarif.toLocation
@@ -115,6 +116,9 @@ private constructor(
 
                 executedFrontends.forEach { it.cleanup() }
             }
+
+            // We need to clear this map to avoid spilling over into other analysis
+            SymbolResolver.componentsToTemplates.clear()
         }
 
         return result

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
@@ -31,7 +31,6 @@ import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.scopes.GlobalScope
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.helpers.Benchmark
-import de.fraunhofer.aisec.cpg.passes.SymbolResolver
 import de.fraunhofer.aisec.cpg.passes.executePass
 import de.fraunhofer.aisec.cpg.passes.executePassesInParallel
 import de.fraunhofer.aisec.cpg.sarif.toLocation
@@ -116,9 +115,6 @@ private constructor(
 
                 executedFrontends.forEach { it.cleanup() }
             }
-
-            // We need to clear this map to avoid spilling over into other analysis
-            SymbolResolver.componentsToTemplates.clear()
         }
 
         return result

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
@@ -33,6 +33,7 @@ import de.fraunhofer.aisec.cpg.graph.types.Type
 import de.fraunhofer.aisec.cpg.helpers.Benchmark
 import de.fraunhofer.aisec.cpg.passes.executePass
 import de.fraunhofer.aisec.cpg.passes.executePassesInParallel
+import de.fraunhofer.aisec.cpg.sarif.toLocation
 import java.io.File
 import java.io.PrintWriter
 import java.lang.reflect.InvocationTargetException
@@ -154,6 +155,7 @@ private constructor(
         for (sc in ctx.config.softwareComponents.keys) {
             val component = Component()
             component.name = Name(sc)
+            component.location = with(ctx) { component.topLevel()?.toPath()?.toLocation() }
             result.addComponent(component)
 
             var sourceLocations: List<File> = ctx.config.softwareComponents[sc] ?: listOf()
@@ -304,6 +306,7 @@ private constructor(
                     if (component == null) {
                         component = Component()
                         component.name = compName
+                        component.location = includePath.toLocation()
                         result.addComponent(component)
                         ctx.config.topLevels.put(includePath.name, includePath.toFile())
                     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
@@ -46,6 +46,7 @@ import org.neo4j.ogm.annotation.Transient
  * This node holds all translation units belonging to this software component as well as (potential)
  * entry points or interactions with other software.
  */
+@Suppress("CONTEXT_RECEIVERS_DEPRECATED")
 open class Component : Node() {
     @Relationship("TRANSLATION_UNITS")
     val translationUnitEdges = astEdgesOf<TranslationUnitDeclaration>()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -314,12 +314,6 @@ abstract class Node() :
                 code == other.code &&
                 comment == other.comment &&
                 location == other.location &&
-                // We need to exclude "file" here, because in C++ the same header node can be
-                // imported in two different files and in this case, the "file" property will be
-                // different. Since want to squash those equal nodes, we will only consider all the
-                // other attributes, including "location" (which contains the *original* file
-                // location in the header file), but not "file".
-                // file == other.file &&
                 isImplicit == other.isImplicit
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -28,12 +28,14 @@
 package de.fraunhofer.aisec.cpg.graph
 
 import de.fraunhofer.aisec.cpg.TranslationContext
-import de.fraunhofer.aisec.cpg.frontends.*
+import de.fraunhofer.aisec.cpg.frontends.Handler
+import de.fraunhofer.aisec.cpg.frontends.Language
+import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.Node.Companion.EMPTY_NAME
 import de.fraunhofer.aisec.cpg.graph.NodeBuilder.LOGGER
 import de.fraunhofer.aisec.cpg.graph.NodeBuilder.log
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.types.HasType
 import de.fraunhofer.aisec.cpg.helpers.getCodeOfSubregion
 import de.fraunhofer.aisec.cpg.passes.inference.IsImplicitProvider

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/sarif/PhysicalLocation.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/sarif/PhysicalLocation.kt
@@ -84,6 +84,6 @@ class PhysicalLocation(uri: URI, region: Region) {
 fun Path.toLocation(): PhysicalLocation {
     return PhysicalLocation(
         uri = this.toUri(),
-        region = Region(startLine = 1, startColumn = 1, endLine = 1, endColumn = 1),
+        region = Region(startLine = -1, startColumn = -1, endLine = -1, endColumn = -1),
     )
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/sarif/PhysicalLocation.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/sarif/PhysicalLocation.kt
@@ -25,7 +25,9 @@
  */
 package de.fraunhofer.aisec.cpg.sarif
 
+import java.io.File
 import java.net.URI
+import java.nio.file.Path
 import java.util.*
 
 /** A SARIF compatible location referring to a location, i.e. file and region within the file. */
@@ -76,4 +78,12 @@ class PhysicalLocation(uri: URI, region: Region) {
             } else "unknown"
         }
     }
+}
+
+/** Converts a [File] to a [PhysicalLocation]. */
+fun Path.toLocation(): PhysicalLocation {
+    return PhysicalLocation(
+        uri = this.toUri(),
+        region = Region(startLine = 1, startColumn = 1, endLine = 1, endColumn = 1),
+    )
 }

--- a/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
+++ b/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Application.kt
@@ -453,7 +453,6 @@ class Application : Callable<Int> {
     fun setupTranslationConfiguration(): TranslationConfiguration {
         val translationConfiguration =
             TranslationConfiguration.builder()
-                .topLevel(topLevel)
                 .optionalLanguage("de.fraunhofer.aisec.cpg.frontends.cxx.CLanguage")
                 .optionalLanguage("de.fraunhofer.aisec.cpg.frontends.cxx.CPPLanguage")
                 .optionalLanguage("de.fraunhofer.aisec.cpg.frontends.java.JavaLanguage")
@@ -470,6 +469,8 @@ class Application : Callable<Int> {
                 .debugParser(DEBUG_PARSER)
                 .useUnityBuild(useUnityBuild)
                 .useParallelPasses(false)
+
+        topLevel?.let { translationConfiguration.topLevel(it) }
 
         if (maxComplexity != -1) {
             translationConfiguration.configurePass<ControlFlowSensitiveDFGPass>(


### PR DESCRIPTION
This issues the component's name as a `uriBaseID` and relativizes paths to the component if possible. Also includes some more file/path related cleanups.

Fixes #2215
