### PR TITLE
Keep order when creating nodes EOGConceptPass

### DIFF
--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGPass.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGPass.kt
@@ -29,12 +29,8 @@ import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.edges.flows.EvaluationOrder
-import de.fraunhofer.aisec.cpg.graph.statements.DoStatement
-import de.fraunhofer.aisec.cpg.graph.statements.ForStatement
-import de.fraunhofer.aisec.cpg.graph.statements.IfStatement
-import de.fraunhofer.aisec.cpg.graph.statements.LoopStatement
-import de.fraunhofer.aisec.cpg.graph.statements.WhileStatement
-import de.fraunhofer.aisec.cpg.helpers.*
+import de.fraunhofer.aisec.cpg.graph.statements.*
+import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.helpers.functional.Lattice
 import de.fraunhofer.aisec.cpg.helpers.functional.MapLattice
 import de.fraunhofer.aisec.cpg.helpers.functional.Order
@@ -278,7 +274,7 @@ class ReachabilityLattice() : Lattice<ReachabilityLattice.Element> {
     }
 
     override var elements =
-        setOf(
+        linkedSetOf(
             Element(Reachability.BOTTOM),
             Element(Reachability.UNREACHABLE),
             Element(Reachability.REACHABLE),

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/functional/BasicLatticesRedesign.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/functional/BasicLatticesRedesign.kt
@@ -31,12 +31,7 @@ import de.fraunhofer.aisec.cpg.helpers.functional.PowersetLattice.Element
 import de.fraunhofer.aisec.cpg.helpers.identitySetOf
 import de.fraunhofer.aisec.cpg.helpers.toIdentitySet
 import java.io.Serializable
-import java.util.IdentityHashMap
-import kotlin.collections.component1
-import kotlin.collections.component2
-import kotlin.collections.fold
-import kotlin.collections.plusAssign
-import kotlin.collections.set
+import java.util.*
 
 /** Used to identify the order of elements */
 enum class Order {
@@ -97,7 +92,7 @@ interface Lattice<T : Lattice.Element> {
     }
 
     /** Allows storing all elements which are part of this lattice */
-    var elements: Set<T>
+    var elements: LinkedHashSet<T>
 
     /** The smallest possible element in the lattice */
     val bottom: T
@@ -208,7 +203,7 @@ interface Lattice<T : Lattice.Element> {
 
 /** Implements a [Lattice] whose elements are the powerset of a given set of values. */
 class PowersetLattice<T>() : Lattice<PowersetLattice.Element<T>> {
-    override lateinit var elements: Set<Element<T>>
+    override lateinit var elements: LinkedHashSet<Element<T>>
 
     class Element<T>(expectedMaxSize: Int) : IdentitySet<T>(expectedMaxSize), Lattice.Element {
         constructor(set: Set<T>) : this(set.size) {
@@ -293,7 +288,7 @@ class PowersetLattice<T>() : Lattice<PowersetLattice.Element<T>> {
  */
 open class MapLattice<K, V : Lattice.Element>(val innerLattice: Lattice<V>) :
     Lattice<MapLattice.Element<K, V>> {
-    override lateinit var elements: Set<Element<K, V>>
+    override lateinit var elements: LinkedHashSet<Element<K, V>>
 
     class Element<K, V : Lattice.Element>(expectedMaxSize: Int) :
         IdentityHashMap<K, V>(expectedMaxSize), Lattice.Element {
@@ -431,7 +426,7 @@ class TupleLattice<S : Lattice.Element, T : Lattice.Element>(
     val innerLattice1: Lattice<S>,
     val innerLattice2: Lattice<T>,
 ) : Lattice<TupleLattice.Element<S, T>> {
-    override lateinit var elements: Set<Element<S, T>>
+    override lateinit var elements: LinkedHashSet<Element<S, T>>
 
     class Element<S : Lattice.Element, T : Lattice.Element>(val first: S, val second: T) :
         Serializable, Lattice.Element {
@@ -510,7 +505,7 @@ class TripleLattice<R : Lattice.Element, S : Lattice.Element, T : Lattice.Elemen
     val innerLattice2: Lattice<S>,
     val innerLattice3: Lattice<T>,
 ) : Lattice<TripleLattice.Element<R, S, T>> {
-    override lateinit var elements: Set<Element<R, S, T>>
+    override lateinit var elements: LinkedHashSet<Element<R, S, T>>
 
     class Element<R : Lattice.Element, S : Lattice.Element, T : Lattice.Element>(
         val first: R,


### PR DESCRIPTION
Currently, when creating nodes in an EOGConceptPass they are first added to a set and then later created via some pass specific internal mechanisms. This means that the order when creating multiple nodes in the pass and the order when they are actually created internally might differ, resulting in unexpected EOG results for example.

- [ ] Do we need to change more sets to ordered sets?
- [ ] Do we want to have this change?