### PR TITLE
Not persisting result of root in type which created several root edges

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/Type.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/types/Type.kt
@@ -140,6 +140,7 @@ abstract class Type : Node {
     }
 
     @get:JsonIgnore
+    @DoNotPersist
     var root: Type
         /**
          * Obtain the root Type Element for a Type Chain (follows Pointer and ReferenceTypes until a


### PR DESCRIPTION
Several duplicate root edges were drawn between types although root itself was not supposed to be persisted to neo4j.