### PR TITLE
Lattice Redesign fixes and performance

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/functional/BasicLatticesRedesign.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/functional/BasicLatticesRedesign.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.helpers.functional
 import de.fraunhofer.aisec.cpg.graph.edges.flows.EvaluationOrder
 import de.fraunhofer.aisec.cpg.helpers.IdentitySet
 import de.fraunhofer.aisec.cpg.helpers.functional.PowersetLattice.Element
+import de.fraunhofer.aisec.cpg.helpers.identitySetOf
 import de.fraunhofer.aisec.cpg.helpers.toIdentitySet
 import java.io.Serializable
 import java.util.IdentityHashMap
@@ -230,6 +231,7 @@ class PowersetLattice<T>() : Lattice<PowersetLattice.Element<T>> {
                     throw IllegalArgumentException(
                         "$other should be of type PowersetLattice.Element<T> but is of type ${other.javaClass}"
                     )
+                this === other -> Order.EQUAL
                 super<IdentitySet>.equals(other) -> Order.EQUAL
                 this.size > other.size && this.containsAll(other) -> Order.GREATER
                 other.size > this.size && other.containsAll(this) -> Order.LESSER
@@ -363,8 +365,10 @@ open class MapLattice<K, V : Lattice.Element>(val innerLattice: Lattice<V>) :
             Order.LESSER,
             Order.UNEQUAL -> {
                 if (allowModify) {
-                    val newKeys = two.keys.filter { it !in one.keys }
-                    val existingKeys = two.keys.minus(newKeys)
+                    // Requires identitySet and toList to avoid accidentally removing equal but not
+                    // identical keys
+                    val newKeys = two.keys.filterTo(identitySetOf()) { it !in one.keys }
+                    val existingKeys = two.keys.toList().minus(newKeys)
                     newKeys.forEach { key -> one[key] = two[key] }
                     existingKeys.forEach { key ->
                         one[key]?.let { oneValue ->


### PR DESCRIPTION
Two things happen in this PR:

* Return `Order.EQUAL` if two lattices are identical to save heavy computations
* Use `IdentitySet` and `List` when calculating key sets because anything else would lose equal but non-identical keys.