### PR TITLE
Use correct arch detection in os.arch to fix #2407

### DIFF
--- a/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/TypeScriptLanguageFrontend.kt
+++ b/cpg-language-typescript/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/typescript/TypeScriptLanguageFrontend.kt
@@ -74,7 +74,7 @@ class TypeScriptLanguageFrontend(
         private val parserFile: File = createTempFile("parser", "")
 
         init {
-            val arch = System.getProperty("os.arch")
+            val arch = System.getProperty("os.arch").replace("amd64", "x86_64")
             val os: String =
                 when {
                     System.getProperty("os.name").startsWith("Mac") -> {


### PR DESCRIPTION
This follows

https://github.com/Fraunhofer-AISEC/cpg/blob/b9d16566cf0f381a883de36289a2a3515eb6ab13/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoStandardLibrary.kt#L836

to unify the arch names