### PR TITLE
Fixing type resolution issue in Java Frontend for fields

### DIFF
--- a/codyze-console/src/main/webapp/pnpm-workspace.yaml
+++ b/codyze-console/src/main/webapp/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - .
+allowBuilds:
+  esbuild: true

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/ExpressionHandler.kt
@@ -31,30 +31,19 @@ import com.github.javaparser.ast.expr.Expression as JPExpression
 import com.github.javaparser.resolution.UnsolvedSymbolException
 import com.github.javaparser.resolution.declarations.ResolvedFieldDeclaration
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration
+import com.github.javaparser.resolution.types.ResolvedPrimitiveType
+import com.github.javaparser.resolution.types.ResolvedType
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade
 import de.fraunhofer.aisec.cpg.frontends.Handler
 import de.fraunhofer.aisec.cpg.frontends.HandlerInterface
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.Record
 import de.fraunhofer.aisec.cpg.graph.declarations.Variable
-import de.fraunhofer.aisec.cpg.graph.expressions.ArrayConstruction
-import de.fraunhofer.aisec.cpg.graph.expressions.Assign
-import de.fraunhofer.aisec.cpg.graph.expressions.BinaryOperator
-import de.fraunhofer.aisec.cpg.graph.expressions.Call
-import de.fraunhofer.aisec.cpg.graph.expressions.Conditional
-import de.fraunhofer.aisec.cpg.graph.expressions.DeclarationStatement
+import de.fraunhofer.aisec.cpg.graph.expressions.*
 import de.fraunhofer.aisec.cpg.graph.expressions.Expression
-import de.fraunhofer.aisec.cpg.graph.expressions.InitializerList
-import de.fraunhofer.aisec.cpg.graph.expressions.Literal
-import de.fraunhofer.aisec.cpg.graph.expressions.MemberAccess
-import de.fraunhofer.aisec.cpg.graph.expressions.New
-import de.fraunhofer.aisec.cpg.graph.expressions.ProblemExpression
-import de.fraunhofer.aisec.cpg.graph.expressions.Reference
-import de.fraunhofer.aisec.cpg.graph.expressions.Subscription
-import de.fraunhofer.aisec.cpg.graph.expressions.UnaryOperator
 import de.fraunhofer.aisec.cpg.graph.types.FunctionType.Companion.computeType
 import de.fraunhofer.aisec.cpg.graph.types.Type
 import java.util.function.Supplier
-import kotlin.collections.set
 import kotlin.jvm.optionals.getOrNull
 import org.slf4j.LoggerFactory
 
@@ -239,11 +228,24 @@ class ExpressionHandler(lang: JavaLanguageFrontend) :
         // this is to get information about system types, as long as we are not fully doing that on
         // our own.
         try {
-            val symbol = fieldAccessExpr.resolve()
-            fieldType = frontend.typeOf(symbol.type)
+            var scopeType: ResolvedType =
+                JavaParserFacade.get(frontend.nativeTypeResolver)
+                    .getType(fieldAccessExpr.getScope())
 
-            if (symbol.isField) {
-                baseType = objectType(symbol.asField().declaringType().qualifiedName)
+            if (scopeType.isConstraint) {
+                scopeType = scopeType.asConstraintType().bound
+            }
+
+            if (scopeType.isArray() && fieldAccessExpr.getNameAsString().equals("length")) {
+                fieldType = frontend.typeOf(ResolvedPrimitiveType.INT)
+                baseType = frontend.typeOf(scopeType.asArrayType().componentType)
+            } else {
+                val symbol = fieldAccessExpr.resolve()
+                fieldType = frontend.typeOf(symbol.type)
+
+                if (symbol.isField) {
+                    baseType = objectType(symbol.asField().declaringType().qualifiedName)
+                }
             }
         } catch (_: UnsolvedSymbolException) {}
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ apache-commons-lang3 = { module = "org.apache.commons:commons-lang3", version = 
 neo4j-driver = { module = "org.neo4j.driver:neo4j-java-driver", version.ref = "neo4j5"}
 classgraph = { module = "io.github.classgraph:classgraph", version = "4.8.179"}
 
-javaparser = { module = "com.github.javaparser:javaparser-symbol-solver-core", version = "3.28.0"}
+javaparser = { module = "com.github.javaparser:javaparser-symbol-solver-core", version = "3.28.1"}
 jackson = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version = "2.21.0"}
 jacksonyml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version = "2.21.0"}
 eclipse-runtime = { module = "org.eclipse.platform:org.eclipse.core.runtime", version = "3.34.100"}


### PR DESCRIPTION
When we have a field access of the type `something.length` and the type of something is a type constraint, e.g. ? extends java.lang.object[]. The type resolver cannot resolve the type correctly and fails.

This PR checks if the type of the base is a constraints, and unwraps them before resolving it further. It also identifies the access to a .length field and sets the type to int.