### PR TITLE
Added API to return methods of a `Type`

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -197,6 +197,7 @@ class ScopeManager(override var ctx: TranslationContext) : ScopeProvider, Contex
             )
             return
         }
+
         scopeMap[scope.astNode] = scope
         if (scope is NameScope) {
             // for this to work, it is essential that RecordDeclaration and NamespaceDeclaration
@@ -266,6 +267,11 @@ class ScopeManager(override var ctx: TranslationContext) : ScopeProvider, Contex
         var existing = scopeMap[nodeToScope]
         if (existing != null) {
             currentScope = existing
+        }
+
+        // Update the "declaresScope", if the node is a declaration that declares a scope
+        if (nodeToScope is Declaration) {
+            nodeToScope.declaringScope = currentScope
         }
     }
 
@@ -870,15 +876,6 @@ class ScopeManager(override var ctx: TranslationContext) : ScopeProvider, Contex
     fun <TypeToInfer : Node> translationUnitForInference(source: Node): TranslationUnitDeclaration {
         return source.language.translationUnitForInference<TypeToInfer>(source)
     }
-
-    /**
-     * Returns the [Scope] that this [Declaration] declares. For example, for a [RecordDeclaration],
-     * this will return the [RecordScope] of the particular record or class.
-     */
-    val Declaration.declaringScope: Scope?
-        get() {
-            return lookupScope(this)
-        }
 }
 
 fun <T : Declaration> ContextProvider.declare(declaration: T): T {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -349,8 +349,9 @@ class ScopeManager(override var ctx: TranslationContext) : ScopeProvider, Contex
      *
      * @param declaration the declaration to add
      */
-    fun addDeclaration(declaration: Declaration) {
+    fun <T : Declaration> addDeclaration(declaration: T): T {
         currentScope.addSymbol(declaration.symbol, declaration)
+        return declaration
     }
 
     /**
@@ -869,6 +870,19 @@ class ScopeManager(override var ctx: TranslationContext) : ScopeProvider, Contex
     fun <TypeToInfer : Node> translationUnitForInference(source: Node): TranslationUnitDeclaration {
         return source.language.translationUnitForInference<TypeToInfer>(source)
     }
+
+    /**
+     * Returns the [Scope] that this [Declaration] declares. For example, for a [RecordDeclaration],
+     * this will return the [RecordScope] of the particular record or class.
+     */
+    val Declaration.declaringScope: Scope?
+        get() {
+            return lookupScope(this)
+        }
+}
+
+fun <T : Declaration> ContextProvider.declare(declaration: T): T {
+    return ctx.scopeManager.addDeclaration(declaration)
 }
 
 /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Declaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Declaration.kt
@@ -27,6 +27,8 @@ package de.fraunhofer.aisec.cpg.graph.declarations
 
 import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.scopes.RecordScope
+import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.graph.scopes.Symbol
 import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
 import org.neo4j.ogm.annotation.NodeEntity
@@ -47,6 +49,12 @@ abstract class Declaration : AstNode() {
         get() {
             return this.name.localName
         }
+
+    /**
+     * Returns the [Scope] that this [Declaration] declares (if it does). For example, for a
+     * [RecordDeclaration], this will return the [RecordScope] of the particular record or class.
+     */
+    var declaringScope: Scope? = null
 
     override fun getExitNextEOG(): Collection<Node> {
         return setOf()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/GlobalScope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/GlobalScope.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.graph.scopes
 
 import de.fraunhofer.aisec.cpg.ScopeManager
 import de.fraunhofer.aisec.cpg.TranslationManager
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.graph.nodes
 
@@ -63,8 +64,13 @@ class GlobalScope() : Scope(null) {
             wildcardImports.addAll(other.wildcardImports)
 
             for (node in other.astNode?.nodes ?: listOf()) {
-                if (node.scope is GlobalScope) {
-                    node.scope = this
+                when {
+                    // If the node's scope is the global scope, we need to update it to point to
+                    // this (the new global scope)
+                    node.scope is GlobalScope -> node.scope = this
+                    // If the node is a declaration, we also need to update the declaring scope
+                    node is Declaration && node.declaringScope is GlobalScope ->
+                        node.declaringScope = this
                 }
             }
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ObjectType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ObjectType.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.PopulatedByPass
 import de.fraunhofer.aisec.cpg.frontends.Language
+import de.fraunhofer.aisec.cpg.graph.declarations.ConstructorDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.FieldDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration
@@ -121,6 +122,15 @@ open class ObjectType : Type, HasSecondaryTypeEdge {
 
     override val secondaryTypes: List<Type>
         get() = generics
+
+    /**
+     * Returns all constructors that are declared in this type and its super types. See
+     * [findMembers] for more details.
+     */
+    val constructors: Set<ConstructorDeclaration>
+        get() {
+            return findMembers<ConstructorDeclaration>()
+        }
 
     /**
      * Returns all methods that are declared in this type and its super types. See [findMembers] for

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ObjectType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ObjectType.kt
@@ -27,7 +27,6 @@ package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.PopulatedByPass
 import de.fraunhofer.aisec.cpg.frontends.Language
-import de.fraunhofer.aisec.cpg.graph.ContextProvider
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.FieldDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration
@@ -127,7 +126,6 @@ open class ObjectType : Type, HasSecondaryTypeEdge {
      * Returns all methods that are declared in this type and its super types. See [findMembers] for
      * more details.
      */
-    context(provider: ContextProvider)
     val methods: Set<MethodDeclaration>
         get() {
             return findMembers<MethodDeclaration>()
@@ -137,7 +135,6 @@ open class ObjectType : Type, HasSecondaryTypeEdge {
      * Returns all fields that are declared in this type and its super types. See [findMembers] for
      * more details.
      */
-    context(provider: ContextProvider)
     val fields: Set<FieldDeclaration>
         get() {
             return findMembers<FieldDeclaration>()
@@ -148,7 +145,6 @@ open class ObjectType : Type, HasSecondaryTypeEdge {
      * types. We use the underlying [recordDeclaration] of the type to find the [Scope] it declares
      * and then look for appropriate symbols pointing to a [Declaration].
      */
-    context(provider: ContextProvider)
     private inline fun <reified T : Declaration> findMembers(): Set<T> {
         // We need to gather all members that are in within the scope of the underlying record
         // declaration, as well as their super types
@@ -161,14 +157,12 @@ open class ObjectType : Type, HasSecondaryTypeEdge {
             val next = worklist.removeFirst()
 
             // Add all members in the declaring scope
-            with(provider.ctx.scopeManager) {
-                next.recordDeclaration
-                    ?.declaringScope
-                    ?.symbols
-                    ?.values
-                    ?.flatten()
-                    ?.filterIsInstanceTo(members)
-            }
+            next.recordDeclaration
+                ?.declaringScope
+                ?.symbols
+                ?.values
+                ?.flatten()
+                ?.filterIsInstanceTo(members)
 
             // Add super types
             worklist += next.superTypes

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ObjectType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/ObjectType.kt
@@ -28,9 +28,11 @@ package de.fraunhofer.aisec.cpg.graph.types
 import de.fraunhofer.aisec.cpg.PopulatedByPass
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.ContextProvider
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
+import de.fraunhofer.aisec.cpg.graph.declarations.FieldDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
-import de.fraunhofer.aisec.cpg.graph.methods
+import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.graph.types.PointerType.PointerOrigin
 import de.fraunhofer.aisec.cpg.graph.unknownType
 import de.fraunhofer.aisec.cpg.helpers.identitySetOf
@@ -121,34 +123,58 @@ open class ObjectType : Type, HasSecondaryTypeEdge {
     override val secondaryTypes: List<Type>
         get() = generics
 
+    /**
+     * Returns all methods that are declared in this type and its super types. See [findMembers] for
+     * more details.
+     */
     context(provider: ContextProvider)
     val methods: Set<MethodDeclaration>
         get() {
-            // We need to gather all methods that are in within the scope of the underlying record
-            // declaration, as well as their super types
-            val methods = mutableSetOf<MethodDeclaration>()
+            return findMembers<MethodDeclaration>()
+        }
 
-            // Gather all methods of this type and its super-types
-            val worklist = mutableListOf<Type>(this)
-            val alreadySeen = identitySetOf<Type>()
-            while (worklist.isNotEmpty()) {
-                val next = worklist.removeFirst()
+    /**
+     * Returns all fields that are declared in this type and its super types. See [findMembers] for
+     * more details.
+     */
+    context(provider: ContextProvider)
+    val fields: Set<FieldDeclaration>
+        get() {
+            return findMembers<FieldDeclaration>()
+        }
 
-                // Add all methods in the declaring scope
-                with(provider.ctx.scopeManager) {
-                    next.recordDeclaration
-                        ?.declaringScope
-                        ?.symbols
-                        ?.values
-                        ?.flatten()
-                        ?.filterIsInstanceTo(methods)
-                }
+    /**
+     * Returns all [Declaration] nodes (of type [T]) that are declared in this type and its super
+     * types. We use the underlying [recordDeclaration] of the type to find the [Scope] it declares
+     * and then look for appropriate symbols pointing to a [Declaration].
+     */
+    context(provider: ContextProvider)
+    private inline fun <reified T : Declaration> findMembers(): Set<T> {
+        // We need to gather all members that are in within the scope of the underlying record
+        // declaration, as well as their super types
+        val members = mutableSetOf<T>()
 
-                // Add super types
-                worklist += next.superTypes
-                alreadySeen.add(next)
+        // Gather all members of this type and its super-types
+        val worklist = mutableListOf<Type>(this)
+        val alreadySeen = identitySetOf<Type>()
+        while (worklist.isNotEmpty()) {
+            val next = worklist.removeFirst()
+
+            // Add all members in the declaring scope
+            with(provider.ctx.scopeManager) {
+                next.recordDeclaration
+                    ?.declaringScope
+                    ?.symbols
+                    ?.values
+                    ?.flatten()
+                    ?.filterIsInstanceTo(members)
             }
 
-            return methods.toSet()
+            // Add super types
+            worklist += next.superTypes
+            alreadySeen.add(next)
         }
+
+        return members.toSet()
+    }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/ScopeTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/ScopeTest.kt
@@ -27,18 +27,20 @@ package de.fraunhofer.aisec.cpg.graph.scopes
 
 import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.newBlock
+import de.fraunhofer.aisec.cpg.graph.newFunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.newLookupScopeStatement
 import de.fraunhofer.aisec.cpg.graph.newVariableDeclaration
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 
 class ScopeTest {
     @Test
     fun testLookup() {
         with(TestLanguageFrontend()) {
             // some mock variable declarations, global and local
-            var globalA = newVariableDeclaration("a")
-            var localA = newVariableDeclaration("a")
+            val globalA = newVariableDeclaration("a")
+            val localA = newVariableDeclaration("a")
 
             // two scopes, global and local
             val globalScope = GlobalScope()
@@ -48,20 +50,32 @@ class ScopeTest {
             scope.addSymbol("a", localA)
 
             // if we try to resolve "a" now, this should point to the local A since we start there
-            // and
-            // move upwards
+            // and move upwards
             var result = scope.lookupSymbol("a")
             assertEquals(listOf(localA), result)
 
             // now, we pretend to have a lookup scope modifier for a symbol, e.g. through "global"
-            // in
-            // Python
-            var stmt = newLookupScopeStatement(listOf("a"), targetScope = globalScope)
+            // in Python
+            val stmt = newLookupScopeStatement(listOf("a"), targetScope = globalScope)
             scope.predefinedLookupScopes["a"] = stmt
 
             // let's try the lookup again, this time it should point to the global A
             result = scope.lookupSymbol("a")
             assertEquals(listOf(globalA), result)
+        }
+    }
+
+    @Test
+    fun testDeclaringScope() {
+        with(TestLanguageFrontend()) {
+            val func = newFunctionDeclaration("foo")
+            scopeManager.enterScope(func)
+
+            scopeManager.leaveScope(func)
+
+            val scope = func.declaringScope
+            assertIs<FunctionScope>(scope)
+            assertEquals(func, scope.astNode)
         }
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/ObjectTypeTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/ObjectTypeTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.graph.types
+
+import de.fraunhofer.aisec.cpg.declare
+import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.newMethodDeclaration
+import de.fraunhofer.aisec.cpg.graph.newRecordDeclaration
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+
+class ObjectTypeTest {
+    @Test
+    fun testMethods() {
+        with(TestLanguageFrontend()) {
+            val parent = newRecordDeclaration("parent", kind = "class")
+            scopeManager.enterScope(parent)
+            val foo = declare(newMethodDeclaration("foo"))
+            parent.methods += foo
+            scopeManager.leaveScope(parent)
+
+            val child = newRecordDeclaration("child", kind = "class")
+            scopeManager.enterScope(child)
+            val bar = declare(newMethodDeclaration("bar"))
+            child.methods += bar
+            child.superClasses += parent.toType()
+            scopeManager.leaveScope(child)
+
+            val childType = child.toType()
+
+            assertIs<ObjectType>(childType)
+            val methods = childType.methods
+            assertNotNull(methods)
+        }
+    }
+}

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/ObjectTypeTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/types/ObjectTypeTest.kt
@@ -30,6 +30,7 @@ import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.newMethodDeclaration
 import de.fraunhofer.aisec.cpg.graph.newRecordDeclaration
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 
@@ -53,8 +54,26 @@ class ObjectTypeTest {
             val childType = child.toType()
 
             assertIs<ObjectType>(childType)
+
             val methods = childType.methods
             assertNotNull(methods)
+            assertEquals(
+                setOf(foo, bar),
+                methods,
+                "Child type should have methods from itself and parent",
+            )
+
+            val fields = childType.fields
+            assertNotNull(fields)
+            assertEquals(0, fields.size, "Child type should not have any fields defined")
+
+            val constructors = childType.constructors
+            assertNotNull(constructors)
+            assertEquals(
+                0,
+                constructors.size,
+                "Child type should not have any constructors defined",
+            )
         }
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/persistence/TestCommon.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/persistence/TestCommon.kt
@@ -62,6 +62,7 @@ class TestCommon {
                 "AST",
                 "BODY",
                 "CDG",
+                "DECLARING_SCOPE",
                 "DEFINES",
                 "DFG",
                 "EOG",


### PR DESCRIPTION
This PR adds (virtual) properties to `ObjectType` to query methods, constructors and fields of a *Type*. Previously this was done via the `RecordDeclaration`.  However, this added confusion when languages declared methods and fields outside of the class construct itself. It was never clear whether to add fields and methods to the `fields` and `methods` property of a `RecordDeclaration`, which is actually an AST element.

This does not (yet) remove `fields` and `methods` from `RecordDeclaration`, this is done in a separate PR.