### PR TITLE
Fix test compilation when cpg-mcp module is disabled

### DIFF
--- a/codyze-console/build.gradle.kts
+++ b/codyze-console/build.gradle.kts
@@ -32,6 +32,8 @@ dependencies {
         // MCP SDK only available at compile time so the files in `/ai` compile,
         compileOnly(libs.mcp)
         compileOnly(libs.mcp.client)
+        testCompileOnly(libs.mcp)
+        testCompileOnly(libs.mcp.client)
     }
 
     // Ktor server dependencies

--- a/codyze-console/build.gradle.kts
+++ b/codyze-console/build.gradle.kts
@@ -32,8 +32,8 @@ dependencies {
         // MCP SDK only available at compile time so the files in `/ai` compile,
         compileOnly(libs.mcp)
         compileOnly(libs.mcp.client)
-        testCompileOnly(libs.mcp)
-        testCompileOnly(libs.mcp.client)
+        testImplementation(libs.mcp)
+        testImplementation(libs.mcp.client)
     }
 
     // Ktor server dependencies

--- a/codyze-console/src/main/kotlin/de/fraunhofer/aisec/codyze/console/ai/clients/OpenAiClient.kt
+++ b/codyze-console/src/main/kotlin/de/fraunhofer/aisec/codyze/console/ai/clients/OpenAiClient.kt
@@ -210,7 +210,7 @@ class OpenAiClient(
      * ```
      *
      * See
-     * [OpenAI streaming events]https://developers.openai.com/api/reference/resources/chat/subresources/completions/streaming-events"></a>
+     * [OpenAI streaming events](https://developers.openai.com/api/reference/resources/chat/subresources/completions/streaming-events)
      * See [OpenAI Streaming API](https://developers.openai.com/api/docs/guides/streaming-responses)
      */
     private suspend fun handleStreamingResponse(


### PR DESCRIPTION
Tests in `codyze-console` don't compile when `cpg-mcp` is not enabled because the mcp sdk types are missing. Added `testImplementation` to fix this.
