### PR TITLE
Fix Deno version due to bug in v2.6.0

### DIFF
--- a/cpg-language-typescript/build.gradle.kts
+++ b/cpg-language-typescript/build.gradle.kts
@@ -38,6 +38,8 @@ mavenPublishing {
     }
 }
 
+deno { version("v2.5.6") }
+
 val compileWindowsX8664 =
     tasks.register<RunDenoTask>("compileWindowsX8664") {
         dependsOn(tasks.installDeno)


### PR DESCRIPTION
There is a bug in Deno v2.6.0 with OSX for x86_64 (cf. denoland/deno#31556). As a temporary solution until the path is released, we're pinning the version to the previous release.