### PR TITLE
Assumption Interface Fix and HashCode adaptation

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/assumptions/Assumption.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/assumptions/Assumption.kt
@@ -34,9 +34,9 @@ import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 import de.fraunhofer.aisec.cpg.sarif.Region
 import java.net.URI
+import java.util.*
 import org.neo4j.ogm.annotation.Relationship
 import org.neo4j.ogm.annotation.typeconversion.Convert
-import java.util.*
 
 /**
  * The minimal properties to identify an assumption, is the assumption type and either node, edge,
@@ -93,13 +93,15 @@ class Assumption(
     }
 
     /**
-     * The hash code of this [Assumption]. It is based on the hash code of the [underlyingNode] or the [edge] that
-     * caused the assumption to be necessary, the [assumptionType], the [message], and the [assumptionLocation]. This
-     * makes the assumption node identifiable across cpg translations.
+     * The hash code of this [Assumption]. It is based on the hash code of the [underlyingNode] or
+     * the [edge] that caused the assumption to be necessary, the [assumptionType], the [message],
+     * and the [assumptionLocation]. This makes the assumption node identifiable across cpg
+     * translations.
      */
     override fun hashCode(): Int {
         // The underlying node is already in the hashCode of the super class implementation
-        // If the assumption is created from an edge, the edge is != null and therefore influences the hashCode
+        // If the assumption is created from an edge, the edge is != null and therefore influences
+        // the hashCode
         return Objects.hash(super.hashCode(), edge, assumptionType, message, assumptionLocation)
     }
 }
