### PR TITLE
Provide `ctx` to `dataFlow`

### DIFF
--- a/cpg-analysis/build.gradle.kts
+++ b/cpg-analysis/build.gradle.kts
@@ -36,4 +36,10 @@ dependencies {
     api(projects.cpgCore)
 
     testImplementation(testFixtures(projects.cpgCore))
+    // We depend on the Python frontend for the integration tests, but the frontend is only
+    // available if enabled.
+    // If it's not available, the integration tests fail (which is ok). But if we would directly
+    // reference the project here, the build system would fail any task since it will not find a
+    // non-enabled project.
+    findProject(":cpg-language-python")?.also { integrationTestImplementation(it) }
 }

--- a/cpg-analysis/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/query/FlowQueriesTest.kt
+++ b/cpg-analysis/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/query/FlowQueriesTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2025, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.query
+
+import de.fraunhofer.aisec.cpg.frontends.python.PythonLanguage
+import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.Literal
+import de.fraunhofer.aisec.cpg.test.analyze
+import kotlin.io.path.Path
+import kotlin.test.*
+
+class FlowQueriesTest {
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun testDataflowWithContext() {
+        val topLevel = Path("src/integrationTest/resources/python")
+        val result =
+            analyze(listOf(topLevel.resolve("context.py").toFile()), topLevel, usePasses = true) {
+                it.registerLanguage<PythonLanguage>()
+            }
+        assertNotNull(result)
+
+        // First, without context
+        var q =
+            result.allExtended<FunctionDeclaration>(
+                sel = { it.name.localName.startsWith("endpoint") }
+            ) { func ->
+                val innerAuthorizeCalls =
+                    func.followEOGEdgesUntilHit(
+                        collectFailedPaths = false,
+                        predicate = { node ->
+                            node is CallExpression && node.name.localName == "inner_authorize"
+                        },
+                    )
+                innerAuthorizeCalls.fulfilled
+                    .map { path ->
+                        val call = path.nodes.last()
+                        val flow =
+                            dataFlow(
+                                startNode = call,
+                                type = Must,
+                                direction = Backward(GraphToFollow.DFG),
+                                predicate = { it is Literal<*> && it.value == func.name.localName },
+                            )
+                        flow
+                    }
+                    .mergeWithAll()
+            }
+        assertNotNull(q)
+        assertEquals(3, q.children.size, "Expected 3 paths for the 3 endpoints")
+
+        var path0 = q.children[0].children[0] as QueryTree<Boolean>
+        assertFalse(path0.value, "Without context, expected false for the first endpoint")
+
+        var path1 = q.children[1].children[0] as QueryTree<Boolean>
+        assertFalse(path1.value, "Without context, expected false for the second endpoint")
+
+        var path2 = q.children[2].children[0] as QueryTree<Boolean>
+        assertFalse(path2.value, "Without context, expected false for the third endpoint")
+
+        // Now, with context
+        q =
+            result.allExtended<FunctionDeclaration>(
+                sel = { it.name.localName.startsWith("endpoint") }
+            ) { func ->
+                val innerAuthorizeCalls =
+                    func.followEOGEdgesUntilHit(
+                        collectFailedPaths = false,
+                        predicate = { node ->
+                            node is CallExpression && node.name.localName == "inner_authorize"
+                        },
+                    )
+                innerAuthorizeCalls.fulfilled
+                    .map { path ->
+                        val call = path.nodes.lastOrNull() as? CallExpression
+                        assertNotNull(call, "Expected last node to be a CallExpression")
+
+                        val flow =
+                            dataFlow(
+                                startNode = call,
+                                type = Must,
+                                direction = Backward(GraphToFollow.DFG),
+                                ctx = Context.ofCallStack(assertNotNull(func.calls["authorize"])),
+                                predicate = { node ->
+                                    node is Literal<*> && node.value == func.name.localName
+                                },
+                            )
+                        flow
+                    }
+                    .mergeWithAll()
+            }
+        assertNotNull(q)
+
+        assertEquals(3, q.children.size, "Expected 3 paths for the 3 endpoints")
+
+        path0 = q.children[0].children[0] as QueryTree<Boolean>
+        assertTrue(path0.value, "With context, expected true for the first endpoint")
+
+        path1 = q.children[1].children[0] as QueryTree<Boolean>
+        assertTrue(path1.value, "With context, expected true for the second endpoint")
+
+        path2 = q.children[2].children[0] as QueryTree<Boolean>
+        assertFalse(path2.value, "With context, expected false for the third endpoint")
+    }
+}

--- a/cpg-analysis/src/integrationTest/resources/python/context.py
+++ b/cpg-analysis/src/integrationTest/resources/python/context.py
@@ -1,0 +1,23 @@
+def endpoint1():
+    policy = "endpoint1"
+    # looks good
+    authorize(policy)
+
+
+def endpoint2():
+    policy = "endpoint2"
+    # looks good
+    authorize(policy)
+
+
+def endpoint3():
+    policy = "endpoint4"
+    # uh-uh, this is not good
+    authorize(policy)
+
+
+# This is a helper function to simulate the authorization process
+def authorize(policy: str) -> bool:
+    # This function simulates the authorization logic. The
+    # policy name should match the endpoint where it's coming from.
+    inner_authorize(policy)

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/FlowQueries.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/FlowQueries.kt
@@ -155,6 +155,7 @@ fun dataFlow(
     type: AnalysisType = May,
     vararg sensitivities: AnalysisSensitivity = FieldSensitive + ContextSensitive,
     scope: AnalysisScope = Interprocedural(),
+    ctx: Context = Context(steps = 0),
     earlyTermination: ((Node) -> Boolean)? = null,
     predicate: (Node) -> Boolean,
 ): QueryTree<Boolean> {
@@ -176,6 +177,7 @@ fun dataFlow(
                         direction = direction,
                         sensitivities = sensitivities,
                         scope = scope,
+                        ctx = ctx,
                         earlyTermination = earlyTermination,
                         predicate = predicate,
                     )


### PR DESCRIPTION
This makes it possible to provide a flow query context to `dataFlow`, e.g., gathered by a previous step.
