### PR TITLE
Deriving ID from hashcode

### DIFF
--- a/codyze-console/src/test/kotlin/de/fraunhofer/aisec/codyze/console/ApplicationTest.kt
+++ b/codyze-console/src/test/kotlin/de/fraunhofer/aisec/codyze/console/ApplicationTest.kt
@@ -1,4 +1,4 @@
-/*
+package de.fraunhofer.aisec.codyze.console/*
  * Copyright (c) 2025, Fraunhofer AISEC. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/codyze-console/src/test/kotlin/de/fraunhofer/aisec/codyze/console/ApplicationTest.kt
+++ b/codyze-console/src/test/kotlin/de/fraunhofer/aisec/codyze/console/ApplicationTest.kt
@@ -1,4 +1,4 @@
-package de.fraunhofer.aisec.codyze.console/*
+/*
  * Copyright (c) 2025, Fraunhofer AISEC. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -254,11 +254,14 @@ abstract class Node() :
     /** Required field for object graph mapping. It contains the node id. */
     @DoNotPersist @Id @GeneratedValue var legacyId: Long? = null
 
-    /** Will replace [legacyId] */
-    @OptIn(ExperimentalStdlibApi::class)
+    /**
+     * A (more or less) unique identifier for this node. It is a [Uuid] derived from
+     * [Node.hashCode]. In this sense, it is definitely deterministic and reproducible, however, in
+     * theory it is not completely unique, as collisions within [Node.hashCode] could occur.
+     */
     val id: Uuid
         get() {
-            return Uuid.parseHex(hashCode().toHexString(HexFormat { number.minLength = 32 }))
+            return Uuid.fromLongs(0, hashCode().toLong())
         }
 
     /** Index of the argument if this node is used in a function call or parameter list. */

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -255,7 +255,11 @@ abstract class Node() :
     @DoNotPersist @Id @GeneratedValue var legacyId: Long? = null
 
     /** Will replace [legacyId] */
-    var id: Uuid = Uuid.random()
+    @OptIn(ExperimentalStdlibApi::class)
+    val id: Uuid
+        get() {
+            return Uuid.parseHex(hashCode().toHexString())
+        }
 
     /** Index of the argument if this node is used in a function call or parameter list. */
     var argumentIndex = 0

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -261,7 +261,11 @@ abstract class Node() :
      */
     val id: Uuid
         get() {
-            return Uuid.fromLongs(0, hashCode().toLong())
+            val parent =
+                astParent?.id?.toLongs { mostSignificantBits, leastSignificantBits ->
+                    leastSignificantBits
+                }
+            return Uuid.fromLongs(parent ?: 0, hashCode().toLong())
         }
 
     /** Index of the argument if this node is used in a function call or parameter list. */

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -258,7 +258,7 @@ abstract class Node() :
     @OptIn(ExperimentalStdlibApi::class)
     val id: Uuid
         get() {
-            return Uuid.parseHex(hashCode().toHexString())
+            return Uuid.parseHex(hashCode().toHexString(HexFormat { number.minLength = 32 }))
         }
 
     /** Index of the argument if this node is used in a function call or parameter list. */

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TranslationUnitDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TranslationUnitDeclaration.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.graph.declarations
 
 import de.fraunhofer.aisec.cpg.graph.*
-import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import de.fraunhofer.aisec.cpg.graph.statements.Statement
@@ -81,11 +80,7 @@ class TranslationUnitDeclaration :
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is TranslationUnitDeclaration) return false
-        // TODO: This statement doesn't make sense to me. The declarationsPropertyEdge comparison is
-        // more strict than the propertyEqualsList() isn't it?
-        return super.equals(other) &&
-            declarations == other.declarations &&
-            propertyEqualsList(declarationEdges, other.declarationEdges)
+        return super.equals(other) && declarations == other.declarations
     }
 
     override fun hashCode() = Objects.hash(super.hashCode(), declarations)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeCollection.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeCollection.kt
