### PR TITLE
Avoid stackoverflow in Evaluator

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluator.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluator.kt
@@ -125,7 +125,7 @@ open class ValueEvaluator(
 
         // If the node is already in the path twice, we are looping, so we can stop here
         if (this.path.filter { it === node }.size > 1) {
-            cannotEvaluate(node, this)
+            return cannotEvaluate(node, this)
         }
 
         // Add the expression to the current path
@@ -474,8 +474,11 @@ open class ValueEvaluator(
             }
 
         return if (prevDFG.size == 1) {
-            // There's only one incoming DFG edge, so we follow this one.
-            evaluateInternal(prevDFG.first(), depth + 1)
+            // There's only one incoming DFG edge, so we follow this one. Except if it brings us
+            // back to the same node
+            val prev = prevDFG.single()
+            if (prev == node) cannotEvaluate(node, this)
+            else evaluateInternal(prev, depth + 1)
         } else if (prevDFG.size > 1) {
             // We cannot have more than ONE valid solution, so we need to abort
             log.warn(
@@ -485,7 +488,7 @@ open class ValueEvaluator(
             cannotEvaluate(node, this)
         } else {
             // No previous DFG node
-            //            log.warn("We cannot evaluate {}: It has no previous DFG edges.", node)
+            log.trace("We cannot evaluate {}: It has no previous DFG edges.", node)
             cannotEvaluate(node, this)
         }
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluator.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluator.kt
@@ -477,8 +477,7 @@ open class ValueEvaluator(
             // There's only one incoming DFG edge, so we follow this one. Except if it brings us
             // back to the same node
             val prev = prevDFG.single()
-            if (prev == node) cannotEvaluate(node, this)
-            else evaluateInternal(prev, depth + 1)
+            if (prev == node) cannotEvaluate(node, this) else evaluateInternal(prev, depth + 1)
         } else if (prevDFG.size > 1) {
             // We cannot have more than ONE valid solution, so we need to abort
             log.warn(

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
@@ -1158,7 +1158,7 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
         }
         val writtenTo: List<Node> =
             // Code from the ControlFlowSensitiveDFGPass suggests we should treat ForEach and
-            // Comprehensions slightly different, so let's to this for now
+            // Comprehensions slightly different, so lets to this for now
             when (currentNode) {
                 is ForEach -> {
                     when (variable) {
@@ -2789,7 +2789,7 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
         // we set both to the ParameterMemoryValue we create in the first step
         var src: Node = param
         var addresses = doubleState.getAddresses(src, src)
-        var prevAddresses: IdentitySet<Node> = identitySetOf<Node>()
+        var prevAddresses: IdentitySet<Node> = identitySetOf()
         // If we have a Pointer as param, we initialize all levels, otherwise, only
         // the first one
         val paramDepth =
@@ -2962,7 +2962,7 @@ suspend fun PointsToState.pushToDeclarationsState(
     val newLatticeCopy = newLatticeElement.duplicate()
 
     coroutineScope {
-        newLatticeElement.second.forEachMaybeParallel() { pair ->
+        newLatticeElement.second.forEachMaybeParallel { pair ->
             if (
                 currentState.declarationsState[newNode]?.second?.any {
                     it.first === pair.first && it.second == pair.second
@@ -2971,7 +2971,7 @@ suspend fun PointsToState.pushToDeclarationsState(
                 newLatticeCopy.second.remove(pair)
         }
 
-        newLatticeElement.third.forEachMaybeParallel() { nwpk ->
+        newLatticeElement.third.forEachMaybeParallel { nwpk ->
             if (currentState.declarationsState[newNode]?.third?.contains(nwpk) == true) {
                 newLatticeCopy.third.remove(nwpk)
             }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
@@ -2761,7 +2761,7 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                             // If the type is unknown or an Object, we also
                             // initialize all levels to be sure
                             param.type is UnknownType ||
-                            param.type is ObjectType ||
+//                            param.type is ObjectType ||
                             // Another guess we take: If the length is the same as the
                             // addressLength, again, to be sure we initialize all levels
                             (param.type as? NumericType)?.bitWidth ==

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
@@ -37,7 +37,6 @@ import de.fraunhofer.aisec.cpg.graph.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.expressions.Return
 import de.fraunhofer.aisec.cpg.graph.expressions.UnknownMemoryValue
 import de.fraunhofer.aisec.cpg.graph.types.NumericType
-import de.fraunhofer.aisec.cpg.graph.types.ObjectType
 import de.fraunhofer.aisec.cpg.graph.types.PointerType
 import de.fraunhofer.aisec.cpg.graph.types.UnknownType
 import de.fraunhofer.aisec.cpg.helpers.ConcurrentIdentitySet
@@ -2761,7 +2760,7 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                             // If the type is unknown or an Object, we also
                             // initialize all levels to be sure
                             param.type is UnknownType ||
-//                            param.type is ObjectType ||
+                            param.type is ObjectType ||
                             // Another guess we take: If the length is the same as the
                             // addressLength, again, to be sure we initialize all levels
                             (param.type as? NumericType)?.bitWidth ==

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
@@ -686,7 +686,7 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
 
         for ((param, fsEntries) in function.functionSummary) {
             fsEntries.forEach { entry ->
-                if (param is Parameter) { // && entry.srcNode is Parameter) {
+                if (param is Parameter) {
                     val dst =
                         doubleState
                             .getNestedValues(
@@ -2758,9 +2758,8 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                 val paramDepth =
                     if (
                         param.type is PointerType ||
-                            // If the type is unknown or an Object, we also initialize all levels to
-                            // be
-                            // sure
+                            // If the type is unknown or an Object, we also
+                            // initialize all levels to be sure
                             param.type is UnknownType ||
                             param.type is ObjectType ||
                             // Another guess we take: If the length is the same as the

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
@@ -37,7 +37,6 @@ import de.fraunhofer.aisec.cpg.graph.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.expressions.Return
 import de.fraunhofer.aisec.cpg.graph.expressions.UnknownMemoryValue
 import de.fraunhofer.aisec.cpg.graph.types.NumericType
-import de.fraunhofer.aisec.cpg.graph.types.ObjectType
 import de.fraunhofer.aisec.cpg.graph.types.PointerType
 import de.fraunhofer.aisec.cpg.graph.types.UnknownType
 import de.fraunhofer.aisec.cpg.helpers.ConcurrentIdentitySet
@@ -687,6 +686,29 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
         for ((param, fsEntries) in function.functionSummary) {
             fsEntries.forEach { entry ->
                 if (param is Parameter) {
+                    // In case this is a Parameter for which we didn't create deref-PMVs for some
+                    // reason (for example an unexpected type) we do create them now
+                    if (
+                        entry.destValueDepth > 1 &&
+                            param.memoryValues.none {
+                                (it as? ParameterMemoryValue)?.name?.localName ==
+                                    "deref".repeat(entry.destValueDepth - 1) + "value"
+                            } &&
+                            doubleState.getValues(param, param).none {
+                                (it.first as? ParameterMemoryValue)?.let { pmv ->
+                                    doubleState.hasDeclarationStateValueEntry(pmv)
+                                } ?: false
+                            }
+                    ) {
+                        doubleState =
+                            initializeParameter(
+                                lattice,
+                                function,
+                                param,
+                                doubleState,
+                                forceDerefPMVCreation = true,
+                            )
+                    }
                     val dst =
                         doubleState
                             .getNestedValues(
@@ -1043,7 +1065,7 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
             when (currentNode) {
                 is Comprehension,
                 is ForEach -> handleForEach(lattice, currentNode, doubleState)
-                is Function -> initializeParameters(lattice, currentNode, doubleState)
+                is Function -> handleFunction(lattice, currentNode, doubleState)
                 is Literal<*> -> {
                     // Literals don't have any prevDFG edges, so we skip those
                     doubleState
@@ -1077,6 +1099,21 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                     else doubleState
                 }
                 else -> doubleState
+            }
+        return doubleState
+    }
+
+    protected suspend fun handleFunction(
+        lattice: PointsToState,
+        function: Function,
+        doubleState: PointsToState.Element,
+    ): PointsToState.Element {
+        // For now, all we do here is to initialize the parameters
+        var doubleState = doubleState
+        function.parameters
+            .filter { it.memoryValues.filterIsInstance<ParameterMemoryValue>().isEmpty() }
+            .forEach { param ->
+                doubleState = initializeParameter(lattice, function, param, doubleState)
             }
         return doubleState
     }
@@ -2734,136 +2771,144 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
     }
 
     /** Create ParameterMemoryValues up to depth `depth` */
-    private suspend fun initializeParameters(
+    private suspend fun initializeParameter(
         lattice: PointsToState,
         function: Function,
+        param: Parameter,
         doubleState: PointsToState.Element,
         // Until which depth do we create ParameterMemoryValues
         depth: Int = 2,
+        // Create the PMVs independent of the parameter type
+        forceDerefPMVCreation: Boolean = false,
     ): PointsToState.Element {
         var doubleState = doubleState
-        function.parameters
-            .filter { it.memoryValues.filterIsInstance<ParameterMemoryValue>().isEmpty() }
-            .forEach { param ->
-                // In the first step, we have a triangle of Parameter, the
-                // Parameter's Memory Address and the ParameterMemoryValue
-                // Therefore, the src and the addresses are different. For all other depths,
-                // we set
-                // both to the ParameterMemoryValue we create in the first step
-                var src: Node = param
-                var addresses = doubleState.getAddresses(src, src)
-                var prevAddresses: IdentitySet<Node> = identitySetOf<Node>()
-                // If we have a Pointer as param, we initialize all levels, otherwise, only
-                // the first one
-                val paramDepth =
-                    if (
-                        param.type is PointerType ||
-                            // If the type is unknown or an Object, we also
-                            // initialize all levels to be sure
-                            param.type is UnknownType ||
-                            param.type is ObjectType ||
-                            // Another guess we take: If the length is the same as the
-                            // addressLength, again, to be sure we initialize all levels
-                            (param.type as? NumericType)?.bitWidth ==
-                                // TODO: passConfig<Configuration> should never be null?
-                                (passConfig<Configuration>()?.addressLength ?: 64)
-                    )
-                        depth
-                    else 0
-                for (i in 0..paramDepth) {
-                    val pmvName = "deref".repeat(i) + "value"
-                    val pmv =
-                        ParameterMemoryValue(
+
+        // In the first step, we have a triangle of Parameter, the
+        // Parameter's Memory Address and the ParameterMemoryValue
+        // Therefore, the src and the addresses are different. For all other depths,
+        // we set both to the ParameterMemoryValue we create in the first step
+        var src: Node = param
+        var addresses = doubleState.getAddresses(src, src)
+        var prevAddresses: IdentitySet<Node> = identitySetOf<Node>()
+        // If we have a Pointer as param, we initialize all levels, otherwise, only
+        // the first one
+        val paramDepth =
+            if (
+                param.type is PointerType ||
+                    forceDerefPMVCreation ||
+                    // If the type is unknown we also
+                    // initialize all levels to be sure
+                    param.type is UnknownType ||
+                    // Another guess we take: If the length is the same as the
+                    // addressLength, again, to be sure we initialize all levels
+                    (param.type as? NumericType)?.bitWidth ==
+                        // TODO: passConfig<Configuration> should never be null?
+                        (passConfig<Configuration>()?.addressLength ?: 64)
+            )
+                depth
+            else 0
+        for (pD in 0..paramDepth) {
+            val pmvName = "deref".repeat(pD) + "value"
+            // If we force the DerefPMVCreation, we probably create the first PMV already, so let's
+            // search it. For this, we check the memoryValues and the
+            // state, and if all is null, we create a new PMV
+            //            var pmv: ParameterMemoryValue?
+            val pmv =
+                if (forceDerefPMVCreation && pD == 0) {
+                    param.memoryValues.singleOrNull { it.name.localName == pmvName }
+                        as? ParameterMemoryValue
+                        ?: doubleState
+                            .getValues(param, param)
+                            .singleOrNull { it.first.name.localName == pmvName }
+                            ?.first as? ParameterMemoryValue
+                        ?: ParameterMemoryValue(
                             Name(pmvName, Name(param.name.localName, function.name))
                         )
-                    (src as? MemoryAddress)?.let { pmv.memoryAddresses = mutableSetOf(it) }
+                } else {
+                    ParameterMemoryValue(Name(pmvName, Name(param.name.localName, function.name)))
+                }
+            (src as? MemoryAddress)?.let { pmv.memoryAddresses = mutableSetOf(it) }
 
-                    // In the first step, we link the Parameter to the PMV to be
-                    // able to also access it outside the function
-                    if (src is Parameter) {
-                        doubleState =
-                            lattice.push(
-                                doubleState,
-                                src,
-                                GeneralStateEntryElement(
-                                    PowersetLattice.Element(addresses),
-                                    PowersetLattice.Element(
-                                        NodeWithPropertiesKey(pmv, equalLinkedHashSetOf())
-                                    ),
-                                    PowersetLattice.Element(),
-                                ),
-                            )
-                    } else {
-                        // Link the PMVs with each other so that we can find them. This is
-                        // especially important outside the respective function where we
-                        // don't have
-                        // a state
-                        addresses.filterIsInstance<ParameterMemoryValue>().forEach {
-                            doubleState =
-                                lattice.push(
-                                    doubleState,
-                                    it,
-                                    GeneralStateEntryElement(
-                                        PowersetLattice.Element(prevAddresses),
-                                        PowersetLattice.Element(
-                                            NodeWithPropertiesKey(pmv, equalLinkedHashSetOf())
-                                        ),
-                                        PowersetLattice.Element(),
-                                    ),
-                                )
-                        }
-                        doubleState =
-                            lattice.push(
-                                doubleState,
-                                pmv,
-                                GeneralStateEntryElement(
-                                    PowersetLattice.Element(addresses),
-                                    PowersetLattice.Element(),
-                                    PowersetLattice.Element(),
-                                ),
-                            )
-                        doubleState =
-                            lattice.push(
-                                doubleState,
-                                param,
-                                GeneralStateEntryElement(
-                                    PowersetLattice.Element(),
-                                    PowersetLattice.Element(
-                                        NodeWithPropertiesKey(pmv, equalLinkedHashSetOf(pmvName))
-                                    ),
-                                    PowersetLattice.Element(),
-                                ),
-                            )
-                    }
-
-                    // Update the states
-                    val declStateElement =
-                        if (src is Parameter)
-                            DeclarationStateEntryElement(
+            // In the first step, we link the Parameter to the PMV to be
+            // able to also access it outside the function
+            if (src is Parameter) {
+                doubleState =
+                    lattice.push(
+                        doubleState,
+                        src,
+                        GeneralStateEntryElement(
+                            PowersetLattice.Element(addresses),
+                            PowersetLattice.Element(
+                                NodeWithPropertiesKey(pmv, equalLinkedHashSetOf())
+                            ),
+                            PowersetLattice.Element(),
+                        ),
+                    )
+            } else {
+                // Link the PMVs with each other so that we can find them. This is
+                // especially important outside the respective function where we
+                // don't have
+                // a state
+                addresses.filterIsInstance<ParameterMemoryValue>().forEach {
+                    doubleState =
+                        lattice.push(
+                            doubleState,
+                            it,
+                            GeneralStateEntryElement(
                                 PowersetLattice.Element(prevAddresses),
-                                PowersetLattice.Element(Pair(pmv, false)),
-                                PowersetLattice.Element(
-                                    NodeWithPropertiesKey(src, equalLinkedHashSetOf())
-                                ),
-                            )
-                        else
-                            DeclarationStateEntryElement(
-                                PowersetLattice.Element(addresses),
-                                PowersetLattice.Element(Pair(pmv, false)),
                                 PowersetLattice.Element(
                                     NodeWithPropertiesKey(pmv, equalLinkedHashSetOf())
                                 ),
-                            )
-                    addresses.forEach { addr ->
-                        doubleState =
-                            lattice.pushToDeclarationsState(doubleState, addr, declStateElement)
-                    }
-
-                    prevAddresses = addresses
-                    src = pmv
-                    addresses = identitySetOf(pmv)
+                                PowersetLattice.Element(),
+                            ),
+                        )
                 }
+                doubleState =
+                    lattice.push(
+                        doubleState,
+                        pmv,
+                        GeneralStateEntryElement(
+                            PowersetLattice.Element(addresses),
+                            PowersetLattice.Element(),
+                            PowersetLattice.Element(),
+                        ),
+                    )
+                doubleState =
+                    lattice.push(
+                        doubleState,
+                        param,
+                        GeneralStateEntryElement(
+                            PowersetLattice.Element(),
+                            PowersetLattice.Element(
+                                NodeWithPropertiesKey(pmv, equalLinkedHashSetOf(pmvName))
+                            ),
+                            PowersetLattice.Element(),
+                        ),
+                    )
             }
+
+            // Update the states
+            val declStateElement =
+                if (src is Parameter)
+                    DeclarationStateEntryElement(
+                        PowersetLattice.Element(prevAddresses),
+                        PowersetLattice.Element(Pair(pmv, false)),
+                        PowersetLattice.Element(NodeWithPropertiesKey(src, equalLinkedHashSetOf())),
+                    )
+                else
+                    DeclarationStateEntryElement(
+                        PowersetLattice.Element(addresses),
+                        PowersetLattice.Element(Pair(pmv, false)),
+                        PowersetLattice.Element(NodeWithPropertiesKey(pmv, equalLinkedHashSetOf())),
+                    )
+            addresses.forEach { addr ->
+                doubleState = lattice.pushToDeclarationsState(doubleState, addr, declStateElement)
+            }
+
+            prevAddresses = addresses
+            src = pmv
+            addresses = identitySetOf(pmv)
+        }
         return doubleState
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
@@ -37,6 +37,7 @@ import de.fraunhofer.aisec.cpg.graph.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.expressions.Return
 import de.fraunhofer.aisec.cpg.graph.expressions.UnknownMemoryValue
 import de.fraunhofer.aisec.cpg.graph.types.NumericType
+import de.fraunhofer.aisec.cpg.graph.types.ObjectType
 import de.fraunhofer.aisec.cpg.graph.types.PointerType
 import de.fraunhofer.aisec.cpg.graph.types.UnknownType
 import de.fraunhofer.aisec.cpg.helpers.ConcurrentIdentitySet
@@ -2757,9 +2758,11 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                 val paramDepth =
                     if (
                         param.type is PointerType ||
-                            // If the type is unknown, we also initialize all levels to be
+                            // If the type is unknown or an Object, we also initialize all levels to
+                            // be
                             // sure
                             param.type is UnknownType ||
+                            param.type is ObjectType ||
                             // Another guess we take: If the length is the same as the
                             // addressLength, again, to be sure we initialize all levels
                             (param.type as? NumericType)?.bitWidth ==

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
@@ -37,6 +37,7 @@ import de.fraunhofer.aisec.cpg.graph.expressions.Expression
 import de.fraunhofer.aisec.cpg.graph.expressions.Return
 import de.fraunhofer.aisec.cpg.graph.expressions.UnknownMemoryValue
 import de.fraunhofer.aisec.cpg.graph.types.NumericType
+import de.fraunhofer.aisec.cpg.graph.types.ObjectType
 import de.fraunhofer.aisec.cpg.graph.types.PointerType
 import de.fraunhofer.aisec.cpg.graph.types.UnknownType
 import de.fraunhofer.aisec.cpg.helpers.ConcurrentIdentitySet

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
@@ -261,6 +261,14 @@ fun getNodeName(node: Node?): Name {
         is Literal<*> -> Name(node.value.toString())
         is UnknownMemoryValue -> Name(node.name.localName, Name("UnknownMemoryValue"))
         is Field -> Name(node.name.localName)
+        is BinaryOperator ->
+            Name(
+                getNodeName(node.lhs).localName +
+                    " " +
+                    node.operatorCode +
+                    " " +
+                    getNodeName(node.rhs).localName
+            )
         else -> node.name
     }
 }
@@ -2603,9 +2611,6 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                     when (ini) {
                         is PointerReference -> handleExpression(lattice, ini.input, doubleState)
                         is PointerDereference -> handleExpression(lattice, ini.input, doubleState)
-                        // For initializerLists, we extract all assigns and handle them
-                        // TODO: We will handle them again afterwards by traversing the EOG, not
-                        // sure if this is a problem
                         else -> handleExpression(lattice, ini, doubleState)
                     }
                 if (ini is InitializerList) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/DFGFunctionSummaries.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/DFGFunctionSummaries.kt
@@ -385,8 +385,7 @@ class DFGFunctionSummaries {
             // TODO: It would make sense to model properties here. Could be the index of a return
             // value, full vs. partial flow or whatever comes to our minds in the future
             // We can't currently draw the edges between ParameterMemoryValues here because we don't
-            // yet have them, so we do
-            // this in handleCallExpression in the pointsToPass
+            // yet have them, so we do this in handleCallExpression in the pointsToPass
             // Note: When we have a Name for a memoryAddress that does not yet exist, we need to
             // draw the DFG edge later in writeEntry()
             if (destValueDepth == 1 && srcValueDepth == 1)

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
@@ -4484,4 +4484,36 @@ class PointsToPassTest {
 
         assertContains(xDerefUse.prevDFG, delete)
     }
+
+    @Test
+    fun testCreationOfPMVsForWrongTypes() {
+        val file = File("src/test/resources/pointsToPass/freeint.cpp")
+        val tu =
+            analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
+                it.registerLanguage<CPPLanguage>()
+                it.registerPass<PointsToPass>()
+                it.registerFunctionSummaries(File("src/test/resources/hardcodedDFGedges.yml"))
+            }
+
+        assertNotNull(tu)
+
+        // Functions
+        val freeFunc = tu.functions["free"]
+        assertNotNull(freeFunc)
+
+        // Params and PMVs
+        val freeParam = freeFunc.parameters.single()
+        val freeDerefPMV = freeParam.memoryValues.singleOrNull { it.name.localName == "derefvalue" }
+        assertNotNull(freeDerefPMV)
+
+        // Usually we wouldn't calculate a PMV for the free function b/c we hand it an int
+        // However, since we have a (hardcoded) FS expecting a PMV we expect the defined DF to the
+        // UMV(freedMemory)
+        // nevertheless
+        assertTrue(
+            (freeDerefPMV as ParameterMemoryValue).prevFullDFG.any {
+                (it as? UnknownMemoryValue)?.name?.localName == "freedMemory"
+            }
+        )
+    }
 }

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
@@ -37,6 +37,7 @@ import de.fraunhofer.aisec.cpg.helpers.toIdentitySet
 import de.fraunhofer.aisec.cpg.test.analyzeAndGetFirstTU
 import de.fraunhofer.aisec.cpg.test.assertLocalName
 import java.io.File
+import kotlin.collections.singleOrNull
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -4515,5 +4516,69 @@ class PointsToPassTest {
                 (it as? UnknownMemoryValue)?.name?.localName == "freedMemory"
             }
         )
+    }
+
+    @Test
+    fun testStructureParameter() {
+        val file = File("src/test/resources/pointsToPass/structures.cpp")
+        val tu =
+            analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
+                it.registerLanguage<CPPLanguage>()
+                it.registerPass<PointsToPass>()
+                it.registerFunctionSummaries(File("src/test/resources/hardcodedDFGedges.yml"))
+            }
+
+        assertNotNull(tu)
+
+        // Functions
+        val mainFunc = tu.functions["CWE416_Use_After_Free__malloc_free_struct_64_bad"]
+        assertNotNull(mainFunc)
+
+        val badFunc = tu.functions["CWE416_Use_After_Free__malloc_free_struct_64b_badSink"]
+        assertNotNull(badFunc)
+
+        val freeFunc = tu.functions["free"]
+        assertNotNull(freeFunc)
+
+        val printFunc = tu.functions["printStructLine"]
+        assertNotNull(printFunc)
+
+        // Parameters and PMVs
+        val badParam = badFunc.parameters.single()
+        val badDerefPMV =
+            badParam.memoryValueEdges
+                .singleOrNull {
+                    (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget ==
+                        "derefvalue"
+                }
+                ?.start
+        assertNotNull(badDerefPMV)
+        val badDerefDerefPMV =
+            badParam.memoryValueEdges
+                .singleOrNull {
+                    (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget ==
+                        "derefderefvalue"
+                }
+                ?.start
+        assertNotNull(badDerefDerefPMV)
+
+        val freeParam = freeFunc.parameters.single()
+        val freeDerefPMV =
+            freeParam.memoryValueEdges
+                .singleOrNull {
+                    (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget ==
+                        "derefvalue"
+                }
+                ?.start
+        assertNotNull(freeDerefPMV)
+
+        // The actual test. We expect a DF from free's DerefPMV to the two PointerDerefences in
+        // printStructLine
+        val endNodes = freeDerefPMV.collectAllNextFullDFGPaths().map { it.nodes.last() }.toSet()
+        // Size 3: The two derefs plus the Subscription that is the call argument
+        assertEquals(3, endNodes.size)
+        printFunc.allChildren<PointerDereference>().forEach { deref ->
+            assertContains(endNodes, deref)
+        }
     }
 }

--- a/cpg-language-cxx/src/test/resources/pointsToPass/freeint.cpp
+++ b/cpg-language-cxx/src/test/resources/pointsToPass/freeint.cpp
@@ -1,0 +1,6 @@
+int main() {
+  int i=0;
+  
+  // This does not make sense, but serves as test if we are able to handle hardcoded FS correctly even if we stumble across wrong types
+  free(i);
+}

--- a/cpg-language-cxx/src/test/resources/pointsToPass/structreference.cpp
+++ b/cpg-language-cxx/src/test/resources/pointsToPass/structreference.cpp
@@ -1,3 +1,7 @@
+/* Part of Juliet Test Suite
+see https://github.com/arichardson/juliet-test-suite-c/blob/master/testcases/CWE416_Use_After_Free/CWE416_Use_After_Free__malloc_free_struct_07.c
+*/
+
 void printStructLine (const twoIntsStruct * structTwoIntsStruct)
 {
     printf("%d -- %d\n", structTwoIntsStruct->intOne, structTwoIntsStruct->intTwo);

--- a/cpg-language-cxx/src/test/resources/pointsToPass/structures.cpp
+++ b/cpg-language-cxx/src/test/resources/pointsToPass/structures.cpp
@@ -1,3 +1,7 @@
+/* Part of Juliet Test Suite
+see https://github.com/arichardson/juliet-test-suite-c/blob/master/testcases/CWE416_Use_After_Free/CWE416_Use_After_Free__malloc_free_struct_64a.c
+*/
+
 void printStructLine (const twoIntsStruct * structTwoIntsStruct)
 {
     printf("%d -- %d\n", structTwoIntsStruct->intOne, structTwoIntsStruct->intTwo);

--- a/cpg-language-cxx/src/test/resources/pointsToPass/structures.cpp
+++ b/cpg-language-cxx/src/test/resources/pointsToPass/structures.cpp
@@ -1,0 +1,35 @@
+void printStructLine (const twoIntsStruct * structTwoIntsStruct)
+{
+    printf("%d -- %d\n", structTwoIntsStruct->intOne, structTwoIntsStruct->intTwo);
+}
+
+void CWE416_Use_After_Free__malloc_free_struct_64b_badSink(void * dataVoidPtr)
+{
+    /* cast void pointer to a pointer of the appropriate type */
+    twoIntsStruct * * dataPtr = (twoIntsStruct * *)dataVoidPtr;
+    /* dereference dataPtr into data */
+    twoIntsStruct * data = (*dataPtr);
+    /* POTENTIAL FLAW: Use of data that may have been freed */
+    printStructLine(&data[0]);
+    /* POTENTIAL INCIDENTAL - Possible memory leak here if data was not freed */
+}
+
+void CWE416_Use_After_Free__malloc_free_struct_64_bad()
+{
+    twoIntsStruct * data;
+    /* Initialize data */
+    data = NULL;
+    data = (twoIntsStruct *)malloc(100*sizeof(twoIntsStruct));
+    if (data == NULL) {exit(-1);}
+    {
+        size_t i;
+        for(i = 0; i < 100; i++)
+        {
+            data[i].intOne = 1;
+            data[i].intTwo = 2;
+        }
+    }
+    /* POTENTIAL FLAW: Free data in the source - the bad sink attempts to use data */
+    free(data);
+    CWE416_Use_After_Free__malloc_free_struct_64b_badSink(&data);
+}


### PR DESCRIPTION
Received a stackoverflow which looked like this: 
```
    java.lang.StackOverflowError                                                                                                         12:54:52 [1011/97491]
        at java.base/java.util.stream.Sink$ChainedReference.cancellationRequested(Sink.java:266)                                                              
        at java.base/java.util.stream.Sink$ChainedReference.cancellationRequested(Sink.java:266)                                                              
        at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)                                                         
        at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)                                                          
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)                                                                    
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)                                                             
        at java.base/java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:150)                                                                     
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)                                                                    
        at java.base/java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:647)                                                                 
        at org.apache.logging.log4j.util.StackLocator.lambda$getCallerClass$2(StackLocator.java:52)                                                           
        at java.base/java.lang.StackStreamFactory$StackFrameTraverser.consumeFrames(StackStreamFactory.java:586)                                              
        at java.base/java.lang.StackStreamFactory$AbstractStackWalker.doStackWalk(StackStreamFactory.java:324)                                                
        at java.base/java.lang.StackStreamFactory$AbstractStackWalker.callStackWalk(Native Method)                                                            
        at java.base/java.lang.StackStreamFactory$AbstractStackWalker.beginStackWalk(StackStreamFactory.java:410)                                             
        at java.base/java.lang.StackStreamFactory$AbstractStackWalker.walkHelper(StackStreamFactory.java:261)                                                 
        at java.base/java.lang.StackStreamFactory$AbstractStackWalker.walk(StackStreamFactory.java:253)                                                       
        at java.base/java.lang.StackWalker.walk(StackWalker.java:589)                                                                                         
        at org.apache.logging.log4j.util.StackLocator.getCallerClass(StackLocator.java:47)                                                                    
        at org.apache.logging.log4j.util.StackLocatorUtil.getCallerClass(StackLocatorUtil.java:103)                                                           
        at org.apache.logging.slf4j.Log4jLoggerFactory.getContext(Log4jLoggerFactory.java:56)                                                                 
        at org.apache.logging.log4j.spi.AbstractLoggerAdapter.getLogger(AbstractLoggerAdapter.java:46)                                                        
        at org.apache.logging.slf4j.Log4jLoggerFactory.getLogger(Log4jLoggerFactory.java:33)                                                                  
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:447)                                                                                          
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:472)
        at de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator.getLog(ValueEvaluator.kt:71)
        at de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator.handlePrevDFG(ValueEvaluator.kt:481)
        at de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator.handleHasInitializer(ValueEvaluator.kt:177)
        at de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator.evaluateInternal(ValueEvaluator.kt:136)
        at de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator.handlePrevDFG(ValueEvaluator.kt:478)
        at de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator.handleReference(ValueEvaluator.kt:165)
        at de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator.evaluateInternal(ValueEvaluator.kt:148)
        at de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator.handleBinaryOperator(ValueEvaluator.kt:207)
        at de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator.evaluateInternal(ValueEvaluator.kt:140)
        at de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator.handlePrevDFG(ValueEvaluator.kt:478)
        at de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator.handleReference(ValueEvaluator.kt:165)
        at de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator.evaluateInternal(ValueEvaluator.kt:148)
        at de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator.handlePrevDFG(ValueEvaluator.kt:478)
        at de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator.handleHasInitializer(ValueEvaluator.kt:177)
        at de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator.evaluateInternal(ValueEvaluator.kt:136)
        at de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator.handlePrevDFG(ValueEvaluator.kt:478)
        at de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator.handleReference(ValueEvaluator.kt:165)
        at de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator.evaluateInternal(ValueEvaluator.kt:148)
        at de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator.handleBinaryOperator(ValueEvaluator.kt:210)
        at de.fraunhofer.aisec.cpg.evaluation.ValueEvaluator.evaluateInternal(ValueEvaluator.kt:140)
```
I hope that the changes fix this. 

Additionally, some improvements to the PtP: 
+ Create PMVs even if the type doesn't match if expected by the FunctionSummary