### PR TITLE
Moving `group` back to `allprojects`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,9 @@ repositories {
     mavenCentral()
 }
 
-group = "de.fraunhofer.aisec"
+allprojects {
+    group = "de.fraunhofer.aisec"
+}
 
 // Configure Dokka for the multi-module cpg project
 dokka {


### PR DESCRIPTION
Reverts a bad config change from #2413 