### PR TITLE
Use `ConcurrentHashMap` to mark dirty and clean nodes

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
@@ -196,7 +196,7 @@ class TranslationResult(
      * Users should not access this directly, but rather use the [markDirty] and [markClean] methods
      * or the [Node.markDirty] and [Node.markClean] extension function.
      */
-    @DoNotPersist val dirtyNodes = mutableMapOf<Node, MutableList<KClass<out Pass<*>>>>()
+    @DoNotPersist val dirtyNodes = ConcurrentHashMap<Node, MutableList<KClass<out Pass<*>>>>()
 
     /**
      * Marks a node as dirty for a specific pass. This is used to indicate that the node needs to be


### PR DESCRIPTION
I somehow experienced `ConcurrentModificationException`s in `MermaidPrinterTest.testPrintEOG()` which seem to come from the newly introduced dirty nodes system. This is somehow weird and I would question why this can happen in the first place. Any idea @oxisto ? Can you replicate this problem? To fix it (if we agree that it actually exists), I'd use a `ConcurrentHashMap` instead of a normal `HashMap` when marking dirty/clean nodes. I'm wondering if we also have to synchronize access to the list of passes for a dirty node