### PR TITLE
Made `name` of translation unit a relative path and not depending on the system

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationBuilder.kt
@@ -59,7 +59,7 @@ fun MetadataProvider.newTranslationUnitDeclaration(
     // machines.
     val relativeName =
         if (path.isAbsolute) {
-            val topLevel = provider.ctx.currentComponent?.topLevel() ?: path.parent.toFile()
+            val topLevel = path.topLevel
             path.toFile().relativeToOrNull(topLevel)?.toString() ?: path.fileName?.toString()
         } else {
             name

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
@@ -76,7 +76,7 @@ fun LanguageFrontend<*, *>.translationUnit(
     name: CharSequence = Node.EMPTY_NAME,
     init: TranslationUnitDeclaration.() -> Unit,
 ): TranslationUnitDeclaration {
-    val node = newTranslationUnitDeclaration(name)
+    val node = with(this) { newTranslationUnitDeclaration(name) }
 
     scopeManager.resetToGlobal(node)
     init(node)


### PR DESCRIPTION
This made our node IDs dependend on the analysis system.