@@ -215,7 +217,9 @@ interface HasAssumptions {
      *
      * @param haveAssumptions nodes that hold assumptions this object dependent on.
      */
-    fun <T : HasAssumptions> T.addAssumptionDependences(haveAssumptions: Collection<HasAssumptions>): T {
+    fun <T : HasAssumptions> T.addAssumptionDependences(
+        haveAssumptions: Collection<HasAssumptions>
+    ): T {
         this.assumptions.addAll(haveAssumptions.flatMap { it.assumptions })
         return this
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/assumptions/Assumption.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/assumptions/Assumption.kt
@@ -98,8 +98,9 @@ class Assumption(
      * makes the assumption node identifiable across cpg translations.
      */
     override fun hashCode(): Int {
-        val cpgReferenceHash = edge?.hashCode() ?: underlyingNode?.hashCode() ?: 0
-        return Objects.hash(super.hashCode(), cpgReferenceHash, assumptionType, message, assumptionLocation)
+        // The underlying node is already in the hashCode of the super class implementation
+        // If the assumption is created from an edge, the edge is != null and therefore influences the hashCode
+        return Objects.hash(super.hashCode(), edge, assumptionType, message, assumptionLocation)
     }
 }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/assumptions/Assumption.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/assumptions/Assumption.kt
@@ -36,6 +36,7 @@ import de.fraunhofer.aisec.cpg.sarif.Region
 import java.net.URI
 import org.neo4j.ogm.annotation.Relationship
 import org.neo4j.ogm.annotation.typeconversion.Convert
+import java.util.*
 
 /**
  * The minimal properties to identify an assumption, is the assumption type and either node, edge,
@@ -89,6 +90,16 @@ class Assumption(
         }
         name = Name(assumptionType.name)
         location = node?.location
+    }
+
+    /**
+     * The hash code of this [Assumption]. It is based on the hash code of the [underlyingNode] or the [edge] that
+     * caused the assumption to be necessary, the [assumptionType], the [message], and the [assumptionLocation]. This
+     * makes the assumption node identifiable across cpg translations.
+     */
+    override fun hashCode(): Int {
+        val cpgReferenceHash = edge?.hashCode() ?: underlyingNode?.hashCode() ?: 0
+        return Objects.hash(super.hashCode(), cpgReferenceHash, assumptionType, message, assumptionLocation)
     }
 }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/assumptions/Assumption.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/assumptions/Assumption.kt
@@ -185,11 +185,11 @@ interface HasAssumptions {
      *   because the assumption is valid for every node in its ast subtree.
      * @param message The message describing the assumption that was taken.
      */
-    fun HasAssumptions.assume(
+    fun <T : HasAssumptions> T.assume(
         assumptionType: AssumptionType,
         message: String,
         scope: Node? = null,
-    ): HasAssumptions {
+    ): T {
         this.assumptions.add(
             Assumption(
                 assumptionType,
@@ -215,8 +215,9 @@ interface HasAssumptions {
      *
      * @param haveAssumptions nodes that hold assumptions this object dependent on.
      */
-    fun HasAssumptions.addAssumptionDependences(haveAssumptions: Collection<HasAssumptions>) {
+    fun <T : HasAssumptions> T.addAssumptionDependences(haveAssumptions: Collection<HasAssumptions>): T {
         this.assumptions.addAll(haveAssumptions.flatMap { it.assumptions })
+        return this
     }
 
     /**
@@ -225,8 +226,9 @@ interface HasAssumptions {
      *
      * @param hasAssumptions add dependence to assumptions of a single other node.
      */
-    fun HasAssumptions.addAssumptionDependence(hasAssumptions: HasAssumptions) {
+    fun <T : HasAssumptions> T.addAssumptionDependence(hasAssumptions: HasAssumptions): T {
         this.addAssumptionDependences(listOf(hasAssumptions))
+        return this
     }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
@@ -28,8 +28,10 @@ package de.fraunhofer.aisec.cpg.passes.inference
 import de.fraunhofer.aisec.cpg.ScopeManager
 import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.TypeManager
+import de.fraunhofer.aisec.cpg.assumptions.AssumptionType
 import de.fraunhofer.aisec.cpg.frontends.HasClasses
 import de.fraunhofer.aisec.cpg.frontends.Language
+import de.fraunhofer.aisec.cpg.frontends.NoLanguage.assume
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
@@ -175,7 +177,7 @@ class Inference internal constructor(val start: Node, override val ctx: Translat
             }
 
             inferred
-        }
+        }.assume(AssumptionType.InferenceAssumption, "Assuming the start of inference is a record, namespace or translation unit")
     }
 
     fun createInferredConstructor(signature: List<Type?>): ConstructorDeclaration {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
@@ -105,79 +105,84 @@ class Inference internal constructor(val start: Node, override val ctx: Translat
         }
 
         return inferInScopeOf(start) {
-            val inferred: FunctionDeclaration =
-                if (record != null) {
-                    newMethodDeclaration(name ?: "", isStatic, record)
-                } else {
-                    newFunctionDeclaration(name ?: "")
+                val inferred: FunctionDeclaration =
+                    if (record != null) {
+                        newMethodDeclaration(name ?: "", isStatic, record)
+                    } else {
+                        newFunctionDeclaration(name ?: "")
+                    }
+                inferred.code = code
+
+                // Create parameter declarations and receiver (only for methods).
+                if (inferred is MethodDeclaration) {
+                    createInferredReceiver(inferred, record)
                 }
-            inferred.code = code
+                createInferredParameters(inferred, signature)
 
-            // Create parameter declarations and receiver (only for methods).
-            if (inferred is MethodDeclaration) {
-                createInferredReceiver(inferred, record)
-            }
-            createInferredParameters(inferred, signature)
+                // Set the type and return type(s)
+                var returnType =
+                    if (
+                        ctx.config.inferenceConfiguration.inferReturnTypes &&
+                            incomingReturnType is UnknownType &&
+                            hint != null
+                    ) {
+                        inferReturnType(hint) ?: unknownType()
+                    } else {
+                        incomingReturnType
+                    }
 
-            // Set the type and return type(s)
-            var returnType =
+                if (returnType is TupleType) {
+                    inferred.returnTypes = returnType.types
+                } else if (returnType != null) {
+                    inferred.returnTypes = listOf(returnType)
+                }
+
+                inferred.type = computeType(inferred)
+
+                debugWithFileLocation(
+                    hint,
+                    log,
+                    "Inferred a new {} declaration {} with parameter types {} and return types {} in {}",
+                    if (inferred is MethodDeclaration) "method" else "function",
+                    inferred.name,
+                    signature.map { it?.name },
+                    inferred.returnTypes.map { it.name },
+                    it,
+                )
+
+                // Add it to the scope
+                scopeManager.addDeclaration(inferred)
+                start.addDeclaration(inferred)
+
+                // Some magic that adds it to static imports. Not sure if this really needed
+                if (record != null && isStatic) {
+                    record.staticImports.add(inferred)
+                }
+
+                // Some more magic, that adds it to the AST. Note: this might not be 100 % compliant
+                // with the language, since in some languages the AST of a method declaration could
+                // be
+                // outside of a method, but this will do for now
+                if (record != null && inferred is MethodDeclaration) {
+                    record.addMethod(inferred)
+                }
+
+                // "upgrade" our struct to a class, if it was inferred by us, since we are calling
+                // methods on it. But only if the language supports classes in the first place.
                 if (
-                    ctx.config.inferenceConfiguration.inferReturnTypes &&
-                        incomingReturnType is UnknownType &&
-                        hint != null
+                    record?.isInferred == true &&
+                        record.kind == "struct" &&
+                        record.language is HasClasses
                 ) {
-                    inferReturnType(hint) ?: unknownType()
-                } else {
-                    incomingReturnType
+                    record.kind = "class"
                 }
 
-            if (returnType is TupleType) {
-                inferred.returnTypes = returnType.types
-            } else if (returnType != null) {
-                inferred.returnTypes = listOf(returnType)
+                inferred
             }
-
-            inferred.type = computeType(inferred)
-
-            debugWithFileLocation(
-                hint,
-                log,
-                "Inferred a new {} declaration {} with parameter types {} and return types {} in {}",
-                if (inferred is MethodDeclaration) "method" else "function",
-                inferred.name,
-                signature.map { it?.name },
-                inferred.returnTypes.map { it.name },
-                it,
+            .assume(
+                AssumptionType.InferenceAssumption,
+                "Assuming the start of inference is a record, namespace or translation unit",
             )
-
-            // Add it to the scope
-            scopeManager.addDeclaration(inferred)
-            start.addDeclaration(inferred)
-
-            // Some magic that adds it to static imports. Not sure if this really needed
-            if (record != null && isStatic) {
-                record.staticImports.add(inferred)
-            }
-
-            // Some more magic, that adds it to the AST. Note: this might not be 100 % compliant
-            // with the language, since in some languages the AST of a method declaration could be
-            // outside of a method, but this will do for now
-            if (record != null && inferred is MethodDeclaration) {
-                record.addMethod(inferred)
-            }
-
-            // "upgrade" our struct to a class, if it was inferred by us, since we are calling
-            // methods on it. But only if the language supports classes in the first place.
-            if (
-                record?.isInferred == true &&
-                    record.kind == "struct" &&
-                    record.language is HasClasses
-            ) {
-                record.kind = "class"
-            }
-
-            inferred
-        }.assume(AssumptionType.InferenceAssumption, "Assuming the start of inference is a record, namespace or translation unit")
     }
 
     fun createInferredConstructor(signature: List<Type?>): ConstructorDeclaration {


### PR DESCRIPTION
This PR add a fix to the assume functions that makes them return the same type as the calling object. The past implementation would return `HasAssumptions` which obviously does not allow us to add `assume` without creating type issues. An additional example is added in form of an inference assumption.

The PR also ads a hashCode implementation for assumptions.