### PR TITLE
Introduction of an `AstNode`

### DIFF
--- a/codyze-console/src/main/kotlin/de/fraunhofer/aisec/codyze/console/Nodes.kt
+++ b/codyze-console/src/main/kotlin/de/fraunhofer/aisec/codyze/console/Nodes.kt
@@ -375,7 +375,9 @@ fun Node.toJSON(noEdges: Boolean = false): NodeJSON {
                 val path = uri.toString()
                 path.substringAfterLast('/').substringAfterLast('\\')
             },
-        astChildren = if (noEdges) emptyList() else this.astChildren.map { it.toJSON() },
+        astChildren =
+            if (noEdges) emptyList()
+            else (this as? AstNode)?.astChildren?.map { it.toJSON() } ?: emptyList(),
         prevDFG = if (noEdges) emptyList() else this.prevDFGEdges.map { it.toJSON() },
         nextDFG = if (noEdges) emptyList() else this.nextDFGEdges.map { it.toJSON() },
         translationUnitId = this.translationUnit?.id,

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGPass.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/UnreachableEOGPass.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationContext
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.edges.flows.EvaluationOrder
@@ -39,6 +40,7 @@ import de.fraunhofer.aisec.cpg.helpers.functional.Lattice
 import de.fraunhofer.aisec.cpg.helpers.functional.MapLattice
 import de.fraunhofer.aisec.cpg.helpers.functional.Order
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
+import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 
 /**
  * A [Pass] which uses a simple logic to determine constant values and mark unreachable code regions
@@ -52,9 +54,12 @@ open class UnreachableEOGPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
     }
 
     override fun accept(node: Node) {
-        val walker = SubgraphWalker.IterativeGraphWalker()
+        val walker = SubgraphWalker.IterativeGraphWalker(strategy = Strategy::AST_FORWARD)
         walker.registerOnNodeVisit(::handle)
-        walker.iterate(node)
+
+        if (node is AstNode) {
+            walker.iterate(node)
+        }
     }
 
     /**

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/FlowQueries.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/query/FlowQueries.kt
@@ -547,11 +547,11 @@ internal fun Node.alwaysFlowsToInternal(
                     node = nodeToTrack.node,
                     terminationReason =
                         if (failureReason == FailureReason.PATH_ENDED) {
-                            PathEnded(nodes.last())
+                            PathEnded(path.nodes.last())
                         } else if (failureReason == FailureReason.HIT_EARLY_TERMINATION) {
-                            HitEarlyTermination(nodes.last())
+                            HitEarlyTermination(path.nodes.last())
                         } else {
-                            StepsExceeded(nodes.last())
+                            StepsExceeded(path.nodes.last())
                         },
                     operator = GenericQueryOperators.EVALUATE,
                 )

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extension.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extension.kt
@@ -31,27 +31,37 @@ import org.reflections.Reflections
 import org.reflections.scanners.Scanners.SubTypes
 
 /**
- * Retrieves a set of all [Concept] nodes associated with this [Node] and its AST children
- * ([Node.nodes]).
+ * Retrieves a set of all [Concept] nodes associated with this [Node] and its AST children (if this
+ * is an [AstNode], see [AstNode.nodes]).
  *
- * @return A set containing all [Concept] nodes found in the overlays of the [Node] and its
- *   children.
+ * @return A set containing all [Concept] nodes found in the overlays of the [Node] and its eventual
+ *   AST children.
  */
-val AstNode.conceptNodes: Set<Concept>
-    get() = this.nodes.flatMapTo(mutableSetOf()) { it.overlays.filterIsInstance<Concept>() }
+val Node.conceptNodes: Set<Concept>
+    get() {
+        return allOverlays<Concept>()
+    }
 
 /**
- * Retrieves a set of all [Operation] nodes associated with this [Node] and its AST children
- * ([Node.nodes]).
+ * Retrieves a set of all [Operation] nodes associated with this [Node] and its AST children (if
+ * this is an [AstNode], see [AstNode.nodes]).
  *
  * @return A set containing all [Operation] nodes found in the overlays of the [Node] and its
- *   children.
+ *   eventual AST children.
  */
 val Node.operationNodes: Set<Operation>