@@ -101,12 +101,20 @@ abstract class UnwrappedEdgeCollection<NodeType : Node, EdgeType : Edge<NodeType
 
         @Suppress("UNCHECKED_CAST")
         override fun next(): NodeType {
-            var next = edgeIterator.next()
+            val next = edgeIterator.next()
             return if (collection.outgoing) {
                 next.end
             } else {
                 next.start as NodeType
             }
         }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return other is UnwrappedEdgeCollection<*, *> && collection == other.collection
+    }
+
+    override fun hashCode(): Int {
+        return collection.hashCode()
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeCollection.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeCollection.kt
@@ -32,7 +32,7 @@ import de.fraunhofer.aisec.cpg.graph.edges.Edge
  * An intelligent [MutableCollection] wrapper around an [EdgeCollection] which supports iterating,
  * adding and removing [Node] elements. Basis for [UnwrappedEdgeList] and [UnwrappedEdgeSet].
  */
-abstract class UnwrappedEdgeCollection<NodeType : Node, EdgeType : Edge<NodeType>>(
+sealed class UnwrappedEdgeCollection<NodeType : Node, EdgeType : Edge<NodeType>>(
     var collection: EdgeCollection<NodeType, EdgeType>
 ) : MutableCollection<NodeType> {
 
@@ -108,13 +108,5 @@ abstract class UnwrappedEdgeCollection<NodeType : Node, EdgeType : Edge<NodeType
                 next.start as NodeType
             }
         }
-    }
-
-    override fun equals(other: Any?): Boolean {
-        return other is UnwrappedEdgeCollection<*, *> && collection == other.collection
-    }
-
-    override fun hashCode(): Int {
-        return collection.hashCode()
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeCollection.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeCollection.kt
@@ -32,6 +32,7 @@ import de.fraunhofer.aisec.cpg.graph.edges.Edge
  * An intelligent [MutableCollection] wrapper around an [EdgeCollection] which supports iterating,
  * adding and removing [Node] elements. Basis for [UnwrappedEdgeList] and [UnwrappedEdgeSet].
  */
+@Suppress("EqualsOrHashCode")
 sealed class UnwrappedEdgeCollection<NodeType : Node, EdgeType : Edge<NodeType>>(
     var collection: EdgeCollection<NodeType, EdgeType>
 ) : MutableCollection<NodeType> {
@@ -109,4 +110,18 @@ sealed class UnwrappedEdgeCollection<NodeType : Node, EdgeType : Edge<NodeType>>
             }
         }
     }
+
+    override fun hashCode(): Int {
+        var hashCode = 1
+
+        val it = iterator()
+        while (it.hasNext()) {
+            val element = it.next()
+            hashCode = 31 * hashCode + element.hashCode()
+        }
+
+        return hashCode
+    }
+
+    abstract override fun equals(other: Any?): Boolean
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeList.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeList.kt
@@ -35,6 +35,7 @@ import org.neo4j.ogm.annotation.Transient
  * An intelligent [MutableList] wrapper around an [EdgeList] which supports iterating, adding and
  * removing [Node] elements.
  */
