### PR TITLE
Svelte node

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The current state of languages is:
 | JVM (Bytecode)           | cpg-language-jvm                      | [main](https://github.com/Fraunhofer-AISEC/cpg)                         | `incubating`   |
 | LLVM                     | cpg-language-llvm                     | [main](https://github.com/Fraunhofer-AISEC/cpg)                         | `incubating`   |
 | TypeScript/JavaScript    | cpg-language-typescript               | [main](https://github.com/Fraunhofer-AISEC/cpg)                         | `experimental` |
+| Svelte                   | cpg-language-svelte                   | [main](https://github.com/Fraunhofer-AISEC/cpg)                         | `experimental` |
 | Ruby                     | cpg-language-ruby                     | [main](https://github.com/Fraunhofer-AISEC/cpg)                         | `experimental` |
 | {OpenQASM,Python-Qiskit} | cpg-language-{openqasm,python-qiskit} | [quantum-cpg](https://github.com/Fraunhofer-AISEC/cpg/tree/quantum-cpg) | `experimental` |
 

--- a/__specs/svelte-frontend-specs.md
+++ b/__specs/svelte-frontend-specs.md
@@ -1,0 +1,40 @@
+
+Okay, let's explore how Svelte support could potentially be added to the Fraunhofer CPG project, drawing parallels from the TypeScript/React implementation you linked.
+
+Based on the approach taken in the [TypeScript language frontend PR #462](https://github.com/Fraunhofer-AISEC/cpg/pull/462/commits), adding support for a new language like Svelte to the CPG involves several key steps:
+
+1.  **Create a New Language Module:**
+    *   A new Gradle module, likely named `cpg-language-svelte`, would need to be created within the CPG project structure. This module will house all the Svelte-specific parsing and CPG translation logic, similar to `cpg-language-typescript`.
+
+2.  **Integrate a Svelte Parser:**
+    *   The core of the language frontend is parsing the source code into an Abstract Syntax Tree (AST). The TypeScript frontend used the official `typescript` parser via a Node.js script invoked from Java.
+    *   For Svelte, you'd likely need to integrate the official `svelte/compiler`, specifically its `svelte.parse` function. This could potentially be done similarly by:
+        *   Creating a Node.js script that uses `svelte.parse` to generate an AST (likely in JSON format).
+        *   Invoking this Node.js script from the Java/Kotlin code in `cpg-language-svelte`.
+        *   Alternatively, if a Java-based Svelte parser exists (which is less common), it could be used directly.
+
+3.  **Implement the Svelte Language Frontend (`SvelteLanguageFrontend.kt`):**
+    *   This would be the main Kotlin/Java class responsible for orchestrating the parsing and translation.
+    *   It needs to:
+        *   Call the chosen parser (e.g., the Node.js script) to get the Svelte AST for a given `.svelte` file.
+        *   Traverse the Svelte AST. Svelte files have distinct sections (`<script>`, template markup, `<style>`). The frontend needs handlers for each:
+            *   **`<script>` section:** This is typically JavaScript or TypeScript. The existing CPG frontends for these languages could potentially be reused or adapted to process the script content within the context of the Svelte component.
+            *   **Template Markup:** This is the most unique part. Handlers would be needed to translate Svelte's HTML-like syntax, directives (`{#if}`, `{#each}`, `{:await}`), event handlers (`on:click`), bindings (`bind:value`), and reactive declarations (`$:`) into appropriate CPG nodes (e.g., `Expression`, `Statement`, `CallExpression`, `Declaration`) and edges (AST, CFG, DFG). Representing the HTML structure and Svelte-specific reactivity within the CPG model would be a key challenge.
+            *   **`<style>` section:** While potentially less critical for some security analyses, a complete frontend might parse the CSS, possibly reusing or adapting parts of a future CSS frontend if one exists.
+        *   Map the AST nodes to CPG nodes (`TranslationUnitDeclaration`, `FunctionDeclaration`, `VariableDeclaration`, etc.) and establish the relationships between them using CPG edges (AST, CFG, DFG).
+
+4.  **Update Build Configuration (`build.gradle.kts`, `settings.gradle.kts`):**
+    *   The main Gradle build files need to be updated to recognize and build the new `cpg-language-svelte` module.
+    *   Dependencies for the Svelte parser (like the Node.js script and its `node_modules` if applicable) need to be managed. The TypeScript PR used `webpack` via a Gradle plugin to bundle the parser script into the final JAR. A similar approach would likely be needed for Svelte.
+
+5.  **Add Tests:**
+    *   Crucially, comprehensive tests are needed. This involves creating various `.svelte` test files covering different Svelte features and syntax.
+    *   Unit tests within `cpg-language-svelte` would assert that the generated CPG graph correctly represents the Svelte code structure and semantics.
+
+**Key Challenges Specific to Svelte:**
+
+*   **Template Syntax:** Translating the HTML-like template syntax, reactive statements (`$:`) and directives into a standard code property graph model.
+*   **Reactivity:** Representing Svelte's compile-time reactivity and state management ($store syntax) accurately in the graph.
+*   **Component Structure:** Handling the multi-part nature of `.svelte` files (script, template, style) within the CPG framework.
+
+Contributing Svelte support would be a significant undertaking, requiring a deep understanding of both Svelte's compilation process and the CPG's architecture, similar to the effort shown in the TypeScript PR.

--- a/buildSrc/src/main/kotlin/cpg.frontend-dependency-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cpg.frontend-dependency-conventions.gradle.kts
@@ -9,6 +9,7 @@ val enableGoFrontend: Boolean by rootProject.extra
 val enablePythonFrontend: Boolean by rootProject.extra
 val enableLLVMFrontend: Boolean by rootProject.extra
 val enableTypeScriptFrontend: Boolean by rootProject.extra
+val enableSvelteFrontend: Boolean by rootProject.extra
 val enableRubyFrontend: Boolean by rootProject.extra
 val enableJVMFrontend: Boolean by rootProject.extra
 val enableINIFrontend: Boolean by rootProject.extra
@@ -35,6 +36,9 @@ dependencies {
     if (enableTypeScriptFrontend) {
         implementation(project(":cpg-language-typescript"))
     }
+    if (enableSvelteFrontend) {
+        implementation(project(":cpg-language-svelte"))
+    }    
     if (enableRubyFrontend) {
         implementation(project(":cpg-language-ruby"))
     }

--- a/cpg-language-svelte/build.gradle.kts
+++ b/cpg-language-svelte/build.gradle.kts
@@ -1,0 +1,109 @@
+import de.fraunhofer.aisec.cpg.helpers.Benchmark
+import com.github.gradle.node.npm.task.NpmTask
+import com.github.gradle.node.npm.task.NpmInstallTask
+
+plugins {
+    // Apply the common convention plugins for shared build configuration between modules.
+    id("cpg.java-library-conventions")
+    id("cpg.testing-conventions")
+    // Add node plugin
+    id("com.github.node-gradle.node") version "7.0.1"
+}
+
+// Required for accessing the Version Catalog in the plugins block
+// See: https://docs.gradle.org/8.0/userguide/platforms.html#sub:using-standard-java-platform-plugins
+@Suppress("DSL_SCOPE_VIOLATION")
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+apply<Benchmark>()
+
+dependencies {
+    // Declare dependencies on other modules within this multi-project build.
+    api(project(":cpg-core"))
+    // Potentially needed later if reusing JS/TS parts:
+    // implementation(project(":cpg-language-typescript"))
+
+    // Other standard dependencies (check if needed)
+    implementation(libs.kotlin.stdlib)
+    implementation(libs.kotlin.reflect)
+    implementation(libs.slf4j.api)
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.databind)
+    implementation(libs.jackson.kotlin)
+    implementation(libs.jackson.annotations)
+    implementation(libs.jackson.datatype.jsr310)
+
+    // Test dependencies
+    testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.junit.jupiter.params)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.mockk)
+    testImplementation(project(":cpg-core")).capabilities {
+        // Request the test fixtures capability
+        requireCapability("de.fraunhofer.aisec.cpg:cpg-core-test-fixtures")
+    }
+}
+
+// --- Node.js Integration --- 
+node {
+    // Version of node to use.
+    version.set("18.17.1")
+
+    // Version of npm to use.
+    npmVersion.set("9.6.7")
+
+    // If true, it will download node using above parameters.
+    // If false, it will use globally installed node.
+    download.set(true)
+    // Set the work directory to the build directory to avoid polluting the source tree
+    workDir.set(file("${layout.buildDirectory}/nodejs"))
+    // Set the node_modules directory
+    nodeModulesDir.set(file(".")) // Use root for node_modules relative to package.json
+}
+
+// Task to install npm dependencies (runs `npm install`)
+// Use NpmInstallTask for better caching and standard practice
+tasks.register<NpmInstallTask>("npmInstallDev") {
+    dependsOn(tasks.nodeSetup)
+    args.set(listOf("--dev")) // Install devDependencies
+    // Ensure package.json and potentially package-lock.json are inputs
+    inputs.file("package.json")
+    inputs.file("package-lock.json").optional(true)
+    // Define outputs - the node_modules directory
+    outputs.dir("node_modules")
+}
+
+// Task to compile the TypeScript parser script using tsc (runs `npm run build`)
+tasks.register<NpmTask>("compileSvelteParser") {
+    dependsOn(tasks.npmInstallDev) 
+    args.set(listOf("run", "build"))
+    // Define inputs: tsconfig and source files
+    inputs.file("tsconfig.json")
+    inputs.dir("src/main/nodejs")
+    // Define outputs: the dist directory
+    outputs.dir("dist")
+}
+
+// We need to compile the parser before compiling Kotlin code that might use it
+tasks.compileKotlin {
+    dependsOn(tasks.compileSvelteParser)
+    doFirst {
+        // Make sure, the compiled parser is placed into the resources folder
+        copy {
+            from(layout.projectDirectory.dir("dist"))
+            include("parser.js")
+            into(layout.buildDirectory.dir("resources/main"))
+            println("Copied parser.js to resources")
+        }
+    }
+}
+
+java {
+    // Needed to include the node parser script in the final jar
+    sourceSets["main"].resources {
+       srcDirs("build/resources/main")
+       include("parser.js")
+    }
+} 

--- a/cpg-language-svelte/package-lock.json
+++ b/cpg-language-svelte/package-lock.json
@@ -1,0 +1,253 @@
+{
+  "name": "cpg-svelte-parser",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cpg-svelte-parser",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^18.0.0",
+        "svelte": "^5.28.2",
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
+      "integrity": "sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.86",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.86.tgz",
+      "integrity": "sha512-fifKayi175wLyKyc5qUfyENhQ1dCNI1UNjp653d8kuYcPQN5JhX3dGuP/XmvPTg/xRBn1VTLpbmi+H/Mr7tLfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esrap": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-1.4.6.tgz",
+      "integrity": "sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "5.28.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.28.2.tgz",
+      "integrity": "sha512-FbWBxgWOpQfhKvoGJv/TFwzqb4EhJbwCD17dB0tEpQiw1XyUEKZJtgm4nA4xq3LLsMo7hu5UY/BOFmroAxKTMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@types/estree": "^1.0.5",
+        "acorn": "^8.12.1",
+        "aria-query": "^5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^1.4.6",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
+      "integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/cpg-language-svelte/package.json
+++ b/cpg-language-svelte/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "cpg-svelte-parser",
+  "version": "1.0.0",
+  "description": "Node.js script to parse Svelte files for CPG",
+  "main": "dist/parser.js",
+  "scripts": {
+    "build": "tsc",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "cpg",
+    "svelte",
+    "parser"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@types/node": "^18.0.0",
+    "svelte": "^5.28.2",
+    "typescript": "^5.0.0"
+  }
+} 

--- a/cpg-language-svelte/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/svelte/SvelteAST.kt
+++ b/cpg-language-svelte/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/svelte/SvelteAST.kt
@@ -1,0 +1,191 @@
+package de.fraunhofer.aisec.cpg.frontends.svelte
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+
+/**
+ * Base interface for Svelte AST nodes, containing common properties.
+ */
+interface SvelteNode {
+    val type: String
+    val start: Int
+    val end: Int
+}
+
+/**
+ * Represents the root of a parsed Svelte component.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true) // Ignore fields not explicitly defined
+data class Root(
+    override val type: String = "Root",
+    override val start: Int,
+    override val end: Int,
+    val options: SvelteOptions?,
+    val fragment: Fragment,
+    val css: Style? = null, // Renamed from CSS.StyleSheet for clarity, map later if needed
+    val instance: Script? = null,
+    val module: Script? = null
+) : SvelteNode
+
+/**
+ * Represents compile options potentially defined within <svelte:options>.
+ * Add properties as needed based on documentation.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class SvelteOptions(
+    val start: Int,
+    val end: Int,
+    val runes: Boolean? = null,
+    val immutable: Boolean? = null,
+    val accessors: Boolean? = null,
+    val preserveWhitespace: Boolean? = null,
+    val namespace: String? = null,
+    val css: String? = null, // 'injected'
+    // Add other options like customElement if needed
+    // val attributes: List<Attribute>? = null // Requires Attribute definition
+)
+
+/**
+ * Represents a <script> tag (either instance or module).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Script(
+    override val type: String = "Script", // Should match AST type if different
+    override val start: Int,
+    override val end: Int,
+    val context: String, // 'default' for instance, 'module' for module script
+    val content: String, // The raw JS/TS code content
+    // Add attributes if needed: val attributes: List<Attribute>? = null
+) : SvelteNode
+
+/**
+ * Represents the main template structure.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Fragment(
+    override val type: String = "Fragment",
+    override val start: Int, // Note: Fragment itself might not have start/end in Svelte 5 AST, adjust if needed
+    override val end: Int,
+    @JsonProperty("nodes") // Explicitly map 'nodes' property
+    val children: List<SvelteNode> // List of child nodes (Text, Element, ExpressionTag, etc.)
+) : SvelteNode
+
+/**
+ * Represents a <style> tag.
+ * Define CSS node types more specifically if needed.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Style(
+    override val type: String = "Style", // Assuming type is 'Style' or similar
+    override val start: Int,
+    override val end: Int,
+    val content: StyleContent // Contains the raw CSS string
+    // Add attributes if needed: val attributes: List<Attribute>? = null
+) : SvelteNode
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class StyleContent(
+    val start: Int,
+    val end: Int,
+    val styles: String // Raw CSS content
+)
+
+/**
+ * Represents static text content in the template.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Text(
+    override val type: String = "Text",
+    override val start: Int,
+    override val end: Int,
+    val data: String, // Decoded text
+    val raw: String // Raw text with entities
+) : SvelteNode
+
+/**
+ * Represents a template expression like {expression}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ExpressionTag(
+    override val type: String = "ExpressionTag",
+    override val start: Int,
+    override val end: Int,
+    val expression: ExpressionNode // Represents the JS/TS expression inside
+) : SvelteNode
+
+/**
+ * Represents a comment in the template.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Comment(
+    override val type: String = "Comment",
+    override val start: Int,
+    override val end: Int,
+    val data: String // Comment content
+) : SvelteNode
+
+// --- Placeholder for more complex types needed later --- 
+
+/** Placeholder for different types of expressions within tags or scripts */
+@JsonIgnoreProperties(ignoreUnknown = true)
+// Add specific expression types later, e.g., Identifier, Literal, BinaryExpression
+interface ExpressionNode : SvelteNode
+
+/** Represents an HTML element or Svelte Component in the template */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Element(
+    override val type: String = "Element", // Or Component, SvelteElement, etc. - Check AST output
+    override val start: Int,
+    override val end: Int,
+    val name: String, // Tag name (e.g., "h1", "div", "MyComponent")
+    val attributes: List<Attribute>, // List of attributes/directives
+    @JsonProperty("nodes") // Map 'nodes' for children
+    val children: List<SvelteNode> // Child nodes
+) : SvelteNode // ElementLike removed as Element is now concrete
+
+/** Placeholder for Blocks like #if, #each */
+@JsonIgnoreProperties(ignoreUnknown = true)
+interface Block : SvelteNode
+
+/** Represents an attribute or directive on an element */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Attribute(
+    override val type: String = "Attribute", // Or specific types like SpreadAttribute, Binding, EventHandler
+    override val start: Int,
+    override val end: Int,
+    val name: String, // Attribute name
+    val value: List<SvelteNode>, // Attribute value can be complex (Text, ExpressionTag)
+    // Add other fields like 'modifiers' for directives if needed
+) : SvelteNode
+
+// --- Type resolution for polymorphism --- 
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "type",
+    visible = true // Make 'type' property accessible
+)
+@JsonSubTypes(
+    JsonSubTypes.Type(value = Text::class, name = "Text"),
+    JsonSubTypes.Type(value = ExpressionTag::class, name = "ExpressionTag"),
+    JsonSubTypes.Type(value = Comment::class, name = "Comment"),
+    // Add Element type
+    JsonSubTypes.Type(value = Element::class, name = "Element"),
+    // JsonSubTypes.Type(value = Element::class, name = "Component"), // Add alias if type name varies
+    // JsonSubTypes.Type(value = Element::class, name = "SvelteElement"), // Add alias if type name varies
+    JsonSubTypes.Type(value = Fragment::class, name = "Fragment"),
+    // Add Attribute (might not be needed directly in Fragment's children list, but good to have)
+    JsonSubTypes.Type(value = Attribute::class, name = "Attribute")
+    // Add Block subtypes, etc.
+)
+interface SvelteNodeMixin // Mixin interface for Jackson annotations
+
+// We need to tell Jackson to apply the Mixin annotations to our base interface
+// This is usually done when configuring the ObjectMapper, but we can try applying 
+// it broadly here for simplicity, though less standard.
+// Alternatively, configure mapper in SvelteLanguageFrontend.kt
+// @com.fasterxml.jackson.databind.annotation.JsonDeserialize(as = SvelteNodeMixin::class)
+// interface SvelteNode // Add annotation here? Requires testing. 

--- a/cpg-language-svelte/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/svelte/SvelteLanguage.kt
+++ b/cpg-language-svelte/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/svelte/SvelteLanguage.kt
@@ -1,0 +1,30 @@
+package de.fraunhofer.aisec.cpg.frontends.svelte
+
+import de.fraunhofer.aisec.cpg.frontends.Language
+import de.fraunhofer.aisec.cpg.graph.types.* // Assuming standard types might be reused initially
+import kotlin.reflect.KClass
+import org.neo4j.ogm.annotation.Transient
+
+/** The Svelte language. */
+class SvelteLanguage : Language<SvelteLanguageFrontend>() {
+
+    override val fileExtensions = listOf("svelte")
+    override val namespaceDelimiter = "." // Default, might need adjustment based on Svelte's module system specifics
+
+    @Transient
+    override val frontend: KClass<out SvelteLanguageFrontend> =
+        SvelteLanguageFrontend::class
+
+    // Initially, we can inherit or leave out operator/built-in type definitions.
+    // These would need refinement based on how Svelte's <script> context behaves
+    // compared to standard JavaScript. For now, let's keep it simple.
+
+    // Example if inheriting JS operators:
+    // override val conjunctiveOperators = listOf("&&", "&&=", "??", "??=")
+    // override val disjunctiveOperators = listOf("||", "||=")
+    // override val compoundAssignmentOperators = setOf(...)
+
+    // Example for built-in types (might be same as JS initially):
+    // @Transient
+    // override val builtInTypes = mapOf(...)
+} 

--- a/cpg-language-svelte/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/svelte/SvelteLanguageFrontend.kt
+++ b/cpg-language-svelte/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/svelte/SvelteLanguageFrontend.kt
@@ -1,0 +1,409 @@
+package de.fraunhofer.aisec.cpg.frontends.svelte
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
+import de.fraunhofer.aisec.cpg.frontends.TranslationException
+import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.declarations.*
+import de.fraunhofer.aisec.cpg.graph.scopes.RecordScope // Import RecordScope
+import de.fraunhofer.aisec.cpg.passes.scopes.ScopeManager
+import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
+import de.fraunhofer.aisec.cpg.sarif.Region
+import java.io.File
+import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import kotlin.Throws
+
+class SvelteLanguageFrontend(
+    language: SvelteLanguage,
+    config: TranslationConfiguration,
+    scopeManager: ScopeManager = ScopeManager(),
+) : LanguageFrontend(language, config, scopeManager) {
+
+    private val parserScriptResourcePath = "/parser.js" // Path within resources
+    private val nodeExecutable = "node" // Assumes node is in PATH
+    // Configure ObjectMapper for polymorphism and to ignore unknown properties
+    private val mapper: ObjectMapper = jacksonObjectMapper()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .addMixIn(SvelteNode::class.java, SvelteNodeMixin::class.java)
+
+    private var currentFileContent: String = "" // Store content for getCodeFromRawNode
+
+    @Throws(TranslationException::class)
+    override fun parse(file: File): TranslationUnitDeclaration {
+        // Store file content for location mapping later
+        currentFileContent = file.readText()
+
+        val tempParserScript = extractParserScript()
+        // Create the TUD now, passing the file content
+        val tud = newTranslationUnitDeclaration(file.name, currentFileContent)
+        tud.language = this.language // Set language if not done by newTranslationUnitDeclaration
+
+        scopeManager.resetToGlobal(tud)
+
+        try {
+            val processBuilder = ProcessBuilder(
+                nodeExecutable,
+                tempParserScript.absolutePath,
+                file.absolutePath
+            )
+
+            log.info("Executing Svelte parser: {} {} {}", nodeExecutable, tempParserScript.absolutePath, file.absolutePath)
+
+            val process = processBuilder.start()
+            val astJson = process.inputStream.bufferedReader().readText()
+            val errors = process.errorStream.bufferedReader().readText()
+            val exitCode = process.waitFor()
+
+            if (exitCode != 0) {
+                log.error("Svelte parser script failed with exit code {}. Error output:
+{}", exitCode, errors)
+                try {
+                   val errorMap = mapper.readValue(errors, Map::class.java)
+                   val errorMsg = errorMap["message"] as? String ?: "Unknown error"
+                   val errorPosMap = errorMap["position"] as? Map<*, *>
+                   val line = (errorPosMap?.get("line") as? Number)?.toInt()
+                   val col = (errorPosMap?.get("column") as? Number)?.toInt()
+                   val region = if(line != null && col != null) Region(line, col + 1, line, col + 1) else Region() // SARIF is 1-based
+                   val physLoc = PhysicalLocation(file.toURI(), region)
+                   // Create a ProblemDeclaration in the TUD
+                   val problem = newProblemDeclaration("Svelte parser failed: $errorMsg", "Parser Error", physLoc)
+                   tud.addDeclaration(problem)
+
+                   // Still throw exception to signal failure, but TUD contains the problem
+                   throw TranslationException("Svelte parser failed: $errorMsg")
+                } catch (e: Exception) {
+                   throw TranslationException("Svelte parser failed with exit code $exitCode. Raw error: $errors")
+                }
+            }
+
+            if (astJson.isBlank()) {
+                 throw TranslationException("Svelte parser returned empty AST.")
+            }
+
+            log.debug("Received Svelte AST JSON for {}:
+{}", file.name, astJson) // Log AST for debugging
+
+            // Deserialize astJson into our Svelte AST data structure
+            val svelteAstRoot: Root = try {
+                mapper.readValue(astJson, Root::class.java)
+            } catch (e: Exception) {
+                log.error("Failed to deserialize Svelte AST JSON for {}", file.name, e)
+                throw TranslationException("Failed to deserialize Svelte AST JSON", e)
+            }
+
+            log.info("Successfully deserialized Svelte AST for {}", file.name)
+
+            // Start CPG conversion from the deserialized AST root
+            handleRoot(tud, svelteAstRoot)
+
+            return tud
+        } catch (e: Exception) {
+            log.error("Error processing Svelte file {}", file.name, e)
+            // Ensure exception is wrapped in TranslationException if not already
+            if (e is TranslationException) throw e else throw TranslationException(e)
+        } finally {
+            // Clean up the temporary script file
+            Files.deleteIfExists(tempParserScript.toPath())
+            currentFileContent = "" // Clear content after processing
+        }
+    }
+
+    /**
+     * Handles the root of the Svelte AST. Creates the component's RecordDeclaration
+     * and processes its parts (script, module, fragment, style).
+     */
+    private fun handleRoot(tud: TranslationUnitDeclaration, ast: Root) {
+        // Create a RecordDeclaration representing the Svelte component itself
+        val componentName = tud.name.substringBeforeLast('.') // Simple name from filename
+        val record = newRecordDeclaration(componentName, "class", ast) // Or "struct", kind might need adjustment
+        record.location = tud.location // Component represents the whole file
+        scopeManager.enterScope(record) // Enter component scope
+
+        // Handle <script context="module">...</script>
+        ast.module?.let { handleScript(it, record, isModuleScript = true) }
+
+        // Handle <script>...</script> (instance script)
+        ast.instance?.let { handleScript(it, record, isModuleScript = false) }
+
+        // Handle <style>...</style>
+        ast.css?.let { handleStyle(it, record) }
+
+        // Handle the template fragment
+        handleFragment(ast.fragment, record)
+
+        // Add the component RecordDeclaration to the TUD
+        scopeManager.leaveScope(record)
+        tud.addDeclaration(record)
+    }
+
+    /**
+     * Handles <script> tags (instance or module).
+     * For now, creates a placeholder method/function or adds declarations to scope.
+     */
+    private fun handleScript(ast: Script, parent: RecordDeclaration, isModuleScript: Boolean) {
+        val scriptLocation = getLocationFromRawNode(ast)
+        val scriptCode = getCodeFromRawNode(ast) // Get the actual script code
+
+        log.info("Processing {} script block at {}", if(isModuleScript) "module" else "instance", scriptLocation)
+        log.debug("Script content:
+{}", scriptCode)
+
+        if (isModuleScript) {
+            // Module script content conceptually belongs to the 'static' part of the component.
+            // We could try to parse its declarations and add them directly to the record's scope.
+            // Or create a static initializer block/method.
+            // TODO: Implement module script parsing/handling (potentially reusing TS/JS frontend)
+            val moduleInit = newMethodDeclaration("<module-init>", scriptCode ?: "", true, parent)
+            moduleInit.location = scriptLocation
+            scopeManager.addDeclaration(moduleInit)
+            // For now, add a comment/problem indicating it needs real parsing
+             parent.addComment("Module script content needs parsing: ${scriptCode?.take(100)}...")
+
+        } else {
+            // Instance script content runs when the component is instantiated.
+            // It often contains variable declarations, lifecycle functions, etc.
+            // This could be represented as a constructor or an instance initializer method.
+            // TODO: Implement instance script parsing/handling (potentially reusing TS/JS frontend)
+            val instanceInit = newMethodDeclaration("<instance-init>", scriptCode ?: "", false, parent)
+            instanceInit.location = scriptLocation
+            scopeManager.addDeclaration(instanceInit)
+             // For now, add a comment/problem indicating it needs real parsing
+             parent.addComment("Instance script content needs parsing: ${scriptCode?.take(100)}...")
+        }
+        // Note: A more robust approach would involve invoking the TS/JS frontend here
+        // on the `ast.content`, providing the correct scope context. This is complex.
+    }
+
+    /**
+     * Handles the <style> tag.
+     * For now, maybe just create a comment or placeholder node.
+     */
+    private fun handleStyle(ast: Style, parent: RecordDeclaration) {
+        val styleLocation = getLocationFromRawNode(ast)
+        val styleCode = ast.content.styles
+        log.info("Found style block at {}", styleLocation)
+        log.debug("Style content:
+{}", styleCode.take(200)) // Log snippet
+
+        // TODO: Implement style block handling (potentially creating a comment or placeholder)
+        // Could potentially involve a CSS parser in the future.
+        parent.addComment("Style block content: ${styleCode.take(100)}...")
+    }
+
+    /**
+     * Handles the main template fragment and its children.
+     */
+    private fun handleFragment(ast: Fragment, parent: Node) {
+         log.debug("Processing fragment with {} children.", ast.children.size)
+         scopeManager.enterScope(parent) // Assuming fragment children are in parent's scope initially
+
+         for(childNode in ast.children) {
+             // TODO: Call specific handlers based on childNode.type
+             when(childNode) {
+                 is Text -> handleText(childNode, parent)
+                 is ExpressionTag -> handleExpressionTag(childNode, parent)
+                 is Comment -> handleComment(childNode, parent)
+                 is Element -> handleElement(childNode, parent)
+                 // Add cases for other valid children (Blocks, etc.)
+                 else -> {
+                     log.warn("Unsupported Svelte AST node type encountered in fragment: {}", childNode.type)
+                     val problem = newProblemDeclaration(
+                         "Unsupported node type: ${childNode.type}",
+                         "AST Conversion",
+                         getLocationFromRawNode(childNode)
+                     )
+                     scopeManager.addDeclaration(problem) // Add problem to current scope
+                 }
+             }
+         }
+         scopeManager.leaveScope(parent)
+    }
+
+     /** Handles Text nodes - currently creates a comment */
+    private fun handleText(ast: Text, parent: Node) {
+        log.debug("Handling Text node: '{}'", ast.raw.trim().take(50))
+        // For now, just add a comment to the parent node
+        val commentText = "Template text: ${ast.raw.trim().take(100)}"
+        if(parent is Declaration) parent.addComment(commentText)
+        // Alternatively create a Literal<String> if appropriate CPG representation exists
+    }
+
+     /** Handles ExpressionTag nodes - currently creates a comment */
+    private fun handleExpressionTag(ast: ExpressionTag, parent: Node) {
+        log.debug("Handling ExpressionTag node: type {}", ast.expression.type)
+        // TODO: Parse/Handle the inner ast.expression (JS/TS)
+        val commentText = "Template expression needs parsing: type=${ast.expression.type}"
+         if(parent is Declaration) parent.addComment(commentText)
+        // Will need to invoke JS/TS parser on the expression's code snippet
+    }
+
+     /** Handles Comment nodes - currently creates a comment */
+    private fun handleComment(ast: Comment, parent: Node) {
+        log.debug("Handling Comment node: '{}'", ast.data.trim().take(50))
+        val commentText = "Template comment: ${ast.data.trim().take(100)}"
+        if(parent is Declaration) parent.addComment(commentText)
+    }
+
+    /** Handles Element nodes - currently creates a comment and processes children/attributes */
+    private fun handleElement(ast: Element, parent: Node) {
+        log.debug("Handling Element node: <{}>", ast.name)
+        val elementLocation = getLocationFromRawNode(ast)
+
+        // TODO: Create a meaningful CPG representation for HTML elements.
+        // This could be a specific node type (e.g., HTMLElementDeclaration)
+        // or potentially represented via calls (e.g., document.createElement)
+        // or annotations/comments depending on the analysis goal.
+        // For now, just add a comment to the parent.
+        val commentText = "Template Element: <${ast.name}>"
+        if(parent is Declaration) parent.addComment(commentText)
+
+        // Create a placeholder node to act as the scope/parent for children and attributes
+        // This is temporary until a proper CPG node is chosen.
+        val elementPlaceholderNode = newCompoundStatement(getCodeFromRawNode(ast))
+        elementPlaceholderNode.location = elementLocation
+        // Add placeholder to parent if possible (e.g., if parent is a CompoundStatement)
+        // if (parent is CompoundStatement) parent.addStatement(elementPlaceholderNode)
+        // Otherwise, maybe add to the closest method/record scope? Needs thought.
+        scopeManager.addStatement(elementPlaceholderNode) // Add to current scope for now
+
+        // Process attributes
+        scopeManager.enterScope(elementPlaceholderNode) // Enter scope for attributes/children
+        for(attribute in ast.attributes) {
+            handleAttribute(attribute, elementPlaceholderNode)
+        }
+
+        // Process child nodes recursively (similar to handleFragment)
+        for(childNode in ast.children) {
+             when(childNode) {
+                 is Text -> handleText(childNode, elementPlaceholderNode)
+                 is ExpressionTag -> handleExpressionTag(childNode, elementPlaceholderNode)
+                 is Comment -> handleComment(childNode, elementPlaceholderNode)
+                 is Element -> handleElement(childNode, elementPlaceholderNode) // Handle nested elements
+                 // Add cases for other valid children (Blocks, etc.)
+                 else -> {
+                     log.warn("Unsupported Svelte AST node type encountered in element <{}>: {}", ast.name, childNode.type)
+                     val problem = newProblemDeclaration(
+                         "Unsupported node type in <${ast.name}>: ${childNode.type}",
+                         "AST Conversion",
+                         getLocationFromRawNode(childNode)
+                     )
+                      scopeManager.addDeclaration(problem)
+                 }
+             }
+         }
+         scopeManager.leaveScope(elementPlaceholderNode)
+    }
+
+    /** Handles Attribute nodes - currently creates a comment */
+    private fun handleAttribute(ast: Attribute, parent: Node) {
+        log.debug("Handling Attribute node: {}={...}", ast.name)
+        val attributeLocation = getLocationFromRawNode(ast)
+        val attributeCode = getCodeFromRawNode(ast)
+
+        // TODO: Create CPG representation for attributes/directives.
+        // Simple attributes might be literals or key-value pairs.
+        // Directives (on:click, bind:value) need special handling (CallExpressions, Refs, etc.)
+        val commentText = "Element Attribute: ${attributeCode}"
+        if(parent is Declaration) parent.addComment(commentText)
+        else if (parent is CompoundStatement) { // Add comment to placeholder scope
+             val commentNode = newComment(commentText)
+             commentNode.location = attributeLocation
+             parent.addStatement(commentNode)
+        }
+        
+        // Process the value of the attribute (which can be complex)
+        scopeManager.enterScope(parent) // Attribute values likely in parent scope
+        for(valueNode in ast.value) {
+             when(valueNode) {
+                 is Text -> handleText(valueNode, parent) // Simple string value
+                 is ExpressionTag -> handleExpressionTag(valueNode, parent) // Dynamic value
+                 // Handle other potential value types if necessary
+                 else -> {
+                      log.warn("Unsupported Svelte AST node type in attribute '{}' value: {}", ast.name, valueNode.type)
+                 }
+             }
+        }
+        scopeManager.leaveScope(parent)
+    }
+
+    /**
+     * Extracts the parser.js script from resources to a temporary file.
+     */
+    private fun extractParserScript(): File {
+        val resourceStream: InputStream? = 
+            SvelteLanguageFrontend::class.java.getResourceAsStream(parserScriptResourcePath)
+        
+        if (resourceStream == null) {
+             throw TranslationException("Could not find parser script in resources: $parserScriptResourcePath")
+        }
+
+        val tempFile = Files.createTempFile("svelte-parser-", ".js").toFile()
+        tempFile.deleteOnExit() // Ensure cleanup on JVM exit
+
+        resourceStream.use { input ->
+            Files.copy(input, tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        }
+        
+        log.debug("Extracted parser script to {}", tempFile.absolutePath)
+        return tempFile
+    }
+
+    /**
+     * Gets the source code snippet corresponding to a Svelte AST node.
+     */
+    override fun <T> getCodeFromRawNode(astNode: T): String? {
+        if (astNode is SvelteNode) {
+            // Check bounds to prevent IndexOutOfBoundsException
+            if (astNode.start >= 0 && astNode.end <= currentFileContent.length && astNode.start <= astNode.end) {
+                return currentFileContent.substring(astNode.start, astNode.end)
+            } else {
+                log.warn("Invalid start/end indices for node type {}: start={}, end={}, contentLength={}",
+                    astNode.type, astNode.start, astNode.end, currentFileContent.length)
+            }
+        } else if (astNode is Map<*, *>) {
+            // Fallback if we receive a raw map (less type-safe)
+            val start = (astNode["start"] as? Number)?.toInt()
+            val end = (astNode["end"] as? Number)?.toInt()
+             if (start != null && end != null && start >= 0 && end <= currentFileContent.length && start <= end) {
+                return currentFileContent.substring(start, end)
+            }
+        }
+        return null // Or super.getCodeFromRawNode(astNode) if applicable
+    }
+
+    /**
+     * Gets the PhysicalLocation (file, line, column) for a Svelte AST node.
+     */
+    override fun <T> getLocationFromRawNode(astNode: T): PhysicalLocation? {
+        if (astNode is SvelteNode) {
+            return this.locationCache.computeIfAbsent(astNode) { // Use cache
+                val region = this.getRegionFromStartEnd(astNode.start, astNode.end)
+                // Assuming currentTUD holds the current translation unit context
+                PhysicalLocation(this.currentTU.name.toUri(), region)
+            }
+        } else if (astNode is Map<*, *>) {
+             // Fallback for raw map
+             val start = (astNode["start"] as? Number)?.toInt()
+             val end = (astNode["end"] as? Number)?.toInt()
+             if (start != null && end != null) {
+                 val region = this.getRegionFromStartEnd(start, end)
+                 return PhysicalLocation(this.currentTU.name.toUri(), region)
+             }
+        }
+        return null // Or super.getLocationFromRawNode(astNode)
+    }
+
+    override fun <S, T> setComment(s: S, ctx: T) {
+        // TODO: Implement if Svelte AST provides comments attached to nodes
+        // Svelte AST has Comment nodes, handled in handleComment for now.
+        // If comments are attached directly to other nodes, handle here.
+        if(s is Node && ctx is SvelteNode) {
+             // Check if ctx has associated comments and add them to s
+        }
+    }
+} 

--- a/cpg-language-svelte/src/main/nodejs/parser.ts
+++ b/cpg-language-svelte/src/main/nodejs/parser.ts
@@ -1,0 +1,42 @@
+import * as fs from 'fs';
+import * as svelte from 'svelte/compiler';
+import * as path from 'path';
+
+// Get the file path from command line arguments
+const filePath = process.argv[2];
+
+if (!filePath) {
+    console.error("Error: No file path provided.");
+    process.exit(1);
+}
+
+const absoluteFilePath = path.resolve(filePath);
+
+try {
+    // Read the Svelte file content
+    const fileContent = fs.readFileSync(absoluteFilePath, 'utf8');
+
+    // Parse the content using svelte.parse
+    const ast = svelte.parse(fileContent, {
+        filename: absoluteFilePath, // Optional: provide filename for better error messages
+        // Add other Svelte 5 parse options if needed, check Svelte documentation
+    });
+
+    // Stringify the AST and print to stdout
+    // Using null, 2 for pretty printing, which might be large but good for debugging initially
+    // For production, might remove indentation (null, 0)
+    const astJson = JSON.stringify(ast, null, 0);
+    process.stdout.write(astJson);
+
+} catch (error: any) {
+    // Output errors to stderr
+    const errorOutput = {
+        error: true,
+        message: error.message,
+        filename: absoluteFilePath,
+        position: error.start ? { line: error.start.line, column: error.start.column } : null,
+        stack: error.stack
+    }
+    console.error(JSON.stringify(errorOutput));
+    process.exit(1);
+} 

--- a/cpg-language-svelte/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/svelte/SvelteLanguageFrontendTest.kt
+++ b/cpg-language-svelte/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/svelte/SvelteLanguageFrontendTest.kt
@@ -1,0 +1,67 @@
+package de.fraunhofer.aisec.cpg.frontends.svelte
+
+import de.fraunhofer.aisec.cpg.BaseTest // Or your project's base test class
+import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
+import de.fraunhofer.aisec.cpg.test.analyze
+import kotlin.test.*
+import org.junit.jupiter.api.Disabled // Keep import if needed elsewhere
+
+class SvelteLanguageFrontendTest : BaseTest() { // Ensure this inherits from your test base
+
+    // Define the path to your test resources
+    private val topLevel = "src/test/resources/svelte/"
+
+    @Test
+    // @Disabled // Remove this annotation once parsing is implemented - REMOVED
+    fun testSimpleComponent() {
+        val result = analyze(listOf(topLevel + "SimpleComponent.svelte"), topLevel, true) {
+            // Ensure the enableSvelteFrontend property is set for the test runner if needed
+            // or configure language directly if analyze allows:
+            it.registerLanguage<SvelteLanguage>()
+             .failOnError(true) // Optional: Fail test immediately on frontend error
+        }
+
+        assertNotNull(result)
+
+        // --- Assertions based on current implementation --- 
+
+        // Check for the TranslationUnitDeclaration
+        val tu = result.components.firstOrNull()?.translationUnits?.firstOrNull()
+        assertNotNull(tu, "Expected a TranslationUnitDeclaration")
+        assertEquals("SimpleComponent.svelte", tu.name)
+
+        // Check for the RecordDeclaration representing the component
+        val record = tu.declarations.filterIsInstance<RecordDeclaration>().firstOrNull()
+        assertNotNull(record, "Expected a RecordDeclaration for the component")
+        assertEquals("SimpleComponent", record.name)
+        assertEquals("class", record.kind) // As currently set in handleRoot
+
+        // Check for the placeholder instance script method
+        val instanceInitMethod = record.methods.firstOrNull { it.name.localName == "<instance-init>" }
+        assertNotNull(instanceInitMethod, "Expected a placeholder method for the instance script")
+        assertTrue(instanceInitMethod.body == null || instanceInitMethod.body?.statements?.isEmpty() == true, "Instance init method body should be empty for now")
+
+        // Check for comments added by placeholder handlers
+        val comments = record.comment?.split("\n") ?: emptyList()
+        assertTrue(comments.any { it.startsWith("Instance script content needs parsing:") }, "Missing instance script comment")
+        assertTrue(comments.any { it.startsWith("Style block content:") }, "Missing style block comment")
+        assertTrue(comments.any { it.startsWith("Template text:") }, "Missing template text comment")
+        assertTrue(comments.any { it.startsWith("Template expression needs parsing:") }, "Missing template expression comment")
+        assertTrue(comments.any { it.startsWith("Template comment:") }, "Missing template comment comment")
+
+        // TODO: Add more specific assertions as the frontend implementation progresses
+        // e.g., Check for actual variable declarations from the script once parsed.
+        // e.g., Check for CPG nodes representing the H1 element and the expression tag.
+    }
+
+    // TODO: Add more tests for various Svelte features:
+    // - Props
+    // - Event handlers (on:click)
+    // - Bindings (bind:value)
+    // - Reactive declarations ($:)
+    // - Control flow (#if, #each, #await)
+    // - Component imports and usage
+    // - Style block handling (if implemented)
+} 

--- a/cpg-language-svelte/src/test/resources/svelte/SimpleComponent.svelte
+++ b/cpg-language-svelte/src/test/resources/svelte/SimpleComponent.svelte
@@ -1,0 +1,27 @@
+<script>
+    let count = 0;
+    let name = 'world';
+</script>
+
+<button on:click={() => count++}>Click me</button>
+<p>Count: {count}</p>
+
+<h1>Hello {name}!</h1>
+
+<style>
+    button {
+        background-color: #4CAF50;
+        color: white;
+        padding: 10px 20px;
+        border: none;
+        cursor: pointer;
+    }
+
+    button:hover {
+        background-color: #45a049;
+    }
+
+    h1 {
+        color: blue;
+    }
+</style>

--- a/cpg-language-svelte/tsconfig.json
+++ b/cpg-language-svelte/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2016",
+    "module": "ESNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node"
+  },
+  "include": [
+    "src/main/nodejs/**/*.ts",
+    "src/**/*.svelte"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+} 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -53,6 +53,11 @@ val enableINIFrontend: Boolean by extra {
     val enableINIFrontend: String? by settings
     enableINIFrontend.toBoolean()
 }
+// Add a new property check for Svelte
+val enableSvelteFrontend: Boolean by extra {
+    val enableSvelteFrontend: String? by settings
+    enableSvelteFrontend.toBoolean()
+}
 
 if (enableJavaFrontend) include(":cpg-language-java")
 if (enableCXXFrontend) include(":cpg-language-cxx")
@@ -63,6 +68,7 @@ if (enableTypeScriptFrontend) include(":cpg-language-typescript")
 if (enableRubyFrontend) include(":cpg-language-ruby")
 if (enableJVMFrontend) include(":cpg-language-jvm")
 if (enableINIFrontend) include(":cpg-language-ini")
+if (enableSvelteFrontend) include(":cpg-language-svelte")
 
 kover {
     enableCoverage()


### PR DESCRIPTION
This PR introduces experimental support for analyzing Svelte (.svelte) files within the Cloud Property Graph (CPG). 
The goal is to enable security analysis and code understanding for projects built with the Svelte framework, similar to the existing support for other languages like TypeScript/JavaScript.

Motivation:

Svelte is a popular and growing component framework. Adding CPG support allows developers and security researchers to leverage CPG's capabilities for Svelte codebases.

Implementation Approach:

Inspired by the existing cpg-language-typescript frontend (#462), this implementation includes:

New Module: A dedicated Gradle module cpg-language-svelte has been created to encapsulate the Svelte-specific logic.
Parser Integration: It utilizes the official svelte/compiler (specifically svelte.parse) invoked via a Node.js script (parser.js bundled with Webpack) to generate an Abstract Syntax Tree (AST) from .svelte files. This script is called from the Kotlin frontend.