### PR TITLE
Consider (almost) all AST nodes in the `EOGStarterPass`

### DIFF
--- a/cpg-concepts/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/TagOverlaysPassTest.kt
+++ b/cpg-concepts/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/TagOverlaysPassTest.kt
@@ -33,11 +33,13 @@ import de.fraunhofer.aisec.cpg.graph.builder.*
 import de.fraunhofer.aisec.cpg.graph.concepts.diskEncryption.Cipher
 import de.fraunhofer.aisec.cpg.graph.concepts.diskEncryption.Encrypt
 import de.fraunhofer.aisec.cpg.graph.concepts.diskEncryption.Secret
+import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
 import kotlin.test.Test
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
+import kotlin.test.assertSame
 
 class TagOverlaysPassTest {
 
@@ -55,18 +57,29 @@ class TagOverlaysPassTest {
                                         TagOverlaysPass.Configuration(
                                             tag =
                                                 tag {
+                                                    each<RecordDeclaration>("Encryption").with {
+                                                        Cipher()
+                                                    }
                                                     each<VariableDeclaration>("key").with {
                                                         Secret()
                                                     }
                                                     each<CallExpression>("encrypt").withMultiple {
                                                         val secrets =
                                                             node.getOverlaysByPrevDFG<Secret>(state)
-                                                        secrets.map { secret ->
-                                                            Encrypt(
-                                                                concept = Cipher(),
-                                                                key = secret,
-                                                            )
-                                                        }
+                                                        val encryptOps =
+                                                            secrets.flatMap { secret ->
+                                                                val ciphers =
+                                                                    state.values
+                                                                        .flatMap { it }
+                                                                        .filterIsInstance<Cipher>()
+                                                                ciphers.map { cipher ->
+                                                                    Encrypt(
+                                                                        concept = cipher,
+                                                                        key = secret,
+                                                                    )
+                                                                }
+                                                            }
+                                                        encryptOps
                                                     }
                                                 }
                                         )
@@ -77,22 +90,36 @@ class TagOverlaysPassTest {
             ) {
                 translationResult {
                     translationUnit {
+                        record("Encryption") {}
                         function("main") {
                             body {
                                 declare {
                                     variable("key", t("string"), init = { literal("secret") })
-                                    call("encrypt") { ref("key") }
                                 }
+                                call("encrypt") { ref("key") }
                             }
                         }
                     }
                 }
             }
 
+        val encryption = result.records["Encryption"]
+        assertNotNull(encryption)
+
+        val cipher = encryption.conceptNodes.singleOrNull()
+        assertIs<Cipher>(cipher)
+
         val key = result.variables["key"]
         assertNotNull(key)
 
         val secret = key.conceptNodes.singleOrNull()
         assertIs<Secret>(secret)
+
+        val encryptCall = result.calls["encrypt"]
+        assertNotNull(encryptCall)
+
+        val encrypt = encryptCall.operationNodes.singleOrNull()
+        assertIs<Encrypt>(encrypt)
+        assertSame(cipher, encrypt.concept)
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -100,6 +100,20 @@ val Node.allEOGStarters: List<Node>
         return this.allChildren<EOGStarterHolder>().flatMap { it.eogStarters }.distinct()
     }
 
+/**
+ * Returns all EOG starters of this node that have no predecessors in the EOG as well as the node
+ * itself if it is an EOG "single", in a way that is has neither a previous nor next EOG edge.
+ */
+val Node.allUniqueEOGStartersOrSingles: List<Node>
+    get() {
+        return allEOGStarters.filter { it.prevEOGEdges.isEmpty() } +
+            if (prevEOGEdges.isEmpty() && nextEOGEdges.isEmpty()) {
+                listOf(this)
+            } else {
+                emptyList()
+            }
+    }
+
 @JvmName("astNodes")
 fun Node.ast(): List<Node> {
     return this.ast<Node>()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -106,12 +106,13 @@ val Node.allEOGStarters: List<Node>
  */
 val Node.allUniqueEOGStartersOrSingles: List<Node>
     get() {
-        return allEOGStarters.filter { it.prevEOGEdges.isEmpty() } +
-            if (prevEOGEdges.isEmpty() && nextEOGEdges.isEmpty()) {
-                listOf(this)
-            } else {
-                emptyList()
-            }
+        return (allEOGStarters.filter { it.prevEOGEdges.isEmpty() } +
+                if (prevEOGEdges.isEmpty() && nextEOGEdges.isEmpty()) {
+                    listOf(this)
+                } else {
+                    emptyList()
+                })
+            .distinct()
     }
 
 @JvmName("astNodes")

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/RecordDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/RecordDeclaration.kt
@@ -178,6 +178,7 @@ open class RecordDeclaration :
             list += fields
             list += methods
             list += constructors
+            list += this
 
             return list
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/RecordDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/RecordDeclaration.kt
@@ -178,7 +178,6 @@ open class RecordDeclaration :
             list += fields
             list += methods
             list += constructors
-            list += this
 
             return list
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
@@ -141,7 +141,15 @@ object LeastImportTranslationUnitSorter : Sorter<TranslationUnitDeclaration>() {
 object EOGStarterLeastTUImportSorter : Sorter<Node>() {
     override fun invoke(result: TranslationResult): List<Node> =
         LeastImportTranslationUnitSorter.invoke(result)
-            .flatMap { it.allEOGStarters.filter { it.prevEOGEdges.isEmpty() } }
+            .map {
+                it.allEOGStarters.filter { it.prevEOGEdges.isEmpty() } +
+                    if (it.prevEOGEdges.isEmpty() && it.nextEOGEdges.isEmpty()) {
+                        listOf(it)
+                    } else {
+                        emptyList()
+                    }
+            }
+            .flatten()
             .toList()
 }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/Pass.kt
@@ -141,15 +141,7 @@ object LeastImportTranslationUnitSorter : Sorter<TranslationUnitDeclaration>() {
 object EOGStarterLeastTUImportSorter : Sorter<Node>() {
     override fun invoke(result: TranslationResult): List<Node> =
         LeastImportTranslationUnitSorter.invoke(result)
-            .map {
-                it.allEOGStarters.filter { it.prevEOGEdges.isEmpty() } +
-                    if (it.prevEOGEdges.isEmpty() && it.nextEOGEdges.isEmpty()) {
-                        listOf(it)
-                    } else {
-                        emptyList()
-                    }
-            }
-            .flatten()
+            .flatMap { it.allUniqueEOGStartersOrSingles }
             .toList()
 }
 
@@ -165,7 +157,7 @@ object EOGStarterLeastTUImportCatchLastSorter : Sorter<Node>() {
     override fun invoke(result: TranslationResult): List<Node> =
         LeastImportTranslationUnitSorter.invoke(result)
             .flatMap {
-                val allUniqueStarters = it.allEOGStarters.filter { it.prevEOGEdges.isEmpty() }
+                val allUniqueStarters = it.allUniqueEOGStartersOrSingles
                 val result = mutableListOf<Node>()
                 result.addAll(allUniqueStarters.filter { it !is CatchClause })
                 result.addAll(allUniqueStarters.filterIsInstance<CatchClause>())

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/ExtensionTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/ExtensionTest.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.graph
 
+import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Block
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Reference
@@ -57,5 +58,22 @@ class ExtensionTest {
 
         var single = func.bodyOrNull<Reference>(0)
         assertEquals(ref, single)
+    }
+
+    @Test
+    fun testAllUniqueEOGStartersOrSingles() {
+        with(TestLanguageFrontend()) {
+            val tu = newTranslationUnitDeclaration("file")
+            val record = newRecordDeclaration("MyClass", "class")
+            tu.declarations += record
+
+            val func = newFunctionDeclaration("myFunc")
+            val block = newBlock()
+            func.body = block
+            func.nextEOG += block
+            tu.declarations += func
+
+            assertEquals(listOf(record, func, tu), tu.allUniqueEOGStartersOrSingles)
+        }
     }
 }


### PR DESCRIPTION
This PR does two things:
- It considered (almost) all AST nodes in the `EOGStarterPass`, even though they have no "next" EOG. This way all AST nodes in the graph are at least reached once
- It considers the outcome of `handleNode` also in the "intermediate" initial states. Previously only nodes that were the target of an incoming EOG edge were handed to `handleNode`