-    get() =
-        (this as? AstNode).nodes.flatMapTo(mutableSetOf()) {
-            it.overlays.filterIsInstance<Operation>()
-        }
+    get() {
+        return allOverlays<Operation>()
+    }
+
+/**
+ * Retrieves a set of all [T] overlay nodes associated with this [Node] and its AST children (if
+ * this is an [AstNode], see [AstNode.nodes]).
+ */
+inline fun <reified T : OverlayNode> Node.allOverlays(): Set<T> {
+    return (this as? AstNode)?.nodes?.flatMap { it.overlays }?.filterIsInstance<T>()?.toSet()
+        ?: emptySet()
+}
 
 /** Returns a [Set] of all subclasses of the class [T]. */
 inline fun <reified T : OverlayNode> listOverlayClasses(

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extension.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extension.kt
@@ -37,7 +37,7 @@ import org.reflections.scanners.Scanners.SubTypes
  * @return A set containing all [Concept] nodes found in the overlays of the [Node] and its
  *   children.
  */
-val Node.conceptNodes: Set<Concept>
+val AstNode.conceptNodes: Set<Concept>
     get() = this.nodes.flatMapTo(mutableSetOf()) { it.overlays.filterIsInstance<Concept>() }
 
 /**
@@ -48,7 +48,10 @@ val Node.conceptNodes: Set<Concept>
  *   children.
  */
 val Node.operationNodes: Set<Operation>
-    get() = this.nodes.flatMapTo(mutableSetOf()) { it.overlays.filterIsInstance<Operation>() }
+    get() =
+        (this as? AstNode).nodes.flatMapTo(mutableSetOf()) {
+            it.overlays.filterIsInstance<Operation>()
+        }
 
 /** Returns a [Set] of all subclasses of the class [T]. */
 inline fun <reified T : OverlayNode> listOverlayClasses(

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/ConceptPass.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/ConceptPass.kt
@@ -46,12 +46,11 @@ import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
  */
 abstract class ConceptPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {
 
-    lateinit var walker: SubgraphWalker.ScopedWalker
+    lateinit var walker: SubgraphWalker.ScopedWalker<Node>
 
     override fun accept(tu: TranslationUnitDeclaration) {
         ctx.currentComponent = tu.component
-        walker = SubgraphWalker.ScopedWalker(ctx.scopeManager)
-        walker.strategy = Strategy::EOG_FORWARD
+        walker = SubgraphWalker.ScopedWalker(ctx.scopeManager, Strategy::EOG_FORWARD)
         walker.registerHandler { node -> handleNode(node, tu) }
 
         // Gather all resolution EOG starters; and make sure they really do not have a

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationResult.kt
@@ -62,7 +62,7 @@ class TranslationResult(
      * dedicated [ScopeManager] each). This property will contain the final, merged context.
      */
     var finalCtx: TranslationContext,
-) : Node(), StatisticsHolder, ContextProvider {
+) : AstNode(), StatisticsHolder, ContextProvider {
 
     @Relationship("COMPONENTS") val componentEdges = astEdgesOf<Component>()
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/FrontendUtils.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/FrontendUtils.kt
@@ -116,7 +116,7 @@ class FrontendUtils {
          * the same line, the comment is matched to that closest predecessor.
          */
         fun matchCommentToNode(comment: String, location: Region, tu: TranslationUnitDeclaration) {
-            val nodes: List<Node> = SubgraphWalker.flattenAST(tu)
+            val nodes = SubgraphWalker.flattenAST(tu)
 
             // Get a List of all Nodes that enclose the comment
             var enclosingNodes =

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
@@ -35,6 +35,7 @@ import de.fraunhofer.aisec.cpg.SignatureResult
 import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.ancestors
 import de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.ContextProvider
 import de.fraunhofer.aisec.cpg.graph.Name
@@ -577,7 +578,7 @@ class MultipleLanguages(val languages: Set<Language<*>>) : Language<Nothing>() {
  * Returns the single language of a node and its children. If the node has multiple children with
  * different languages, it returns a [MultipleLanguages] object.
  */
-fun Node.multiLanguage(): Language<*> {
+fun AstNode.multiLanguage(): Language<*> {
     val languages = astChildren.map { it.language }.toSet()
     return if (languages.size == 1) {
         languages.single()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Annotation.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Annotation.kt
@@ -28,7 +28,7 @@ package de.fraunhofer.aisec.cpg.graph
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 import java.util.*
 
-class Annotation : Node() {
+class Annotation : AstNode() {
     var members = mutableListOf<AnnotationMember>()
 
     fun getValueForName(name: String): Expression? {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/AstNode.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/AstNode.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.graph
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
+import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
+import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
+import de.fraunhofer.aisec.cpg.graph.statements.Statement
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
+import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
+import org.neo4j.ogm.annotation.Relationship
+
+/**
+ * This is the base class for all AST nodes in the CPG. It is used to represent any node in the
+ * abstract syntax tree (AST) of a program. It serves as a base class for more specific node types
+ * such as [Statement]s, [Expression]s, [Declaration]s, etc.
+ */
+abstract class AstNode : Node() {
+
+    /**
+     * Virtual property to return a list of the node's children. Uses the [SubgraphWalker] to
+     * retrieve the appropriate nodes.
+     *
+     * Note: This only returns the *direct* children of this node. If you want to have *all*
+     * children, e.g., a flattened AST, you need to call [AstNode.allChildren].
+     *
+     * For Neo4J OGM, this relationship will be automatically filled by a pre-save event before OGM
+     * persistence. Therefore, this property is a `var` and not a `val`.
+     */
+    @Relationship("AST")
+    @JsonIgnore
+    var astChildren: List<AstNode> = listOf()
+        get() = SubgraphWalker.getAstChildren(this)
+
+    /** List of [Annotation]s associated with that node. */
+    @Relationship("ANNOTATIONS") var annotationEdges = astEdgesOf<Annotation>()
+    var annotations by unwrapping(AstNode::annotationEdges)
+
+    override fun disconnectFromGraph() {
+        super.disconnectFromGraph()
+
+        // Disconnect all AST children first
+        astChildren.forEach { it.disconnectFromGraph() }
+    }
+}

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/BranchingNode.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/BranchingNode.kt
@@ -28,5 +28,5 @@ package de.fraunhofer.aisec.cpg.graph
 /** A node triggering a conditional execution of other code. */
 interface BranchingNode {
     /** The node which affects the next EOG edge. Typically, this is a condition or similar. */
-    val branchedBy: Node?
+    val branchedBy: AstNode?
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Component.kt
@@ -48,7 +48,7 @@ import org.neo4j.ogm.annotation.Transient
  * entry points or interactions with other software.
  */
 @Suppress("CONTEXT_RECEIVERS_DEPRECATED")
-open class Component : Node() {
+open class Component : AstNode() {
     @Relationship("TRANSLATION_UNITS")
     val translationUnitEdges = astEdgesOf<TranslationUnitDeclaration>()
     /** All translation units belonging to this application. */

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationHolder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationHolder.kt
@@ -46,11 +46,11 @@ interface DeclarationHolder {
         }
     }
 
-    fun <T : Node, P : AstEdge<T>> addIfNotContains(collection: AstEdges<T, P>, declaration: T) {
+    fun <T : AstNode, P : AstEdge<T>> addIfNotContains(collection: AstEdges<T, P>, declaration: T) {
         addIfNotContains(collection, declaration, true)
     }
 
-    fun <T : Node, P : Edge<T>> addIfNotContains(collection: EdgeList<T, P>, declaration: T) {
+    fun <T : AstNode, P : Edge<T>> addIfNotContains(collection: EdgeList<T, P>, declaration: T) {
         addIfNotContains(collection, declaration, true)
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -54,7 +54,7 @@ import kotlin.math.absoluteValue
  * @param predicate Indicates if the node should be included in the result.
  */
 @JvmOverloads
-inline fun <reified T> Node?.allChildren(
+inline fun <reified T> AstNode?.allChildren(
     noinline stopAtNode: (Node) -> Boolean = { false },
     noinline predicate: ((T) -> Boolean)? = null,
 ): List<T> {
@@ -92,7 +92,7 @@ fun Node.hasLocation(pathSuffix: String?, startLine: Int?, endLine: Int?): Boole
 inline fun <reified T> Node?.allChildrenWithOverlays(
     noinline predicate: ((T) -> Boolean)? = null
 ): List<T> {
-    val nodes = SubgraphWalker.flattenAST(this)
+    val nodes = SubgraphWalker.flattenAST(this as AstNode?)
     val nodesWithOverlays = nodes + nodes.flatMap { it.overlays }
     val filtered = nodesWithOverlays.filterIsInstance<T>()
 
@@ -118,7 +118,7 @@ inline fun <reified T : OverlayNode> Node.hasOverlay(): Boolean {
  * include retrieving it from either an individual [TranslationUnitDeclaration] or the complete
  * [TranslationResult].
  */
-val Node.allEOGStarters: List<Node>
+val AstNode.allEOGStarters: List<Node>
     get() {
         return this.allChildren<EOGStarterHolder>().flatMap { it.eogStarters }.distinct()
     }
@@ -127,7 +127,7 @@ val Node.allEOGStarters: List<Node>
  * Returns all EOG starters of this node that have no predecessors in the EOG as well as the node
  * itself if it is an EOG "single", in a way that is has neither a previous nor next EOG edge.
  */
-val Node.allUniqueEOGStartersOrSingles: List<Node>
+val AstNode.allUniqueEOGStartersOrSingles: List<Node>
     get() {
         return (allEOGStarters.filter { it.prevEOGEdges.isEmpty() } +
                 if (prevEOGEdges.isEmpty() && nextEOGEdges.isEmpty()) {
@@ -139,11 +139,11 @@ val Node.allUniqueEOGStartersOrSingles: List<Node>
     }
 
 @JvmName("astNodes")
-fun Node.ast(): List<Node> {
-    return this.ast<Node>()
+fun AstNode.ast(): List<AstNode> {
+    return this.ast<AstNode>()
 }
 
-inline fun <reified T : Node> Node.ast(): List<T> {
+inline fun <reified T : AstNode> AstNode.ast(): List<T> {
     val children = SubgraphWalker.getAstChildren(this)
 
     return children.filterIsInstance<T>()
@@ -1118,131 +1118,131 @@ fun Node.followPrevDFG(predicate: (Node) -> Boolean): NodePath? {
 }
 
 /** Returns all [Node] children in the AST-subgraph, starting with this [Node]. */
-val Node?.nodes: List<Node>
+val AstNode?.nodes: List<AstNode>
     get() = this.allChildren()
 
 /** Returns all [CallExpression] children in this graph, starting with this [Node]. */
-val Node?.calls: List<CallExpression>
+val AstNode?.calls: List<CallExpression>
     get() = this.allChildren()
 
 /** Returns all [OperatorCallExpression] children in this graph, starting with this [Node]. */
-val Node?.operatorCalls: List<OperatorCallExpression>
+val AstNode?.operatorCalls: List<OperatorCallExpression>
     get() = this.allChildren()
 
 /** Returns all [MemberCallExpression] children in this graph, starting with this [Node]. */
-val Node?.mcalls: List<MemberCallExpression>
+val AstNode?.mcalls: List<MemberCallExpression>
     get() = this.allChildren()
 
 /** Returns all [CastExpression] children in this graph, starting with this [Node]. */
-val Node?.casts: List<CastExpression>
+val AstNode?.casts: List<CastExpression>
     get() = this.allChildren()
 
 /** Returns all [MethodDeclaration] children in this graph, starting with this [Node]. */
-val Node?.methods: List<MethodDeclaration>
+val AstNode?.methods: List<MethodDeclaration>
     get() = this.allChildren()
 
 /** Returns all [OperatorDeclaration] children in this graph, starting with this [Node]. */
-val Node?.operators: List<OperatorDeclaration>
+val AstNode?.operators: List<OperatorDeclaration>
     get() = this.allChildren()
 
 /** Returns all [FieldDeclaration] children in this graph, starting with this [Node]. */
-val Node?.fields: List<FieldDeclaration>
+val AstNode?.fields: List<FieldDeclaration>
     get() = this.allChildren()
 
 /** Returns all [ParameterDeclaration] children in this graph, starting with this [Node]. */
-val Node?.parameters: List<ParameterDeclaration>
+val AstNode?.parameters: List<ParameterDeclaration>
     get() = this.allChildren()
 
 /** Returns all [FunctionDeclaration] children in this graph, starting with this [Node]. */
-val Node?.functions: List<FunctionDeclaration>
+val AstNode?.functions: List<FunctionDeclaration>
     get() = this.allChildren()
 
 /** Returns all [RecordDeclaration] children in this graph, starting with this [Node]. */
-val Node?.records: List<RecordDeclaration>
+val AstNode?.records: List<RecordDeclaration>
     get() = this.allChildren()
 
 /** Returns all [RecordDeclaration] children in this graph, starting with this [Node]. */
-val Node?.namespaces: List<NamespaceDeclaration>
+val AstNode?.namespaces: List<NamespaceDeclaration>
     get() = this.allChildren()
 
 /** Returns all [ImportDeclaration] children in this graph, starting with this [Node]. */
-val Node?.imports: List<ImportDeclaration>
+val AstNode?.imports: List<ImportDeclaration>
     get() = this.allChildren()
 
 /** Returns all [VariableDeclaration] children in this graph, starting with this [Node]. */
-val Node?.variables: List<VariableDeclaration>
+val AstNode?.variables: List<VariableDeclaration>
     get() = this.allChildren()
 
 /** Returns all [Literal] children in this graph, starting with this [Node]. */
-val Node?.literals: List<Literal<*>>
+val AstNode?.literals: List<Literal<*>>
     get() = this.allChildren()
 
 /** Returns all [Block] child edges in this graph, starting with this [Node]. */
-val Node?.blocks: List<Block>
+val AstNode?.blocks: List<Block>
     get() = this.allChildren()
 
 /** Returns all [Reference] children in this graph, starting with this [Node]. */
-val Node?.refs: List<Reference>
+val AstNode?.refs: List<Reference>
     get() = this.allChildren()
 
 /** Returns all [MemberExpression] children in this graph, starting with this [Node]. */
-val Node?.memberExpressions: List<MemberExpression>
+val AstNode?.memberExpressions: List<MemberExpression>
     get() = this.allChildren()
 
 /** Returns all [Statement] child edges in this graph, starting with this [Node]. */
-val Node?.statements: List<Statement>
+val AstNode?.statements: List<Statement>
     get() = this.allChildren()
 
 /** Returns all [ForStatement] child edges in this graph, starting with this [Node]. */
-val Node?.forLoops: List<ForStatement>
+val AstNode?.forLoops: List<ForStatement>
     get() = this.allChildren()
 
 /** Returns all [TryStatement] child edges in this graph, starting with this [Node]. */
-val Node?.trys: List<TryStatement>
+val AstNode?.trys: List<TryStatement>
     get() = this.allChildren()
 
 /** Returns all [ThrowExpression] child edges in this graph, starting with this [Node]. */
-val Node?.throws: List<ThrowExpression>
+val AstNode?.throws: List<ThrowExpression>
     get() = this.allChildren()
 
 /** Returns all [ForEachStatement] child edges in this graph, starting with this [Node]. */
-val Node?.forEachLoops: List<ForEachStatement>
+val AstNode?.forEachLoops: List<ForEachStatement>
     get() = this.allChildren()
 
 /** Returns all [SwitchStatement] child edges in this graph, starting with this [Node]. */
-val Node?.switches: List<SwitchStatement>
+val AstNode?.switches: List<SwitchStatement>
     get() = this.allChildren()
 
 /** Returns all [WhileStatement] child edges in this graph, starting with this [Node]. */
-val Node?.whileLoops: List<WhileStatement>
+val AstNode?.whileLoops: List<WhileStatement>
     get() = this.allChildren()
 
 /** Returns all [DoStatement] child edges in this graph, starting with this [Node]. */
-val Node?.doLoops: List<DoStatement>
+val AstNode?.doLoops: List<DoStatement>
     get() = this.allChildren()
 
 /** Returns all [BreakStatement] child edges in this graph, starting with this [Node]. */
-val Node?.breaks: List<BreakStatement>
+val AstNode?.breaks: List<BreakStatement>
     get() = this.allChildren()
 
 /** Returns all [ContinueStatement] child edges in this graph, starting with this [Node]. */
-val Node?.continues: List<ContinueStatement>
+val AstNode?.continues: List<ContinueStatement>
     get() = this.allChildren()
 
 /** Returns all [IfStatement] child edges in this graph, starting with this [Node]. */
-val Node?.ifs: List<IfStatement>
+val AstNode?.ifs: List<IfStatement>
     get() = this.allChildren()
 
 /** Returns all [LabelStatement] child edges in this graph, starting with this [Node]. */
-val Node?.labels: List<LabelStatement>
+val AstNode?.labels: List<LabelStatement>
     get() = this.allChildren()
 
 /** Returns all [ReturnStatement] child edges in this graph, starting with this [Node]. */
-val Node?.returns: List<ReturnStatement>
+val AstNode?.returns: List<ReturnStatement>
     get() = this.allChildren()
 
 /** Returns all [AssignExpression] child edges in this graph, starting with this [Node]. */
-val Node?.assigns: List<AssignExpression>
+val AstNode?.assigns: List<AssignExpression>
     get() = this.allChildren()
 
 /**
@@ -1300,7 +1300,7 @@ inline fun <reified T : Scope> Scope.firstScopeParentOrNull(
  * Return all [ProblemNode] children in this graph (either stored directly or in
  * [Node.additionalProblems]), starting with this [Node].
  */
-val Node?.problems: List<ProblemNode>
+val AstNode?.problems: List<ProblemNode>
     get() {
         val relevantNodes =
             this.allChildren<Node> { it is ProblemNode || it.additionalProblems.isNotEmpty() }
@@ -1320,7 +1320,7 @@ val Node?.problems: List<ProblemNode>
     }
 
 /** Returns all [Assignment] child edges in this graph, starting with this [Node]. */
-val Node?.assignments: List<Assignment>
+val AstNode?.assignments: List<Assignment>
     get() {
         return this?.allChildren<Node>()?.filterIsInstance<AssignmentHolder>()?.flatMap {
             it.assignments

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/MermaidPrinter.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/MermaidPrinter.kt
@@ -58,10 +58,10 @@ fun Node.printEOG(
 }
 
 /** Utility function to print the AST using [printGraph]. */
-fun Node.printAST(
+fun AstNode.printAST(
     maxConnections: Int = 25,
-    vararg strategies: (Node) -> Iterator<AstEdge<out Node>> =
-        arrayOf<(Node) -> Iterator<AstEdge<out Node>>>(
+    vararg strategies: (AstNode) -> Iterator<AstEdge<out AstNode>> =
+        arrayOf<(AstNode) -> Iterator<AstEdge<out AstNode>>>(
             Strategy::AST_EDGES_FORWARD,
             Strategy::AST_EDGES_BACKWARD,
         ),
@@ -80,9 +80,9 @@ fun Node.printAST(
  *   implementations.
  * @return The Mermaid graph as a string encapsulated in triple-backticks.
  */
-fun <EdgeType : Edge<out Node>> Node.printGraph(
+fun <NodeType : Node, EdgeType : Edge<out NodeType>> NodeType.printGraph(
     maxConnections: Int = 25,
-    vararg strategies: (Node) -> Iterator<EdgeType>,
+    vararg strategies: (NodeType) -> Iterator<EdgeType>,
 ): String {
     val builder = StringBuilder()
 
@@ -122,7 +122,7 @@ fun <EdgeType : Edge<out Node>> Node.printGraph(
         // Add start and edges to the work-list.
         strategies.forEach { strategy ->
             worklist += strategy(end).asSequence().sortedBy { it.end.name }
-            worklist += strategy(start).asSequence().sortedBy { it.end.name }
+            worklist += strategy(start as NodeType).asSequence().sortedBy { it.end.name }
         }
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -38,14 +38,12 @@ import de.fraunhofer.aisec.cpg.frontends.UnknownLanguage
 import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.RecordDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
-import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.flows.*
 import de.fraunhofer.aisec.cpg.graph.edges.overlay.Overlays
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import de.fraunhofer.aisec.cpg.graph.scopes.GlobalScope
 import de.fraunhofer.aisec.cpg.graph.scopes.RecordScope
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
-import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.helpers.neo4j.LocationConverter
 import de.fraunhofer.aisec.cpg.helpers.neo4j.NameConverter
 import de.fraunhofer.aisec.cpg.passes.*
@@ -66,7 +64,7 @@ import org.slf4j.LoggerFactory
 
 /** The base class for all graph objects that are going to be persisted in the database. */
 abstract class Node() :
-    IVisitable<Node>,
+    IVisitable,
     Persistable,
     LanguageProvider,
     ScopeProvider,
@@ -147,22 +145,7 @@ abstract class Node() :
 
     var prevCDG by unwrapping(Node::prevCDGEdges)
 
-    /**
-     * Virtual property to return a list of the node's children. Uses the [SubgraphWalker] to
-     * retrieve the appropriate nodes.
-     *
-     * Note: This only returns the *direct* children of this node. If you want to have *all*
-     * children, e.g., a flattened AST, you need to call [Node.allChildren].
-     *
-     * For Neo4J OGM, this relationship will be automatically filled by a pre-save event before OGM
-     * persistence. Therefore, this property is a `var` and not a `val`.
-     */
-    @Relationship("AST")
-    @JsonIgnore
-    var astChildren: List<Node> = listOf()
-        get() = SubgraphWalker.getAstChildren(this)
-
-    @DoNotPersist @Transient @JsonIgnore var astParent: Node? = null
+    @DoNotPersist @Transient @JsonIgnore var astParent: AstNode? = null
 
     /** Virtual property for accessing [prevEOGEdges] without property edges. */
     @PopulatedByPass(EvaluationOrderGraphPass::class) var prevEOG by unwrapping(Node::prevEOGEdges)
@@ -271,10 +254,6 @@ abstract class Node() :
     /** Index of the argument if this node is used in a function call or parameter list. */
     var argumentIndex = 0
 
-    /** List of annotations associated with that node. */
-    @Relationship("ANNOTATIONS") var annotationEdges = astEdgesOf<Annotation>()
-    var annotations by unwrapping(Node::annotationEdges)
-
     /**
      * Additional problem nodes. These nodes represent problems which occurred during processing of
      * a node (i.e. only partially processed).
@@ -303,10 +282,7 @@ abstract class Node() :
      * ATTENTION! Please note that this might kill an entire subgraph, if the node to disconnect has
      * further children that have no alternative connection paths to the rest of the graph.
      */
-    fun disconnectFromGraph() {
-        // Disconnect all AST children first
-        astChildren.forEach { it.disconnectFromGraph() }
-
+    open fun disconnectFromGraph() {
         nextDFGEdges.clear()
         prevDFGEdges.clear()
         prevCDGEdges.clear()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -307,9 +307,9 @@ fun <T : Node, AstNode> T.codeAndLocationFromOtherRawNode(rawNode: AstNode?): T 
  *   This is needed because the location block spanning the children usually comprises more than one
  *   line.
  */
-context(provider: CodeAndLocationProvider<AstNode>)
-fun <T : Node, AstNode> T.codeAndLocationFromChildren(
-    parentNode: AstNode,
+context(provider: CodeAndLocationProvider<AstNodeType>)
+fun <T : AstNode, AstNodeType> T.codeAndLocationFromChildren(
+    parentNode: AstNodeType,
     lineBreakSequence: CharSequence = "\n",
 ): T {
     var first: Node? = null
@@ -317,7 +317,7 @@ fun <T : Node, AstNode> T.codeAndLocationFromChildren(
 
     // Search through all children to find the first and last node based on region startLine and
     // startColumn
-    val worklist: MutableList<Node> = this.astChildren.toMutableList()
+    val worklist = this.astChildren.toMutableList()
     while (worklist.isNotEmpty()) {
         val current = worklist.removeFirst()
         if (current.location == null || current.location?.region == Region()) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Declaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Declaration.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.graph.declarations
 
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.scopes.Symbol
 import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
@@ -40,7 +41,7 @@ import org.neo4j.ogm.annotation.NodeEntity
  * however clang does establish a connection between those nodes, we currently do not.
  */
 @NodeEntity
-abstract class Declaration : Node() {
+abstract class Declaration : AstNode() {
     @DoNotPersist
     val symbol: Symbol
         get() {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TemplateDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TemplateDeclaration.kt
@@ -25,8 +25,8 @@
  */
 package de.fraunhofer.aisec.cpg.graph.declarations
 
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
-import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
@@ -69,9 +69,9 @@ abstract class TemplateDeclaration : Declaration(), DeclarationHolder {
             return parametersWithDefaults
         }
 
-    val parameterDefaults: List<Node?>
+    val parameterDefaults: List<AstNode?>
         get() {
-            val defaults: MutableList<Node?> = ArrayList()
+            val defaults: MutableList<AstNode?> = ArrayList()
             for (declaration in parameters) {
                 if (declaration is TypeParameterDeclaration) {
                     defaults.add(declaration.default)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TypeParameterDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TypeParameterDeclaration.kt
@@ -28,16 +28,18 @@ package de.fraunhofer.aisec.cpg.graph.declarations
 import de.fraunhofer.aisec.cpg.graph.HasDefault
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astOptionalEdgeOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
-import de.fraunhofer.aisec.cpg.graph.types.Type
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.TypeExpression
 import java.util.*
 import org.neo4j.ogm.annotation.Relationship
 
 /** A declaration of a type template parameter */
-class TypeParameterDeclaration : ValueDeclaration(), HasDefault<Type?> {
+class TypeParameterDeclaration : ValueDeclaration(), HasDefault<TypeExpression?> {
     @Relationship(value = "DEFAULT", direction = Relationship.Direction.OUTGOING)
-    var defaultEdge = astOptionalEdgeOf<Type>()
+    var defaultEdge = astOptionalEdgeOf<TypeExpression>()
     /** TemplateParameters can define a default for the type parameter. */
     override var default by unwrapping(TypeParameterDeclaration::defaultEdge)
+
+    var expression: TypeExpression? = null
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TypeParameterDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/TypeParameterDeclaration.kt
@@ -39,8 +39,6 @@ class TypeParameterDeclaration : ValueDeclaration(), HasDefault<TypeExpression?>
     /** TemplateParameters can define a default for the type parameter. */
     override var default by unwrapping(TypeParameterDeclaration::defaultEdge)
 
-    var expression: TypeExpression? = null
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || javaClass != other.javaClass) return false

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/VariableDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/VariableDeclaration.kt
@@ -48,7 +48,7 @@ open class VariableDeclaration : ValueDeclaration(), HasInitializer, HasType.Typ
      * the [ConstructExpression] is created.
      */
     @Relationship(value = "TEMPLATE_PARAMETERS", direction = Relationship.Direction.OUTGOING)
-    var templateParameterEdges = astEdgesOf<Node>()
+    var templateParameterEdges = astEdgesOf<AstNode>()
     var templateParameters by unwrapping(VariableDeclaration::templateParameterEdges)
 
     /** Determines if this is a global variable. */

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/EdgeWalker.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/EdgeWalker.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.graph.edges
 
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
 import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeCollection
@@ -99,7 +100,7 @@ inline fun <reified EdgeType : Edge<out Node>> Node.allEdges(
 }
 
 /** A shortcut to return all [AstEdge] edges starting from this node. */
-val Node.astEdges: Collection<AstEdge<out Node>>
+val Node.astEdges: Collection<AstEdge<out AstNode>>
     get() {
         return allEdges()
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/ast/AstEdge.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/ast/AstEdge.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.graph.edges.ast
 
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.edges.Edge
 import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeList
@@ -33,7 +34,7 @@ import org.neo4j.ogm.annotation.*
 
 /** This property edge describes a parent/child relationship in the Abstract Syntax Tree (AST). */
 @RelationshipEntity
-open class AstEdge<T : Node>(start: Node, end: T) : Edge<T>(start, end) {
+open class AstEdge<T : AstNode>(start: AstNode, end: T) : Edge<T>(start, end) {
     init {
         end.astParent = start
     }
@@ -42,7 +43,7 @@ open class AstEdge<T : Node>(start: Node, end: T) : Edge<T>(start, end) {
 }
 
 /** Creates an [AstEdges] container starting from this node. */
-fun <NodeType : Node> Node.astEdgesOf(
+fun <NodeType : AstNode> AstNode.astEdgesOf(
     onAdd: ((AstEdge<NodeType>) -> Unit)? = null,
     onRemove: ((AstEdge<NodeType>) -> Unit)? = null,
 ): AstEdges<NodeType, AstEdge<NodeType>> {
@@ -53,12 +54,12 @@ fun <NodeType : Node> Node.astEdgesOf(
  * Creates a single optional [AstEdge] starting from this node (wrapped in a [EdgeSingletonList]
  * container).
  */
-fun <NodeType : Node> Node.astOptionalEdgeOf(
+fun <NodeType : AstNode> AstNode.astOptionalEdgeOf(
     onChanged: ((old: AstEdge<NodeType>?, new: AstEdge<NodeType>?) -> Unit)? = null
 ): EdgeSingletonList<NodeType, NodeType?, AstEdge<NodeType>> {
     return EdgeSingletonList(
         thisRef = this,
-        init = ::AstEdge,
+        init = { start, end -> AstEdge(start as AstNode, end) },
         outgoing = true,
         onChanged = onChanged,
         of = null,
@@ -68,13 +69,13 @@ fun <NodeType : Node> Node.astOptionalEdgeOf(
 /**
  * Creates a single [AstEdge] starting from this node (wrapped in a [EdgeSingletonList] container).
  */
-fun <NodeType : Node> Node.astEdgeOf(
+fun <NodeType : AstNode> AstNode.astEdgeOf(
     of: NodeType,
     onChanged: ((old: AstEdge<NodeType>?, new: AstEdge<NodeType>?) -> Unit)? = null,
 ): EdgeSingletonList<NodeType, NodeType, AstEdge<NodeType>> {
     return EdgeSingletonList(
         thisRef = this,
-        init = ::AstEdge,
+        init = { start, end -> AstEdge(start as AstNode, end) },
         outgoing = true,
         onChanged = onChanged,
         of = of,
@@ -82,13 +83,13 @@ fun <NodeType : Node> Node.astEdgeOf(
 }
 
 /** This property edge list describes elements that are AST children of a node. */
-open class AstEdges<NodeType : Node, PropertyEdgeType : AstEdge<NodeType>>(
+open class AstEdges<NodeType : AstNode, PropertyEdgeType : AstEdge<NodeType>>(
     thisRef: Node,
     onAdd: ((PropertyEdgeType) -> Unit)? = null,
     onRemove: ((PropertyEdgeType) -> Unit)? = null,
     @Suppress("UNCHECKED_CAST")
     init: (start: Node, end: NodeType) -> PropertyEdgeType = { start, end ->
-        AstEdge(start, end) as PropertyEdgeType
+        AstEdge(start as AstNode, end) as PropertyEdgeType
     },
 ) :
     EdgeList<NodeType, PropertyEdgeType>(

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/ast/TemplateArgument.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/ast/TemplateArgument.kt
@@ -25,19 +25,20 @@
  */
 package de.fraunhofer.aisec.cpg.graph.edges.ast
 
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.TemplateDeclaration.TemplateInitialization
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
 
 /** This edge represents a template argument that is attached to a [CallExpression]. */
-class TemplateArgument<NodeType : Node>(
+class TemplateArgument<NodeType : AstNode>(
     start: Node,
     end: NodeType,
     var instantiation: TemplateInitialization? = TemplateInitialization.EXPLICIT,
-) : AstEdge<NodeType>(start, end)
+) : AstEdge<NodeType>(start as AstNode, end)
 
 /** A container for [TemplateArgument] edges. */
-class TemplateArguments<NodeType : Node>(thisRef: Node) :
+class TemplateArguments<NodeType : AstNode>(thisRef: Node) :
     AstEdges<NodeType, TemplateArgument<NodeType>>(
         thisRef,
         init = { start, end -> TemplateArgument(start, end) },

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/LocalScope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/LocalScope.kt
@@ -25,10 +25,10 @@
  */
 package de.fraunhofer.aisec.cpg.graph.scopes
 
-import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.AstNode
 
 /**
  * Scope of validity associated to the local statement. Variables declared inside this statement are
  * not visible outside.
  */
-class LocalScope(astNode: Node) : Scope(astNode)
+class LocalScope(astNode: AstNode) : Scope(astNode)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/NameScope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/NameScope.kt
@@ -25,14 +25,14 @@
  */
 package de.fraunhofer.aisec.cpg.graph.scopes
 
-import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.AstNode
 
 /**
  * A scope which acts as a namespace with a certain name, which is prefixed to all local names
  * declared in it. This could be a package or other structural elements, like a class. In the first
  * case, the derived [NamespaceScope], in the latter case, the derived [RecordScope] should be used.
  */
-sealed class NameScope(node: Node) : Scope(node) {
+sealed class NameScope(node: AstNode) : Scope(node) {
 
     init {
         astNode = node

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
@@ -30,6 +30,7 @@ import de.fraunhofer.aisec.cpg.PopulatedByPass
 import de.fraunhofer.aisec.cpg.frontends.HasBuiltins
 import de.fraunhofer.aisec.cpg.frontends.HasImplicitReceiver
 import de.fraunhofer.aisec.cpg.frontends.Language
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.ContextProvider
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.Node
@@ -66,7 +67,7 @@ typealias SymbolMap = MutableMap<Symbol, MutableList<Declaration>>
 sealed class Scope(
     @Relationship(value = "SCOPE", direction = Relationship.Direction.INCOMING)
     @JsonBackReference
-    open var astNode: Node?
+    open var astNode: AstNode?
 ) : Node() {
 
     /** FQN Name currently valid */

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/TemplateScope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/TemplateScope.kt
@@ -25,10 +25,10 @@
  */
 package de.fraunhofer.aisec.cpg.graph.scopes
 
-import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.AstNode
 
 /**
  * Represents a scope that is only visible in the current template. This is usually to hold template
  * parameters.
  */
-class TemplateScope(node: Node) : Scope(node)
+class TemplateScope(node: AstNode) : Scope(node)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/CatchClause.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/CatchClause.kt
@@ -45,7 +45,7 @@ class CatchClause : Statement(), BranchingNode, EOGStarterHolder {
     var body by unwrapping(CatchClause::bodyEdge)
 
     @DoNotPersist
-    override val branchedBy: Node?
+    override val branchedBy
         get() = parameter
 
     @DoNotPersist

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/ForEachStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/ForEachStatement.kt
@@ -58,7 +58,7 @@ class ForEachStatement : LoopStatement(), BranchingNode, StatementHolder {
     /** This field contains the iteration subject of the loop. */
     var iterable by unwrapping(ForEachStatement::iterableEdge)
 
-    override val branchedBy: Node?
+    override val branchedBy
         get() = iterable
 
     override var statementEdges: AstEdges<Statement, AstEdge<Statement>>

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/ForStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/ForStatement.kt
@@ -58,7 +58,7 @@ class ForStatement : LoopStatement(), BranchingNode, StatementHolder {
     @Relationship("ITERATION_STATEMENT") var iterationStatementEdge = astOptionalEdgeOf<Statement>()
     var iterationStatement by unwrapping(ForStatement::iterationStatementEdge)
 
-    override val branchedBy: Node?
+    override val branchedBy
         get() = condition ?: conditionDeclaration
 
     override var statementEdges: AstEdges<Statement, AstEdge<Statement>>

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/IfStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/IfStatement.kt
@@ -54,7 +54,7 @@ class IfStatement : Statement(), BranchingNode, ArgumentHolder {
     /** The condition to be evaluated. */
     var condition by unwrapping(IfStatement::conditionEdge)
 
-    override val branchedBy: Node?
+    override val branchedBy
         get() = condition ?: conditionDeclaration
 
     /** C++ constexpr construct. */

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/Statement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/Statement.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.graph.statements
 
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
@@ -43,7 +44,7 @@ import org.neo4j.ogm.annotation.Relationship
  * executable code.
  */
 @NodeEntity
-abstract class Statement : Node(), DeclarationHolder {
+abstract class Statement : AstNode(), DeclarationHolder {
     /**
      * A list of local variables (or other values) associated to this statement, defined by their
      * [ValueDeclaration] extracted from Block because `for`, `while`, `if`, and `switch` can

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/SwitchStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/SwitchStatement.kt
@@ -62,7 +62,7 @@ class SwitchStatement : Statement(), BranchingNode {
      */
     var statement by unwrapping(SwitchStatement::statementEdge)
 
-    override val branchedBy: Node?
+    override val branchedBy
         get() = selector
 
     override fun equals(other: Any?): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/WhileStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/WhileStatement.kt
@@ -51,7 +51,7 @@ class WhileStatement : LoopStatement(), BranchingNode, ArgumentHolder {
     /** The condition that decides if the block is executed. */
     var condition by unwrapping(WhileStatement::conditionEdge)
 
-    override val branchedBy: Node?
+    override val branchedBy
         get() = condition ?: conditionDeclaration
 
     override fun toString(): String {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/CallExpression.kt
@@ -160,14 +160,14 @@ open class CallExpression :
 
     /** If the CallExpression instantiates a template, the call can provide template arguments. */
     @Relationship(value = "TEMPLATE_ARGUMENTS", direction = Relationship.Direction.OUTGOING)
-    var templateArgumentEdges: TemplateArguments<Node>? = null
+    var templateArgumentEdges: TemplateArguments<AstNode>? = null
         set(value) {
             field = value
             template = value != null
         }
 
-    val templateArguments: List<Node>
-        get(): List<Node> {
+    val templateArguments: List<AstNode>
+        get(): List<AstNode> {
             return templateArgumentEdges?.toNodeCollection() ?: listOf()
         }
 
@@ -189,10 +189,10 @@ open class CallExpression :
      */
     @JvmOverloads
     fun addTemplateParameter(
-        templateParam: Node,
+        templateParam: AstNode,
         templateInitialization: TemplateInitialization? = TemplateInitialization.EXPLICIT,
     ) {
-        if (templateParam is Expression || templateParam is Type) {
+        if (templateParam is Expression) {
             if (templateArgumentEdges == null) {
                 templateArgumentEdges = TemplateArguments(this)
             }
@@ -203,8 +203,8 @@ open class CallExpression :
     }
 
     fun updateTemplateParameters(
-        initializationType: Map<Node?, TemplateInitialization?>,
-        orderedInitializationSignature: List<Node>,
+        initializationType: Map<AstNode?, TemplateInitialization?>,
+        orderedInitializationSignature: List<AstNode>,
     ) {
         if (templateArgumentEdges == null) {
             templateArgumentEdges = TemplateArguments(this)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/ConditionalExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/ConditionalExpression.kt
@@ -75,7 +75,7 @@ class ConditionalExpression : Expression(), ArgumentHolder, BranchingNode, HasTy
             .build()
     }
 
-    override val branchedBy: Node
+    override val branchedBy
         get() = condition
 
     override fun addArgument(expression: Expression) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/NewExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/NewExpression.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.graph.statements.expressions
 
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.HasInitializer
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
@@ -46,7 +47,7 @@ class NewExpression : Expression(), HasInitializer {
      * ConstructExpression is created
      */
     @Relationship(value = "TEMPLATE_PARAMETERS", direction = Relationship.Direction.OUTGOING)
-    var templateParameterEdges = astEdgesOf<Node>()
+    var templateParameterEdges = astEdgesOf<AstNode>()
     var templateParameters by unwrapping(NewExpression::templateParameterEdges)
 
     override fun toString(): String {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/ShortCircuitOperator.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/ShortCircuitOperator.kt
@@ -25,18 +25,16 @@
  */
 package de.fraunhofer.aisec.cpg.graph.statements.expressions
 
+import de.fraunhofer.aisec.cpg.frontends.HasShortCircuitOperators
 import de.fraunhofer.aisec.cpg.graph.BranchingNode
-import de.fraunhofer.aisec.cpg.graph.Node
 
 /**
  * A [BinaryOperator] which only evaluates [BinaryOperator.rhs] if [BinaryOperator.lhs] fulfils some
- * condition. For the operators in
- * [de.fraunhofer.aisec.cpg.frontends.HasShortCircuitOperators.conjunctiveOperators], the rhs has to
+ * condition. For the operators in [HasShortCircuitOperators.conjunctiveOperators], the rhs has to
  * evaluate to "true" or so to continue on the lhs, whereas for the operators in
- * [de.fraunhofer.aisec.cpg.frontends.HasShortCircuitOperators.disjunctiveOperators], the lhs has to
- * evaluate to "false" (or similar).
+ * [HasShortCircuitOperators.disjunctiveOperators], the lhs has to evaluate to "false" (or similar).
  */
 class ShortCircuitOperator : BinaryOperator(), BranchingNode {
-    override val branchedBy: Node
+    override val branchedBy
         get() = lhs
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/TypeExpression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/statements/expressions/TypeExpression.kt
@@ -26,7 +26,7 @@
 package de.fraunhofer.aisec.cpg.graph.statements.expressions
 
 /**
- * Represets a Type used as an expression for instance when instantiating templates
+ * Represents a Type used as an expression for instance when instantiating templates
  *
  * Note: This Expression is required since we cannot have ASTChilds directly connected to a Type
  * since they are merged.

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/HasType.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/HasType.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.graph.types
 
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.LanguageProvider
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.applyMetadata
@@ -145,10 +146,9 @@ interface HasType : LanguageProvider {
         /**
          * A helper function that can be used for [EdgeSingletonList.onChanged]. It unregisters this
          * [TypeObserver] with the [old] node and registers it with the [new] one. It updates the
-         * [de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression.access] property of
-         * [new.end].
+         * [Expression.access] property of [AstEdge.end].
          */
-        fun <NodeType : Node> exchangeTypeObserverWithAccessPropagation(
+        fun <NodeType : AstNode> exchangeTypeObserverWithAccessPropagation(
             old: AstEdge<NodeType>?,
             new: AstEdge<NodeType>?,
         ) {
@@ -158,10 +158,9 @@ interface HasType : LanguageProvider {
         /**
          * A helper function that can be used for [EdgeSingletonList.onChanged]. It unregisters this
          * [TypeObserver] with the [old] node and registers it with the [new] one. It also updates
-         * the [de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression.access] property of
-         * [new.end] if [propagateAccess] is set to `true`.
+         * the [Expression.access] property of [AstEdge.end] if [propagateAccess] is set to `true`.
          */
-        fun <NodeType : Node> exchangeTypeObserver(
+        fun <NodeType : AstNode> exchangeTypeObserver(
             old: AstEdge<NodeType>?,
             new: AstEdge<NodeType>?,
             propagateAccess: Boolean,
@@ -176,10 +175,9 @@ interface HasType : LanguageProvider {
         /**
          * A helper function that can be used for [EdgeSingletonList.onChanged]. It unregisters this
          * [TypeObserver] with the [old] node and registers it with the [new] one. It does not
-         * update the [de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression.access]
-         * property of [new.end].
+         * update the [Expression.access] property of [AstEdge.end].
          */
-        fun <NodeType : Node> exchangeTypeObserverWithoutAccessPropagation(
+        fun <NodeType : AstNode> exchangeTypeObserverWithoutAccessPropagation(
             old: AstEdge<NodeType>?,
             new: AstEdge<NodeType>?,
         ) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/CommentMatcher.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/CommentMatcher.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.helpers
 
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.NamespaceDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
@@ -43,10 +44,10 @@ class CommentMatcher {
      * region.
      */
     fun getEnclosingChild(
-        node: Node,
+        node: AstNode,
         location: Region,
         artifactLocation: PhysicalLocation.ArtifactLocation?,
-    ): Node {
+    ): AstNode {
         // If there's an ArtifactLocation specified, it should at least be in the same file.
         val children =
             node.astChildren
@@ -87,7 +88,7 @@ class CommentMatcher {
         artifactLocation: PhysicalLocation.ArtifactLocation? = null,
     ) {
         var enclosingNode: Node = tu
-        var smallestEnclosingNode: Node = getEnclosingChild(tu, location, artifactLocation)
+        var smallestEnclosingNode = getEnclosingChild(tu, location, artifactLocation)
         while (enclosingNode != smallestEnclosingNode) {
             enclosingNode = smallestEnclosingNode
             smallestEnclosingNode =

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SubgraphWalker.kt
@@ -28,8 +28,8 @@
 package de.fraunhofer.aisec.cpg.helpers
 
 import de.fraunhofer.aisec.cpg.ScopeManager
-import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.ArgumentHolder
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.ContextProvider
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.StatementHolder
@@ -45,9 +45,6 @@ import java.lang.annotation.AnnotationFormatError
 import java.lang.reflect.Field
 import java.util.*
 import org.slf4j.LoggerFactory
-
-/** A type for a node visitor callback for the [SubgraphWalker]. */
-typealias Callback = (node: Node, parent: Node?) -> Unit
 
 /** Helper class for graph walking: Walking through ast-, cfg-, ...- edges */
 object SubgraphWalker {
@@ -95,8 +92,11 @@ object SubgraphWalker {
      * @return a list of children from the node's AST
      */
     @JvmStatic
-    fun getAstChildren(node: Node?, stopAtNode: (Node) -> Boolean = { false }): List<Node> {
-        val children = ArrayList<Node>()
+    fun getAstChildren(
+        node: AstNode?,
+        stopAtNode: (AstNode) -> Boolean = { false },
+    ): List<AstNode> {
+        val children = ArrayList<AstNode>()
         if (node == null) return children
         val classType: Class<*> = node.javaClass
 
@@ -107,7 +107,7 @@ object SubgraphWalker {
                 // We need to synchronize access to the field, because otherwise different
                 // threads might restore the isAccessible property while this thread is still
                 // accessing the field
-                var obj =
+                val obj =
                     synchronized(field) {
                         // disable access mechanisms
                         field.trySetAccessible()
@@ -120,7 +120,7 @@ object SubgraphWalker {
 
                 when (obj) {
                     is EdgeCollection<*, *> -> {
-                        children.addAll(obj.toNodeCollection({ it is AstEdge<*> }))
+                        obj.toNodeCollection({ it is AstEdge<*> }).filterIsInstanceTo(children)
                     }
                     else -> {
                         throw AnnotationFormatError(
@@ -145,22 +145,22 @@ object SubgraphWalker {
      *   include that node and its ast children)
      * @return the flattened nodes
      */
-    fun flattenAST(n: Node?, stopAtNode: (Node) -> Boolean = { false }): List<Node> {
+    fun flattenAST(n: AstNode?, stopAtNode: (Node) -> Boolean = { false }): List<AstNode> {
         if (n == null) {
             return ArrayList()
         }
 
         // We are using an identity set here, to avoid placing the *same* node in the identitySet
         // twice, possibly resulting in loops
-        val identitySet = IdentitySet<Node>()
+        val identitySet = IdentitySet<AstNode>()
         flattenASTInternal(identitySet, n, stopAtNode)
         return identitySet.toSortedList()
     }
 
     private fun flattenASTInternal(
-        identitySet: MutableSet<Node>,
-        n: Node,
-        stopAtNode: (Node) -> Boolean,
+        identitySet: MutableSet<AstNode>,
+        n: AstNode,
+        stopAtNode: (AstNode) -> Boolean,
     ) {
         // Add the node itself and abort if its already there, to detect possible loops
         if (stopAtNode(n) || !identitySet.add(n)) {
@@ -180,13 +180,11 @@ object SubgraphWalker {
      * @param n - root of the subgraph.
      * @return Two lists, list 1 contains all eog entries and list 2 contains all exits.
      */
-    fun getEOGPathEdges(n: Node?): Border {
+    fun getEOGPathEdges(n: AstNode?): Border {
         val border = Border()
         val flattedASTTree = flattenAST(n)
         val eogNodes =
-            flattedASTTree.filter { node: Node ->
-                node.prevEOG.isNotEmpty() || node.nextEOG.isNotEmpty()
-            }
+            flattedASTTree.filter { node -> node.prevEOG.isNotEmpty() || node.nextEOG.isNotEmpty() }
         // Nodes that are incoming edges, no other node
         border.entries =
             eogNodes
@@ -205,21 +203,21 @@ object SubgraphWalker {
      * EOG subgraph, EOG entries and exits in a CFG subgraph.
      */
     class Border {
-        var entries = mutableListOf<Node>()
-        var exits = mutableListOf<Node>()
+        var entries = mutableListOf<AstNode>()
+        var exits = mutableListOf<AstNode>()
     }
 
-    class IterativeGraphWalker {
-        var strategy: (Node) -> Iterator<Node> = Strategy::AST_FORWARD
+    class IterativeGraphWalker<NodeType : Node>(var strategy: (NodeType) -> Iterator<NodeType>) {
 
         /**
          * This callback is triggered whenever a new node is visited for the first time. This is the
          * place where usual graph manipulation will happen. The current node and its parent are
          * passed to the consumer.
          */
-        private val onNodeVisit: MutableList<Callback> = mutableListOf()
+        private val onNodeVisit: MutableList<(node: NodeType, parent: NodeType?) -> Unit> =
+            mutableListOf()
 
-        private val replacements = mutableMapOf<Node, Node>()
+        private val replacements = mutableMapOf<NodeType, NodeType>()
 
         /**
          * The core iterative AST traversal algorithm: In a depth-first way we descend into the
@@ -227,7 +225,7 @@ object SubgraphWalker {
          *
          * @param root The node where we should start
          */
-        fun iterate(root: Node) {
+        fun iterate(root: NodeType) {
             iterateAll(listOf(root))
         }
 
@@ -239,13 +237,13 @@ object SubgraphWalker {
          * If you require a node to be visited multiple times, i.e. once for every entry it is
          * reachable by, use [iterate].
          */
-        fun iterateAll(entries: List<Node>) {
-            var todo = ArrayDeque<Pair<Node, Node?>>()
-            val seen = identitySetOf<Node>()
+        fun iterateAll(entries: List<NodeType>) {
+            val todo = ArrayDeque<Pair<NodeType, NodeType?>>()
+            val seen = identitySetOf<NodeType>()
 
             entries.forEach { entry ->
                 if (entry !in seen) {
-                    todo.push(Pair<Node, Node?>(entry, null))
+                    todo.push(Pair(entry, null))
                 }
 
                 while (todo.isNotEmpty()) {
@@ -263,9 +261,7 @@ object SubgraphWalker {
                         strategy(current).asSequence().filter { it !in seen }.toMutableList()
 
                     seen.addAll(unseenChildren)
-                    unseenChildren.asReversed().forEach { child: Node ->
-                        todo.push(Pair(child, current))
-                    }
+                    unseenChildren.asReversed().forEach { child -> todo.push(Pair(child, current)) }
                 }
             }
         }
@@ -275,12 +271,12 @@ object SubgraphWalker {
          * problems, that the walker still assumes the old node. Calling this function will ensure
          * that the walker knows about the new node.
          */
-        fun registerReplacement(from: Node, to: Node) {
+        fun registerReplacement(from: NodeType, to: NodeType) {
             replacements[from] = to
         }
 
-        /** Registers a [Callback]. */
-        fun registerOnNodeVisit(callback: Callback) {
+        /** Registers a callback. */
+        fun registerOnNodeVisit(callback: (node: NodeType, parent: NodeType?) -> Unit) {
             onNodeVisit.add(callback)
         }
     }
@@ -292,19 +288,12 @@ object SubgraphWalker {
      * currently in the scope of the "consumed" node in the callback. This can be useful for
      * resolving declarations or other scope-related tasks.
      */
-    class ScopedWalker {
-        lateinit var strategy: (Node) -> Iterator<Node>
-        private var walker: IterativeGraphWalker? = null
+    class ScopedWalker<out NodeType : Node> {
+        val strategy: (@UnsafeVariance NodeType) -> Iterator<NodeType>
+        private var walker: IterativeGraphWalker<NodeType>? = null
         private val scopeManager: ScopeManager
 
-        constructor(lang: LanguageFrontend<*, *>) {
-            scopeManager = lang.scopeManager
-        }
-
-        constructor(
-            scopeManager: ScopeManager,
-            strategy: (Node) -> Iterator<Node> = Strategy::AST_FORWARD,
-        ) {
+        constructor(scopeManager: ScopeManager, strategy: (NodeType) -> Iterator<NodeType>) {
             this.scopeManager = scopeManager
             this.strategy = strategy
         }
@@ -317,7 +306,7 @@ object SubgraphWalker {
          * previous node is equal to [Node.astParent]. But for a strategy like
          * [Strategy.EOG_FORWARD], the previous node was the previous EOG node.
          */
-        private val handlers = mutableListOf<(node: Node, previous: Node?) -> (Unit)>()
+        private val handlers = mutableListOf<(node: NodeType, previous: NodeType?) -> (Unit)>()
 
         fun clearCallbacks() {
             handlers.clear()
@@ -327,7 +316,7 @@ object SubgraphWalker {
          * Registers a handler that is called whenever a new node is visited. The handler is passed
          * the current node.
          */
-        fun registerHandler(handler: (node: Node) -> (Unit)) {
+        fun registerHandler(handler: (node: NodeType) -> (Unit)) {
             handlers.add { node, previous -> handler(node) }
         }
 
@@ -335,12 +324,12 @@ object SubgraphWalker {
          * Registers a handler that is called whenever a new node is visited. The handler is passed
          * the current node and the previous node (if it exists).
          */
-        fun registerHandler(handler: (node: Node, previous: Node?) -> (Unit)) {
+        fun registerHandler(handler: (node: NodeType, previous: NodeType?) -> (Unit)) {
             handlers.add(handler)
         }
 
         /** Informs the walker that a replacement of [from] with [to] was done. */
-        fun registerReplacement(from: Node, to: Node) {
+        fun registerReplacement(from: @UnsafeVariance NodeType, to: @UnsafeVariance NodeType) {
             walker?.registerReplacement(from, to)
         }
 
@@ -349,8 +338,8 @@ object SubgraphWalker {
          *
          * @param root The node where AST descent is started
          */
-        fun iterate(root: Node) {
-            val walker = IterativeGraphWalker()
+        fun iterate(root: @UnsafeVariance NodeType) {
+            val walker = IterativeGraphWalker(strategy)
             walker.strategy = this.strategy
             handlers.forEach { h -> walker.registerOnNodeVisit { n, p -> handleNode(n, p, h) } }
 
@@ -370,8 +359,8 @@ object SubgraphWalker {
          *
          * @param entries The nodes where the exploration is started from.
          */
-        fun iterateAll(entries: List<Node>) {
-            val walker = IterativeGraphWalker()
+        fun iterateAll(entries: List<@UnsafeVariance NodeType>) {
+            val walker = IterativeGraphWalker(strategy)
             walker.strategy = this.strategy
             handlers.forEach { h -> walker.registerOnNodeVisit { n, p -> handleNode(n, p, h) } }
 
@@ -381,9 +370,9 @@ object SubgraphWalker {
         }
 
         private fun handleNode(
-            current: Node,
-            previous: Node?,
-            handler: (node: Node, previous: Node?) -> (Unit),
+            current: NodeType,
+            previous: NodeType?,
+            handler: (node: NodeType, previous: NodeType?) -> (Unit),
         ) {
             // Jump to the node's scope, if it is different from ours.
             if (scopeManager.currentScope != current.scope) {
@@ -411,7 +400,11 @@ object SubgraphWalker {
  *   [MemberExpression]), we also replace the [CallExpression] with a [MemberCallExpression].
  */
 context(provider: ContextProvider)
-fun SubgraphWalker.ScopedWalker.replace(parent: Node?, old: Expression, new: Expression): Boolean {
+fun SubgraphWalker.ScopedWalker<Node>.replace(
+    parent: AstNode?,
+    old: Expression,
+    new: Expression,
+): Boolean {
     // We do not allow to replace nodes where the DFG (or other dependent nodes, such as PDG have
     // been set). The reason for that is that these edges contain a lot of information on the edges
     // themselves and replacing this edge would be very complicated.
@@ -436,9 +429,7 @@ fun SubgraphWalker.ScopedWalker.replace(parent: Node?, old: Expression, new: Exp
                         parent.callee = new
                         true
                     }
-                } else {
-                    parent.replace(old, new)
-                }
+                } else run { parent.replace(old, new) }
             }
             is ArgumentHolder -> parent.replace(old, new)
             is StatementHolder -> parent.replace(old, new)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/Util.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/Util.kt
@@ -26,7 +26,9 @@
 package de.fraunhofer.aisec.cpg.helpers
 
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration
 import de.fraunhofer.aisec.cpg.graph.edges.flows.CallingContextIn
@@ -47,8 +49,8 @@ object Util {
      * @param searchCode exact code that a node needs to have.
      * @return a list of nodes with the specified String.
      */
-    fun subnodesOfCode(node: Node?, searchCode: String): List<Node> {
-        return SubgraphWalker.flattenAST(node).filter { n: Node ->
+    fun subnodesOfCode(node: AstNode?, searchCode: String): List<AstNode> {
+        return SubgraphWalker.flattenAST(node).filter { n ->
             n.code != null && n.code == searchCode
         }
     }
@@ -81,10 +83,10 @@ object Util {
         quantifier: Quantifier = Quantifier.ALL,
         connectStart: Connect = Connect.SUBTREE,
         edgeDirection: Edge,
-        startNode: Node?,
+        startNode: AstNode?,
         connectEnd: Connect = Connect.SUBTREE,
         predicate: ((EvaluationOrder) -> Boolean)? = null,
-        endNodes: List<Node?>,
+        endNodes: List<AstNode?>,
     ): Boolean {
         if (startNode == null) {
             return false
@@ -94,7 +96,7 @@ object Util {
         val er = if (edgeDirection == Edge.ENTRIES) Edge.EXITS else Edge.ENTRIES
         var refSide = endNodes
         nodeSide =
-            if (connectStart == Connect.SUBTREE) {
+            (if (connectStart == Connect.SUBTREE) {
                 val border = SubgraphWalker.getEOGPathEdges(startNode)
                 if (edgeDirection == Edge.ENTRIES) {
                     val pe = border.entries.flatMap { it.prevEOGEdges }
@@ -114,9 +116,10 @@ object Util {
                         pe.filter { predicate?.invoke(it) != false }.map { it.start }
                     } else listOf(it)
                 }
-            }
+            })
+                as List<AstNode>
         refSide =
-            if (connectEnd == Connect.SUBTREE) {
+            (if (connectEnd == Connect.SUBTREE) {
                 val borders = endNodes.map { SubgraphWalker.getEOGPathEdges(it) }
 
                 borders.flatMap { border ->
@@ -142,7 +145,8 @@ object Util {
                         pe.filter { predicate?.invoke(it) != false }.map { it.start }
                     } else listOf(node)
                 }
-            }
+            })
+                as List<AstNode?>
         val refNodes = refSide
         return if (Quantifier.ANY == quantifier) nodeSide.any { it in refNodes }
         else refNodes.containsAll(nodeSide)
@@ -499,7 +503,7 @@ object Util {
      * @param incoming whether the node connected by an incoming or, if false, outgoing DFG edge
      * @return
      */
-    fun getAdjacentDFGNodes(n: Node?, incoming: Boolean): MutableList<Node> {
+    fun getAdjacentDFGNodes(n: AstNode, incoming: Boolean): MutableList<AstNode> {
         val subnodes = n?.astChildren ?: listOf()
         val adjacentNodes =
             if (incoming) {
@@ -521,10 +525,10 @@ object Util {
      */
     fun addDFGEdgesForMutuallyExclusiveBranchingExpression(
         n: Node,
-        branchingExp: Node?,
-        branchingDeclaration: Node?,
+        branchingExp: Expression?,
+        branchingDeclaration: Declaration?,
     ) {
-        var conditionNodes = mutableListOf<Node>()
+        var conditionNodes = mutableListOf<AstNode>()
         if (branchingExp != null) {
             conditionNodes = mutableListOf()
             conditionNodes.add(branchingExp)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CXXCallResolverHelper.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CXXCallResolverHelper.kt
@@ -75,12 +75,12 @@ fun applyTemplateInstantiation(
     templateCall: CallExpression,
     functionTemplateDeclaration: FunctionTemplateDeclaration?,
     function: FunctionDeclaration,
-    initializationSignature: Map<Declaration?, Node?>,
-    initializationType: Map<Node?, TemplateDeclaration.TemplateInitialization?>,
+    initializationSignature: Map<Declaration?, AstNode?>,
+    initializationType: Map<AstNode?, TemplateDeclaration.TemplateInitialization?>,
     orderedInitializationSignature: Map<Declaration, Int>,
 ): List<FunctionDeclaration> {
     val templateInstantiationParameters =
-        mutableListOf<Node>(*orderedInitializationSignature.keys.toTypedArray())
+        mutableListOf<AstNode>(*orderedInitializationSignature.keys.toTypedArray())
     for ((key, value) in orderedInitializationSignature) {
         initializationSignature[key]?.let { templateInstantiationParameters[value] = it }
     }
@@ -213,10 +213,10 @@ fun getParameterizedSignaturesFromInitialization(
 fun getTemplateInitializationSignature(
     functionTemplateDeclaration: FunctionTemplateDeclaration,
     templateCall: CallExpression,
-    instantiationType: MutableMap<Node?, TemplateDeclaration.TemplateInitialization?>,
+    instantiationType: MutableMap<AstNode?, TemplateDeclaration.TemplateInitialization?>,
     orderedInitializationSignature: MutableMap<Declaration, Int>,
     explicitInstantiated: MutableList<ParameterizedType>,
-): Map<Declaration?, Node?>? {
+): Map<Declaration?, AstNode?>? {
     // Construct Signature
     val signature =
         constructTemplateInitializationSignatureFromTemplateParameters(
@@ -274,11 +274,11 @@ fun getTemplateInitializationSignature(
 fun constructTemplateInitializationSignatureFromTemplateParameters(
     functionTemplateDeclaration: FunctionTemplateDeclaration,
     templateCall: CallExpression,
-    instantiationType: MutableMap<Node?, TemplateDeclaration.TemplateInitialization?>,
+    instantiationType: MutableMap<AstNode?, TemplateDeclaration.TemplateInitialization?>,
     orderedInitializationSignature: MutableMap<Declaration, Int>,
     explicitInstantiated: MutableList<ParameterizedType>,
-): MutableMap<Declaration?, Node?>? {
-    val instantiationSignature: MutableMap<Declaration?, Node?> = HashMap()
+): MutableMap<Declaration?, AstNode?>? {
+    val instantiationSignature: MutableMap<Declaration?, AstNode?> = HashMap()
     for (i in functionTemplateDeclaration.parameters.indices) {
         if (i < templateCall.templateArguments.size) {
             val callParameter = templateCall.templateArguments[i]
@@ -348,18 +348,19 @@ fun isInstantiated(callParameterArg: Node, templateParameter: Declaration?): Boo
 fun handleImplicitTemplateParameter(
     functionTemplateDeclaration: FunctionTemplateDeclaration,
     index: Int,
-    instantiationSignature: MutableMap<Declaration?, Node?>,
-    instantiationType: MutableMap<Node?, TemplateDeclaration.TemplateInitialization?>,
+    instantiationSignature: MutableMap<Declaration?, AstNode?>,
+    instantiationType: MutableMap<AstNode?, TemplateDeclaration.TemplateInitialization?>,
     orderedInitializationSignature: MutableMap<Declaration, Int>,
 ) {
     if ((functionTemplateDeclaration.parameters[index] as HasDefault<*>).default != null) {
         // If we have a default we fill it in
-        var defaultNode = (functionTemplateDeclaration.parameters[index] as HasDefault<*>).default
-        if (defaultNode is Type) {
+        var defaultNode =
+            (functionTemplateDeclaration.parameters[index] as HasDefault<*>).default as Expression
+        /*if (defaultNode is Type) {
             defaultNode =
                 functionTemplateDeclaration.newTypeExpression(defaultNode.name, defaultNode)
             defaultNode.isImplicit = true
-        }
+        }*/
         instantiationSignature[functionTemplateDeclaration.parameters[index]] = defaultNode
         instantiationType[defaultNode] = TemplateDeclaration.TemplateInitialization.DEFAULT
         orderedInitializationSignature[functionTemplateDeclaration.parameters[index]] = index

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
@@ -71,6 +71,7 @@ open class ControlFlowSensitiveDFGPass(ctx: TranslationContext) : EOGStarterPass
             // more than it helps.
             return
         }
+
         // These are EOGStarterHolders but do not have an EOG which means, they will just cause
         // problems. Again, if we delete information/edges, we will never be able to recover them.
         if (node is FunctionTemplateDeclaration) return
@@ -87,7 +88,10 @@ open class ControlFlowSensitiveDFGPass(ctx: TranslationContext) : EOGStarterPass
 
         log.trace("Handling {} (complexity: {})", node.name, c)
 
-        clearFlowsOfVariableDeclarations(node)
+        if (node is AstNode) {
+            clearFlowsOfVariableDeclarations(node)
+        }
+
         val startState = DFGPassState<Set<Node>>()
 
         startState.declarationsState.push(node, PowersetLattice(identitySetOf()))
@@ -164,7 +168,7 @@ open class ControlFlowSensitiveDFGPass(ctx: TranslationContext) : EOGStarterPass
      * Removes all the incoming and outgoing DFG edges for each variable declaration in the block of
      * code [node].
      */
-    protected fun clearFlowsOfVariableDeclarations(node: Node) {
+    protected fun clearFlowsOfVariableDeclarations(node: AstNode) {
         // Get all children of the node which are not part of child EOG starters' children. We need
         // this to filter out effects on the childStarters' children. We do not want to impact them,
         // so we later filter out all things which occur in the children or even completely outside

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
@@ -40,6 +40,7 @@ import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker.IterativeGraphWalker
 import de.fraunhofer.aisec.cpg.helpers.Util
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
 import de.fraunhofer.aisec.cpg.passes.inference.DFGFunctionSummaries
+import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 
 /** Adds the DFG edges for various types of nodes. */
 @DependsOn(SymbolResolver::class)
@@ -53,7 +54,7 @@ class DFGPass(ctx: TranslationContext) : ComponentPass(ctx) {
         )
 
         val inferDfgForUnresolvedCalls = config.inferenceConfiguration.inferDfgForUnresolvedSymbols
-        val walker = IterativeGraphWalker()
+        val walker = IterativeGraphWalker(Strategy::AST_FORWARD)
         walker.registerOnNodeVisit { node, parent ->
             handle(node, parent, inferDfgForUnresolvedCalls, config.functionSummaries)
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DynamicInvokeResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DynamicInvokeResolver.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.passes
 import de.fraunhofer.aisec.cpg.IncompatibleSignature
 import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.graph.AccessValues
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.FieldDeclaration
@@ -44,6 +45,7 @@ import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker.ScopedWalker
 import de.fraunhofer.aisec.cpg.helpers.identitySetOf
 import de.fraunhofer.aisec.cpg.matchesSignature
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
+import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 import java.util.*
 import java.util.function.Consumer
 
@@ -60,12 +62,12 @@ import java.util.function.Consumer
 @DependsOn(DFGPass::class)
 @DependsOn(ControlFlowSensitiveDFGPass::class, softDependency = true)
 class DynamicInvokeResolver(ctx: TranslationContext) : ComponentPass(ctx) {
-    private lateinit var walker: ScopedWalker
+    private lateinit var walker: ScopedWalker<AstNode>
     private var inferDfgForUnresolvedCalls = false
 
     override fun accept(component: Component) {
         inferDfgForUnresolvedCalls = config.inferenceConfiguration.inferDfgForUnresolvedSymbols
-        walker = ScopedWalker(scopeManager)
+        walker = ScopedWalker(scopeManager, Strategy::AST_FORWARD)
         walker.registerHandler { node -> handle(node) }
 
         for (tu in component.translationUnits) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
@@ -29,6 +29,7 @@ import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.CastNotPossible
 import de.fraunhofer.aisec.cpg.frontends.HasShortCircuitOperators
 import de.fraunhofer.aisec.cpg.frontends.ProcessedListener
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.EOGStarterHolder
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.StatementHolder
@@ -1383,7 +1384,7 @@ open class EvaluationOrderGraphPass(ctx: TranslationContext) : TranslationUnitPa
          * @param n
          * @return
          */
-        fun checkEOGInvariant(n: Node): Boolean {
+        fun checkEOGInvariant(n: AstNode): Boolean {
             val allNodes = SubgraphWalker.flattenAST(n)
             var ret = true
             for (node in allNodes) {
@@ -1449,7 +1450,7 @@ open class EvaluationOrderGraphPass(ctx: TranslationContext) : TranslationUnitPa
      * to be extended if new nodes are added that have a condition relevant as entry points when
      * looping.
      */
-    val Node.conditions: List<Node>
+    val Node.conditions: List<AstNode>
         get() =
             when (this) {
                 is WhileStatement ->
@@ -1485,7 +1486,7 @@ open class EvaluationOrderGraphPass(ctx: TranslationContext) : TranslationUnitPa
         }
     }
 
-    fun drawEOGToEntriesOf(from: List<Node>, toEntriesOf: Node?, branchLabel: Boolean? = null) {
+    fun drawEOGToEntriesOf(from: List<Node>, toEntriesOf: AstNode?, branchLabel: Boolean? = null) {
         val tmpBranchLabel = nextEdgeBranch
         branchLabel?.let { nextEdgeBranch = it }
         SubgraphWalker.getEOGPathEdges(toEntriesOf).entries.forEach { entrance ->

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.passes
 import de.fraunhofer.aisec.cpg.ScopeManager
 import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.Node
@@ -198,7 +199,7 @@ class ImportDependencies<T : Node>(modules: MutableList<T>) : IdentityHashMap<T,
  */
 class ImportResolver(ctx: TranslationContext) : TranslationResultPass(ctx) {
 
-    lateinit var walker: SubgraphWalker.ScopedWalker
+    lateinit var walker: SubgraphWalker.ScopedWalker<AstNode>
     lateinit var tr: TranslationResult
 
     override fun accept(tr: TranslationResult) {
@@ -210,7 +211,7 @@ class ImportResolver(ctx: TranslationContext) : TranslationResultPass(ctx) {
 
         // In order to resolve imports as good as possible, we need the information which namespace
         // does an import on which other
-        walker = SubgraphWalker.ScopedWalker(scopeManager)
+        walker = SubgraphWalker.ScopedWalker(scopeManager, Strategy::AST_FORWARD)
         walker.registerHandler { node ->
             if (node is Component) {
                 // Create a new import dependency object for the component, to make sure that all

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PrepareSerialization.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PrepareSerialization.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationContext
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.allChildren
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
@@ -50,7 +51,7 @@ class PrepareSerialization(ctx: TranslationContext) : TranslationUnitPass(ctx) {
     }
 
     override fun accept(tr: TranslationUnitDeclaration) {
-        tr.allChildren<Node>().map { node ->
+        tr.allChildren<AstNode>().map { node ->
             // Add explicit AST edge
             node.astChildren = SubgraphWalker.getAstChildren(node)
             // CallExpression overwrites name property and must be copied to JvmField

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ProgramDependenceGraphPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ProgramDependenceGraphPass.kt
@@ -47,12 +47,12 @@ import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 @DependsOn(DynamicInvokeResolver::class)
 class ProgramDependenceGraphPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {
     private val visitor =
-        object : IVisitor<Node>() {
+        object : IVisitor<AstNode>() {
             /**
              * Collects the data and control dependence edges of a node and adds them to the program
              * dependence edges
              */
-            override fun visit(t: Node) {
+            override fun visit(t: AstNode) {
                 if (t is Reference) {
                     // We filter all prevDFGEdges if the condition affects the variable of t and
                     // if there's a flow from the prevDFGEdge's node through the condition to t.
@@ -136,6 +136,8 @@ class ProgramDependenceGraphPass(ctx: TranslationContext) : TranslationUnitPass(
     }
 
     private fun handle(node: Node) {
-        node.accept(Strategy::AST_FORWARD, visitor)
+        if (node is AstNode) {
+            node.accept<AstNode>(Strategy::AST_FORWARD, visitor)
+        }
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveCallExpressionAmbiguityPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveCallExpressionAmbiguityPass.kt
@@ -47,6 +47,7 @@ import de.fraunhofer.aisec.cpg.nameIsType
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
 import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
 import de.fraunhofer.aisec.cpg.passes.configuration.RequiresLanguageTrait
+import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 
 /**
  * If a [Language] has the trait [HasCallExpressionAmbiguity], we cannot distinguish between
@@ -60,10 +61,10 @@ import de.fraunhofer.aisec.cpg.passes.configuration.RequiresLanguageTrait
 @DependsOn(TypeResolver::class)
 @RequiresLanguageTrait(HasCallExpressionAmbiguity::class)
 class ResolveCallExpressionAmbiguityPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {
-    private lateinit var walker: SubgraphWalker.ScopedWalker
+    private lateinit var walker: SubgraphWalker.ScopedWalker<AstNode>
 
     override fun accept(tu: TranslationUnitDeclaration) {
-        walker = SubgraphWalker.ScopedWalker(ctx.scopeManager)
+        walker = SubgraphWalker.ScopedWalker(ctx.scopeManager, Strategy::AST_FORWARD)
         walker.registerHandler { node ->
             when (node) {
                 is CallExpression -> handleCall(node)
@@ -103,7 +104,7 @@ class ResolveCallExpressionAmbiguityPass(ctx: TranslationContext) : TranslationU
         // functional-constructs)
         if (language is HasFunctionStyleConstruction) {
             // Check for our type. We are only interested in object types
-            var type = ref.nameIsType()
+            val type = ref.nameIsType()
             if (type is ObjectType && !type.isPrimitive) {
                 walker.replaceCallWithConstruct(type, parent, call)
             }
@@ -127,9 +128,9 @@ class ResolveCallExpressionAmbiguityPass(ctx: TranslationContext) : TranslationU
 }
 
 context(provider: ContextProvider)
-fun SubgraphWalker.ScopedWalker.replaceCallWithCast(
+fun SubgraphWalker.ScopedWalker<Node>.replaceCallWithCast(
     type: Type,
-    parent: Node,
+    parent: AstNode,
     call: CallExpression,
     pointer: Boolean,
 ) {
@@ -150,9 +151,9 @@ fun SubgraphWalker.ScopedWalker.replaceCallWithCast(
 }
 
 context(_: ContextProvider)
-fun SubgraphWalker.ScopedWalker.replaceCallWithConstruct(
+fun SubgraphWalker.ScopedWalker<Node>.replaceCallWithConstruct(
     type: ObjectType,
-    parent: Node,
+    parent: AstNode,
     call: CallExpression,
 ) {
     val callee = call.callee

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveMemberExpressionAmbiguityPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ResolveMemberExpressionAmbiguityPass.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.passes
 import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.HasCallExpressionAmbiguity
 import de.fraunhofer.aisec.cpg.frontends.HasMemberExpressionAmbiguity
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.HasBase
 import de.fraunhofer.aisec.cpg.graph.Name
 import de.fraunhofer.aisec.cpg.graph.codeAndLocationFrom
@@ -45,6 +46,7 @@ import de.fraunhofer.aisec.cpg.helpers.replace
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
 import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
 import de.fraunhofer.aisec.cpg.passes.configuration.RequiresLanguageTrait
+import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 
 /**
  * A translation unit pass that resolves ambiguities in member expressions within a translation
@@ -62,10 +64,10 @@ import de.fraunhofer.aisec.cpg.passes.configuration.RequiresLanguageTrait
 @RequiresLanguageTrait(HasMemberExpressionAmbiguity::class)
 class ResolveMemberExpressionAmbiguityPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {
 
-    lateinit var walker: SubgraphWalker.ScopedWalker
+    lateinit var walker: SubgraphWalker.ScopedWalker<AstNode>
 
     override fun accept(tu: TranslationUnitDeclaration) {
-        walker = SubgraphWalker.ScopedWalker(ctx.scopeManager)
+        walker = SubgraphWalker.ScopedWalker(ctx.scopeManager, Strategy::AST_FORWARD)
         walker.registerHandler { node ->
             when (node) {
                 is MemberExpression -> resolveAmbiguity(node)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/StatisticsCollectionPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/StatisticsCollectionPass.kt
@@ -31,6 +31,7 @@ import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.ProblemNode
 import de.fraunhofer.aisec.cpg.helpers.MeasurementHolder
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker.ScopedWalker
+import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 
 /**
  * A [Pass] collecting statistics for the graph. Currently, it collects the number of nodes and the
@@ -42,7 +43,7 @@ class StatisticsCollectionPass(ctx: TranslationContext) : TranslationResultPass(
     override fun accept(result: TranslationResult) {
         var problemNodes = 0
         var nodes = 0
-        val walker = ScopedWalker(ctx.scopeManager)
+        val walker = ScopedWalker(ctx.scopeManager, Strategy::AST_FORWARD)
         walker.registerHandler { node: Node ->
             nodes++
             if (node is ProblemNode) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeHierarchyResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeHierarchyResolver.kt
@@ -26,9 +26,9 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationContext
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Name
-import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.EnumDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration
@@ -79,12 +79,12 @@ open class TypeHierarchyResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         }
     }
 
-    protected fun findRecordsAndEnums(node: Node) {
+    protected fun findRecordsAndEnums(node: AstNode) {
         // Using a visitor to avoid loops in the AST
         node.accept(
             Strategy::AST_FORWARD,
-            object : IVisitor<Node>() {
-                override fun visit(t: Node) {
+            object : IVisitor<AstNode>() {
+                override fun visit(t: AstNode) {
                     if (t is EnumDeclaration) {
                         enums.add(t)
                     } else if (t is RecordDeclaration) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/TypeResolver.kt
@@ -51,7 +51,7 @@ import kotlin.collections.plusAssign
 @DependsOn(ImportResolver::class)
 open class TypeResolver(ctx: TranslationContext) : ComponentPass(ctx) {
 
-    lateinit var walker: SubgraphWalker.ScopedWalker
+    lateinit var walker: SubgraphWalker.ScopedWalker<AstNode>
 
     override fun accept(component: Component) {
         ctx.currentComponent = component
@@ -63,7 +63,7 @@ open class TypeResolver(ctx: TranslationContext) : ComponentPass(ctx) {
     /**
      * This function is called for each [Node] in the component. It checks if the node has a type or
      * declares a type. If so, it tries to resolve the type using [resolveType]. It also checks for
-     * secondary type edges (see [HasSecondaryTypeEdge] and resolves them as well.
+     * secondary type edges (see [HasSecondaryTypeEdge]) and resolves them as well.
      *
      * @param node The node to handle.
      */

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
@@ -302,7 +302,7 @@ class Inference internal constructor(val start: Node, override val ctx: Translat
 
         val decl = newTypeParameterDeclaration(name)
         decl.code = name
-        decl.expression = newTypeExpression(name, type = parameterizedType)
+        decl.type = parameterizedType
 
         return decl
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/Inference.kt
@@ -302,7 +302,7 @@ class Inference internal constructor(val start: Node, override val ctx: Translat
 
         val decl = newTypeParameterDeclaration(name)
         decl.code = name
-        decl.type = parameterizedType
+        decl.expression = newTypeExpression(name, type = parameterizedType)
 
         return decl
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/processing/IVisitable.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/processing/IVisitable.kt
@@ -25,17 +25,19 @@
  */
 package de.fraunhofer.aisec.cpg.processing
 
+import de.fraunhofer.aisec.cpg.graph.Node
+
 /**
  * An object that can be visited by a visitor.
  *
  * @param <V> </V>
  */
-interface IVisitable<V : IVisitable<V>> {
+interface IVisitable {
     /**
      * @param strategy Traversal strategy.
      * @param visitor Instance of the visitor to call.
      */
-    fun accept(strategy: IStrategy<V>, visitor: IVisitor<V>) {
+    fun <V : Node> accept(strategy: IStrategy<V>, visitor: IVisitor<V>) {
         @Suppress("UNCHECKED_CAST")
         if (visitor.visited.add(this as V)) {
             visitor.visit(this)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/processing/IVisitor.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/processing/IVisitor.kt
@@ -33,7 +33,7 @@ import java.lang.reflect.InvocationTargetException
  *
  * @param <V> V must implement `IVisitable`. </V>
  */
-abstract class IVisitor<V : IVisitable<V>> {
+abstract class IVisitor<V : IVisitable> {
     @JvmField val visited = IdentitySet<V>()
 
     open fun visit(t: V) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/processing/strategy/Strategy.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/processing/strategy/Strategy.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.processing.strategy
 
 import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
@@ -122,7 +123,7 @@ object Strategy {
      * @param x
      * @return
      */
-    fun AST_FORWARD(x: Node): Iterator<Node> {
+    fun AST_FORWARD(x: AstNode): Iterator<AstNode> {
         return x.astChildren.iterator()
     }
 
@@ -172,7 +173,7 @@ object Strategy {
      * @param x Current node in EOG.
      * @return Iterator over successor edges.
      */
-    fun AST_EDGES_FORWARD(x: Node): Iterator<AstEdge<out Node>> {
+    fun AST_EDGES_FORWARD(x: AstNode): Iterator<AstEdge<out AstNode>> {
         return x.astEdges.iterator()
     }
 
@@ -182,7 +183,7 @@ object Strategy {
      * @param x Current node in EOG.
      * @return Iterator over successor edges.
      */
-    fun AST_EDGES_BACKWARD(x: Node): Iterator<AstEdge<out Node>> {
+    fun AST_EDGES_BACKWARD(x: AstNode): Iterator<AstEdge<out AstNode>> {
         return (x.astParent?.astEdges?.filter { it.end == x } ?: emptyList()).iterator()
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeListTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeListTest.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.graph.edges.collections
 
 import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
 import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdges
@@ -42,7 +43,7 @@ class EdgeListTest {
             val node3 = newLiteral(3)
             val node4 = newLiteral(4)
 
-            val list = AstEdges<Node, AstEdge<Node>>(thisRef = node1)
+            val list = AstEdges<AstNode, AstEdge<AstNode>>(thisRef = node1)
             list += node2
             list += node3
 

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSingletonListTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSingletonListTest.kt
@@ -26,7 +26,7 @@
 package de.fraunhofer.aisec.cpg.graph.edges.collections
 
 import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
-import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astOptionalEdgeOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import de.fraunhofer.aisec.cpg.graph.newLiteral
@@ -39,7 +39,7 @@ class EdgeSingletonListTest {
     @Test
     fun testNullable() {
         with(TestLanguageFrontend()) {
-            class MyNode : Node() {
+            class MyNode : AstNode() {
                 var edge = astOptionalEdgeOf<Expression>()
                 var unwrapped by unwrapping(MyNode::edge)
             }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeListTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeListTest.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.graph.edges.collections
 
 import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
 import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdges
@@ -67,7 +68,7 @@ class UnwrappedEdgeListTest {
             val node3 = newLiteral(3)
             val node4 = newLiteral(4)
 
-            val list = AstEdges<Node, AstEdge<Node>>(thisRef = node1)
+            val list = AstEdges<AstNode, AstEdge<AstNode>>(thisRef = node1)
             list += node2
             list += node3
 

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ProgramDependenceGraphPassTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ProgramDependenceGraphPassTest.kt
@@ -28,7 +28,7 @@ package de.fraunhofer.aisec.cpg.passes
 import de.fraunhofer.aisec.cpg.*
 import de.fraunhofer.aisec.cpg.frontends.TestLanguage
 import de.fraunhofer.aisec.cpg.frontends.testFrontend
-import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.builder.*
 import de.fraunhofer.aisec.cpg.graph.functions
 import de.fraunhofer.aisec.cpg.graph.get
@@ -52,8 +52,8 @@ class ProgramDependenceGraphPassTest {
 
         main.accept(
             Strategy::AST_FORWARD,
-            object : IVisitor<Node>() {
-                override fun visit(t: Node) {
+            object : IVisitor<AstNode>() {
+                override fun visit(t: AstNode) {
                     val expectedPrevEdges =
                         t.prevCDGEdges +
                             t.prevDFGEdges.filter {

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/processing/VisitorTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/processing/VisitorTest.kt
@@ -60,8 +60,8 @@ class VisitorTest : BaseTest() {
         // Let's visit
         tu.accept(
             Strategy::AST_FORWARD,
-            object : IVisitor<Node>() {
-                override fun visit(t: Node) {
+            object : IVisitor<AstNode>() {
+                override fun visit(t: AstNode) {
                     visited += t
                 }
             },
@@ -104,8 +104,8 @@ class VisitorTest : BaseTest() {
         val nodeList = mutableListOf<Node>()
         recordDeclaration!!.accept(
             Strategy::AST_FORWARD,
-            object : IVisitor<Node>() {
-                override fun visit(t: Node) {
+            object : IVisitor<AstNode>() {
+                override fun visit(t: AstNode) {
                     log.info("Node: $t")
                     nodeList.add(t)
                 }
@@ -125,7 +125,7 @@ class VisitorTest : BaseTest() {
 
         recordDeclaration!!.accept(
             Strategy::AST_FORWARD,
-            object : IVisitor<Node>() {
+            object : IVisitor<AstNode>() {
                 fun visit(r: ReturnStatement) {
                     returnStatements.add(r)
                 }

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CPPLanguage.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CPPLanguage.kt
@@ -29,9 +29,9 @@ import de.fraunhofer.aisec.cpg.CallResolutionResult
 import de.fraunhofer.aisec.cpg.SignatureMatches
 import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.frontends.*
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.ContextProvider
 import de.fraunhofer.aisec.cpg.graph.HasOverloadedOperation
-import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.primitiveType
 import de.fraunhofer.aisec.cpg.graph.scopes.Symbol
@@ -250,7 +250,7 @@ open class CPPLanguage() :
             ctx.scopeManager.lookupSymbolByNodeNameOfType<FunctionTemplateDeclaration>(templateCall)
         for (functionTemplateDeclaration in instantiationCandidates) {
             val initializationType =
-                mutableMapOf<Node?, TemplateDeclaration.TemplateInitialization?>()
+                mutableMapOf<AstNode?, TemplateDeclaration.TemplateInitialization?>()
             val orderedInitializationSignature = mutableMapOf<Declaration, Int>()
             val explicitInstantiation = mutableListOf<ParameterizedType>()
             if (

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontend.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontend.kt
@@ -378,7 +378,7 @@ open class CXXLanguageFrontend(ctx: TranslationContext, language: Language<CXXLa
      * @param node the node to process
      * @param owner the AST node which holds the attribute
      */
-    fun processAttributes(node: Node, owner: IASTNode) {
+    fun processAttributes(node: AstNode, owner: IASTNode) {
         if (config.processAnnotations && owner is IASTAttributeOwner) { // set attributes
             node.annotations += handleAttributes(owner)
         }

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
@@ -321,8 +321,6 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
                         templateParameter.name.toString(),
                         language,
                     )
-                typeParamDecl.expression =
-                    newTypeExpression(templateParameter.name.toString(), type = parameterizedType)
                 typeParamDecl.type = parameterizedType
                 if (templateParameter.defaultType != null) {
                     val defaultType = frontend.typeOf(templateParameter.defaultType)

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
@@ -324,7 +324,7 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
                 typeParamDecl.type = parameterizedType
                 if (templateParameter.defaultType != null) {
                     val defaultType = frontend.typeOf(templateParameter.defaultType)
-                    typeParamDecl.default = defaultType
+                    typeParamDecl.default = newTypeExpression("", type = defaultType)
                 }
                 templateDeclaration.parameters += typeParamDecl
             } else if (templateParameter is CPPASTParameterDeclaration) {
@@ -590,13 +590,13 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
     private fun extractTemplateParams(
         ctx: IASTSimpleDeclaration,
         declSpecifier: IASTDeclSpecifier,
-    ): MutableList<Node>? {
+    ): MutableList<AstNode>? {
         if (
             !ctx.isTypedef &&
                 declSpecifier is CPPASTNamedTypeSpecifier &&
                 declSpecifier.name is CPPASTTemplateId
         ) {
-            val templateParams = mutableListOf<Node>()
+            val templateParams = mutableListOf<AstNode>()
             val templateId = declSpecifier.name as CPPASTTemplateId
             for (templateArgument in templateId.templateArguments) {
                 if (templateArgument is CPPASTTypeId) {

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/DeclarationHandler.kt
@@ -321,10 +321,12 @@ class DeclarationHandler(lang: CXXLanguageFrontend) :
                         templateParameter.name.toString(),
                         language,
                     )
+                typeParamDecl.expression =
+                    newTypeExpression(templateParameter.name.toString(), type = parameterizedType)
                 typeParamDecl.type = parameterizedType
                 if (templateParameter.defaultType != null) {
                     val defaultType = frontend.typeOf(templateParameter.defaultType)
-                    typeParamDecl.default = newTypeExpression("", type = defaultType)
+                    typeParamDecl.default = newTypeExpression(defaultType.name, type = defaultType)
                 }
                 templateDeclaration.parameters += typeParamDecl
             } else if (templateParameter is CPPASTParameterDeclaration) {

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/ExpressionHandler.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/ExpressionHandler.kt
@@ -287,8 +287,8 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
      * @param template
      * @return List of Nodes containing the all the arguments the template was instantiated with.
      */
-    private fun getTemplateArguments(template: CPPASTTemplateId): MutableList<Node> {
-        val templateArguments = mutableListOf<Node>()
+    private fun getTemplateArguments(template: CPPASTTemplateId): MutableList<AstNode> {
+        val templateArguments = mutableListOf<AstNode>()
         for (argument in template.templateArguments) {
             when (argument) {
                 is IASTTypeId -> {
@@ -306,6 +306,7 @@ class ExpressionHandler(lang: CXXLanguageFrontend) :
                 }
             }
         }
+
         return templateArguments
     }
 

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CXXExtraPass.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CXXExtraPass.kt
@@ -38,6 +38,7 @@ import de.fraunhofer.aisec.cpg.helpers.replace
 import de.fraunhofer.aisec.cpg.nameIsType
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
 import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
+import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 
 /**
  * This [Pass] executes certain C++ specific conversions on initializers, that are only possible
@@ -50,10 +51,10 @@ import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
 @DependsOn(TypeResolver::class)
 class CXXExtraPass(ctx: TranslationContext) : ComponentPass(ctx) {
 
-    private lateinit var walker: SubgraphWalker.ScopedWalker
+    private lateinit var walker: SubgraphWalker.ScopedWalker<AstNode>
 
     override fun accept(component: Component) {
-        walker = SubgraphWalker.ScopedWalker(ctx.scopeManager)
+        walker = SubgraphWalker.ScopedWalker(ctx.scopeManager, Strategy::AST_FORWARD)
 
         walker.registerHandler(::fixInitializers)
         walker.registerHandler { node ->

--- a/cpg-language-cxx/src/performanceTest/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/PerformanceRegressionTest.kt
+++ b/cpg-language-cxx/src/performanceTest/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/PerformanceRegressionTest.kt
@@ -26,7 +26,7 @@
 package de.fraunhofer.aisec.cpg.frontends.cxx
 
 import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
-import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
@@ -100,7 +100,7 @@ class PerformanceRegressionTest {
         }
     }
 
-    fun doNothing(node: Node) {
+    fun doNothing(node: AstNode) {
         for (child in node.astChildren) {
             doNothing(child)
         }

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/EOGTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/EOGTest.kt
@@ -1017,7 +1017,7 @@ internal class EOGTest : BaseTest() {
      * - path for the file to test.
      */
     @Throws(Exception::class)
-    private fun translateToNodes(path: String): List<Node> {
+    private fun translateToNodes(path: String): List<AstNode> {
         val toTranslate = File(path)
         val topLevel = toTranslate.parentFile.toPath()
         val tu =

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/templates/ClassTemplateTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/templates/ClassTemplateTest.kt
@@ -321,7 +321,7 @@ internal class ClassTemplateTest : BaseTest() {
 
         val type2ParameterizedType = type2.type as? ParameterizedType
         assertNotNull(type2ParameterizedType)
-        assertEquals(type1ParameterizedType, type2.default)
+        assertEquals(type1ParameterizedType, type2.default?.type)
 
         val pairType =
             (pairConstructorDecl.type as FunctionType).returnTypes.firstOrNull() as? ObjectType

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/templates/FunctionTemplateTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/templates/FunctionTemplateTest.kt
@@ -113,7 +113,7 @@ internal class FunctionTemplateTest : BaseTest() {
         val intType = IntegerType("int", 32, language, NumericType.Modifier.SIGNED)
         val floatType = FloatingPointType("float", 32, language, NumericType.Modifier.SIGNED)
         assertEquals(typeT, typeParamDeclaration.type)
-        assertEquals(intType, typeParamDeclaration.default)
+        assertEquals(intType, typeParamDeclaration.default?.type)
 
         val N = findByUniqueName(result.parameters, "N")
         val int2 = findByUniquePredicate(result.literals { it.value == 2 }) { it.value == 2 }

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/templates/FunctionTemplateTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/templates/FunctionTemplateTest.kt
@@ -316,12 +316,12 @@ internal class FunctionTemplateTest : BaseTest() {
         assertEquals(fixedMultiply, call.invokes[0])
 
         // Check template parameters
-        val intType =
-            findByUniquePredicate(result.allChildren()) { t: ObjectType ->
+        val intTypeExpression =
+            findByUniquePredicate(result.allChildren()) { t: TypeExpression ->
                 t.name.localName == "int"
             }
-        val literal5 =
-            findByUniquePredicate<Literal<*>>(result.literals) { l: Literal<*> -> l.value == 5 }
+        val intType = intTypeExpression.type
+        val literal5 = findByUniquePredicate(result.literals) { l: Literal<*> -> l.value == 5 }
         assertEquals(2, call.templateArguments.size)
         assertEquals(intType, (call.templateArguments[0] as TypeExpression).type)
         assertEquals(literal5, call.templateArguments[1])
@@ -418,10 +418,13 @@ internal class FunctionTemplateTest : BaseTest() {
         assertEquals(fixedMultiply, call.invokes[0])
 
         // Check template parameters
-        val intType =
-            findByUniquePredicate(result.allChildren<ObjectType>()) { t: ObjectType ->
+        val intTypeExpression =
+            findByUniquePredicate(
+                result.allChildren<FunctionTemplateDeclaration>().flatMap { it.allChildren() }
+            ) { t: TypeExpression ->
                 t.name.localName == "int"
             }
+        val intType = intTypeExpression.type
         val literal5 = findByUniquePredicate(result.literals) { l: Literal<*> -> l.value == 5 }
         assertEquals(2, call.templateArguments.size)
         assertEquals(intType, (call.templateArguments[0] as TypeExpression).type)

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/GoExtraPass.kt
@@ -37,6 +37,7 @@ import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
 import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
+import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 
 /**
  * This pass takes care of several things that we need to clean up, once all translation units are
@@ -98,7 +99,7 @@ import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
 @DependsOn(TypeResolver::class)
 class GoExtraPass(ctx: TranslationContext) : ComponentPass(ctx) {
 
-    private lateinit var walker: SubgraphWalker.ScopedWalker
+    private lateinit var walker: SubgraphWalker.ScopedWalker<AstNode>
 
     override val scope: Scope?
         get() = scopeManager.currentScope
@@ -109,7 +110,7 @@ class GoExtraPass(ctx: TranslationContext) : ComponentPass(ctx) {
             component.translationUnits += addBuiltIn()
         }
 
-        walker = SubgraphWalker.ScopedWalker(scopeManager)
+        walker = SubgraphWalker.ScopedWalker(scopeManager, Strategy::AST_FORWARD)
         walker.registerHandler { node ->
             when (node) {
                 is RecordDeclaration -> handleRecordDeclaration(node)

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguageFrontend.kt
@@ -468,10 +468,7 @@ open class JavaLanguageFrontend(ctx: TranslationContext, language: Language<Java
      * @param node the node
      * @param owner the AST owner node
      */
-    fun processAnnotations(
-        node: de.fraunhofer.aisec.cpg.graph.Node,
-        owner: NodeWithAnnotations<*>,
-    ) {
+    fun processAnnotations(node: AstNode, owner: NodeWithAnnotations<*>) {
         if (config.processAnnotations) {
             node.annotations += handleAnnotations(owner)
         }

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaExtraPass.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaExtraPass.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationContext
+import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.codeAndLocationFrom
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnitDeclaration
 import de.fraunhofer.aisec.cpg.graph.fqn
@@ -38,6 +39,7 @@ import de.fraunhofer.aisec.cpg.helpers.replace
 import de.fraunhofer.aisec.cpg.nameIsType
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
 import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
+import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 
 /**
  * This pass is responsible for handling Java-specific cases that are not covered by the general CPG
@@ -48,11 +50,11 @@ import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
 @DependsOn(TypeResolver::class)
 @ExecuteBefore(SymbolResolver::class)
 class JavaExtraPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {
-    private lateinit var walker: SubgraphWalker.ScopedWalker
+    private lateinit var walker: SubgraphWalker.ScopedWalker<AstNode>
 
     override fun accept(tu: TranslationUnitDeclaration) {
         // Loop through all member expressions
-        walker = SubgraphWalker.ScopedWalker(ctx.scopeManager)
+        walker = SubgraphWalker.ScopedWalker(ctx.scopeManager, Strategy::AST_FORWARD)
         walker.registerHandler { node ->
             when (node) {
                 is MemberExpression -> handleMemberExpression(node)

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaImportResolver.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaImportResolver.kt
@@ -163,12 +163,12 @@ open class JavaImportResolver(ctx: TranslationContext) : ComponentPass(ctx) {
         return result
     }
 
-    protected fun findImportables(node: Node) {
+    protected fun findImportables(node: AstNode) {
         // Using a visitor to avoid loops in the AST
         node.accept(
             Strategy::AST_FORWARD,
-            object : IVisitor<Node>() {
-                override fun visit(t: Node) {
+            object : IVisitor<AstNode>() {
+                override fun visit(t: AstNode) {
                     if (t is RecordDeclaration) {
                         records.add(t)
                         importables.putIfAbsent(t.name.toString(), t)

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/EOGTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/EOGTest.kt
@@ -982,7 +982,7 @@ internal class EOGTest : BaseTest() {
      * - path for the file to test.
      */
     @Throws(Exception::class)
-    private fun translateToNodes(path: String): List<Node> {
+    private fun translateToNodes(path: String): List<AstNode> {
         val toTranslate = File(path)
         val topLevel = toTranslate.parentFile.toPath()
         val tu =

--- a/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/WalkerTest.kt
+++ b/cpg-language-java/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/WalkerTest.kt
@@ -55,11 +55,9 @@ class WalkerTest {
         val result = analyzer.analyze().get()
         assertNotNull(result)
         val scopeManager = result.finalCtx.scopeManager
-        val walker = SubgraphWalker.ScopedWalker(scopeManager)
+        val walker = SubgraphWalker.ScopedWalker(scopeManager, Strategy::EOG_FORWARD)
 
         val visitedNodes = mutableSetOf<Node>()
-
-        walker.strategy = Strategy::EOG_FORWARD
         walker.registerHandler { node ->
             assertTrue(visitedNodes.add(node), "Visited node $node multiple times")
         }

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/StatementHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/StatementHandler.kt
@@ -1336,7 +1336,11 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
      * therefore adds dummy statements to the end of basic blocks where a certain variable is
      * declared and initialized. The original phi instruction is not added to the CPG.
      */
-    fun handlePhi(instr: LLVMValueRef, tu: TranslationUnitDeclaration, flatAST: MutableList<Node>) {
+    fun handlePhi(
+        instr: LLVMValueRef,
+        tu: TranslationUnitDeclaration,
+        flatAST: MutableList<AstNode>,
+    ) {
         val labelMap = mutableMapOf<LabelStatement, Expression>()
         val numOps = LLVMGetNumOperands(instr)
         var i = 0

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CompressLLVMPass.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CompressLLVMPass.kt
@@ -204,15 +204,15 @@ class CompressLLVMPass(ctx: TranslationContext) : ComponentPass(ctx) {
     }
 
     /**
-     * Iterates through all nodes which are reachable from the catch clause. Note: When reaching a
-     * `TryStatement`, we do not follow the path further. This is why we can't use the `allChildren`
-     * extension.
+     * Iterates through all [AstNode]s which are reachable from the catch clause. Note: When
+     * reaching a `TryStatement`, we do not follow the path further. This is why we can't use the
+     * `allChildren` extension.
      */
-    private fun getAllChildrenRecursively(node: CatchClause?): Set<Node> {
+    private fun getAllChildrenRecursively(node: CatchClause?): Set<AstNode> {
         if (node == null) return setOf()
-        val worklist: Queue<Node> = LinkedList()
+        val worklist: Queue<AstNode> = LinkedList()
         worklist.add(node.body)
-        val alreadyChecked = LinkedHashSet<Node>()
+        val alreadyChecked = LinkedHashSet<AstNode>()
         while (worklist.isNotEmpty()) {
             val currentNode = worklist.remove()
             alreadyChecked.add(currentNode)

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PythonAddDeclarationsPass.kt
@@ -46,20 +46,21 @@ import de.fraunhofer.aisec.cpg.graph.types.UnknownType
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
 import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
 import de.fraunhofer.aisec.cpg.passes.configuration.RequiredFrontend
+import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
 
 @ExecuteBefore(ImportResolver::class)
 @ExecuteBefore(SymbolResolver::class)
 @RequiredFrontend(PythonLanguageFrontend::class)
 class PythonAddDeclarationsPass(ctx: TranslationContext) : ComponentPass(ctx), LanguageProvider {
 
-    lateinit var walker: SubgraphWalker.ScopedWalker
+    lateinit var walker: SubgraphWalker.ScopedWalker<AstNode>
 
     override fun cleanup() {
         // nothing to do
     }
 
     override fun accept(p0: Component) {
-        walker = SubgraphWalker.ScopedWalker(ctx.scopeManager)
+        walker = SubgraphWalker.ScopedWalker(ctx.scopeManager, Strategy::AST_FORWARD)
         walker.registerHandler { node -> handle(node) }
 
         for (tu in p0.translationUnits) {

--- a/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/TypeScriptLanguageFrontend.kt
+++ b/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/TypeScriptLanguageFrontend.kt
@@ -218,7 +218,7 @@ class TypeScriptLanguageFrontend(
     internal fun getIdentifierName(node: TypeScriptNode) =
         node.firstChild("Identifier")?.let { this.codeOf(it) } ?: ""
 
-    fun processAnnotations(node: Node, astNode: TypeScriptNode) {
+    fun processAnnotations(node: AstNode, astNode: TypeScriptNode) {
         // filter for decorators
         astNode.children
             ?.filter { it.type == "Decorator" }


### PR DESCRIPTION
This PR introduces an `AstNode`, in order to (later) restrict certain extension functions that only make sense on AST nodes.