### PR TITLE
Specify what the text of assumptions should look like

### DIFF
--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/FlowQueries.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/FlowQueries.kt
@@ -342,9 +342,9 @@ fun Node.generatesNewData(): NodeCollectionWithAssumption {
         .addAssumptionDependences(tempAssumptions + splitNodes + this)
         .assume(
             AssumptionType.DataFlowAssumption,
-            "The node generates the following new \"objects\" which require separate handling as they represent copies/clones of the original \"object\": $splitNodes.\n\n" +
+            "We assume that the node $this generates the following new \"objects\" which require separate handling as they represent copies/clones of the original \"object\": $splitNodes.\n\n" +
                 "We assume that this list is complete and does not contain additional elements.\n" +
-                "This assumption can be split up into the following (global) sub-assumptions, where all of them have to hold:\n" +
+                "To verify this assumption, we need to check if all of the following (global) sub-assumptions hold:\n" +
                 "1. The list of mutable and immutable types is complete and sound for each programming language used in the analyzed project.\n" +
                 "2. Copies of data happen exclusively by one of the following patterns:\n" +
                 "2.a) Constructing a new object where our data flow to by a constructor invocation or by a collection comprehension: We should track this object and the target of the operation separately." +

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/assumptions/Assumption.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/assumptions/Assumption.kt
@@ -298,6 +298,13 @@ interface HasAssumptions {
      * assumption is also added to the [assumptions] list. In the future the [Node.id] will be
      * deterministic across functions.
      *
+     * Notes on writing the [message]: The message should specify what we assume, the condition, and
+     * ideally the reason why this assumption was necessary and how it can be verified. The text
+     * should start with a pattern such as "We assume that ... .", where "..." contains a
+     * description of the assumption with the reference to concrete nodes or edges affected by it.
+     * Afterward, it is beneficial to continue with a paragraph "To verify this assumption, we need
+     * to check ...".
+     *
      * @param assumptionType The type of assumption used to differentiate between assumptions and
      *   group similar assumptions.
      * @param scope The scope that the assumption has validity for, here the scope is a node,

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/assumptions/Assumption.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/assumptions/Assumption.kt
@@ -42,6 +42,12 @@ import org.neo4j.ogm.annotation.typeconversion.Convert
  * The minimal properties to identify an assumption, is the assumption type and either node, edge,
  * or node [id] if deterministic. Only one of the three should be provided.
  *
+ * Notes on writing the [message]: The message should specify what we assume, the condition, and
+ * ideally the reason why this assumption was necessary and how it can be verified. The text should
+ * start with a pattern such as "We assume that ... .", where "..." contains a description of the
+ * assumption with the reference to concrete nodes or edges affected by it. Afterward, it is
+ * beneficial to continue with a paragraph "To verify this assumption, we need to check ...".
+ *
  * @param assumptionType One of many finite assumption types used to differentiate between
  *   assumptions and group similar assumptions.
  * @param message The message describing the assumption that was taken.

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
@@ -306,16 +306,15 @@ class DFGPass(ctx: TranslationContext) : ComponentPass(ctx) {
                 }
             } else {
                 node.variable.variables.lastOrNull()?.prevDFGEdges += iterable
+                node.assume(
+                    AssumptionType.AmbiguityAssumption,
+                    "We assume that the last VariableDeclaration in the statement kept in \"variable\" is the variable we care about in the ForEachStatement if there is no DeclarationStatement related to $node.\n\n" +
+                        "To verify this assumption, we need to check if the last VariableDeclaration of the variable is indeed the one where we assign the iterable's elements to.",
+                )
             }
         }
 
-        node.variable?.let {
-            node.prevDFGEdges += it
-            node.assume(
-                AssumptionType.AmbiguityAssumption,
-                "If this is not the case, we assume that the last VariableDeclaration in the statement is the one we care about.",
-            )
-        }
+        node.variable?.let { node.prevDFGEdges += it }
     }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
@@ -161,8 +161,7 @@ class Inference internal constructor(val start: Node, override val ctx: Translat
 
                 // Some more magic, that adds it to the AST. Note: this might not be 100 % compliant
                 // with the language, since in some languages the AST of a method declaration could
-                // be
-                // outside of a method, but this will do for now
+                // be outside a method, but this will do for now
                 if (record != null && inferred is MethodDeclaration) {
                     record.addMethod(inferred)
                 }
@@ -181,7 +180,8 @@ class Inference internal constructor(val start: Node, override val ctx: Translat
             }
             .assume(
                 AssumptionType.InferenceAssumption,
-                "Assuming the start of inference is a record, namespace or translation unit",
+                "We assume that the start of inference is a record, namespace or translation unit.\n\n" +
+                    "To verify this assumption, we should check if the function is indeed part of the parent where it was inferred in external code.",
             )
     }
 


### PR DESCRIPTION
Elaborates the documentation of the `assume` function to specify the format of the message parameter.

It also updates existing texts accordingly

Fixes #2275 