### PR TITLE
Update AssumptionStatus and better assumption collection before decide

### DIFF
--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/FlowQueries.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/FlowQueries.kt
@@ -265,12 +265,11 @@ fun dataFlowWithValidator(
  * computing this node as the result of a function.
  */
 data class NodeWithAssumption(val node: Node) : HasAssumptions {
-    /** See [HasAssumptions.assumptions]. */
     override val assumptions: MutableSet<Assumption> = mutableSetOf()
 
     /**
      * Adds the [assumptions] of the current [NodeCollectionWithAssumption] and the assumptions of
-     * the node that is the result. See [HasAssumptions.collectAssumptions].
+     * the node that is the result.
      */
     override fun collectAssumptions(): Set<Assumption> {
         return super.collectAssumptions() + node.collectAssumptions()
@@ -283,12 +282,11 @@ data class NodeWithAssumption(val node: Node) : HasAssumptions {
  * taken when computing this collection of nodes as the result of a function.
  */
 data class NodeCollectionWithAssumption(val nodes: Collection<Node>) : HasAssumptions {
-    /** See [HasAssumptions.assumptions]. */
     override val assumptions: MutableSet<Assumption> = mutableSetOf()
 
     /**
      * Adds the [assumptions] of the current [NodeCollectionWithAssumption] and the assumptions of
-     * all nodes contained in the object. See [HasAssumptions.collectAssumptions].
+     * all nodes contained in the object.
      */
     override fun collectAssumptions(): Set<Assumption> {
         return super.collectAssumptions() + nodes.flatMap { it.collectAssumptions() }

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/FlowQueries.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/FlowQueries.kt
@@ -265,8 +265,13 @@ fun dataFlowWithValidator(
  * computing this node as the result of a function.
  */
 data class NodeWithAssumption(val node: Node) : HasAssumptions {
+    /** See [HasAssumptions.assumptions]. */
     override val assumptions: MutableSet<Assumption> = mutableSetOf()
 
+    /**
+     * Adds the [assumptions] of the current [NodeCollectionWithAssumption] and the assumptions of
+     * the node that is the result. See [HasAssumptions.collectAssumptions].
+     */
     override fun collectAssumptions(): Set<Assumption> {
         return super.collectAssumptions() + node.collectAssumptions()
     }
@@ -278,8 +283,13 @@ data class NodeWithAssumption(val node: Node) : HasAssumptions {
  * taken when computing this collection of nodes as the result of a function.
  */
 data class NodeCollectionWithAssumption(val nodes: Collection<Node>) : HasAssumptions {
+    /** See [HasAssumptions.assumptions]. */
     override val assumptions: MutableSet<Assumption> = mutableSetOf()
 
+    /**
+     * Adds the [assumptions] of the current [NodeCollectionWithAssumption] and the assumptions of
+     * all nodes contained in the object. See [HasAssumptions.collectAssumptions].
+     */
     override fun collectAssumptions(): Set<Assumption> {
         return super.collectAssumptions() + nodes.flatMap { it.collectAssumptions() }
     }

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/FlowQueries.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/FlowQueries.kt
@@ -268,7 +268,7 @@ data class NodeWithAssumption(val node: Node) : HasAssumptions {
     override val assumptions: MutableSet<Assumption> = mutableSetOf()
 
     override fun collectAssumptions(): Set<Assumption> {
-        return super.collectAssumptions() + node.assumptions
+        return super.collectAssumptions() + node.collectAssumptions()
     }
 }
 
@@ -281,7 +281,7 @@ data class NodeCollectionWithAssumption(val nodes: Collection<Node>) : HasAssump
     override val assumptions: MutableSet<Assumption> = mutableSetOf()
 
     override fun collectAssumptions(): Set<Assumption> {
-        return super.collectAssumptions() + nodes.flatMap { it.assumptions }
+        return super.collectAssumptions() + nodes.flatMap { it.collectAssumptions() }
     }
 }
 

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/QueryStates.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/QueryStates.kt
@@ -73,9 +73,9 @@ fun QueryTree<Boolean>.decide(): Decision {
     // The assumptions need to be collected, as they are located at the respective construct they are placed on and only
     // forwarded on evaluation. Accepting or rejecting an assumption has a different impact on query evaluation depending
     // on the sup-query tree the assumption is placed on.
-    val assumptions = this.collectAssumptions()
-    // Todo kw: Include global or component wide assumptions?
-    this@TranslationResult.collectAssumptions()
+    // Global assumptions are also included below, component wide assumptions are included with collectAssumptions() in
+    // the individual nodes.
+    val assumptions = this.collectAssumptions() + this@TranslationResult.collectAssumptions()
 
 
     assumptions.forEach {

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/QueryStates.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/QueryStates.kt
@@ -71,13 +71,10 @@ context(TranslationResult)
 fun QueryTree<Boolean>.decide(): Decision {
     val statues = this@TranslationResult.assumptionStatuses
     // The assumptions need to be collected, as they are located at the respective construct they
-    // are placed on and only
-    // forwarded on evaluation. Accepting or rejecting an assumption has a different impact on query
-    // evaluation depending
-    // on the sup-query tree the assumption is placed on.
-    // Global assumptions are also included below, component wide assumptions are included with
-    // collectAssumptions() in
-    // the individual nodes.
+    // are placed on and only forwarded on evaluation. Accepting or rejecting an assumption has a
+    // different impact on query evaluation depending on the sup-query tree the assumption is placed
+    // on. Global assumptions are also included below, component wide assumptions are included with
+    // collectAssumptions() in the individual nodes.
     val assumptions = this.collectAssumptions() + this@TranslationResult.collectAssumptions()
 
     assumptions.forEach { it.status = statues.getOrDefault(it.id, it.status) }

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/QueryStates.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/QueryStates.kt
@@ -64,23 +64,23 @@ data object NotYetEvaluated : DecisionState()
 /**
  * Wraps the given [QueryTree] in a new [Decision] object by checking if the value is `true` or
  * `false` and based on the [de.fraunhofer.aisec.cpg.assumptions.Assumption.status] of all
- * [QueryTree.collectAssumptions] (i.e., it checks if all are [AssumptionStatus.Accepted] or if some are
- * [AssumptionStatus.Rejected] or [AssumptionStatus.Undecided]).
+ * [QueryTree.collectAssumptions] (i.e., it checks if all are [AssumptionStatus.Accepted] or if some
+ * are [AssumptionStatus.Rejected] or [AssumptionStatus.Undecided]).
  */
 context(TranslationResult)
 fun QueryTree<Boolean>.decide(): Decision {
     val statues = this@TranslationResult.assumptionStatuses
-    // The assumptions need to be collected, as they are located at the respective construct they are placed on and only
-    // forwarded on evaluation. Accepting or rejecting an assumption has a different impact on query evaluation depending
+    // The assumptions need to be collected, as they are located at the respective construct they
+    // are placed on and only
+    // forwarded on evaluation. Accepting or rejecting an assumption has a different impact on query
+    // evaluation depending
     // on the sup-query tree the assumption is placed on.
-    // Global assumptions are also included below, component wide assumptions are included with collectAssumptions() in
+    // Global assumptions are also included below, component wide assumptions are included with
+    // collectAssumptions() in
     // the individual nodes.
     val assumptions = this.collectAssumptions() + this@TranslationResult.collectAssumptions()
 
-
-    assumptions.forEach {
-        it.status = statues.getOrDefault(it.id, it.status)
-    }
+    assumptions.forEach { it.status = statues.getOrDefault(it.id, it.status) }
 
     val (newValue, stringInfo) =
         when {
@@ -90,7 +90,6 @@ fun QueryTree<Boolean>.decide(): Decision {
                     else
                         "the assumptions ${assumptions.filter { it.status == AssumptionStatus.Rejected }.map { it.id.toHexDashString() }.joinToString(", ") } were rejected")
 
-
             assumptions.any { it.status == AssumptionStatus.Undecided } ->
                 Undecided to
                     "the assumptions ${assumptions.filter { it.status == AssumptionStatus.Undecided }.map { it.id.toHexDashString() }.joinToString(", ")} are not yet decided"
@@ -99,7 +98,8 @@ fun QueryTree<Boolean>.decide(): Decision {
                 assumptions.all {
                     it.status == AssumptionStatus.Ignored || it.status == AssumptionStatus.Accepted
                 } ->
-                Succeeded to "the query was evaluated to true and all assumptions were accepted or deemed not influencing the result."
+                Succeeded to
+                    "the query was evaluated to true and all assumptions were accepted or deemed not influencing the result."
 
             else -> NotYetEvaluated to "Something went wrong"
         }

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/QueryTree.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/QueryTree.kt
@@ -70,7 +70,6 @@ open class QueryTree<T>(
      */
     open var node: Node? = null,
 
-    /** See [HasAssumptions.assumptions]. */
     override var assumptions: MutableSet<Assumption> = mutableSetOf(),
 ) : Comparable<QueryTree<T>>, HasAssumptions {
     fun printNicely(depth: Int = 0): String {
@@ -116,7 +115,7 @@ open class QueryTree<T>(
 
     /**
      * Adds the [assumptions] attached to the [QueryTree] itself and of all sub [QueryTree]s that
-     * were declared as children. See [HasAssumptions.collectAssumptions].
+     * were declared as children.
      */
     override fun collectAssumptions(): Set<Assumption> {
         return super.collectAssumptions() + children.flatMap { it.collectAssumptions() }.toSet()

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/QueryTree.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/QueryTree.kt
@@ -69,7 +69,6 @@ open class QueryTree<T>(
      * in [stringRepresentation].
      */
     open var node: Node? = null,
-
     override var assumptions: MutableSet<Assumption> = mutableSetOf(),
 ) : Comparable<QueryTree<T>>, HasAssumptions {
     fun printNicely(depth: Int = 0): String {

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/QueryTree.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/QueryTree.kt
@@ -70,10 +70,7 @@ open class QueryTree<T>(
      */
     open var node: Node? = null,
 
-    /**
-     * Assumptions can be created in the QueryTree object with the [assume] function ore by adding
-     * an assumption manually.
-     */
+    /** See [HasAssumptions.assumptions]. */
     override var assumptions: MutableSet<Assumption> = mutableSetOf(),
 ) : Comparable<QueryTree<T>>, HasAssumptions {
     fun printNicely(depth: Int = 0): String {
@@ -117,6 +114,10 @@ open class QueryTree<T>(
         throw QueryException("Cannot compare objects of type ${this.value} and ${other.value}")
     }
 
+    /**
+     * Adds the [assumptions] attached to the [QueryTree] itself and of all sub [QueryTree]s that
+     * were declared as children. See [HasAssumptions.collectAssumptions].
+     */
     override fun collectAssumptions(): Set<Assumption> {
         return super.collectAssumptions() + children.flatMap { it.collectAssumptions() }.toSet()
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/assumptions/Assumption.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/assumptions/Assumption.kt
@@ -287,6 +287,13 @@ enum class AssumptionType {
  * [HasAssumptions.addAssumptionDependence] or [HasAssumptions.addAssumptionDependence].
  */
 interface HasAssumptions {
+
+    /**
+     * This set only contains the assumptions that were added by invoking [assume] or [addAssumptionDependence]
+     * to this object. To gather all assumptions that are relevant for this object, call [collectAssumptions].
+     * This is necessary as different parts of cpg construction and augmentation can add assumptions to a
+     * dependent object.
+     */
     val assumptions: MutableSet<Assumption>
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/assumptions/Assumption.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/assumptions/Assumption.kt
@@ -289,10 +289,10 @@ enum class AssumptionType {
 interface HasAssumptions {
 
     /**
-     * This set only contains the assumptions that were added by invoking [assume] or [addAssumptionDependence]
-     * to this object. To gather all assumptions that are relevant for this object, call [collectAssumptions].
-     * This is necessary as different parts of cpg construction and augmentation can add assumptions to a
-     * dependent object.
+     * This set only contains the assumptions that were added by invoking [assume] or
+     * [addAssumptionDependence] to this object. To gather all assumptions that are relevant for
+     * this object, call [collectAssumptions]. This is necessary as different parts of cpg
+     * construction and augmentation can add assumptions to a dependent object.
      */
     val assumptions: MutableSet<Assumption>
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
@@ -70,7 +70,7 @@ open class Component : Node() {
 
     /**
      * In contrast to other Nodes we do not add the assumptions collected over the component because
-     * we are already the component. See [HasAssumptions.collectAssumptions].
+     * we are already the component.
      */
     override fun collectAssumptions(): Set<Assumption> {
         return assumptions.toSet()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
@@ -27,6 +27,8 @@ package de.fraunhofer.aisec.cpg.graph
 
 import de.fraunhofer.aisec.cpg.PopulatedByPass
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.assumptions.Assumption
+import de.fraunhofer.aisec.cpg.assumptions.HasAssumptions
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.multiLanguage
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
@@ -64,6 +66,14 @@ open class Component : Node() {
     @Synchronized
     fun addTranslationUnit(tu: TranslationUnitDeclaration) {
         translationUnits.add(tu)
+    }
+
+    /**
+     * In contrast to other Nodes we do not add the assumptions collected over the component because
+     * we are already the component. See [HasAssumptions.collectAssumptions].
+     */
+    override fun collectAssumptions(): Set<Assumption> {
+        return assumptions.toSet()
     }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
@@ -28,7 +28,6 @@ package de.fraunhofer.aisec.cpg.graph
 import de.fraunhofer.aisec.cpg.PopulatedByPass
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.assumptions.Assumption
-import de.fraunhofer.aisec.cpg.assumptions.HasAssumptions
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.multiLanguage
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -261,8 +261,13 @@ enum class FailureReason {
  */
 data class NodePath(
     val nodes: List<Node>,
+    /** See [HasAssumptions.assumptions]. */
     override val assumptions: MutableSet<Assumption> = mutableSetOf(),
 ) : HasAssumptions {
+
+    /**
+     * Adds the [assumptions] attached to the [NodePath] itself and of all [Node] contained in the path. See [HasAssumptions.collectAssumptions].
+     */
     override fun collectAssumptions(): Set<Assumption> {
         return super.collectAssumptions() + nodes.flatMap { it.collectAssumptions() }
     }
@@ -414,6 +419,7 @@ class Context(
     var steps: Int,
 ) : HasAssumptions {
 
+    /** See [HasAssumptions.assumptions]. */
     override val assumptions: MutableSet<Assumption> = mutableSetOf()
 
     fun clone(): Context {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -261,12 +261,11 @@ enum class FailureReason {
  */
 data class NodePath(
     val nodes: List<Node>,
-    /** See [HasAssumptions.assumptions]. */
     override val assumptions: MutableSet<Assumption> = mutableSetOf(),
 ) : HasAssumptions {
 
     /**
-     * Adds the [assumptions] attached to the [NodePath] itself and of all [Node] contained in the path. See [HasAssumptions.collectAssumptions].
+     * Adds the [assumptions] attached to the [NodePath] itself and of all [Node] contained in the path.
      */
     override fun collectAssumptions(): Set<Assumption> {
         return super.collectAssumptions() + nodes.flatMap { it.collectAssumptions() }
@@ -419,7 +418,6 @@ class Context(
     var steps: Int,
 ) : HasAssumptions {
 
-    /** See [HasAssumptions.assumptions]. */
     override val assumptions: MutableSet<Assumption> = mutableSetOf()
 
     fun clone(): Context {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -264,7 +264,7 @@ data class NodePath(
     override val assumptions: MutableSet<Assumption> = mutableSetOf(),
 ) : HasAssumptions {
     override fun collectAssumptions(): Set<Assumption> {
-        return super.collectAssumptions() + nodes.flatMap { it.assumptions }
+        return super.collectAssumptions() + nodes.flatMap { it.collectAssumptions() }
     }
 }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -265,7 +265,8 @@ data class NodePath(
 ) : HasAssumptions {
 
     /**
-     * Adds the [assumptions] attached to the [NodePath] itself and of all [Node] contained in the path.
+     * Adds the [assumptions] attached to the [NodePath] itself and of all [Node] contained in the
+     * path.
      */
     override fun collectAssumptions(): Set<Assumption> {
         return super.collectAssumptions() + nodes.flatMap { it.collectAssumptions() }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -287,7 +287,7 @@ abstract class Node() :
     var overlays by unwrapping(Node::overlayEdges)
 
     override fun collectAssumptions(): Set<Assumption> {
-        return super.collectAssumptions() + (component?.collectAssumptions() ?: emptySet())
+        return super.collectAssumptions() + (component?.assumptions ?: emptySet())
     }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -292,7 +292,7 @@ abstract class Node() :
      * [Component]. See [HasAssumptions.collectAssumptions].
      */
     override fun collectAssumptions(): Set<Assumption> {
-        return super.collectAssumptions() + (component?.assumptions ?: emptySet())
+        return super.collectAssumptions() + (component?.collectAssumptions() ?: emptySet())
     }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -234,6 +234,7 @@ abstract class Node() :
 
     var prevPDG by unwrapping(Node::prevPDGEdges)
 
+    /** See [HasAssumptions.assumptions]. */
     @DoNotPersist override val assumptions: MutableSet<Assumption> = mutableSetOf()
 
     /**
@@ -286,6 +287,10 @@ abstract class Node() :
         Overlays(this, mirrorProperty = OverlayNode::underlyingNodeEdge, outgoing = true)
     var overlays by unwrapping(Node::overlayEdges)
 
+    /**
+     * Adds the [assumptions] attached to the [Node] and of relevant supernodes in the AST. Currently, of the
+     * [Component]. See [HasAssumptions.collectAssumptions].
+     */
     override fun collectAssumptions(): Set<Assumption> {
         return super.collectAssumptions() + (component?.assumptions ?: emptySet())
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -286,6 +286,10 @@ abstract class Node() :
         Overlays(this, mirrorProperty = OverlayNode::underlyingNodeEdge, outgoing = true)
     var overlays by unwrapping(Node::overlayEdges)
 
+    override fun collectAssumptions(): Set<Assumption> {
+        return super.collectAssumptions() + (component?.collectAssumptions() ?: emptySet())
+    }
+
     /**
      * If a node should be removed from the graph, just removing it from the AST is not enough (see
      * issue #60). It will most probably be referenced somewhere via DFG or EOG edges. Thus, if it

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -287,8 +287,8 @@ abstract class Node() :
     var overlays by unwrapping(Node::overlayEdges)
 
     /**
-     * Adds the [assumptions] attached to the [Node] and of relevant supernodes in the AST. Currently, of the
-     * [Component].
+     * Adds the [assumptions] attached to the [Node] and of relevant supernodes in the AST.
+     * Currently, of the [Component].
      */
     override fun collectAssumptions(): Set<Assumption> {
         return super.collectAssumptions() + (component?.collectAssumptions() ?: emptySet())

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -234,7 +234,6 @@ abstract class Node() :
 
     var prevPDG by unwrapping(Node::prevPDGEdges)
 
-    /** See [HasAssumptions.assumptions]. */
     @DoNotPersist override val assumptions: MutableSet<Assumption> = mutableSetOf()
 
     /**
@@ -289,7 +288,7 @@ abstract class Node() :
 
     /**
      * Adds the [assumptions] attached to the [Node] and of relevant supernodes in the AST. Currently, of the
-     * [Component]. See [HasAssumptions.collectAssumptions].
+     * [Component].
      */
     override fun collectAssumptions(): Set<Assumption> {
         return super.collectAssumptions() + (component?.collectAssumptions() ?: emptySet())

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/Edge.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/Edge.kt
@@ -63,7 +63,6 @@ abstract class Edge<NodeType : Node> : Persistable, Cloneable, HasAssumptions {
     // Node where the edge is ingoing
     @JsonBackReference @field:EndNode var end: NodeType
 
-    /** See [HasAssumptions.assumptions]. */
     @DoNotPersist override val assumptions: MutableSet<Assumption> = mutableSetOf()
 
     constructor(start: Node, end: NodeType) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/Edge.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/Edge.kt
@@ -63,6 +63,7 @@ abstract class Edge<NodeType : Node> : Persistable, Cloneable, HasAssumptions {
     // Node where the edge is ingoing
     @JsonBackReference @field:EndNode var end: NodeType
 
+    /** See [HasAssumptions.assumptions]. */
     @DoNotPersist override val assumptions: MutableSet<Assumption> = mutableSetOf()
 
     constructor(start: Node, end: NodeType) {


### PR DESCRIPTION
This PR does the following:

- Uses the assumption statuses in the translation results to update the assumption status of a `QueryTree` before the decision process.
- Fixes a mistake, at least one IMO, in the decision logic.
- Collects all assumptions related to a `QueryTree`.
- Adds global assumptions that are attached to the `TranslationResult` and `Component` assumptions in the `collectAssumptions` of the Node class.
