### PR TITLE
Jep link error: refere to the README

### DIFF
--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/JepSingleton.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/JepSingleton.kt
@@ -26,7 +26,6 @@
 package de.fraunhofer.aisec.cpg.frontends.python
 
 import java.io.File
-import java.lang.RuntimeException
 import java.nio.file.Path
 import java.nio.file.Paths
 import jep.JepConfig
@@ -131,6 +130,13 @@ object JepSingleton {
 
     /** Setup and configure (load the Python code and trigger the debug script) an interpreter. */
     fun getInterp(): SharedInterpreter {
-        return SharedInterpreter()
+        try {
+            return SharedInterpreter()
+        } catch (e: UnsatisfiedLinkError) {
+            log.error(
+                "Failed to create Jep interpreter. Did you set up Jep correctly? Note: the Jep module has to be rebuild after a Python upgrade. Consult [the README](https://github.com/Fraunhofer-AISEC/cpg/?tab=readme-ov-file#virtual-env) for detailed instructions."
+            )
+            throw e
+        }
     }
 }


### PR DESCRIPTION
The Jep module has to be rebuild after a Python update. This PR adds an `error` log referencing the README to help users solve this issue faster.