### PR TITLE
Add tag for self-hosted runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   build:
     timeout-minutes: 15
-    runs-on: [self-hosted, Linux, ARM64]
+    runs-on: [self-hosted, Linux, ARM64, cpg]
     steps:
       - uses: actions/checkout@v6
       - run: |


### PR DESCRIPTION
We're running into problems with the self-hosted runners provided through our organisation. We've added an additional tag to our self-hosted runner to make individual selection possible.

This updates the corresponding workflow.