### PR TITLE
Upgrade SootUp to 2.0.0

### DIFF
--- a/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/ExpressionHandler.kt
+++ b/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/ExpressionHandler.kt
@@ -43,6 +43,7 @@ class ExpressionHandler(frontend: JVMLanguageFrontend) :
     Handler<Expression, Value, JVMLanguageFrontend>(::ProblemExpression, frontend) {
 
     init {
+        map.put(JCaughtExceptionRef::class.java) { handleExceptionRef(it as JCaughtExceptionRef) }
         map.put(Local::class.java) { handleLocal(it as Local) }
         map.put(JavaLocal::class.java) { handleLocal(it as Local) }
         map.put(JThisRef::class.java) { handleThisRef(it as JThisRef) }
@@ -116,6 +117,12 @@ class ExpressionHandler(frontend: JVMLanguageFrontend) :
         map.put(StringConstant::class.java) { handleStringConstant(it as StringConstant) }
         map.put(NullConstant::class.java) { handleNullConstant(it as NullConstant) }
         map.put(ClassConstant::class.java) { handleClassConstant(it as ClassConstant) }
+    }
+
+    private fun handleExceptionRef(exceptionRef: JCaughtExceptionRef): Expression {
+        return newReference(name = "@caughtexception").apply {
+            this.type = frontend.typeOf(exceptionRef.type)
+        }
     }
 
     private fun handleLocal(local: Local): Expression {

--- a/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMLanguage.kt
+++ b/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMLanguage.kt
@@ -31,7 +31,7 @@ import kotlin.reflect.KClass
 
 class JVMLanguage : Language<JVMLanguageFrontend>() {
     override val fileExtensions: List<String>
-        get() = listOf("class", "java", "jimple", "jar")
+        get() = listOf("class", "java", "jimple", "jar", "apk")
 
     override val namespaceDelimiter: String
         get() = "."

--- a/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/StatementHandler.kt
+++ b/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/StatementHandler.kt
@@ -31,21 +31,43 @@ import de.fraunhofer.aisec.cpg.graph.statements.*
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.AssignExpression
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Block
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.ProblemExpression
+import kotlin.jvm.optionals.getOrNull
 import sootup.core.jimple.common.stmt.*
 import sootup.core.model.Body
 import sootup.core.util.printer.NormalStmtPrinter
 
 class StatementHandler(frontend: JVMLanguageFrontend) :
-    Handler<Statement, Any, JVMLanguageFrontend>(::ProblemExpression, frontend) {
-    init {
-        map.put(Body::class.java) { handleBody(it as Body) }
-        map.put(JAssignStmt::class.java) { handleAbstractDefinitionStmt(it as JAssignStmt) }
-        map.put(JIdentityStmt::class.java) { handleAbstractDefinitionStmt(it as JIdentityStmt) }
-        map.put(JIfStmt::class.java) { handleIfStmt(it as JIfStmt) }
-        map.put(JGotoStmt::class.java) { handleGotoStmt(it as JGotoStmt) }
-        map.put(JInvokeStmt::class.java) { handleInvokeStmt(it as JInvokeStmt) }
-        map.put(JReturnStmt::class.java) { handleReturnStmt(it as JReturnStmt) }
-        map.put(JReturnVoidStmt::class.java) { handleReturnVoidStmt(it as JReturnVoidStmt) }
+    Handler<Statement?, Any, JVMLanguageFrontend>(::ProblemExpression, frontend) {
+
+    override fun handle(ctx: Any): Statement? {
+        return when (ctx) {
+            is Body -> handleBody(ctx)
+            is JAssignStmt -> handleAbstractDefinitionStmt(ctx)
+            is JIdentityStmt -> handleAbstractDefinitionStmt(ctx)
+            is JIfStmt -> handleIfStmt(ctx)
+            is JGotoStmt -> handleGotoStmt(ctx)
+            is JInvokeStmt -> handleInvokeStmt(ctx)
+            is JReturnStmt -> handleReturnStmt(ctx)
+            is JReturnVoidStmt -> handleReturnVoidStmt(ctx)
+            is JThrowStmt -> handleThrowExpression(ctx)
+            is JNopStmt -> newEmptyStatement(ctx)
+            else -> {
+                log.error("Unhandled statement type: ${ctx.javaClass.simpleName}")
+                newProblemExpression(
+                    "Unhandled statement type: ${ctx.javaClass.simpleName}",
+                    rawNode = ctx,
+                )
+            }
+        }
+    }
+
+    private fun handleThrowExpression(throwStmt: JThrowStmt): ThrowExpression {
+        val expr = newThrowExpression(rawNode = throwStmt)
+        expr.exception =
+            frontend.expressionHandler.handle(throwStmt.op)
+                ?: newProblemExpression("missing throwable expression")
+
+        return expr
     }
 
     private fun handleBody(body: Body): Block {
@@ -150,7 +172,9 @@ class StatementHandler(frontend: JVMLanguageFrontend) :
     }
 
     private fun handleInvokeStmt(invokeStmt: JInvokeStmt) =
-        frontend.expressionHandler.handle(invokeStmt.invokeExpr)
+        invokeStmt.invokeExpr.getOrNull()?.let { invokeExpr ->
+            frontend.expressionHandler.handle(invokeExpr)
+        }
 
     private fun handleReturnStmt(returnStmt: JReturnStmt): ReturnStatement {
         val stmt = newReturnStatement(rawNode = returnStmt)

--- a/cpg-language-jvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMLanguageFrontendTest.kt
+++ b/cpg-language-jvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMLanguageFrontendTest.kt
@@ -189,6 +189,25 @@ class JVMLanguageFrontendTest {
         tu.methods.forEach { println(it.code) }
     }
 
+    @Ignore
+    @Test
+    fun testHelloWorldApk() {
+        // This will be our classpath
+        val topLevel = Path.of("src", "test", "resources", "apk", "HelloWorld")
+        val tu =
+            analyzeAndGetFirstTU(
+                // In case of a jar, the jar is directly used as a class path
+                listOf(topLevel.resolve("app-debug.apk").toFile()),
+                topLevel,
+                true,
+            ) {
+                it.registerLanguage<JVMLanguage>()
+            }
+        assertNotNull(tu)
+        assertEquals(0, tu.problems.size)
+        tu.methods.forEach { println(it.code) }
+    }
+
     @Test
     fun testInheritanceClass() {
         // This will be our classpath

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ neo4j5 = "5.28.2"
 log4j = "2.24.0"
 spotless = "7.0.4"
 publish = "0.32.0"
-sootup = "1.3.0"
+sootup = "2.0.0"
 slf4j = "2.0.16"
 clikt = "5.0.2"
 kaml = "0.82.0"
@@ -78,14 +78,15 @@ spotless-gradle = { module = "com.diffplug.spotless:spotless-plugin-gradle", ver
 
 sootup-core = { module = "org.soot-oss:sootup.core", version.ref = "sootup" }
 sootup-java-core = { module = "org.soot-oss:sootup.java.core", version.ref = "sootup" }
-sootup-java-sourcecode = { module = "org.soot-oss:sootup.java.sourcecode", version.ref = "sootup" }
-sootup-java-bytecode = { module = "org.soot-oss:sootup.java.bytecode", version.ref = "sootup" }
-sootup-jimple-parser = { module = "org.soot-oss:sootup.jimple.parser", version.ref = "sootup" }
+sootup-java-sourcecode = { module = "org.soot-oss:sootup.java.sourcecode.frontend", version.ref = "sootup" }
+sootup-java-bytecode = { module = "org.soot-oss:sootup.java.bytecode.frontend", version.ref = "sootup" }
+sootup-apk = { module = "org.soot-oss:sootup.apk.frontend", version.ref = "sootup" }
+sootup-jimple = { module = "org.soot-oss:sootup.jimple.frontend", version.ref = "sootup" }
 
 [bundles]
 log4j = ["log4j-impl", "log4j-core"]
 neo4j = ["neo4j-ogm-core", "neo4j-ogm-bolt-driver"]
-sootup = ["sootup-core", "sootup-java-core", "sootup-java-sourcecode", "sootup-java-bytecode", "sootup-jimple-parser"]
+sootup = ["sootup-core", "sootup-java-core", "sootup-java-sourcecode", "sootup-java-bytecode", "sootup-jimple", "sootup-apk"]
 ktor = ["ktor-server-core", "ktor-server-netty", "ktor-server-cors","ktor-server-content-negotiation", "ktor-serialization-kotlinx-json"]
 
 [plugins]


### PR DESCRIPTION
We're currently stuck in SootUp version 1.3.0 due to some breaking API changes in subsequent versions. This PR upgrades to the most recent version 2.0.0 and also tries to enable analysis of apk files. However, the latter does not work properly yet and we fail with an OutOfMemoryException. This problem needs further investigation.