### PR TITLE
Prevent potential division by zero when calculating 'time per LoC'

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationManager.kt
@@ -49,6 +49,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.io.path.absolute
 import kotlin.io.path.name
 import kotlin.io.path.readText
+import kotlin.math.max
 import kotlin.reflect.full.findAnnotation
 import kotlin.time.DurationUnit
 import org.slf4j.LoggerFactory
@@ -110,12 +111,10 @@ private constructor(
         }
 
         // ensure LoC is non-zero for division in average time per LoC
-        val divisionSafeLoC =
-            if (result.stats.totalLinesOfCode > 0) result.stats.totalLinesOfCode else 1
         log.info(
             "Translated {} LoC in total ({} / LoC)",
             result.stats.totalLinesOfCode,
-            (outerBench.duration / divisionSafeLoC).toString(
+            (outerBench.duration / max(result.stats.totalLinesOfCode, 1)).toString(
                 DurationUnit.MILLISECONDS,
                 decimals = 3,
             ),


### PR DESCRIPTION
We have seen circumstances (cf. PR #2558), where an analysis takes 0ms and 0 LoC are analyzed. This causes a division by zero error in the log statement providing average execution time per LoC statistic.

We ensure that LoC is safe for division by assuming 1 if it is 0. Using 1 as fallback should retain sufficient meaning for the average statistic.