+@Suppress("EqualsOrHashCode")
 class UnwrappedEdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
     var list: EdgeList<NodeType, EdgeType>
 ) : UnwrappedEdgeCollection<NodeType, EdgeType>(list), MutableList<NodeType> {
@@ -236,17 +237,5 @@ class UnwrappedEdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
 
     override fun equals(other: Any?): Boolean {
         return other is List<*> && this.iterator().asSequence().toList() == other
-    }
-
-    override fun hashCode(): Int {
-        var hashCode = 1
-
-        val it = iterator()
-        while (it.hasNext()) {
-            val element = it.next()
-            hashCode = 31 * hashCode + element.hashCode()
-        }
-
-        return hashCode
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeList.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeList.kt
@@ -56,7 +56,7 @@ class UnwrappedEdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
     }
 
     override fun removeAt(index: Int): NodeType {
-        var edge = list.removeAt(index)
+        val edge = list.removeAt(index)
         return if (list.outgoing) {
             edge.end
         } else {
@@ -239,6 +239,14 @@ class UnwrappedEdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
     }
 
     override fun hashCode(): Int {
-        return list.hashCode()
+        var hashCode = 1
+
+        val it = list.iterator()
+        while (it.hasNext()) {
+            val element = it.next()
+            hashCode = 31 * hashCode + element.hashCode()
+        }
+
+        return hashCode
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeList.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeList.kt
@@ -241,7 +241,7 @@ class UnwrappedEdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
     override fun hashCode(): Int {
         var hashCode = 1
 
-        val it = list.iterator()
+        val it = iterator()
         while (it.hasNext()) {
             val element = it.next()
             hashCode = 31 * hashCode + element.hashCode()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeList.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeList.kt
@@ -233,4 +233,12 @@ class UnwrappedEdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
     ): Delegate<ThisType> {
         return Delegate()
     }
+
+    override fun equals(other: Any?): Boolean {
+        return other is List<*> && this.iterator().asSequence().toList() == other
+    }
+
+    override fun hashCode(): Int {
+        return list.hashCode()
+    }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeSet.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeSet.kt
@@ -78,4 +78,20 @@ class UnwrappedEdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
     ): Delegate<ThisType> {
         return Delegate()
     }
+
+    override fun equals(other: Any?): Boolean {
+        return other is Set<*> && this.iterator().asSequence().toSet() == other
+    }
+
+    override fun hashCode(): Int {
+        var hashCode = super.hashCode()
+
+        val it = set.iterator()
+        while (it.hasNext()) {
+            val element = it.next()
+            hashCode += 31 * element.hashCode()
+        }
+
+        return hashCode
+    }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeSet.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeSet.kt
@@ -86,7 +86,7 @@ class UnwrappedEdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
     override fun hashCode(): Int {
         var hashCode = 1
 
-        val it = set.iterator()
+        val it = iterator()
         while (it.hasNext()) {
             val element = it.next()
             hashCode = 31 * hashCode + element.hashCode()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeSet.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeSet.kt
@@ -84,12 +84,12 @@ class UnwrappedEdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
     }
 
     override fun hashCode(): Int {
-        var hashCode = super.hashCode()
+        var hashCode = 1
 
         val it = set.iterator()
         while (it.hasNext()) {
             val element = it.next()
-            hashCode += 31 * element.hashCode()
+            hashCode = 31 * hashCode + element.hashCode()
         }
 
         return hashCode

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeSet.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeSet.kt
@@ -34,6 +34,7 @@ import org.neo4j.ogm.annotation.Transient
  * An intelligent [MutableSet] wrapper around an [EdgeSet] which supports iterating, adding and
  * removing [Node] elements.
  */
+@Suppress("EqualsOrHashCode")
 class UnwrappedEdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
     var set: EdgeSet<NodeType, EdgeType>
 ) : UnwrappedEdgeCollection<NodeType, EdgeType>(set), MutableSet<NodeType> {
@@ -81,17 +82,5 @@ class UnwrappedEdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
 
     override fun equals(other: Any?): Boolean {
         return other is Set<*> && this.iterator().asSequence().toSet() == other
-    }
-
-    override fun hashCode(): Int {
-        var hashCode = 1
-
-        val it = iterator()
-        while (it.hasNext()) {
-            val element = it.next()
-            hashCode = 31 * hashCode + element.hashCode()
-        }
-
-        return hashCode
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/EmptyStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/EmptyStatement.kt
@@ -30,5 +30,4 @@ class EmptyStatement : Statement() {
     override fun equals(other: Any?): Boolean {
         return other is EmptyStatement && super.equals(other)
     }
-
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/EmptyStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/EmptyStatement.kt
@@ -25,4 +25,10 @@
  */
 package de.fraunhofer.aisec.cpg.graph.statements
 
-class EmptyStatement : Statement()
+@Suppress("EqualsOrHashCode")
+class EmptyStatement : Statement() {
+    override fun equals(other: Any?): Boolean {
+        return other is EmptyStatement && super.equals(other)
+    }
+
+}

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/LookupScopeStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/LookupScopeStatement.kt
@@ -57,5 +57,5 @@ class LookupScopeStatement : Statement() {
         return super.equals(other) && symbols == other.symbols && targetScope == other.targetScope
     }
 
-    override fun hashCode() = Objects.hash(super.hashCode(), symbols, targetScope)
+    override fun hashCode() = Objects.hash(super.hashCode(), symbols)
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/NodeTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/NodeTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.graph
+
+import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
+import kotlin.test.Test
+
+class NodeTest {
+    @Test
+    fun testId() {
+        with(TestLanguageFrontend()) {
+            val node1 = newLiteral(1)
+            val node2 = newLiteral(2)
+
+            // Check that the IDs are unique
+            assert(node1.id != node2.id) { "Node IDs should be unique" }
+        }
+    }
+}

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeListTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeListTest.kt
@@ -37,12 +37,12 @@ class EdgeListTest {
     @Test
     fun testAddIndex() {
         with(TestLanguageFrontend()) {
-            var node1 = newLiteral(1)
-            var node2 = newLiteral(2)
-            var node3 = newLiteral(3)
-            var node4 = newLiteral(4)
+            val node1 = newLiteral(1)
+            val node2 = newLiteral(2)
+            val node3 = newLiteral(3)
+            val node4 = newLiteral(4)
 
-            var list = AstEdges<Node, AstEdge<Node>>(thisRef = node1)
+            val list = AstEdges<Node, AstEdge<Node>>(thisRef = node1)
             list += node2
             list += node3
 
@@ -62,7 +62,7 @@ class EdgeListTest {
             }
 
             // the order should be node2, node4, node3
-            var unwrapped = list.unwrap()
+            val unwrapped = list.unwrap()
             assertEquals<List<Node>>(listOf(node2, node4, node3), unwrapped)
         }
     }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSingletonListTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSingletonListTest.kt
@@ -44,7 +44,7 @@ class EdgeSingletonListTest {
                 var unwrapped by unwrapping(MyNode::edge)
             }
 
-            var node = MyNode()
+            val node = MyNode()
             assertNull(node.unwrapped)
 
             node.unwrapped = newLiteral(1)

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeListTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeListTest.kt
@@ -43,7 +43,7 @@ class UnwrappedEdgeListTest {
 
             node1.nextEOGEdges += node2
 
-            // this should trigger add of the edge underneath (node1.nextEOGEdges += node3)
+            // this should trigger "add" of the edge underneath (node1.nextEOGEdges += node3)
             node1.nextEOG += node3
 
             // should contain 2 nodes now

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeListTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeListTest.kt
@@ -93,6 +93,25 @@ class UnwrappedEdgeListTest {
     }
 
     @Test
+    fun testRemoveAt() {
+        with(TestLanguageFrontend()) {
+            val node1 = newLiteral(1)
+            val node2 = newLiteral(2)
+            val node3 = newLiteral(3)
+
+            node1.nextEOG += node2
+            node1.nextEOG += node3
+
+            assertEquals(2, node1.nextEOGEdges.size)
+
+            // remove the element at index 1 (node3)
+            node1.nextEOG.removeAt(1)
+
+            assertEquals(node2, node1.nextEOG.singleOrNull())
+        }
+    }
+
+    @Test
     fun testIterator() {
         with(TestLanguageFrontend()) {
             val node1 = newLiteral(1)

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeListTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeListTest.kt
@@ -37,9 +37,9 @@ class UnwrappedEdgeListTest {
     @Test
     fun testAdd() {
         with(TestLanguageFrontend()) {
-            var node1 = newLiteral(1)
-            var node2 = newLiteral(2)
-            var node3 = newLiteral(3)
+            val node1 = newLiteral(1)
+            val node2 = newLiteral(2)
+            val node3 = newLiteral(3)
 
             node1.nextEOGEdges += node2
 
@@ -62,12 +62,12 @@ class UnwrappedEdgeListTest {
     @Test
     fun testAddIndex() {
         with(TestLanguageFrontend()) {
-            var node1 = newLiteral(1)
-            var node2 = newLiteral(2)
-            var node3 = newLiteral(3)
-            var node4 = newLiteral(4)
+            val node1 = newLiteral(1)
+            val node2 = newLiteral(2)
+            val node3 = newLiteral(3)
+            val node4 = newLiteral(4)
 
-            var list = AstEdges<Node, AstEdge<Node>>(thisRef = node1)
+            val list = AstEdges<Node, AstEdge<Node>>(thisRef = node1)
             list += node2
             list += node3
 
@@ -78,7 +78,7 @@ class UnwrappedEdgeListTest {
 
             // insert something at position 1 (using the unwrapped list), this should shift the
             // existing entries (after the position) + 1
-            var unwrapped = list.unwrap()
+            val unwrapped = list.unwrap()
             unwrapped.add(1, node4)
             assertEquals(3, list.size)
 
@@ -95,29 +95,47 @@ class UnwrappedEdgeListTest {
     @Test
     fun testIterator() {
         with(TestLanguageFrontend()) {
-            var node1 = newLiteral(1)
-            var node2 = newLiteral(2)
-            var node3 = newLiteral(3)
+            val node1 = newLiteral(1)
+            val node2 = newLiteral(2)
+            val node3 = newLiteral(3)
 
             node1.nextEOGEdges += node2
 
             node1.nextEOG += node3
 
-            var list = node1.nextEOG.toList()
+            val list = node1.nextEOG.toList()
             assertEquals(2, list.size)
 
             // test our mutable iterator
-            var iter = node1.nextEOG.iterator()
+            val iter = node1.nextEOG.iterator()
             iter.next()
             iter.remove()
 
             assertEquals(1, node1.nextEOGEdges.size)
 
             // test our list iterator
-            var listIter = node1.nextEOG.listIterator()
+            val listIter = node1.nextEOG.listIterator()
             listIter.add(node2)
 
             assertEquals(2, node1.nextEOGEdges.size)
+        }
+    }
+
+    @Test
+    fun testEquals() {
+        with(TestLanguageFrontend()) {
+            val node1 = newLiteral(1)
+            val node2 = newLiteral(2)
+            val node3 = newLiteral(3)
+
+            node1.nextEOG += node2
+            node1.nextEOG += node3
+
+            val eogList = node1.nextEOG
+            val nodeList = listOf<Node>(node2, node3)
+
+            assertEquals(nodeList, eogList)
+            assertEquals(eogList, nodeList)
         }
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeSetTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeSetTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.graph.edges.collections
+
+import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.newLiteral
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UnwrappedEdgeSetTest {
+    @Test
+    fun testEquals() {
+        with(TestLanguageFrontend()) {
+            val node1 = newLiteral(1)
+            val node2 = newLiteral(2)
+            val node3 = newLiteral(3)
+
+            node1.nextDFG += node2
+            node1.nextDFG += node3
+
+            val dfgSet = node1.nextDFG
+            val nodeSet = setOf<Node>(node3, node2)
+
+            assertEquals(nodeSet, dfgSet)
+            assertEquals(dfgSet, nodeSet)
+        }
+    }
+}

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonFrontendTest.kt
@@ -54,6 +54,32 @@ import kotlin.test.*
 class PythonFrontendTest : BaseTest() {
 
     @Test
+    fun testNodeID() {
+        val topLevel = Path.of("src", "test", "resources", "python")
+
+        val tu1 =
+            analyzeAndGetFirstTU(listOf(topLevel.resolve("fields.py").toFile()), topLevel, true) {
+                it.registerLanguage<PythonLanguage>()
+            }
+        assertNotNull(tu1)
+        val myClass1 = tu1.records["fields.MyClass"]
+        assertNotNull(myClass1)
+
+        val tu2 =
+            analyzeAndGetFirstTU(listOf(topLevel.resolve("fields.py").toFile()), topLevel, true) {
+                it.registerLanguage<PythonLanguage>()
+            }
+        assertNotNull(tu2)
+        val myClass2 = tu2.records["fields.MyClass"]
+        assertNotNull(myClass2)
+        assertEquals(
+            myClass1.id,
+            myClass2.id,
+            "Expecting the same ID for the same class across two different analysis runs",
+        )
+    }
+
+    @Test
     fun test1740EndlessCDG() {
         val topLevel = Path.of("src", "test", "resources", "python")
         val tu =


### PR DESCRIPTION
This PR makes the node's `id` derive from its hash-code. This is probably not a 100 % solution, but it should do for those cases where we need an ID that persists beyond translations.

In the course of using hashcode this way, I discovered several problems with some hashcode implementations, such as in the unwrapped lists.