### PR TITLE
Add whitelisting file

### DIFF
--- a/codyze-console/src/main/webapp/pnpm-workspace.yaml
+++ b/codyze-console/src/main/webapp/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - .
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
Esbuild needs to run scripts and currently we consider it to be trustworthy.