### PR TITLE
Implementing a simple running counter for our legacy ID 

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -235,7 +235,11 @@ abstract class Node() :
     var isImplicit = false
 
     /** Required field for object graph mapping. It contains the node id. */
-    @DoNotPersist @Id @GeneratedValue var legacyId: Long? = null
+    @DoNotPersist @Id @GeneratedValue var legacyId: Long? = availableID.let {
+        val id = availableID
+        availableID++
+        id
+    }
 
     /**
      * A (more or less) unique identifier for this node. It is a [Uuid] derived from
@@ -361,6 +365,8 @@ abstract class Node() :
         @JvmStatic protected val log: Logger = LoggerFactory.getLogger(Node::class.java)
 
         const val EMPTY_NAME = ""
+
+        var availableID = 0
     }
 }
 


### PR DESCRIPTION
The running counter is necessary for the fluent dsl to allow for testing.