### PR TITLE
Implicit cast pointers to `void*` in C

### DIFF
--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CLanguage.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CLanguage.kt
@@ -131,6 +131,15 @@ open class CLanguage :
             return ImplicitCast
         }
 
+        // In C, any pointer can be implicitly cast to void*
+        if (
+            type is PointerType &&
+                targetType is PointerType &&
+                targetType.elementType is IncompleteType
+        ) {
+            return ImplicitCast
+        }
+
         return CastNotPossible
     }
 }

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
@@ -1831,4 +1831,34 @@ internal class CXXLanguageFrontendTest : BaseTest() {
 
         assertEquals(label, goto.targetLabel)
     }
+
+    @Test
+    fun testCLanguagePointerToVoidCast() {
+        val file = File("src/test/resources/c/pointer_to_void.c")
+        val tu =
+            analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
+                it.registerLanguage<CLanguage>()
+            }
+        assertNotNull(tu)
+
+        val main = tu.functions["main"]
+        assertNotNull(main)
+
+        val takesVoidPtr = tu.functions["takesVoidPtr"]
+        assertNotNull(takesVoidPtr)
+        assertLocalName("void", (takesVoidPtr.parameters[0].type as PointerType).elementType)
+
+        val calls = main.calls
+        assertEquals(4, calls.size, "main should have 4 calls to takesVoidPtr")
+
+        for (call in calls) {
+            assertInvokes(call, takesVoidPtr, "call should invoke takesVoidPtr")
+            val arg = call.arguments.firstOrNull()
+            assertNotNull(arg, "call should have an argument")
+            val argType = arg.type
+            assertTrue(argType is PointerType, "argument should be a pointer type")
+            val elementType = (argType as PointerType).elementType
+            assertFalse(elementType is IncompleteType, "argument should not be void*")
+        }
+    }
 }

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
@@ -1846,7 +1846,8 @@ internal class CXXLanguageFrontendTest : BaseTest() {
 
         val takesVoidPtr = tu.functions["takesVoidPtr"]
         assertNotNull(takesVoidPtr)
-        assertLocalName("void", (takesVoidPtr.parameters[0].type as PointerType).elementType)
+        val takesVoidPtrParameterType = assertIs<PointerType>(takesVoidPtr.parameters[0].type)
+        assertLocalName("void", takesVoidPtrParameterType.elementType)
 
         val calls = main.calls
         assertEquals(4, calls.size, "main should have 4 calls to takesVoidPtr")

--- a/cpg-language-cxx/src/test/resources/c/pointer_to_void.c
+++ b/cpg-language-cxx/src/test/resources/c/pointer_to_void.c
@@ -1,0 +1,17 @@
+void takesVoidPtr(void* ptr) {}
+
+int main() {
+    int x;
+    int* intPtr = &x;
+    takesVoidPtr(intPtr);
+
+    double d;
+    double* doublePtr = &d;
+    takesVoidPtr(doublePtr);
+
+    int** intPtrPtr = &intPtr;
+    takesVoidPtr(intPtrPtr);
+
+    double** doublePtrPtr = &doublePtr;
+    takesVoidPtr(doublePtrPtr);
+}


### PR DESCRIPTION
In C, any pointer can be implicitly cast to a `void*` pointer.