### PR TITLE
Fixing a loop in the exporter that considers the astParent 

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationConfiguration.kt
@@ -107,6 +107,7 @@ private constructor(
      * passes. It can either be filled with the [Builder.replacePass] or by using the [ReplacePass]
      * annotation on a [LanguageFrontend].
      */
+    @JsonIgnore
     val replacedPasses:
         Map<Pair<KClass<out Pass<out Node>>, KClass<out Language<*>>>, KClass<out Pass<out Node>>>,
     /** This list contains the files with function summaries which should be considered. */

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -162,7 +162,7 @@ abstract class Node() :
     var astChildren: List<Node> = listOf()
         get() = SubgraphWalker.getAstChildren(this)
 
-    @DoNotPersist @Transient var astParent: Node? = null
+    @DoNotPersist @Transient @JsonIgnore var astParent: Node? = null
 
     /** Virtual property for accessing [prevEOGEdges] without property edges. */
     @PopulatedByPass(EvaluationOrderGraphPass::class) var prevEOG by unwrapping(Node::prevEOGEdges)


### PR DESCRIPTION
The `astParent` that we already ignore through `@Transient` and `@DoNotPersist` in other serializers or Transfers to persistent data, here picks up the field. I therefore added `@JSONIgnore`.

Closes #2370 