### PR TITLE
Adding a `Pass::finalCleanup` method

### DIFF
--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/file/python/PythonFileConceptPass.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/file/python/PythonFileConceptPass.kt
@@ -424,4 +424,8 @@ class PythonFileConceptPass(ctx: TranslationContext) : EOGConceptPass(ctx) {
             }
         }
     }
+
+    override fun finalCleanup() {
+        fileCache.clear()
+    }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
@@ -197,7 +197,14 @@ sealed class Pass<T : Node>(final override val ctx: TranslationContext, val sort
     override val scope: Scope?
         get() = scopeManager.currentScope
 
+    /** This method is called for each "target" that is passed to the pass. */
     abstract fun cleanup()
+
+    /**
+     * This method is called after all targets have been processed. It can be used to do some
+     * cleanup of static fields, e.g., in companion objects.
+     */
+    open fun finalCleanup() {}
 
     /**
      * Check if the pass requires a specific language frontend and if that frontend has been
@@ -376,6 +383,7 @@ fun executePass(
         }
     }
 
+    prototype.finalCleanup()
     bench.stop()
 }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -158,6 +158,10 @@ open class SymbolResolver(ctx: TranslationContext) : EOGStarterPass(ctx) {
         templateList.clear()
     }
 
+    override fun finalCleanup() {
+        componentsToTemplates.clear()
+    }
+
     /**
      * This function caches all [TemplateDeclaration]s into [templateList]. It either fetches the
      * existing result from [componentsToTemplates] or fills [templateList] for the first time and


### PR DESCRIPTION
Passes are currently instantiated for each "target" (e.g., a component or EOG starter). Therefore, the existing `cleanup` method can only clean the state of the current pass instantiation. But sometimes we need to clean "global" state that exists beyond multiple invocations but need to be cleaned before the next analysis. 

Therefore, this pass introduces a `finalCleanup` method which is called after all targets are handled. We call it on the pass prototype that we create before each target.