### PR TITLE
Loop-detection in ast parent traversal

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -1525,6 +1525,7 @@ val AstNode?.assigns: List<Assign>
 inline fun <reified T : Node> Node.firstParentOrNull(
     noinline predicate: ((T) -> Boolean)? = null
 ): T? {
+    val alreadySeen = identitySetOf<Node>()
     // start at searchNodes parent
     var node = this.astParent
 
@@ -1535,6 +1536,7 @@ inline fun <reified T : Node> Node.firstParentOrNull(
 
         // go upwards in the ast tree
         node = node.astParent
+        if (node == null || !alreadySeen.add(node)) return null
     }
 
     return null


### PR DESCRIPTION
In some cases, the AST parent traversal may loop (if the AST is not a real tree). Therefore, I added a basic loop detection