### PR TITLE
Make assumptions a set and add collectAssumptions 

### DIFF
--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/FlowQueries.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/FlowQueries.kt
@@ -260,7 +260,11 @@ fun dataFlowWithValidator(
  * computing this node as the result of a function.
  */
 data class NodeWithAssumption(val node: Node) : HasAssumptions {
-    override val assumptions: MutableList<Assumption> = mutableListOf()
+    override val assumptions: MutableSet<Assumption> = mutableSetOf()
+
+    override fun collectAssumptions(): Set<Assumption> {
+        return super.collectAssumptions() + node.assumptions
+    }
 }
 
 /**
@@ -269,7 +273,11 @@ data class NodeWithAssumption(val node: Node) : HasAssumptions {
  * taken when computing this collection of nodes as the result of a function.
  */
 data class NodeCollectionWithAssumption(val nodes: Collection<Node>) : HasAssumptions {
-    override val assumptions: MutableList<Assumption> = mutableListOf()
+    override val assumptions: MutableSet<Assumption> = mutableSetOf()
+
+    override fun collectAssumptions(): Set<Assumption> {
+        return super.collectAssumptions() + nodes.flatMap { it.assumptions }
+    }
 }
 
 /**
@@ -492,7 +500,7 @@ fun Node.alwaysFlowsTo(
                 "Some EOG paths failed to fulfill the predicate"
             },
         node = this,
-        assumptions = nodesToTrack.flatMap { it.assumptions }.toMutableList(),
+        assumptions = nodesToTrack.flatMap { it.assumptions }.toMutableSet(),
     )
 }
 

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/QueryTree.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/QueryTree.kt
@@ -74,7 +74,7 @@ open class QueryTree<T>(
      * Assumptions can be created in the QueryTree object with the [assume] function ore by adding
      * an assumption manually.
      */
-    override var assumptions: MutableList<Assumption> = mutableListOf(),
+    override var assumptions: MutableSet<Assumption> = mutableSetOf(),
 ) : Comparable<QueryTree<T>>, HasAssumptions {
     fun printNicely(depth: Int = 0): String {
         var res =
@@ -181,6 +181,10 @@ open class QueryTree<T>(
             return (this.value as Number).compareTo(other)
         }
         throw QueryException("Cannot compare objects of type ${this.value} and $other")
+    }
+
+    override fun collectAssumptions(): Set<Assumption> {
+        return super.collectAssumptions() + children.flatMap { it.collectAssumptions() }.toSet()
     }
 }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/assumptions/Assumption.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/assumptions/Assumption.kt
@@ -290,7 +290,7 @@ enum class AssumptionType {
  * [HasAssumptions.addAssumptionDependences] or [HasAssumptions.addAssumptionDependence].
  */
 interface HasAssumptions {
-    val assumptions: MutableList<Assumption>
+    val assumptions: MutableSet<Assumption>
 
     /**
      * This function adds a new assumption to the object it is called on. If the object is a node or
@@ -323,6 +323,15 @@ interface HasAssumptions {
     }
 
     /**
+     * This is function is used to collect all assumptions stored in the [HasAssumptions] object and
+     * its contained objects that can have assumptions. While this default implementation is simple,
+     * composite [HasAssumptions] objects should return the assumptions of the contained objects.
+     */
+    fun collectAssumptions(): Set<Assumption> {
+        return assumptions.toSet()
+    }
+
+    /**
      * This function is supposed to be used when a new object is created after searching through the
      * graph that can depend on assumptions made on other objects. One example is when creating
      * concepts after following a DFG path. Concepts are added to the graph and then serve as nodes
@@ -337,7 +346,7 @@ interface HasAssumptions {
     fun <T : HasAssumptions> T.addAssumptionDependences(
         haveAssumptions: Collection<HasAssumptions>
     ): T {
-        this.assumptions.addAll(haveAssumptions.flatMap { it.assumptions })
+        this.assumptions.addAll(haveAssumptions.flatMap { it.collectAssumptions() })
         return this
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -234,7 +234,7 @@ abstract class Node() :
 
     var prevPDG by unwrapping(Node::prevPDGEdges)
 
-    @DoNotPersist override val assumptions: MutableList<Assumption> = mutableListOf()
+    @DoNotPersist override val assumptions: MutableSet<Assumption> = mutableSetOf()
 
     /**
      * If a node is marked as being inferred, it means that it was created artificially and does not

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/Edge.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/Edge.kt
@@ -63,7 +63,7 @@ abstract class Edge<NodeType : Node> : Persistable, Cloneable, HasAssumptions {
     // Node where the edge is ingoing
     @JsonBackReference @field:EndNode var end: NodeType
 
-    @DoNotPersist override val assumptions: MutableList<Assumption> = mutableListOf()
+    @DoNotPersist override val assumptions: MutableSet<Assumption> = mutableSetOf()
 
     constructor(start: Node, end: NodeType) {
         this.start = start


### PR DESCRIPTION
Sets are more adequate for holding assumptions to avoid storing the same assumptions multiple times at a node or in a result object.

The `collectAssumptions` function allows for retrieval of all contained assumptions in the final result when the assumption holding object is a composite type, e.g., QueryTree that holds QueryTree, and does not force us to rewrite setters to copy assumptions every time we add a `HasAssumptions` implementing object to another `HasAssumptions` implementing object. The use of `collectAssumptions` in `addAssumptionDependences` helps with the propagation of assumptions in composite `HasAssumptions` types, e.g., QueryTree, NodeWithAssumption.