### PR TITLE
Split getArgumentByNameOrPosistion

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/EvaluationExtensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/EvaluationExtensions.kt
@@ -41,7 +41,7 @@ val NewArrayExpression.capacity: Int
 
 /**
  * A little helper function to find a [CallExpression]s argument [Node] by argument [name] or
- * argument [position].
+ * argument [position]. The function prioritizes resolution by [name] over the [position].
  *
  * @param this The [CallExpression] to analyze.
  * @param name Optionally: the [CallExpression.arguments] name.


### PR DESCRIPTION
A helper function to fetch a CallExpressions argument by its name or position.