### PR TITLE
Cleanup state on finalCleanup & documentation

### DIFF
--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/EOGConceptPass.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/EOGConceptPass.kt
@@ -37,8 +37,8 @@ import de.fraunhofer.aisec.cpg.helpers.functional.Lattice
 import de.fraunhofer.aisec.cpg.helpers.functional.MapLattice
 import de.fraunhofer.aisec.cpg.helpers.functional.PowersetLattice
 import de.fraunhofer.aisec.cpg.passes.*
+import de.fraunhofer.aisec.cpg.passes.concepts.EOGConceptPass.Companion.intermediateState
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
-import kotlin.collections.none
 
 typealias NodeToOverlayStateElement = MapLattice.Element<Node, PowersetLattice.Element<OverlayNode>>
 
@@ -59,6 +59,8 @@ typealias NodeToOverlayState = MapLattice<Node, PowersetLattice.Element<OverlayN
  * * These methods must not connect the created [OverlayNode]s to the underlying node! This is done
  *   in the pass itself after having collected all overlays. Use a builder based with the flag
  *   `connect` set to `false` to do this.
+ * * If you require the [OverlayNode]s to be created in a specific EOG order, you have to return an
+ *   ordered collection.
  */
 @DependsOn(EvaluationOrderGraphPass::class)
 @DependsOn(DFGPass::class)
@@ -93,6 +95,9 @@ open class EOGConceptPass(ctx: TranslationContext) :
                 }
             }
         }
+        // clean up the state in order to not mess up other [EOGConceptPass]
+        // instances
+        finalState.clear()
     }
 
     override fun accept(node: Node) {
@@ -111,6 +116,8 @@ open class EOGConceptPass(ctx: TranslationContext) :
     /**
      * Generates [OverlayNode]s belonging to the given [node]. The [state] contains a map of nodes
      * to their respective [OverlayNode]s created by this instance of the pass.
+     *
+     * Note: see the class documentation for more information about creating [OverlayNode]s.
      */
     open fun handleCallExpression(
         state: NodeToOverlayStateElement,
@@ -125,6 +132,8 @@ open class EOGConceptPass(ctx: TranslationContext) :
      *
      * This is the advanced version and passes the [lattice] in case the [state] should be
      * manipulated. We do not recommend using this!
+     *
+     * Note: see the class documentation for more information about creating [OverlayNode]s.
      */
     open fun handleCallExpression(
         lattice: NodeToOverlayState,
@@ -137,6 +146,8 @@ open class EOGConceptPass(ctx: TranslationContext) :
     /**
      * Generates [OverlayNode]s belonging to the given [node]. The [state] contains a map of nodes
      * to their respective [OverlayNode]s created by this instance of the pass.
+     *
+     * Note: see the class documentation for more information about creating [OverlayNode]s.
      */
     open fun handleMemberCallExpression(
         state: NodeToOverlayStateElement,
@@ -151,6 +162,8 @@ open class EOGConceptPass(ctx: TranslationContext) :
      *
      * This is the advanced version and passes the [lattice] in case the [state] should be
      * manipulated. We do not recommend using this!
+     *
+     * Note: see the class documentation for more information about creating [OverlayNode]s.
      */
     open fun handleMemberCallExpression(
         lattice: NodeToOverlayState,
@@ -163,6 +176,8 @@ open class EOGConceptPass(ctx: TranslationContext) :
     /**
      * This function is called for each node in the graph. The specific nodes are always handled in
      * the same order. It calls the basic and advanced version of the handleX-methods.
+     *
+     * Note: see the class documentation for more information about creating [OverlayNode]s.
      */
     // TODO: Once we use tasks, we iterate over all tasks registered to this pass.
     open fun handleNode(


### PR DESCRIPTION
The `intermediateState` object must be cleared once the pass is done or it will interfere with other passes.