### PR TITLE
Overhaul of PtP Member Handling

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/AnalysisConfiguration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/AnalysisConfiguration.kt
@@ -652,7 +652,8 @@ object OnlyFullDFG : AnalysisSensitivity() {
         analysisDirection: AnalysisDirection,
         interproceduralEdgesExist: Boolean,
     ): Boolean {
-        return edge !is Dataflow || edge.granularity is FullDataflowGranularity
+        return edge !is Dataflow ||
+            (edge.granularity is FullDataflowGranularity && edge.derefDepth == null)
     }
 }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/MermaidPrinter.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/MermaidPrinter.kt
@@ -329,6 +329,8 @@ private fun Edge<out Node>.label(): String {
         } else {
             builder.append(" (full)")
         }
+
+        derefDepth?.let { builder.append("${it.name}") }
     }
 
     builder.append("\"")

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -212,7 +212,11 @@ abstract class Node() :
     val nextFullDFG: List<Node>
         get() {
             return nextDFGEdges
-                .filter { it.granularity is FullDataflowGranularity && !it.functionSummary }
+                .filter {
+                    it.granularity is FullDataflowGranularity &&
+                        !it.functionSummary &&
+                        it.derefDepth == null
+                }
                 .map { it.end }
         }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -179,7 +179,11 @@ abstract class Node() :
     val prevFullDFG: List<Node>
         get() {
             return prevDFGEdges
-                .filter { it.granularity is FullDataflowGranularity && !it.functionSummary }
+                .filter {
+                    it.granularity is FullDataflowGranularity &&
+                        !it.functionSummary &&
+                        it.derefDepth == null
+                }
                 .map { it.start }
         }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Dataflow.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Dataflow.kt
@@ -67,8 +67,8 @@ data class PointerDataflowGranularity(
 
 /**
  * This dataflow granularity denotes that not the "whole" object is flowing from [Dataflow.start] to
- * [Dataflow.end] but only parts of it. Common examples include [MemberAccess]s, array or tuple
- * accesses. This class should allow
+ * [Dataflow.end] but only parts of it. Common examples include [MemberAccess]s, array, pointer
+ * dereference values or tuple accesses. This class should allow
  */
 open class PartialDataflowGranularity<T>(
     /** The target that is affected by this partial dataflow. */
@@ -172,18 +172,22 @@ open class Dataflow(
     @JsonIgnore
     var granularity: Granularity = default(),
     open val functionSummary: Boolean = false,
+    open val derefDepth: PointerAccess? = null,
 ) : ProgramDependence(start, end, DependenceType.DATA) {
     override var labels = super.labels.plus("DFG")
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is Dataflow) return false
-        return this.granularity == other.granularity && super.equals(other)
+        return this.granularity == other.granularity &&
+            this.derefDepth == other.derefDepth &&
+            super.equals(other)
     }
 
     override fun hashCode(): Int {
         var result = super.hashCode()
         result = 31 * result + granularity.hashCode()
+        result = 31 * result + derefDepth.hashCode()
         return result
     }
 }
@@ -232,6 +236,7 @@ class ContextSensitiveDataflow(
     granularity: Granularity = default(),
     val callingContext: CallingContext,
     override val functionSummary: Boolean = false,
+    override val derefDepth: PointerAccess? = null,
 ) : Dataflow(start, end, granularity) {
 
     override fun equals(other: Any?): Boolean {
@@ -265,6 +270,7 @@ class Dataflows<T : Node>(
         granularity: Granularity = default(),
         callingContext: CallingContext,
         functionSummary: Boolean = false,
+        derefDepth: PointerAccess? = null,
     ) {
         val edge =
             if (outgoing) {
@@ -274,6 +280,7 @@ class Dataflows<T : Node>(
                     granularity,
                     callingContext,
                     functionSummary,
+                    derefDepth,
                 )
             } else {
                 ContextSensitiveDataflow(
@@ -282,6 +289,7 @@ class Dataflows<T : Node>(
                     granularity,
                     callingContext,
                     functionSummary,
+                    derefDepth,
                 )
             }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
@@ -350,20 +350,20 @@ fun isGlobal(node: Node): Boolean {
     }
 }
 
-/* Recursively collect the bases from MemberAccesses and SubscriptExpressions */
-fun collectBases(node: Node): IdentitySet<Node> {
-    val ret = identitySetOf<Node>()
+/* Recursively collect the bases and offsets from MemberAccesses and SubscriptExpressions */
+fun collectBasesAndOffsets(node: Node): IdentitySet<Pair<Node, Any?>> {
+    val ret = identitySetOf<Pair<Node, Any?>>()
 
     var n: Node? = node
     while (n != null) {
         when (n) {
             is MemberAccess -> {
+                ret.add(n.base to n.refersTo)
                 n = n.base
-                ret.add(n)
             }
             is Subscription -> {
+                ret.add(n.arrayExpression to n.subscriptExpression)
                 n = n.arrayExpression
-                ret.add(n)
             }
             is Cast -> {
                 n = n.expression
@@ -1202,8 +1202,8 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
             // the loop may not get executed)
             val newVals = doubleState.getValues(wT, wT) + doubleState.getValues(iterable, iterable)
             val sources =
-                newVals.mapTo(PowersetLattice.Element<Triple<Node?, Boolean, Boolean>>()) {
-                    Triple(it.first, it.second, false)
+                newVals.mapTo(PowersetLattice.Element<Triple<Node?, Boolean, Field?>>()) {
+                    Triple(it.first, it.second, null)
                 }
             val destinations = identitySetOf<Node>()
             if (wT is InitializerList) destinations.addAll(wT.initializers)
@@ -1240,8 +1240,8 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
     ): PointsToState.Element {
         var doubleState = doubleState
         val sources =
-            PowersetLattice.Element<Triple<Node?, Boolean, Boolean>>(
-                Triple(currentNode, false, false)
+            PowersetLattice.Element<Triple<Node?, Boolean, Field?>>(
+                Triple(currentNode, false, null)
             )
         val destinationsAddresses =
             currentNode.operands.flatMapTo(identitySetOf()) {
@@ -1732,11 +1732,6 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
         // DeclarationStateEntry
         val propertySet = equalLinkedHashSetOf<Any>()
         propertySet.addAll(properties)
-        if (subAccessName.isNotEmpty()) {
-            propertySet.add(
-                PartialDataflowGranularity(Field().apply { name = Name(subAccessName) })
-            )
-        }
 
         // If the srcNode is a MemoryAddress, we look it up in a map to ensure that we have a
         // different MemoryAddress for each Call, but the same if the Call is
@@ -1776,6 +1771,7 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
             currentNode,
             prev,
             param,
+            subAccessName,
         )
     }
 
@@ -1934,7 +1930,10 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                     Triple(
                         it.srcNode,
                         true in it.propertySet,
-                        it.propertySet.any { it is PartialDataflowGranularity<*> },
+                        it.propertySet
+                            .filterIsInstance<PartialDataflowGranularity<*>>()
+                            .singleOrNull()
+                            ?.partialTarget as? Field,
                     )
                 }
             )
@@ -2018,6 +2017,7 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
         currentNode: Call,
         lastWrites: MutableSet<NodeWithPropertiesKey>,
         param: Node,
+        subAccessName: String,
     ): ConcurrentIdentityHashMap<Node, ConcurrentIdentitySet<MapDstToSrcEntry>> {
         val doubleState = doubleState
         when (srcNode) {
@@ -2064,10 +2064,17 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                                     equalLinkedHashSetOf<Any>().apply {
                                         addAll(propertySet)
                                         add(shortFS)
+                                        // If the partialWrite is null, it means this is the base
+                                        // memory address and no field, so we add the partial write
+                                        // property
+                                        if (partialWrite == null) {
+                                            add(
+                                                PartialDataflowGranularity(
+                                                    Field().apply { name = Name(subAccessName) }
+                                                )
+                                            )
+                                        }
                                     }
-                                partialWrite?.let {
-                                    updatedPropertySet.add(PartialDataflowGranularity(it))
-                                }
                                 val currentSet =
                                     mapDstToSrc.computeIfAbsent(d!!) { concurrentIdentitySetOf() }
                                 if (
@@ -2112,10 +2119,17 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                                         equalLinkedHashSetOf<Any>().apply {
                                             addAll(propertySet)
                                             add(shortFS)
+                                            // If the partialWrite is null, it means this is the
+                                            // base memory address and no field, so we add the
+                                            // partial write property
+                                            if (partialWrite == null) {
+                                                add(
+                                                    PartialDataflowGranularity(
+                                                        Field().apply { name = Name(subAccessName) }
+                                                    )
+                                                )
+                                            }
                                         }
-                                    partialWrite?.let {
-                                        updatedPropertySet.add(PartialDataflowGranularity(it))
-                                    }
                                     val currentSet =
                                         mapDstToSrc.computeIfAbsent(d!!) {
                                             concurrentIdentitySetOf()
@@ -2156,8 +2170,17 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                             equalLinkedHashSetOf<Any>().apply {
                                 addAll(propertySet)
                                 add(shortFS)
+                                // If the partialWrite is null, it means this is the base
+                                // memory address and no field, so we add the partial write
+                                // property
+                                if (partialWrite == null) {
+                                    add(
+                                        PartialDataflowGranularity(
+                                            Field().apply { name = Name(subAccessName) }
+                                        )
+                                    )
+                                }
                             }
-                        partialWrite?.let { updatedPropertySet.add(PartialDataflowGranularity(it)) }
                         if (
                             currentSet.none {
                                 it.srcNode === srcNode &&
@@ -2206,10 +2229,17 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                                     equalLinkedHashSetOf<Any>().apply {
                                         addAll(propertySet)
                                         add(shortFS)
+                                        // If the partialWrite is null, it means this is the base
+                                        // memory address and no field, so we add the partial write
+                                        // property
+                                        if (partialWrite == null) {
+                                            add(
+                                                PartialDataflowGranularity(
+                                                    Field().apply { name = Name(subAccessName) }
+                                                )
+                                            )
+                                        }
                                     }
-                                partialWrite?.let {
-                                    updatedPropertySet.add(PartialDataflowGranularity(it))
-                                }
                                 currentSet +=
                                     MapDstToSrcEntry(
                                         param,
@@ -2300,7 +2330,6 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
             argumentValues.forEach { (v, _) ->
                 // We over approximate here and also add the main memory Address to the list of
                 // destinations
-                // TODO: Should this be true?
                 fieldAddresses.add(v to null)
 
                 val parentName = getNodeName(v)
@@ -2308,7 +2337,9 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                     subAccessName.ifEmpty { (partialAccess?.partialTarget as? String) ?: "" }
                 val newName = Name(partialString, parentName)
                 fieldAddresses.addAll(
-                    doubleState.fetchFieldAddresses(identitySetOf(v), newName).map { it to null }
+                    doubleState.fetchFieldAddresses(identitySetOf(v), newName).map {
+                        it to partialString
+                    }
                 )
             }
             return Pair(fieldAddresses, destination)
@@ -2320,7 +2351,7 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                     it.first to null
                 }
             // If the argument is a MemberAccess, we also collect the addresses of the bases
-            collectBases(argument).forEach { base ->
+            collectBasesAndOffsets(argument).forEach { (base, _) ->
                 doubleState.getAddresses(base, base).forEach { addr ->
                     destinationAddresses.add(addr to base.name.toString())
                 }
@@ -2402,8 +2433,8 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
         var doubleState = doubleState
         /* For Assigns, we update the value of the lhs with the rhs */
         val sources =
-            currentNode.rhs.flatMapTo(PowersetLattice.Element<Triple<Node?, Boolean, Boolean>>()) {
-                doubleState.getValues(it, it).map { Triple(it.first, it.second, false) }
+            currentNode.rhs.flatMapTo(PowersetLattice.Element<Triple<Node?, Boolean, Field?>>()) {
+                doubleState.getValues(it, it).map { Triple(it.first, it.second, null) }
             }
         val destinations = identitySetOf<Node>()
         currentNode.lhs.forEach {
@@ -2488,8 +2519,9 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
         destinations: IdentitySet<Node>,
     ): PointsToState.Element {
         val doubleState = doubleState
-        val bases = destinations.flatMap { destination -> collectBases(destination) }
-        bases.forEach { base ->
+        val basesAndOffsets =
+            destinations.flatMap { destination -> collectBasesAndOffsets(destination) }
+        basesAndOffsets.forEach { (base, offset) ->
             doubleState.getAddresses(base, base).forEach { baseAddress ->
                 val entry =
                     doubleState.declarationsState.computeIfAbsent(baseAddress) {
@@ -2499,8 +2531,11 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                             PowersetLattice.Element(),
                         )
                     }
-                entry.third.clear()
-                entry.third.add(NodeWithPropertiesKey(base, equalLinkedHashSetOf(false)))
+                val newProperties = equalLinkedHashSetOf(false, PartialDataflowGranularity(offset))
+                // If we already have an entry with exactly the same properties (so a write to the
+                // same field), we remove that one
+                entry.third.removeIf { nwpk -> nwpk.properties.containsAll(newProperties) }
+                entry.third.add(NodeWithPropertiesKey(base, newProperties))
             }
         }
         return doubleState
@@ -3707,8 +3742,8 @@ fun PointsToState.Element.getNestedValues(
                 }
                 // If we have a MemberAccess, also check for the addresses of the bases
                 &&
-                collectBases(node)
-                    .flatMap { base -> this.getAddresses(base, base) }
+                collectBasesAndOffsets(node)
+                    .flatMap { (base, _) -> this.getAddresses(base, base) }
                     .none { addr -> this.hasDeclarationStateValueEntry(addr, excludeShortFSValues) }
         )
             PowersetLattice.Element()
@@ -3803,7 +3838,7 @@ fun PointsToState.Element.fetchFieldAddresses(
 suspend fun PointsToState.Element.updateValues(
     lattice: PointsToState,
     doubleState: PointsToState.Element,
-    sources: PowersetLattice.Element<Triple<Node?, Boolean, Boolean>>,
+    sources: PowersetLattice.Element<Triple<Node?, Boolean, Field?>>,
     destinations: IdentitySet<Node>,
     // Node and short FS yes or no
     destinationAddresses: IdentitySet<Node>,
@@ -3832,9 +3867,6 @@ suspend fun PointsToState.Element.updateValues(
                     .filterTo(PowersetLattice.Element()) { it.first != null }
                     .mapTo(PowersetLattice.Element()) { Pair(it.first!!, it.second) }
 
-            // Check if we have any full writes
-            val fullSourcesExist = sources.any { !it.third }
-
             // TODO: Do we also need to fetch some properties here?
             // If we already have exactly this value in the state for the prevDFGs, we take that in
             // order not to confuse the iterateEOG function
@@ -3845,6 +3877,10 @@ suspend fun PointsToState.Element.updateValues(
                 if (existingEntries?.isNotEmpty() == true) prevDFG.addAll(existingEntries)
                 else prevDFG.add(lw)
             }
+
+            // Check if we have any full writes. This is the case if a source has as third element
+            // null, AKA does not write to a field
+            val fullSourcesExist = sources.any { it.third == null }
 
             // If we have any full writes, we eliminate the previous state
             if (fullSourcesExist) {
@@ -3857,6 +3893,17 @@ suspend fun PointsToState.Element.updateValues(
                     ),
                 )
             } else {
+                // Check if we have any writes to the same field and remove those
+                // TODO: this should be fields, but for now we deal with the names
+                val writtenFields = sources.mapNotNullTo(HashSet()) { it.third?.name?.localName }
+                doubleState.declarationsState[destAddr]?.third?.removeIf {
+                    it.properties.any { p ->
+                        ((p as? PartialDataflowGranularity<*>)?.partialTarget as? Field)
+                            ?.name
+                            ?.localName in writtenFields
+                    }
+                }
+
                 doubleState =
                     lattice.pushToDeclarationsState(
                         doubleState,

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
@@ -269,6 +269,7 @@ fun getNodeName(node: Node?): Name {
                     " " +
                     getNodeName(node.rhs).localName
             )
+        is Construction -> Name(node.code ?: "")
         else -> node.name
     }
 }
@@ -351,14 +352,14 @@ fun isGlobal(node: Node): Boolean {
 }
 
 /* Recursively collect the bases and offsets from MemberAccesses and SubscriptExpressions */
-fun collectBasesAndOffsets(node: Node): IdentitySet<Pair<Node, Any?>> {
-    val ret = identitySetOf<Pair<Node, Any?>>()
+fun collectBasesAndOffsets(node: Node): List<Pair<Node, Any?>> {
+    val ret = mutableListOf<Pair<Node, Any?>>()
 
     var n: Node? = node
     while (n != null) {
         when (n) {
             is MemberAccess -> {
-                ret.add(n.base to n.refersTo)
+                ret.add(n.base to (n.refersTo ?: n.name.localName))
                 n = n.base
             }
             is Subscription -> {
@@ -580,26 +581,30 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                 var context: CallingContext? = null
                 var granularity = default()
                 var functionSummary = false
+                var derefDepth: PointerAccess? = null
 
                 // the properties can contain a lot of things. A granularity, a
                 // callingcontext, or a boolean indicating if this is a functionSummary edge or
                 // not
                 properties.forEach { property ->
                     when (property) {
+                        is PointerDataflowGranularity -> derefDepth = property.pointerTarget
                         is Granularity -> granularity = property
                         is CallingContext -> context = property
                         is Boolean -> functionSummary = property
                     }
                 }
 
-                if (context == null) // TODO: add functionSummary flag for contextSensitive DFs
-                 key.prevDFGEdges += Dataflow(prev, key, granularity, functionSummary)
+                if (context == null)
+                    key.prevDFGEdges +=
+                        Dataflow(prev, key, granularity, functionSummary, derefDepth)
                 else
                     key.prevDFGEdges.addContextSensitive(
                         prev,
                         granularity,
                         context,
                         functionSummary,
+                        derefDepth,
                     )
             }
         }
@@ -2064,13 +2069,15 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                                     equalLinkedHashSetOf<Any>().apply {
                                         addAll(propertySet)
                                         add(shortFS)
-                                        // If the partialWrite is null, it means this is the base
+                                        // If the partialWrite is not null, it means this is the
+                                        // base
                                         // memory address and no field, so we add the partial write
                                         // property
-                                        if (partialWrite == null) {
+                                        partialWrite?.let {
+                                            removeIf { it is FullDataflowGranularity }
                                             add(
                                                 PartialDataflowGranularity(
-                                                    Field().apply { name = Name(subAccessName) }
+                                                    Field().apply { name = Name(it) }
                                                 )
                                             )
                                         }
@@ -2122,10 +2129,11 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                                             // If the partialWrite is null, it means this is the
                                             // base memory address and no field, so we add the
                                             // partial write property
-                                            if (partialWrite == null) {
+                                            partialWrite?.let {
+                                                removeIf { it is FullDataflowGranularity }
                                                 add(
                                                     PartialDataflowGranularity(
-                                                        Field().apply { name = Name(subAccessName) }
+                                                        Field().apply { name = Name(it) }
                                                     )
                                                 )
                                             }
@@ -2170,13 +2178,14 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                             equalLinkedHashSetOf<Any>().apply {
                                 addAll(propertySet)
                                 add(shortFS)
-                                // If the partialWrite is null, it means this is the base
+                                // If the partialWrite is not null, it means this is the base
                                 // memory address and no field, so we add the partial write
                                 // property
-                                if (partialWrite == null) {
+                                partialWrite?.let {
+                                    removeIf { it is FullDataflowGranularity }
                                     add(
                                         PartialDataflowGranularity(
-                                            Field().apply { name = Name(subAccessName) }
+                                            Field().apply { name = Name(it) }
                                         )
                                     )
                                 }
@@ -2229,13 +2238,15 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                                     equalLinkedHashSetOf<Any>().apply {
                                         addAll(propertySet)
                                         add(shortFS)
-                                        // If the partialWrite is null, it means this is the base
+                                        // If the partialWrite is not null, it means this is the
+                                        // base
                                         // memory address and no field, so we add the partial write
                                         // property
-                                        if (partialWrite == null) {
+                                        partialWrite?.let {
+                                            removeIf { it is FullDataflowGranularity }
                                             add(
                                                 PartialDataflowGranularity(
-                                                    Field().apply { name = Name(subAccessName) }
+                                                    Field().apply { name = Name(it) }
                                                 )
                                             )
                                         }
@@ -2256,7 +2267,12 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
         return mapDstToSrc
     }
 
-    /** Returns a Pair of destination (for the general State) and destinationAddresses */
+    /**
+     * Returns a Pair of destination (for the general State) and destinationAddresses The return
+     * address are a Pair. The string has the following coding:
+     * 1) null: No partial write
+     * 2) any other value: The field to which we write to
+     */
     private fun calculateCallDestinations(
         doubleState: PointsToState.Element,
         mapDstToSrc: ConcurrentIdentityHashMap<Node, ConcurrentIdentitySet<MapDstToSrcEntry>>,
@@ -2330,16 +2346,14 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
             argumentValues.forEach { (v, _) ->
                 // We over approximate here and also add the main memory Address to the list of
                 // destinations
-                fieldAddresses.add(v to null)
+                fieldAddresses.add(v to subAccessName)
 
                 val parentName = getNodeName(v)
                 val partialString =
                     subAccessName.ifEmpty { (partialAccess?.partialTarget as? String) ?: "" }
                 val newName = Name(partialString, parentName)
                 fieldAddresses.addAll(
-                    doubleState.fetchFieldAddresses(identitySetOf(v), newName).map {
-                        it to partialString
-                    }
+                    doubleState.fetchFieldAddresses(identitySetOf(v), newName).map { it to null }
                 )
             }
             return Pair(fieldAddresses, destination)
@@ -2351,9 +2365,19 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                     it.first to null
                 }
             // If the argument is a MemberAccess, we also collect the addresses of the bases
-            collectBasesAndOffsets(argument).forEach { (base, _) ->
-                doubleState.getAddresses(base, base).forEach { addr ->
-                    destinationAddresses.add(addr to base.name.toString())
+            // We build the offsetStr from all offsets we find, so if the argument is 'a.b.c.d', the
+            // offset str of the last element should be 'b.c.d'
+            var offsetStr = ""
+            collectBasesAndOffsets(argument).reversed().forEach { (base, offset) ->
+                if (offsetStr != "") offsetStr += "."
+                offsetStr +=
+                    ((offset as? String)
+                        ?: (offset as? Field)?.name?.toString()
+                        ?: (offset as? Field)?.name?.localName)
+                doubleState.getNestedValues(base, destAddrDepth).forEach { (value, isShortFS) ->
+                    if (!isShortFS) {
+                        destinationAddresses.add(value to offsetStr)
+                    }
                 }
             }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
@@ -1408,13 +1408,12 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
         function: Function,
         call: Call,
         doubleState: PointsToState.Element,
-    ): PointsToState.Element = coroutineScope {
+    ): PointsToState.Element {
         var doubleState = doubleState
         val callingContext =
             CallingContextIn(
                 mutableListOf(call)
             ) // TODO: Indicate somehow if this has already been done?
-        val innerConcurrencyCounter = calculateInnerConcurrencyCounter(call.arguments.size)
 
         if (call is MemberCall && function is Method) {
             val base = call.base
@@ -1443,175 +1442,175 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
         val paramArgMatching = matchArgumentsToCallParameters(function, call)
 
         call.arguments.forEach { arg ->
-            launch(Dispatchers.Default) {
-                if (arg.argumentIndex < function.parameters.size) {
-                    // In C(++), the reference to an array is a
-                    // pointer, leading to the
-                    // situation that handing "arg" or "&arg" as
-                    // argument is the same
-                    // We deal with this by drawing a DFG-Edge from
-                    // the arg to the
-                    // derefPMV in case of an array pointerType.
-                    val argVals =
-                        if (
-                            (arg.type as? PointerType)?.pointerOrigin ==
-                                PointerType.PointerOrigin.ARRAY
-                        )
-                            PowersetLattice.Element(Pair(arg, true))
-                        else doubleState.getCachedNestedValues(getNestedValuesCache, arg, 1, false)
-                    // Create a DFG-Edge from the argument to the Parameter or its
-                    // ParameterMemoryValue
-                    val p = paramArgMatching[arg]
-                    if (p == null) {
-                        log.warn(
-                            "Did not find a matching parameter for argument $arg of call $call and function $function"
-                        )
-                        return@launch
-                    }
-                    val derefPMVs =
-                        p.memoryValueEdges
-                            .filter {
-                                (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget ==
-                                    "derefvalue"
-                            }
-                            .map { it.start }
-                    val derefderefPMVs =
-                        p.memoryValueEdges
-                            .filter {
-                                (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget ==
-                                    "derefderefvalue"
-                            }
-                            .map { it.start }
-                    argVals.forEachMaybeParallel(parallelism = innerConcurrencyCounter) {
-                        (argVal, _) ->
-                        val argDerefVals =
-                            if (
-                                (arg.type as? PointerType)?.pointerOrigin ==
-                                    PointerType.PointerOrigin.ARRAY
-                            )
-                                equalLinkedHashSetOf<Node>(arg)
-                            else {
-                                doubleState
-                                    .getCachedNestedValues(
-                                        getNestedValuesCache,
-                                        argVal,
-                                        1,
-                                        fetchFields = false,
-                                    )
-                                    .mapTo(equalLinkedHashSetOf()) { it.first }
-                            }
-                        val lastDerefWrites =
-                            if (
-                                (arg.type as? PointerType)?.pointerOrigin ==
-                                    PointerType.PointerOrigin.ARRAY
-                            )
-                                PowersetLattice.Element(
-                                    NodeWithPropertiesKey(
-                                        arg,
-                                        equalLinkedHashSetOf(callingContext, false),
-                                    )
-                                )
-                            else {
-                                // Since we already have the argVal, AKA the memoryAddress
-                                // of the argDerefVal, we simply fetch the last write for the
-                                // argVal from the declarationState and add the properties
-                                doubleState.declarationsState[argVal]?.third?.mapTo(
-                                    PowersetLattice.Element()
-                                ) {
-                                    NodeWithPropertiesKey(
-                                        it.node,
-                                        equalLinkedHashSetOf(callingContext, true in it.properties),
-                                    )
-                                } ?: PowersetLattice.Element()
-                            }
-                        // Also draw the edges for the (deref)derefvalues if we have
-                        // any and are dealing with a pointer parameter (AKA memoryValue is
-                        // not null)
-                        val argDerefValsElement =
-                            PowersetLattice.Element(
-                                argDerefVals.mapTo(PowersetLattice.Element()) {
-                                    NodeWithPropertiesKey(it, equalLinkedHashSetOf())
-                                }
-                            )
-                        val argDerefDerefVals =
-                            argDerefVals
-                                .flatMap {
-                                    doubleState.getCachedNestedValues(
-                                        getNestedValuesCache,
-                                        it,
-                                        1,
-                                        fetchFields = false,
-                                    )
-                                }
-                                .mapTo(equalLinkedHashSetOf()) { it.first }
-                        val derefderefElement =
-                            argDerefDerefVals.mapTo(PowersetLattice.Element()) { derefderefValue ->
-                                NodeWithPropertiesKey(derefderefValue, equalLinkedHashSetOf())
-                            }
-                        val lastDerefDerefWrites =
-                            if (
-                                (arg.type as? PointerType)?.pointerOrigin ==
-                                    PointerType.PointerOrigin.ARRAY
-                            )
-                                argDerefVals.mapTo(PowersetLattice.Element()) { argDerefVal ->
-                                    NodeWithPropertiesKey(
-                                        argDerefVal,
-                                        equalLinkedHashSetOf(callingContext, false),
-                                    )
-                                }
-                            else {
-                                // As for the lastDerefWrites, we already have the ArgDerefVals
-                                // which we treat as the addresses, so we directly look up the
-                                // lastWrites for those addresses in the declarationState
-                                argDerefVals.flatMapTo(PowersetLattice.Element()) { argDerefVal ->
-                                    doubleState.declarationsState[argDerefVal]?.third
-                                        ?: PowersetLattice.Element()
-                                }
-                            }
-                        derefPMVs.forEach { derefPMV ->
-                            doubleState =
-                                lattice.push(
-                                    doubleState,
-                                    derefPMV,
-                                    GeneralStateEntryElement(
-                                        PowersetLattice.Element(),
-                                        argDerefValsElement,
-                                        lastDerefWrites,
-                                    ),
-                                )
-                            // The same for the derefderef values
-                            derefderefPMVs.forEach { derefderefPMV ->
-                                doubleState =
-                                    lattice.push(
-                                        doubleState,
-                                        derefderefPMV,
-                                        GeneralStateEntryElement(
-                                            PowersetLattice.Element(derefPMV),
-                                            derefderefElement,
-                                            PowersetLattice.Element(lastDerefDerefWrites),
-                                        ),
-                                    )
-                            }
+            if (arg.argumentIndex < function.parameters.size) {
+                // In C(++), the reference to an array is a pointer, leading to the situation that
+                // handing "arg" or "&arg" as argument is the same
+                // We deal with this by drawing a DFG-Edge from the arg to the derefPMV in case of
+                // an array pointerType.
+                val argVals =
+                    if (
+                        (arg.type as? PointerType)?.pointerOrigin == PointerType.PointerOrigin.ARRAY
+                    )
+                        PowersetLattice.Element(Pair(arg, true))
+                    else doubleState.getCachedNestedValues(getNestedValuesCache, arg, 1, false)
+                // Create a DFG-Edge from the argument to the Parameter or its
+                // ParameterMemoryValue
+                val p = paramArgMatching[arg]
+                if (p == null) {
+                    log.warn(
+                        "Did not find a matching parameter for argument $arg of call $call and function $function"
+                    )
+                    return@forEach
+                }
+                val derefPMVs =
+                    p.memoryValueEdges
+                        .filter {
+                            (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget ==
+                                "derefvalue"
                         }
-                    }
+                        .map { it.start }
+                val derefderefPMVs =
+                    p.memoryValueEdges
+                        .filter {
+                            (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget ==
+                                "derefderefvalue"
+                        }
+                        .map { it.start }
+                argVals.forEachMaybeParallel(minChunkSize = MIN_CHUNK_SIZE / 10) { (argVal, _) ->
                     doubleState =
-                        lattice.push(
+                        innerCalculateIncomingCallingContexts(
+                            arg,
                             doubleState,
-                            p,
-                            GeneralStateEntryElement(
-                                PowersetLattice.Element(),
-                                PowersetLattice.Element(
-                                    NodeWithPropertiesKey(arg, equalLinkedHashSetOf())
-                                ),
-                                PowersetLattice.Element(
-                                    NodeWithPropertiesKey(arg, equalLinkedHashSetOf(callingContext))
-                                ),
-                            ),
+                            getNestedValuesCache,
+                            argVal,
+                            callingContext,
+                            derefPMVs,
+                            lattice,
+                            derefderefPMVs,
                         )
                 }
+                doubleState =
+                    lattice.push(
+                        doubleState,
+                        p,
+                        GeneralStateEntryElement(
+                            PowersetLattice.Element(),
+                            PowersetLattice.Element(
+                                NodeWithPropertiesKey(arg, equalLinkedHashSetOf())
+                            ),
+                            PowersetLattice.Element(
+                                NodeWithPropertiesKey(arg, equalLinkedHashSetOf(callingContext))
+                            ),
+                        ),
+                    )
             }
         }
-        return@coroutineScope doubleState
+        return doubleState
+    }
+
+    private suspend fun innerCalculateIncomingCallingContexts(
+        arg: Expression,
+        doubleState: PointsToState.Element,
+        getNestedValuesCache:
+            ConcurrentHashMap<
+                Triple<Node, Int, Boolean>,
+                PowersetLattice.Element<Pair<Node, Boolean>>,
+            >,
+        argVal: Node,
+        callingContext: CallingContextIn,
+        derefPMVs: List<Node>,
+        lattice: PointsToState,
+        derefderefPMVs: List<Node>,
+    ): PointsToState.Element {
+        var retDoubleState = doubleState
+        val argDerefVals =
+            if ((arg.type as? PointerType)?.pointerOrigin == PointerType.PointerOrigin.ARRAY)
+                equalLinkedHashSetOf<Node>(arg)
+            else {
+                retDoubleState
+                    .getCachedNestedValues(getNestedValuesCache, argVal, 1, fetchFields = false)
+                    .mapTo(equalLinkedHashSetOf()) { it.first }
+            }
+        val lastDerefWrites =
+            if ((arg.type as? PointerType)?.pointerOrigin == PointerType.PointerOrigin.ARRAY)
+                PowersetLattice.Element(
+                    NodeWithPropertiesKey(arg, equalLinkedHashSetOf(callingContext, false))
+                )
+            else {
+                // Since we already have the argVal, AKA the memoryAddress
+                // of the argDerefVal, we simply fetch the last write for the
+                // argVal from the declarationState and add the properties
+                retDoubleState.declarationsState[argVal]?.third?.mapTo(PowersetLattice.Element()) {
+                    NodeWithPropertiesKey(
+                        it.node,
+                        equalLinkedHashSetOf(callingContext, true in it.properties),
+                    )
+                } ?: PowersetLattice.Element()
+            }
+        // Also draw the edges for the (deref)derefvalues if we have
+        // any and are dealing with a pointer parameter (AKA memoryValue is
+        // not null)
+        val argDerefValsElement =
+            PowersetLattice.Element(
+                argDerefVals.mapTo(PowersetLattice.Element()) {
+                    NodeWithPropertiesKey(it, equalLinkedHashSetOf())
+                }
+            )
+        val argDerefDerefVals =
+            argDerefVals
+                .flatMap {
+                    retDoubleState.getCachedNestedValues(
+                        getNestedValuesCache,
+                        it,
+                        1,
+                        fetchFields = false,
+                    )
+                }
+                .mapTo(equalLinkedHashSetOf()) { it.first }
+        val derefderefElement =
+            argDerefDerefVals.mapTo(PowersetLattice.Element()) { derefderefValue ->
+                NodeWithPropertiesKey(derefderefValue, equalLinkedHashSetOf())
+            }
+        val lastDerefDerefWrites =
+            if ((arg.type as? PointerType)?.pointerOrigin == PointerType.PointerOrigin.ARRAY)
+                argDerefVals.mapTo(PowersetLattice.Element()) { argDerefVal ->
+                    NodeWithPropertiesKey(argDerefVal, equalLinkedHashSetOf(callingContext, false))
+                }
+            else {
+                // As for the lastDerefWrites, we already have the ArgDerefVals
+                // which we treat as the addresses, so we directly look up the
+                // lastWrites for those addresses in the declarationState
+                argDerefVals.flatMapTo(PowersetLattice.Element()) { argDerefVal ->
+                    retDoubleState.declarationsState[argDerefVal]?.third
+                        ?: PowersetLattice.Element()
+                }
+            }
+        derefPMVs.forEach { derefPMV ->
+            retDoubleState =
+                lattice.push(
+                    retDoubleState,
+                    derefPMV,
+                    GeneralStateEntryElement(
+                        PowersetLattice.Element(),
+                        argDerefValsElement,
+                        lastDerefWrites,
+                    ),
+                )
+            // The same for the derefderef values
+            derefderefPMVs.forEach { derefderefPMV ->
+                retDoubleState =
+                    lattice.push(
+                        retDoubleState,
+                        derefderefPMV,
+                        GeneralStateEntryElement(
+                            PowersetLattice.Element(derefPMV),
+                            derefderefElement,
+                            PowersetLattice.Element(lastDerefDerefWrites),
+                        ),
+                    )
+            }
+        }
+        return retDoubleState
     }
 
     data class MapDstToSrcEntry(

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
@@ -1513,10 +1513,8 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                                 )
                             else {
                                 // Since we already have the argVal, AKA the memoryAddress
-                                // of the
-                                // argDerefVal, we simply fetch the last write for the
-                                // argVal from the
-                                // declarationState and add the properties
+                                // of the argDerefVal, we simply fetch the last write for the
+                                // argVal from the declarationState and add the properties
                                 doubleState.declarationsState[argVal]?.third?.mapTo(
                                     PowersetLattice.Element()
                                 ) {
@@ -1528,8 +1526,7 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                             }
                         // Also draw the edges for the (deref)derefvalues if we have
                         // any and are dealing with a pointer parameter (AKA memoryValue is
-                        // not
-                        // null)
+                        // not null)
                         val argDerefValsElement =
                             PowersetLattice.Element(
                                 argDerefVals.mapTo(PowersetLattice.Element()) {
@@ -1563,11 +1560,9 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                                     )
                                 }
                             else {
-                                // As for the lastDerefWrites, we already have the
-                                // ArgDerefVals which we
-                                // treat as the addresses, so we directly look up the
-                                // lastWrites for
-                                // those addresses in the declarationState
+                                // As for the lastDerefWrites, we already have the ArgDerefVals
+                                // which we treat as the addresses, so we directly look up the
+                                // lastWrites for those addresses in the declarationState
                                 argDerefVals.flatMapTo(PowersetLattice.Element()) { argDerefVal ->
                                     doubleState.declarationsState[argDerefVal]?.third
                                         ?: PowersetLattice.Element()
@@ -1829,20 +1824,13 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                 // affect a higher level. So let's do this step by step
                 for (depth in 0..3) {
                     coroutineScope {
-                        // We use coroutines in coroutines. So, in order not to launch way too
-                        // many of them, we calculate the amount of inner coroutines that we can
-                        // reasonably launch
-                        val innerConcurrencyCounter =
-                            calculateInnerConcurrencyCounter(inv.functionSummary.size)
                         for (work in parameterWork) {
                             if (work.entriesByDepth[depth].isEmpty()) {
                                 continue
                             }
 
                             launch(Dispatchers.Default) {
-                                work.entriesByDepth[depth].forEachMaybeParallel(
-                                    parallelism = innerConcurrencyCounter
-                                ) { entry ->
+                                work.entriesByDepth[depth].forEachMaybeParallel { entry ->
                                     writeEntry(
                                         doubleState,
                                         mapDstToSrc,

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
@@ -984,7 +984,22 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                                     excludeShortFSValues = true,
                                 )
                                 .filterTo(PowersetLattice.Element()) { it.value.name != param.name }
-                        stateEntries
+                        // Remove overapproximated entries that do not indicate a subAccess
+                        data class KeyWithSubAccessEntry(val value: Any, val shortFS: Any)
+                        val keysWithSubAccess =
+                            stateEntries
+                                .filter { it.subAccessName.isNotEmpty() }
+                                .mapTo(mutableSetOf()) {
+                                    KeyWithSubAccessEntry(it.value, it.shortFS)
+                                }
+
+                        val filteredStateEntries =
+                            stateEntries.filterNot { entry ->
+                                entry.subAccessName.isEmpty() &&
+                                    KeyWithSubAccessEntry(entry.value, entry.shortFS) in
+                                        keysWithSubAccess
+                            }
+                        filteredStateEntries
                             /* See if we can find something that is different from the initial value*/
                             .filterTo(PowersetLattice.Element()) {
                                 /* Filter the PMVs from this parameter*/

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/DFGFunctionSummariesTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/enhancements/DFGFunctionSummariesTest.kt
@@ -35,7 +35,6 @@ import de.fraunhofer.aisec.cpg.graph.builder.*
 import de.fraunhofer.aisec.cpg.graph.edges.flows.CallingContextIn
 import de.fraunhofer.aisec.cpg.graph.edges.flows.CallingContextOut
 import de.fraunhofer.aisec.cpg.graph.edges.flows.ContextSensitiveDataflow
-import de.fraunhofer.aisec.cpg.graph.edges.flows.PointerDataflowGranularity
 import de.fraunhofer.aisec.cpg.graph.expressions.ParameterMemoryValue
 import de.fraunhofer.aisec.cpg.graph.expressions.Reference
 import de.fraunhofer.aisec.cpg.graph.expressions.Return
@@ -263,10 +262,7 @@ class DFGFunctionSummariesTest {
         assertEquals(1, argA.nextDFG.size)
         // The MemoryAddress a
         assertEquals(1, argA.prevFullDFG.size)
-        assertEquals(
-            1,
-            argA.prevDFGEdges.filter { it.granularity is PointerDataflowGranularity }.size,
-        )
+        assertEquals(1, argA.prevDFGEdges.filter { it.derefDepth != null }.size)
 
         val nextDfg = argA.nextDFGEdges.single()
         assertEquals(

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPassTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPassTest.kt
@@ -31,6 +31,7 @@ import de.fraunhofer.aisec.cpg.frontends.testFrontend
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.builder.*
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Field
 import de.fraunhofer.aisec.cpg.graph.edges.flows.Dataflow
 import de.fraunhofer.aisec.cpg.graph.edges.flows.FieldDataflowGranularity
 import de.fraunhofer.aisec.cpg.graph.edges.flows.FullDataflowGranularity
@@ -81,9 +82,9 @@ class ControlFlowSensitiveDFGPassTest {
         with(s1) {
             // The DFG from the variable declaration of s1 should go to base of the member
             // expression s1.field1 of the first doSomething call (line 11) as well as the s1.field1
-            // in the assignment (line 13)
+            // in the assignment (line 13) and the base of the second doSomething call (line 15)
             val next = this.nextDFGEdges.sortedBy { it.end.location?.region?.startLine }
-            assertEquals(2, next.size)
+            assertEquals(3, next.size)
 
             val baseOfMemberRead11 = assertNotNull(next.firstOrNull()?.end)
             assertEquals(11, baseOfMemberRead11.location?.region?.startLine)
@@ -178,15 +179,28 @@ class ControlFlowSensitiveDFGPassTest {
             }
         }
 
-        // The DFG from the variable declaration of s2 should only go the s2.field1 of the
-        // assignment (line 14)
+        // The DFG from the variable declaration of s2 should go the base of s2.field1 of the
+        // assignment (line 14) and to the base of argument of the call doSomething (line 16)
         with(s2) {
             val next = this.nextDFGEdges.sortedBy { it.end.location?.region?.startLine }
-            val single = assertNotNull(next.singleOrNull()?.end)
-            assertEquals(14, single.location?.region?.startLine)
-            assertIs<Reference>(single)
-            val me = assertIs<MemberAccess>(single.astParent)
-            assertEquals(AccessValues.WRITE, me.access)
+            assertEquals(2, next.size)
+
+            val baseOfMemberWrite14 = assertNotNull(next.getOrNull(0)?.end)
+            assertEquals(14, baseOfMemberWrite14.location?.region?.startLine)
+            assertIs<Reference>(baseOfMemberWrite14)
+            assertIs<MemberAccess>(baseOfMemberWrite14.astParent)
+            assertEquals(AccessValues.READ, baseOfMemberWrite14.access)
+
+            val baseOfArg16 = assertNotNull(next.getOrNull(1)?.end)
+            assertEquals(16, baseOfArg16.location?.region?.startLine)
+            assertIs<Reference>(baseOfArg16)
+            assertIs<MemberAccess>(baseOfArg16.astParent)
+            assertEquals(AccessValues.READ, baseOfMemberWrite14.access)
+
+            assertEquals(
+                mutableSetOf<Node>(baseOfMemberWrite14, baseOfArg16),
+                next.mapTo(mutableSetOf()) { it.end },
+            )
 
             // The rest should be the same as s1, so we can probably skip the rest of the asserts
         }
@@ -221,11 +235,32 @@ class ControlFlowSensitiveDFGPassTest {
         val refO = main.refs("o")
         assertEquals(2, refO.size)
 
-        // There should be a full flow from each first individual ref and member expression (line
-        // 13) to the second one (line 15)
+        // There should be a full flow from the field to the argument (since this is the only one
+        // that is fully written) and partial flows between the middle MemberAccess and the second
+        // as well as for the ref
         assertFullEdgeBetween(meFields[0], meFields[1])
-        assertFullEdgeBetween(meIn[0], meIn[1])
-        assertFullEdgeBetween(refO[0], refO[1])
+        assertEquals(
+            meIn[1],
+            meIn[0]
+                .nextDFGEdges
+                .singleOrNull {
+                    ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Field)
+                        ?.name
+                        ?.toString() == "inner.field"
+                }
+                ?.end,
+        )
+        assertEquals(
+            refO[1],
+            refO[0]
+                .nextDFGEdges
+                .singleOrNull {
+                    ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Field)
+                        ?.name
+                        ?.toString() == "outer.in"
+                }
+                ?.end,
+        )
 
         // There should be a partial flow from the first '.field' which writes to the first '.in'
         assertPartialEdgeBetween(meFields[0], meIn[0], field)

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
@@ -1214,11 +1214,7 @@ class PointsToPassTest {
         assertEquals(
             aDecl,
             bRefLine138.prevDFGEdges
-                .singleOrNull {
-                    it.granularity is PointerDataflowGranularity &&
-                        (it.granularity as PointerDataflowGranularity).pointerTarget ==
-                            PointerAccess.CURRENT_DEREF_VALUE
-                }
+                .singleOrNull { it.derefDepth == PointerAccess.CURRENT_DEREF_VALUE }
                 ?.start,
         )
         assertEquals(bDecl, bRefLine138.prevFullDFG.singleOrNull())
@@ -1251,11 +1247,7 @@ class PointsToPassTest {
         assertEquals(
             aDecl,
             bRefLine139.prevDFGEdges
-                .singleOrNull {
-                    it.granularity is PointerDataflowGranularity &&
-                        (it.granularity as PointerDataflowGranularity).pointerTarget ==
-                            PointerAccess.CURRENT_DEREF_VALUE
-                }
+                .singleOrNull { it.derefDepth == PointerAccess.CURRENT_DEREF_VALUE }
                 ?.start,
         )
         assertEquals(bDecl, bRefLine139.prevFullDFG.singleOrNull())
@@ -1269,21 +1261,13 @@ class PointsToPassTest {
         assertEquals(
             bDecl,
             cRefLine139.prevDFGEdges
-                .singleOrNull {
-                    it.granularity is PointerDataflowGranularity &&
-                        (it.granularity as PointerDataflowGranularity).pointerTarget ==
-                            PointerAccess.CURRENT_DEREF_VALUE
-                }
+                .singleOrNull { it.derefDepth == PointerAccess.CURRENT_DEREF_VALUE }
                 ?.start,
         )
         assertEquals(
             aDecl,
             cRefLine139.prevDFGEdges
-                .singleOrNull {
-                    it.granularity is PointerDataflowGranularity &&
-                        (it.granularity as PointerDataflowGranularity).pointerTarget ==
-                            PointerAccess.CURRENT_DEREF_DEREF_VALUE
-                }
+                .singleOrNull { it.derefDepth == PointerAccess.CURRENT_DEREF_DEREF_VALUE }
                 ?.start,
         )
 
@@ -1299,11 +1283,7 @@ class PointsToPassTest {
         assertEquals(
             aDecl,
             cPointerDerefLine139.prevDFGEdges
-                .singleOrNull {
-                    it.granularity is PointerDataflowGranularity &&
-                        (it.granularity as PointerDataflowGranularity).pointerTarget ==
-                            PointerAccess.CURRENT_DEREF_VALUE
-                }
+                .singleOrNull { it.derefDepth == PointerAccess.CURRENT_DEREF_VALUE }
                 ?.start,
         )
         assertEquals(
@@ -2510,39 +2490,26 @@ class PointsToPassTest {
             p2pLine262.prevDFGEdges
                 .filter {
                     it.granularity is PointerDataflowGranularity &&
-                        (it.granularity as PointerDataflowGranularity).pointerTarget ==
-                            PointerAccess.CURRENT_DEREF_VALUE
+                        it.derefDepth == PointerAccess.CURRENT_DEREF_VALUE
                 }
                 .size,
         )
         assertEquals(
             p_oldvalDecl,
             p2pLine262.prevDFGEdges
-                .first {
-                    it.granularity is PointerDataflowGranularity &&
-                        (it.granularity as PointerDataflowGranularity).pointerTarget ==
-                            PointerAccess.CURRENT_DEREF_VALUE
-                }
+                .first { it.derefDepth == PointerAccess.CURRENT_DEREF_VALUE }
                 .start,
         )
         assertEquals(
             1,
             p2pLine262.prevDFGEdges
-                .filter {
-                    it.granularity is PointerDataflowGranularity &&
-                        (it.granularity as PointerDataflowGranularity).pointerTarget ==
-                            PointerAccess.CURRENT_DEREF_DEREF_VALUE
-                }
+                .filter { it.derefDepth == PointerAccess.CURRENT_DEREF_DEREF_VALUE }
                 .size,
         )
         assertEquals(
             oldvalDecl,
             p2pLine262.prevDFGEdges
-                .first {
-                    it.granularity is PointerDataflowGranularity &&
-                        (it.granularity as PointerDataflowGranularity).pointerTarget ==
-                            PointerAccess.CURRENT_DEREF_DEREF_VALUE
-                }
+                .first { it.derefDepth == PointerAccess.CURRENT_DEREF_DEREF_VALUE }
                 .start,
         )
 
@@ -2553,41 +2520,25 @@ class PointsToPassTest {
         assertEquals(
             1,
             p2pLine264.prevDFGEdges
-                .filter {
-                    it.granularity is PointerDataflowGranularity &&
-                        (it.granularity as PointerDataflowGranularity).pointerTarget ==
-                            PointerAccess.CURRENT_DEREF_VALUE
-                }
+                .filter { it.derefDepth == PointerAccess.CURRENT_DEREF_VALUE }
                 .size,
         )
         assertEquals(
             pDerefLine246,
             p2pLine264.prevDFGEdges
-                .first {
-                    it.granularity is PointerDataflowGranularity &&
-                        (it.granularity as PointerDataflowGranularity).pointerTarget ==
-                            PointerAccess.CURRENT_DEREF_VALUE
-                }
+                .first { it.derefDepth == PointerAccess.CURRENT_DEREF_VALUE }
                 .start,
         )
         assertEquals(
             1,
             p2pLine264.prevDFGEdges
-                .filter {
-                    it.granularity is PointerDataflowGranularity &&
-                        (it.granularity as PointerDataflowGranularity).pointerTarget ==
-                            PointerAccess.CURRENT_DEREF_DEREF_VALUE
-                }
+                .filter { it.derefDepth == PointerAccess.CURRENT_DEREF_DEREF_VALUE }
                 .size,
         )
         assertEquals(
             pDerefDerefLine247,
             p2pLine264.prevDFGEdges
-                .first {
-                    it.granularity is PointerDataflowGranularity &&
-                        (it.granularity as PointerDataflowGranularity).pointerTarget ==
-                            PointerAccess.CURRENT_DEREF_DEREF_VALUE
-                }
+                .first { it.derefDepth == PointerAccess.CURRENT_DEREF_DEREF_VALUE }
                 .start,
         )
     }
@@ -3521,8 +3472,7 @@ class PointsToPassTest {
         assertNotNull(tu)
         val outerSubFSEntries =
             tu.functions
-                .filter { it.name.localName == "outer_sub" }
-                .singleOrNull()
+                .singleOrNull { it.name.localName == "outer_sub" }
                 ?.functionSummary
                 ?.entries
                 ?.singleOrNull()
@@ -4264,13 +4214,25 @@ class PointsToPassTest {
         // prevDFG Edge to the strlcpy in Line 11 from here
         // TODO: We have deref(deref)value edges to the strlcpy PMV, not sure if this makes sense
         // Start with b
-        // 3 edges: The full to the variable, the partial to the DerefPMV of strlcpy, and the
-        // fieldgranularity
-        assertEquals(
-            3,
-            b1.prevDFGEdges.filter { it.granularity !is PointerDataflowGranularity }.size,
-        )
+        // 3 edges: The full to the variable, the fieldgranularity and three derefvalue edges, which
+        // all point to the PMV of strlcpy
+        assertEquals(5, b1.prevDFG.size)
         assertEquals(testFunc.variables("b").single(), b1.prevFullDFG.single())
+        assertEquals(
+            bd1,
+            b1.prevDFGEdges.single { (it.granularity is FieldDataflowGranularity) }.start,
+        )
+        assertEquals(3, b1.prevDFGEdges.filter { it.derefDepth != null }.size)
+        assertEquals(
+            strlDstDerefPMV,
+            b1.prevDFGEdges
+                .single {
+                    it.granularity is FullDataflowGranularity &&
+                        (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
+                            strlcpy2Call
+                }
+                .start,
+        )
         assertEquals(
             strlDstDerefPMV,
             b1.prevDFGEdges
@@ -4284,17 +4246,24 @@ class PointsToPassTest {
                 .start,
         )
         assertEquals(
-            bd1,
-            b1.prevDFGEdges.single { (it.granularity is FieldDataflowGranularity) }.start,
+            strlDstDerefPMV,
+            b1.prevDFGEdges
+                .single {
+                    ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Field)
+                        ?.name
+                        ?.localName == "d.f" &&
+                        (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
+                            strlcpy2Call
+                }
+                .start,
         )
         // Now the b.d
-        // We expect one Full prevDFG to ?, and 3 partial ones: to both strcpys and to the memset
-        assertEquals(
-            4,
-            bd1.prevDFGEdges.filter { it.granularity !is PointerDataflowGranularity }.size,
-        )
-        // TODO
-        //        assertEquals(null, bd1.prevFullDFG.singleOrNull())
+        // We have 5 edges:
+        // A full to the field declaration and another full to the member b.d.g in this line
+        // TODO: (not sure where the prevDFG to the member is coming from)
+        // Additionally, the same current-deref-value edges as for b.
+        assertEquals(5, bd1.prevDFGEdges.size)
+        assertContains(bd1.prevFullDFG, tu.fields["d"] as Field)
         assertEquals(
             memsetDstDerefPMV,
             bd1.prevDFGEdges
@@ -4393,10 +4362,7 @@ class PointsToPassTest {
                 credentialAssign2.lhs.singleOrNull() as Node,
             ),
             realCodeCallArg.prevDFGEdges
-                .filter {
-                    (it.granularity as? PointerDataflowGranularity)?.pointerTarget ==
-                        PointerAccess.CURRENT_DEREF_DEREF_VALUE
-                }
+                .filter { it.derefDepth == PointerAccess.CURRENT_DEREF_DEREF_VALUE }
                 .map { it.start }
                 .toSet(),
         )
@@ -4488,9 +4454,7 @@ class PointsToPassTest {
             printStructLineArgBase.prevDFGEdges
                 .singleOrNull {
                     (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
-                        freeCall &&
-                        (it.granularity as? PointerDataflowGranularity)?.pointerTarget ==
-                            PointerAccess.CURRENT_DEREF_VALUE
+                        freeCall && it.derefDepth == PointerAccess.CURRENT_DEREF_VALUE
                 }
                 ?.start,
         )
@@ -4626,10 +4590,7 @@ class PointsToPassTest {
         assertEquals(
             xAssign,
             xRefDelete.prevDFGEdges
-                .singleOrNull {
-                    (it.granularity as? PointerDataflowGranularity)?.pointerTarget ==
-                        PointerAccess.CURRENT_DEREF_VALUE
-                }
+                .singleOrNull { it.derefDepth == PointerAccess.CURRENT_DEREF_VALUE }
                 ?.start,
         )
 
@@ -4800,9 +4761,7 @@ class PointsToPassTest {
                     .singleOrNull {
                         (it as? ContextSensitiveDataflow)?.callingContext?.calls?.any {
                             it === testCall2
-                        } == true &&
-                            (it.granularity as? PointerDataflowGranularity)?.pointerTarget ==
-                                PointerAccess.CURRENT_DEREF_VALUE
+                        } == true && it.derefDepth == PointerAccess.CURRENT_DEREF_VALUE
                     }
                     ?.start as? ParameterMemoryValue)
                 ?.name

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
@@ -29,6 +29,7 @@ import de.fraunhofer.aisec.cpg.frontends.cxx.CLanguage
 import de.fraunhofer.aisec.cpg.frontends.cxx.CPPLanguage
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Field
 import de.fraunhofer.aisec.cpg.graph.declarations.Function
 import de.fraunhofer.aisec.cpg.graph.declarations.Parameter
 import de.fraunhofer.aisec.cpg.graph.declarations.Variable
@@ -4688,5 +4689,186 @@ class PointsToPassTest {
                 ?.name
                 ?.toString(),
         )
+    }
+
+    @Test
+    fun testMemberWriteDFG() {
+        val file = File("src/test/resources/pointsToPass/member_write_in_function.c")
+        val tu =
+            analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
+                it.registerLanguage<CLanguage>()
+                it.registerPass<PointsToPass>()
+                it.registerFunctionSummaries(File("src/test/resources/hardcodedDFGedges.yml"))
+            }
+        assertNotNull(tu)
+
+        // Functions
+        val mainFunc = tu.functions("main").single()
+        val setPointXFunc = tu.functions("set_point_x").single()
+
+        // Calls
+        val printfCall1 = mainFunc.calls("printf").first()
+        val printfCall2 = mainFunc.calls("printf").last()
+        val setPointXCall = mainFunc.calls[1]
+        assertNotNull(setPointXCall)
+
+        // Args
+        val pxArg1 = printfCall1.arguments[1] as? MemberAccess
+        assertNotNull(pxArg1)
+        val pyArg1 = printfCall1.arguments[2] as? MemberAccess
+        assertNotNull(pyArg1)
+        val pxArg2 = printfCall2.arguments[1] as? MemberAccess
+        assertNotNull(pxArg2)
+        val pyArg2 = printfCall2.arguments[2] as? MemberAccess
+        assertNotNull(pyArg2)
+
+        // Variables, Structs and Fields
+        val pVar = mainFunc.variables["p"]
+        assertNotNull(pVar)
+
+        val xField = tu.fields["x"]
+        assertNotNull(xField)
+
+        val yField = tu.fields["y"]
+        assertNotNull(yField)
+
+        // Div
+        val pxWrite = mainFunc.assigns[0].lhs.single() as? MemberAccess
+        assertNotNull(pxWrite)
+
+        val pyWrite = mainFunc.assigns[1].lhs.single() as? MemberAccess
+        assertNotNull(pyWrite)
+
+        val ppyWrite = mainFunc.assigns[2].lhs.single() as? MemberAccess
+        assertNotNull(ppyWrite)
+
+        val ppxWrite = setPointXFunc.assigns.single().lhs.single()
+        assertNotNull(ppxWrite)
+
+        // The actual tests
+        // In the 1st printf, p.x should have 2 prevDFG Edges:
+        // 1) One full to the lhs of the assign in Line 14
+        // 2) The fieldGranularity Edge to the base
+        assertEquals(2, pxArg1.prevDFG.size)
+        assertEquals(pxWrite, pxArg1.prevFullDFG.singleOrNull())
+        assertEquals(
+            pxArg1.base,
+            pxArg1.prevDFGEdges.singleOrNull { it.granularity is FieldDataflowGranularity }?.start,
+        )
+
+        // p.y should have the following DFG-Edges
+        // 1) One full to the lhs of the assign in Line 15
+        // 2) The fieldGranularity Edge to the base
+        assertEquals(2, pyArg1.prevDFG.size)
+        assertEquals(pyWrite, pyArg1.prevFullDFG.singleOrNull())
+        assertEquals(
+            pyArg1.base,
+            pyArg1.prevDFGEdges.singleOrNull { it.granularity is FieldDataflowGranularity }?.start,
+        )
+
+        // Their bases should have the same DFG edges:
+        // 1) One full to the variable
+        // 2) A partial to the lhs of the assign in Line 14
+        // 3) A partial to the lhs of the assign in Line 15
+        setOf(pxArg1.base, pyArg1.base).forEach { base ->
+            assertEquals(3, base.prevDFG.size)
+            assertEquals(pVar, base.prevFullDFG.singleOrNull())
+            assertEquals(
+                pxWrite.base,
+                base.prevDFGEdges
+                    .singleOrNull {
+                        ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget
+                                as? Field)
+                            ?.name
+                            ?.localName == "x"
+                    }
+                    ?.start,
+            )
+            assertEquals(
+                pyWrite.base,
+                base.prevDFGEdges
+                    .singleOrNull {
+                        ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget
+                                as? Field)
+                            ?.name
+                            ?.localName == "y"
+                    }
+                    ?.start,
+            )
+        }
+
+        ///////////////////////////////////// 2nd printf /////////////////
+
+        // The p.x from the 2nd printf should have 4 prevDFG Edges:
+        // 1) A fullDFG to the lhs of the assign in the set_point_x function
+        // 2) The fieldGranularity Edge to the base
+        // 3+4) The shortFS edges to the parameter and the call of set_point_x
+        assertEquals(4, pxArg2.prevDFG.size)
+        assertEquals(
+            ppxWrite,
+            pxArg2.prevDFGEdges
+                .singleOrNull {
+                    (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
+                        setPointXCall
+                }
+                ?.start,
+        )
+        assertEquals(
+            1,
+            pxArg2.prevDFGEdges.filter { it.granularity is FieldDataflowGranularity }.size,
+        )
+        assertEquals(
+            setOf(setPointXCall.arguments[1], setPointXCall),
+            pxArg2.prevFunctionSummaryDFG.toSet(),
+        )
+
+        // The p.y from the printf should have 2 prevDFG Edges:
+        // 1) A fullDFG to the lhs of the assign in Line 19
+        // 2) The fieldGranularity Edge to the base
+        assertEquals(ppyWrite, pyArg2.prevFullDFG.single())
+        assertEquals(
+            pyArg2.base,
+            pyArg2.prevDFGEdges.singleOrNull { it.granularity is FieldDataflowGranularity }?.start,
+        )
+
+        // Their basees have the same DFG-Edges:
+        // 1) One Full to the variable
+        // 2) One to the last write of field y in Line 18
+        // 3) One to the last write of field x via set_point_x
+        // 4+5) 2 ShortFS Edges to the call and the parameter of set_point_x
+        setOf(pyArg2.base, pxArg2.base).forEach { base ->
+            assertEquals(5, base.prevDFG.size)
+            assertEquals(pVar, base.prevFullDFG.singleOrNull())
+            assertEquals(
+                ppyWrite.base,
+                base.prevDFGEdges
+                    .singleOrNull {
+                        ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget
+                                as? Field)
+                            ?.name
+                            ?.localName == "y"
+                    }
+                    ?.start,
+            )
+            assertEquals(
+                ppxWrite,
+                (base.prevDFGEdges.singleOrNull {
+                        ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget
+                                as? Field)
+                            ?.name
+                            ?.localName == "x" &&
+                            !it.functionSummary &&
+                            (it as? ContextSensitiveDataflow)
+                                ?.callingContext
+                                ?.calls
+                                ?.singleOrNull() == setPointXCall
+                    } as ContextSensitiveDataflow)
+                    .start,
+            )
+            assertEquals(
+                setOf(setPointXCall.arguments[1], setPointXCall),
+                base.prevFunctionSummaryDFG.toSet(),
+            )
+        }
     }
 }

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
@@ -3665,28 +3665,20 @@ class PointsToPassTest {
             setOf<Node>(unknownAssignsAssign1.target as Node, unknownAssignsAssign2.target as Node),
             unknownAssigns0.prevFullDFG.toSet(),
         )
-        // For the base of unknownAssigns0, we expect the following FullDFG-Path:
-        //        unknownAssigns0.base <- <MemberAccessLine10.base> <- <MemberAccessLine9.base> <-
-        // Variable
+        // The base of unknownAssigns0 points to its variable declaration
+        // TODO: We could also check for the partial DFG Edges
         assertEquals(
-            (unknownAssignsAssign2.target as? MemberAccess)?.base,
+            tu.variables("unknown_assigns").single(),
             unknownAssigns0.base.prevFullDFG.singleOrNull(),
-        )
-        assertEquals(
-            (unknownAssignsAssign1.target as? MemberAccess)?.base,
-            (unknownAssignsAssign2.target as? MemberAccess)?.base?.prevFullDFG?.singleOrNull(),
-        )
-        assertEquals(
-            testFD.variables["unknown_assigns"],
-            (unknownAssignsAssign1.target as? MemberAccess)?.base?.prevFullDFG?.singleOrNull(),
         )
 
         // For known_assigns, we know the struct, so we expect the prevDFG edge to point to the
         // lastWrite of the first element
         assertEquals(knownAssignsAssign2.target as Node, knownAssigns0.prevFullDFG.singleOrNull())
-        // The base of the knownassign points to the 3rd assignment
+        // The base of the known_assigns points to its variable declaration
+        // TODO: We could also check for the partial DFG Edges
         assertEquals(
-            (knownAssignsAssign3.target as? MemberAccess)?.base,
+            tu.variables("known_assigns").single(),
             knownAssigns0.base.prevFullDFG.singleOrNull(),
         )
     }
@@ -3936,7 +3928,7 @@ class PointsToPassTest {
         assertNotNull(testFuncDerefPMV)
 
         // The returned PointerReference
-        val finalConfPointerReference = testFunc.returns.single().returnValue
+        val finalConfPointerReference = testFunc.returns.single().returnValue as? PointerReference
         assertNotNull(finalConfPointerReference)
 
         val memsetDstParam = memsetFunc.parameters[0]
@@ -3949,17 +3941,46 @@ class PointsToPassTest {
         assertNotNull(strlDstDerefPMV)
 
         // Actual tests
-        // For the arg of the printf, we except a Full prevDFG to the variable and a partial to the
-        // memset dst deref PMV
+        // For the arg of the printf, we except a Full prevDFG to the variable. Additionally, due to
+        // the memset, we expect 3 DEREF_VALUE edges:
+        // One full, one to the "st.s" and one to the "st" field.
+        // Note: Since we don't know much about conf_t, all member accesses resolve to the same
+        // address, causing the 3 different edges to the same value
+        assertEquals(4, printf1Arg.prevDFG.size)
+        assertEquals(testFunc.variables["conf"], printf1Arg.prevFullDFG.singleOrNull())
         assertEquals(
             memsetDstDerefPMV,
             printf1Arg.prevDFGEdges
                 .singleOrNull {
-                    (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget == "conf"
+                    it.derefDepth == PointerAccess.CURRENT_DEREF_VALUE &&
+                        it.granularity is FullDataflowGranularity
                 }
                 ?.start,
         )
-        assertEquals(testFunc.variables["conf"], printf1Arg.prevFullDFG.singleOrNull())
+        assertEquals(
+            memsetDstDerefPMV,
+            printf1Arg.prevDFGEdges
+                .singleOrNull {
+                    it.derefDepth == PointerAccess.CURRENT_DEREF_VALUE &&
+                        ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget
+                                as? Field)
+                            ?.name
+                            ?.localName == "st"
+                }
+                ?.start,
+        )
+        assertEquals(
+            memsetDstDerefPMV,
+            printf1Arg.prevDFGEdges
+                .singleOrNull {
+                    it.derefDepth == PointerAccess.CURRENT_DEREF_VALUE &&
+                        ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget
+                                as? Field)
+                            ?.name
+                            ?.localName == "st.s"
+                }
+                ?.start,
+        )
 
         // The 2nd argument to strlcpy should have a prevDFG with FieldGranularity to its base. From
         // there, we expect a Full DFG to the PMV derefvalue of parameter c
@@ -3973,16 +3994,16 @@ class PointsToPassTest {
         )
 
         // For the 2nd printf, we except the prevFullDFG of the `conf` to point to the variable
-        // "conf". Additionally, we except partial prevDFGs to the memset and strlcpy derefvalues
-        // TODO: We could be more precise and delete the partial prevDFG to the memset since strlcpy
-        // also writes to conf.st.s
+        // "conf". Additionally, as above, we except 3 DEREF_VALUE edges with different
+        // granularities.
+        assertEquals(4, printf2Arg1.prevDFG.size)
         assertEquals(testFunc.variables["conf"], printf2Arg1.prevFullDFG.singleOrNull())
         assertEquals(
-            memsetDstDerefPMV,
+            strlDstDerefPMV,
             printf2Arg1.prevDFGEdges
                 .single {
-                    it.granularity is PartialDataflowGranularity<*> &&
-                        (it as ContextSensitiveDataflow).callingContext.calls.single() == memsetCall
+                    (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
+                        strlcpyCall && it.granularity is FullDataflowGranularity
                 }
                 .start,
         )
@@ -3990,28 +4011,48 @@ class PointsToPassTest {
             strlDstDerefPMV,
             printf2Arg1.prevDFGEdges
                 .single {
-                    it.granularity is PartialDataflowGranularity<*> &&
-                        (it as ContextSensitiveDataflow).callingContext.calls.single() ==
-                            strlcpyCall
+                    (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
+                        strlcpyCall &&
+                        ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget
+                                as? Field)
+                            ?.name
+                            ?.localName == "st"
+                }
+                .start,
+        )
+        assertEquals(
+            strlDstDerefPMV,
+            printf2Arg1.prevDFGEdges
+                .single {
+                    (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
+                        strlcpyCall &&
+                        ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget
+                                as? Field)
+                            ?.name
+                            ?.localName == "st.s"
                 }
                 .start,
         )
 
-        // For conf.st, we don't really have a prevFullDFG
-        // However, we want the same partialDataFlowGranularities as above plus one to the conf
-        // reference
-        assertTrue(printf2Arg2.prevFullDFG.isEmpty())
+        // conf.st has as prevFullDFG the field declaration
+        // Additionally, we expect: One FieldGranularityEdge to the base and the same 3 DEREF_VALUE
+        // edges as for conf. Note that 2 (a full and a partial for ".st" would be enough, but as
+        // noted above, they all point to the same memory address, so they get the same DFG edges
+        //
+        assertEquals(5, printf2Arg2.prevDFG.size)
+        assertEquals(tu.fields["st"], printf2Arg2.prevFullDFG.singleOrNull())
         assertEquals(
-            3,
-            printf2Arg2.prevDFGEdges.filter { it.granularity is PartialDataflowGranularity<*> }.size,
+            (printf2Arg2 as MemberAccess).base as Node,
+            (printf2Arg2.prevDFGEdges.singleOrNull { it.granularity is FieldDataflowGranularity }
+                    as Dataflow)
+                .start,
         )
         assertEquals(
-            memsetDstDerefPMV,
+            strlDstDerefPMV,
             printf2Arg2.prevDFGEdges
                 .single {
-                    it.granularity is PartialDataflowGranularity<*> &&
-                        (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
-                            memsetCall
+                    (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
+                        strlcpyCall && it.granularity is FullDataflowGranularity
                 }
                 .start,
         )
@@ -4019,62 +4060,80 @@ class PointsToPassTest {
             strlDstDerefPMV,
             printf2Arg2.prevDFGEdges
                 .single {
-                    it.granularity is PartialDataflowGranularity<*> &&
-                        (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
-                            strlcpyCall
+                    (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
+                        strlcpyCall &&
+                        ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget
+                                as? Field)
+                            ?.name
+                            ?.localName == "st"
                 }
                 .start,
         )
         assertEquals(
-            (printf2Arg2 as MemberAccess).base,
+            strlDstDerefPMV,
             printf2Arg2.prevDFGEdges
                 .single {
-                    it.granularity is PartialDataflowGranularity<*> &&
-                        it !is ContextSensitiveDataflow
+                    (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
+                        strlcpyCall &&
+                        ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget
+                                as? Field)
+                            ?.name
+                            ?.localName == "st.s"
                 }
                 .start,
         )
 
-        // The same partial edges apply to the PointerReference that is returned
+        // The returned pointerreference has 6 prevDFG edges
+        // a full one to the memory address of conf
+        // a DEREF-VALUE edge to the variable declaration of conf
+        // a pointerReference granularity edge to the input
+        // 3 DEREF-DEREF-VALUE edges to the param of strlcpy
+        assertEquals(6, finalConfPointerReference.prevDFG.size)
         assertEquals(
-            3,
-            finalConfPointerReference.prevDFGEdges
-                .filter { it.granularity is PartialDataflowGranularity<*> }
-                .size,
+            finalConfPointerReference.input.memoryAddresses.single(),
+            finalConfPointerReference.prevFullDFG.singleOrNull(),
         )
         assertEquals(
-            memsetDstDerefPMV,
+            finalConfPointerReference.input,
             finalConfPointerReference.prevDFGEdges
-                .single {
-                    it.granularity is PartialDataflowGranularity<*> &&
-                        (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
-                            memsetCall
+                .singleOrNull {
+                    (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget ==
+                        "PointerReference"
                 }
-                .start,
+                ?.start,
         )
         assertEquals(
             strlDstDerefPMV,
             finalConfPointerReference.prevDFGEdges
-                .single {
-                    it.granularity is PartialDataflowGranularity<*> &&
-                        (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
-                            strlcpyCall
+                .singleOrNull {
+                    it.derefDepth == PointerAccess.CURRENT_DEREF_DEREF_VALUE &&
+                        it.granularity is FullDataflowGranularity
                 }
-                .start,
+                ?.start,
         )
         assertEquals(
-            (finalConfPointerReference as PointerReference).input,
+            strlDstDerefPMV,
             finalConfPointerReference.prevDFGEdges
-                .single {
-                    it.granularity is PartialDataflowGranularity<*> &&
-                        it !is ContextSensitiveDataflow
+                .singleOrNull {
+                    it.derefDepth == PointerAccess.CURRENT_DEREF_DEREF_VALUE &&
+                        ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget
+                                as? Field)
+                            ?.name
+                            ?.localName == "st"
                 }
-                .start,
+                ?.start,
         )
-        // The prevFullDFG should be the memoryAddress of conf
-        assertLocalName(
-            "conf",
-            finalConfPointerReference.prevFullDFG.singleOrNull() as MemoryAddress,
+        assertEquals(
+            strlDstDerefPMV,
+            finalConfPointerReference.prevDFGEdges
+                .singleOrNull {
+                    it.derefDepth == PointerAccess.CURRENT_DEREF_DEREF_VALUE &&
+                        ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget
+                                as? Field)
+                            ?.name
+                            ?.localName == "st.s"
+                }
+                ?.start,
         )
     }
 
@@ -4200,55 +4259,79 @@ class PointsToPassTest {
         )
 
         // Let's analyze the assign after the strlcpy. Here, both the b and the b.d should have 2
-        // partial prevDFGto the strlcpys dstParam
-        // (one from each strlcpy)
+        // partial prevDFGto to the strlcpy dstParam
+        // Note: Since we only detect the first subaccess (so b.d in this case), we don't have a
+        // prevDFG Edge to the strlcpy in Line 11 from here
+        // TODO: We have deref(deref)value edges to the strlcpy PMV, not sure if this makes sense
+        // Start with b
+        // 3 edges: The full to the variable, the partial to the DerefPMV of strlcpy, and the
+        // fieldgranularity
         assertEquals(
-            2,
+            3,
+            b1.prevDFGEdges.filter { it.granularity !is PointerDataflowGranularity }.size,
+        )
+        assertEquals(testFunc.variables("b").single(), b1.prevFullDFG.single())
+        assertEquals(
+            strlDstDerefPMV,
             b1.prevDFGEdges
-                .filter {
-                    (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget == "b" &&
-                        it.start == strlDstDerefPMV &&
-                        (it as ContextSensitiveDataflow).callingContext.calls.single() in
-                            setOf(strlcpy1Call, strlcpy2Call)
+                .single {
+                    ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Field)
+                        ?.name
+                        ?.localName == "d" &&
+                        (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
+                            strlcpy2Call
                 }
-                .size,
+                .start,
         )
         assertEquals(
-            2,
+            bd1,
+            b1.prevDFGEdges.single { (it.granularity is FieldDataflowGranularity) }.start,
+        )
+        // Now the b.d
+        // We expect one Full prevDFG to ?, and 3 partial ones: to both strcpys and to the memset
+        assertEquals(
+            4,
+            bd1.prevDFGEdges.filter { it.granularity !is PointerDataflowGranularity }.size,
+        )
+        // TODO
+        //        assertEquals(null, bd1.prevFullDFG.singleOrNull())
+        assertEquals(
+            memsetDstDerefPMV,
             bd1.prevDFGEdges
-                .filter {
-                    (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget ==
-                        "conf_t::d" &&
-                        it.start == strlDstDerefPMV &&
-                        (it as ContextSensitiveDataflow).callingContext.calls.single() in
-                            setOf(strlcpy1Call, strlcpy2Call)
+                .single {
+                    ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Field)
+                        ?.name
+                        ?.localName == "e" &&
+                        (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
+                            memset1Call
                 }
-                .size,
-        )
-
-        // And we also want to edges like this to the memsets
-        assertEquals(
-            2,
-            b1.prevDFGEdges
-                .filter {
-                    (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget == "b" &&
-                        it.start == memsetDstDerefPMV &&
-                        (it as ContextSensitiveDataflow).callingContext.calls.single() in
-                            setOf(memset1Call, memset2Call)
-                }
-                .size,
+                .start,
         )
         assertEquals(
-            2,
+            strlDstDerefPMV,
             bd1.prevDFGEdges
-                .filter {
-                    (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget ==
-                        "conf_t::d" &&
-                        it.start == memsetDstDerefPMV &&
-                        (it as ContextSensitiveDataflow).callingContext.calls.single() in
-                            setOf(memset1Call, memset2Call)
+                .single {
+                    ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Field)
+                        ?.name
+                        ?.localName == "e" &&
+                        (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
+                            strlcpy1Call
                 }
-                .size,
+                .start,
+        )
+        // For "f", we have no edge to the memset in Line 13 b/c the edge is overwritten by the
+        // strlcpy in Line 16
+        assertEquals(
+            strlDstDerefPMV,
+            bd1.prevDFGEdges
+                .single {
+                    ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Field)
+                        ?.name
+                        ?.localName == "f" &&
+                        (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
+                            strlcpy2Call
+                }
+                .start,
         )
 
         // Back in the main function, let's check the prevDFGs from the PointerReference argument to
@@ -4258,8 +4341,38 @@ class PointsToPassTest {
             "credentials",
             realCodeCallArg.prevFullDFG.singleOrNull { it is MemoryAddress },
         )
-        // For the argument's input, the prevFullDFG is the base of the 2nd assign in the construtor
-        assertEquals(credentialLastWrite, realCodeCallArgInput.prevFullDFG.singleOrNull())
+        // For the argument's input we have 3 prevDFG edges, the prevFullDFG is the variable
+        assertEquals(
+            3,
+            realCodeCallArgInput.prevDFGEdges
+                .filter { it.granularity !is PointerDataflowGranularity }
+                .size,
+        )
+        assertEquals(
+            mainFunc.variables("credentials").single(),
+            realCodeCallArgInput.prevFullDFG.singleOrNull(),
+        )
+        // And we also have the partial ones to the assigns in the constructor
+        assertEquals(
+            (credentialAssign1.lhs.single() as? MemberAccess)?.base as Node,
+            realCodeCallArgInput.prevDFGEdges
+                .single {
+                    ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Field)
+                        ?.name
+                        ?.localName == "ssid"
+                }
+                .start,
+        )
+        assertEquals(
+            (credentialAssign2.lhs.single() as? MemberAccess)?.base as Node,
+            realCodeCallArgInput.prevDFGEdges
+                .single {
+                    ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Field)
+                        ?.name
+                        ?.localName == "pswd"
+                }
+                .start,
+        )
 
         // The derefPMV has as prevFullDFG has the same prevFullDFG
         assertEquals(credentialLastWrite, realCodeDerefPMV.prevFullDFG.singleOrNull())
@@ -4332,51 +4445,79 @@ class PointsToPassTest {
 
         // Parameters and PMVs
         val printStructLineParam = printStructLineFunc.parameters.single()
-        val printStructLineDerefPMV =
-            printStructLineParam.memoryValues.singleOrNull { it.name.localName == "derefvalue" }
 
         val freeParam = freeFunc.parameters.single()
         val freeDerefPMV = freeParam.memoryValues.singleOrNull { it.name.localName == "derefvalue" }
 
         // Stuff
-        val dataIIntTwoLine20 = testFunc.assignments[5].target
-        assertNotNull(dataIIntTwoLine20)
+        val dataIIntOneLine23 = testFunc.assignments[4].target as? MemberAccess
+        assertNotNull(dataIIntOneLine23)
 
-        val dataLine13 = testFunc.assignments[2].target
-        assertNotNull(dataLine13)
+        val dataIIntTwoLine24 = testFunc.assignments[5].target as? MemberAccess
+        assertNotNull(dataIIntTwoLine24)
 
-        val dataLine10 = testFunc.assignments[1].target
-        assertNotNull(dataLine10)
+        val dataLine17 = testFunc.assignments[2].target
+        assertNotNull(dataLine17)
+
+        val dataLine14 = testFunc.assignments[1].target
+        assertNotNull(dataLine14)
+
+        val IindexLine23 = testFunc.refs("i")[0]
+        assertNotNull(IindexLine23)
+
+        val IindexLine24 = testFunc.refs("i")[1]
+        assertNotNull(IindexLine24)
 
         // We except the following DFG-Edges for the printStructLine Call
         // 2) The argument has a DFG-Edge to the param
         // 3) The currentderefvalue edge of the arg is the derefValue of free
 
         // 1) the argument as well as data have 4 prevDFG edges:
-        //   + a ContextSensitive one to the PMVDerefValue of free
-        //   + a Full one to the base of the write to data[i].intTwo in Line 20 (TODO: Partial?)
-        //   + a Full one to the real initialization (Line 13)
-        //   + a Full one to the initialization to null ( Line 10)
+        //   + a ContextSensitive deref_deref_value to the PMVDerefValue of free
+        // TODO: If we are being picky, since the partial edge points to "i", should we really have
+        // both partials?
+        //   + a partial one to the base of the write to data[i].intOne in Line 24
+        //   + a partial one to the base of the write to data[i].intTwo in Line 245
+        //   + a Full one to the real initialization (Line 17)
+        //   + a Full one to the initialization to null ( Line 14)
         // First the checks for data
-        assertEquals(4, printStructLineArgBase.prevDFG.size)
+        assertEquals(5, printStructLineArgBase.prevDFG.size)
+        assertEquals(2, printStructLineArgBase.prevFullDFG.size)
         assertEquals(
             freeDerefPMV,
             printStructLineArgBase.prevDFGEdges
                 .singleOrNull {
-                    (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() == freeCall
+                    (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
+                        freeCall &&
+                        (it.granularity as? PointerDataflowGranularity)?.pointerTarget ==
+                            PointerAccess.CURRENT_DEREF_VALUE
                 }
                 ?.start,
         )
-        assertNotNull(
-            printStructLineArgBase.prevDFG.singleOrNull {
-                it == ((dataIIntTwoLine20 as? MemberAccess)?.base as? Subscription)?.arrayExpression
-            }
+        assertEquals(
+            (dataIIntOneLine23.base as? Subscription)?.arrayExpression,
+            printStructLineArgBase.prevDFGEdges
+                .singleOrNull {
+                    (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget ==
+                        IindexLine23
+                }
+                ?.start,
         )
-        assertNotNull(printStructLineArgBase.prevDFG.singleOrNull { it == dataLine13 })
-        assertNotNull(printStructLineArgBase.prevDFG.singleOrNull { it == dataLine10 })
+        assertEquals(
+            (dataIIntTwoLine24.base as? Subscription)?.arrayExpression,
+            printStructLineArgBase.prevDFGEdges
+                .singleOrNull {
+                    (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget ==
+                        IindexLine24
+                }
+                ?.start,
+        )
+
+        assertNotNull(printStructLineArgBase.prevDFG.singleOrNull { it == dataLine17 })
+        assertNotNull(printStructLineArgBase.prevDFG.singleOrNull { it == dataLine14 })
 
         // Now the same for the argument. Here we have an additional pointerReference-Edge
-        assertEquals(5, printStructLineArg.prevDFG.size)
+        assertEquals(6, printStructLineArg.prevDFG.size)
         assertEquals(
             freeDerefPMV,
             printStructLineArg.prevDFGEdges
@@ -4385,13 +4526,26 @@ class PointsToPassTest {
                 }
                 ?.start,
         )
-        assertNotNull(
-            printStructLineArg.prevDFG.singleOrNull {
-                it == ((dataIIntTwoLine20 as? MemberAccess)?.base as? Subscription)?.arrayExpression
-            }
+        assertEquals(
+            (dataIIntOneLine23.base as? Subscription)?.arrayExpression,
+            printStructLineArg.prevDFGEdges
+                .singleOrNull {
+                    (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget ==
+                        IindexLine23
+                }
+                ?.start,
         )
-        assertNotNull(printStructLineArg.prevDFG.singleOrNull { it == dataLine13 })
-        assertNotNull(printStructLineArg.prevDFG.singleOrNull { it == dataLine10 })
+        assertEquals(
+            (dataIIntTwoLine24.base as? Subscription)?.arrayExpression,
+            printStructLineArg.prevDFGEdges
+                .singleOrNull {
+                    (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget ==
+                        IindexLine24
+                }
+                ?.start,
+        )
+        assertNotNull(printStructLineArg.prevDFG.singleOrNull { it == dataLine17 })
+        assertNotNull(printStructLineArg.prevDFG.singleOrNull { it == dataLine14 })
         assertEquals(
             printStructLineArg.input,
             printStructLineArg.prevDFGEdges
@@ -4404,7 +4558,7 @@ class PointsToPassTest {
 
         // For data[0], we expect the following prevDFG Edges:
         // 1) The fullprevDFG to the PMVDerefValue of free (and to the original assignment in Line
-        // 10 if we didn't enter the if in Line 11)
+        // 14 if we didn't enter the if in Line 15)
         // 2) the index prevDFG
         assertTrue(printStructLineArgInput.prevFullDFG.contains(freeDerefPMV))
         assertEquals(

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
@@ -2488,10 +2488,7 @@ class PointsToPassTest {
         assertEquals(
             1,
             p2pLine262.prevDFGEdges
-                .filter {
-                    it.granularity is PointerDataflowGranularity &&
-                        it.derefDepth == PointerAccess.CURRENT_DEREF_VALUE
-                }
+                .filter { it.derefDepth == PointerAccess.CURRENT_DEREF_VALUE }
                 .size,
         )
         assertEquals(
@@ -3257,10 +3254,10 @@ class PointsToPassTest {
             pDerefLine466Left.nextDFGEdges
                 .filter {
                     it.granularity is FullDataflowGranularity &&
+                        it.derefDepth == null &&
                         it is ContextSensitiveDataflow &&
                         it.callingContext.calls ==
-                            mutableListOf(veryInnerFuncCE, innerFuncCE, outerFuncCE) &&
-                        it.granularity is FullDataflowGranularity
+                            mutableListOf(veryInnerFuncCE, innerFuncCE, outerFuncCE)
                 }
                 .map { it.end }
                 .toSet(),
@@ -4175,6 +4172,11 @@ class PointsToPassTest {
             realCodeParam.memoryValues.singleOrNull { it.name.localName == "derefderefvalue" }
         assertNotNull(realCodeDerefDerefPMV)
 
+        val mainFuncArgv = mainFunc.parameters.last()
+        val mainFuncArgvDerefDerefPMV =
+            mainFuncArgv.memoryValues.singleOrNull { it.name.localName == "derefderefvalue" }
+        assertNotNull(realCodeDerefDerefPMV)
+
         // Other stuff
         val bdgh1 = testFunc.assignments[2].target as? MemberAccess
         assertNotNull(bdgh1)
@@ -4216,6 +4218,8 @@ class PointsToPassTest {
         // Start with b
         // 3 edges: The full to the variable, the fieldgranularity and three derefvalue edges, which
         // all point to the PMV of strlcpy
+        // TODO: shouldn't b also have partial edges to other previous writes such as the other
+        // strlcpy?
         assertEquals(5, b1.prevDFG.size)
         assertEquals(testFunc.variables("b").single(), b1.prevFullDFG.single())
         assertEquals(
@@ -4265,26 +4269,25 @@ class PointsToPassTest {
         assertEquals(5, bd1.prevDFGEdges.size)
         assertContains(bd1.prevFullDFG, tu.fields["d"] as Field)
         assertEquals(
-            memsetDstDerefPMV,
+            strlDstDerefPMV,
             bd1.prevDFGEdges
                 .single {
-                    ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Field)
-                        ?.name
-                        ?.localName == "e" &&
+                    it.granularity is FullDataflowGranularity &&
                         (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
-                            memset1Call
+                            strlcpy2Call
                 }
                 .start,
         )
+
         assertEquals(
             strlDstDerefPMV,
             bd1.prevDFGEdges
                 .single {
                     ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Field)
                         ?.name
-                        ?.localName == "e" &&
+                        ?.localName == "d" &&
                         (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
-                            strlcpy1Call
+                            strlcpy2Call
                 }
                 .start,
         )
@@ -4296,7 +4299,7 @@ class PointsToPassTest {
                 .single {
                     ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Field)
                         ?.name
-                        ?.localName == "f" &&
+                        ?.localName == "d.f" &&
                         (it as? ContextSensitiveDataflow)?.callingContext?.calls?.single() ==
                             strlcpy2Call
                 }
@@ -4310,18 +4313,19 @@ class PointsToPassTest {
             "credentials",
             realCodeCallArg.prevFullDFG.singleOrNull { it is MemoryAddress },
         )
-        // For the argument's input we have 3 prevDFG edges, the prevFullDFG is the variable
-        assertEquals(
-            3,
-            realCodeCallArgInput.prevDFGEdges
-                .filter { it.granularity !is PointerDataflowGranularity }
-                .size,
-        )
+        // For the argument's input we have 6 prevDFG edges
+        // + The prevFullDFG is the variable
+        // + 2 partial ones to the bases of the writes in the constructor
+        // + 2 current-deref-value edges to the lhs in the constructor, since dereferencing
+        // credentials should
+        // bring us to the first element in the struct, and since we don't know the struct, we
+        // create dfg-edges to all of them
+        // + a current-deref-deref-value to argv
+        assertEquals(6, realCodeCallArgInput.prevDFG.size)
         assertEquals(
             mainFunc.variables("credentials").single(),
             realCodeCallArgInput.prevFullDFG.singleOrNull(),
         )
-        // And we also have the partial ones to the assigns in the constructor
         assertEquals(
             (credentialAssign1.lhs.single() as? MemberAccess)?.base as Node,
             realCodeCallArgInput.prevDFGEdges
@@ -4342,14 +4346,27 @@ class PointsToPassTest {
                 }
                 .start,
         )
+        assertEquals(
+            mutableSetOf<Node>(credentialAssign1.lhs.single(), credentialAssign2.lhs.single()),
+            realCodeCallArgInput.prevDFGEdges
+                .filter { it.derefDepth == PointerAccess.CURRENT_DEREF_VALUE }
+                .mapTo(mutableSetOf()) { it.start },
+        )
+        assertEquals(
+            mainFuncArgvDerefDerefPMV,
+            realCodeCallArgInput.prevDFGEdges
+                .single { it.derefDepth == PointerAccess.CURRENT_DEREF_DEREF_VALUE }
+                .start,
+        )
 
-        // The derefPMV has as prevFullDFG has the same prevFullDFG
+        // The derefPMV has 3 prevFullDFG edges: The variable, and due to overapproximation, also
+        // the has the same prevFullDFG
         assertEquals(credentialLastWrite, realCodeDerefPMV.prevFullDFG.singleOrNull())
 
         // The derefderefPMV and the currentderefderefValues of the argument point to both
         // memberAccesses, as the struct is unknown
         assertEquals(
-            setOf<Node>(
+            setOf(
                 credentialAssign1.lhs.singleOrNull() as Node,
                 credentialAssign2.lhs.singleOrNull() as Node,
             ),
@@ -4357,7 +4374,7 @@ class PointsToPassTest {
         )
 
         assertEquals(
-            setOf<Node>(
+            setOf(
                 credentialAssign1.lhs.singleOrNull() as Node,
                 credentialAssign2.lhs.singleOrNull() as Node,
             ),

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
@@ -1955,7 +1955,6 @@ class PointsToPassTest {
             3,
             fssgxecallkeytoout.filter { it.key !is Return }.entries.firstOrNull()?.value?.size,
         )
-        // TODO: Should this really be 3?
         assertEquals(
             2,
             fssgxecallkeytoout
@@ -2372,9 +2371,7 @@ class PointsToPassTest {
         val preciseFSrenegotiate =
             FSrenegotiate.entries.firstOrNull()?.value?.filter { it.properties.none { it == true } }
         assertNotNull(preciseFSrenegotiate)
-        // Since we overapproximate, we have 5 entries here: The writes in Line 15 & 16 appear once
-        // with and once w/o the subAccesses
-        assertEquals(5, preciseFSrenegotiate.size)
+        assertEquals(3, preciseFSrenegotiate.size)
         assertTrue(preciseFSrenegotiate.any { it.srcNode == literal5 && it.subAccessName == "i" })
         assertTrue(preciseFSrenegotiate.any { it.srcNode == literal6 && it.subAccessName == "j" })
         assertTrue(

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
@@ -4359,9 +4359,17 @@ class PointsToPassTest {
                 .start,
         )
 
-        // The derefPMV has 3 prevFullDFG edges: The variable, and due to overapproximation, also
-        // the has the same prevFullDFG
-        assertEquals(credentialLastWrite, realCodeDerefPMV.prevFullDFG.singleOrNull())
+        // The derefPMV has 3 prevFullDFG edges: The variable, and also the edges of the partial
+        // writes
+        // TODO: the partial writes should have a partial Granularity
+        assertEquals(
+            setOf(
+                mainFunc.variables("credentials").single(),
+                (credentialAssign1.lhs.single() as MemberAccess).base,
+                (credentialAssign2.lhs.single() as MemberAccess).base,
+            ),
+            realCodeDerefPMV.prevFullDFG.toSet(),
+        )
 
         // The derefderefPMV and the currentderefderefValues of the argument point to both
         // memberAccesses, as the struct is unknown

--- a/cpg-language-cxx/src/test/resources/pointsToPass/member_write_in_function.c
+++ b/cpg-language-cxx/src/test/resources/pointsToPass/member_write_in_function.c
@@ -1,0 +1,23 @@
+#include<stdio.h>
+
+struct Point {
+  int x;
+  int y;
+};
+
+static void set_point_x(struct Point *pp, int val) {
+    pp->x = val;
+}
+
+int main(void) {
+    struct Point p;
+    p.x = 10;
+    p.y = 20;
+    printf("eval_struct_member: %d %d\n", p.x, p.y);
+    /* Pointer to struct, then dereference */
+    struct Point *pp = &p;
+    (*pp).y = 25;
+    /* Inter-procedural: pass pointer to struct */
+    set_point_x(&p, 99);
+    printf("eval_struct_member: %d %d\n", p.x, p.y);
+}

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DFGTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DFGTest.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.frontends.python
 
 import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.declarations.Field
 import de.fraunhofer.aisec.cpg.graph.declarations.Function
 import de.fraunhofer.aisec.cpg.graph.edges.flows.FullDataflowGranularity
 import de.fraunhofer.aisec.cpg.graph.edges.flows.IndexedDataflowGranularity
@@ -849,6 +850,9 @@ class DFGTest {
 
         // Test the DFG edges for the reference d and the access d.b printed in line 10 of the
         // file.
+        val dLine2 = result.refs("d").first()
+        assertNotNull(dLine2)
+
         val printDLine10 =
             result.refs[{ it.name.localName == "d" && it.location?.region?.startLine == 10 }]
         assertIs<Reference>(
@@ -856,22 +860,34 @@ class DFGTest {
             "We expect that there is a reference called \"d\" in line 10 of the file.",
         )
         assertEquals(
-            1,
+            2,
             printDLine10.prevDFGEdges.size,
-            "We expect one incoming DFG edges: The full edge from line 9.",
+            "We expect two incoming DFG edges: A full edge from line 2 and a partial edge from line 9.",
         )
-        val dfgToInitializationLine10 = printDLine10.prevDFGEdges.singleOrNull()
+        val dfgToInitializationLine10 =
+            printDLine10.prevDFGEdges.singleOrNull { it.granularity is FullDataflowGranularity }
         assertNotNull(
             dfgToInitializationLine10,
+            "We expect one incoming full DFG edges: The full edge from line 2.",
+        )
+        assertEquals(
+            dLine2,
+            dfgToInitializationLine10.start,
             "We expect one incoming DFG edges: The full edge from line 9.",
         )
-        assertIs<FullDataflowGranularity>(
-            dfgToInitializationLine10.granularity,
-            "We expect one incoming DFG edges: The full edge from line 9.",
+        val dfgToPartialLine10 =
+            printDLine10.prevDFGEdges.singleOrNull {
+                ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Field)
+                    ?.name
+                    ?.localName == "b"
+            }
+        assertNotNull(
+            dfgToPartialLine10,
+            "We expect one incoming full DFG edges: The full edge from line 2.",
         )
         assertEquals(
             dLine9,
-            dfgToInitializationLine10.start,
+            dfgToPartialLine10.start,
             "We expect one incoming DFG edges: The full edge from line 9.",
         )
 
@@ -899,7 +915,9 @@ class DFGTest {
         )
         val dToMemberDB =
             subscriptLine10.prevDFGEdges.singleOrNull {
-                it.granularity is PartialDataflowGranularity<*>
+                ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Field)
+                    ?.name
+                    ?.localName == "b"
             }
         assertNotNull(
             dToMemberDB,
@@ -930,22 +948,32 @@ class DFGTest {
             "We expect that there is a reference called \"d\" in line 11 of the file.",
         )
         assertEquals(
-            1,
+            2,
             printDLine11.prevDFGEdges.size,
             "We expect one incoming DFG edges: The full edge from the initialization and the partial edge from line 9.",
         )
-        val dfgToPartialWriteLine11 = printDLine11.prevDFGEdges.singleOrNull()
+        val dfgToPartialWriteLine11 =
+            printDLine11.prevDFGEdges.singleOrNull {
+                it.granularity is PartialDataflowGranularity<*>
+            }
         assertNotNull(
             dfgToPartialWriteLine11,
             "We expect two incoming DFG edges: The full edge from the initialization and the partial edge from line 9.",
         )
-        assertIs<FullDataflowGranularity>(
-            dfgToPartialWriteLine11.granularity,
-            "We expect one incoming DFG edges: The full edge from the initialization and the partial edge from line 9.",
-        )
         assertEquals(
             dLine9,
             dfgToPartialWriteLine11.start,
+            "We expect two incoming DFG edges: The full edge from the initialization and the partial edge from line 9.",
+        )
+        val dfgToFullLine11 =
+            printDLine11.prevDFGEdges.singleOrNull { it.granularity is FullDataflowGranularity }
+        assertNotNull(
+            dfgToFullLine11,
+            "We expect two incoming DFG edges: The full edge from the initialization and the partial edge from line 9.",
+        )
+        assertEquals(
+            dLine2,
+            dfgToFullLine11.start,
             "We expect two incoming DFG edges: The full edge from the initialization and the partial edge from line 9.",
         )
 
@@ -1007,19 +1035,28 @@ class DFGTest {
             "We expect that there is a reference called \"d\" in line 12 of the file.",
         )
         assertEquals(
-            1,
+            2,
             printD.prevDFGEdges.size,
             "We expect two incoming DFG edges: The full edge from line 9.",
         )
-        val dfgTodB = printD.prevDFGEdges.singleOrNull()
+        val dfgTodB =
+            printD.prevDFGEdges.singleOrNull {
+                ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Field)
+                    ?.name
+                    ?.localName == "b"
+            }
         assertNotNull(dfgTodB, "We expect two incoming DFG edges: The full edge from line 9.")
-        assertIs<FullDataflowGranularity>(
-            dfgTodB.granularity,
-            "We expect two incoming DFG edges: The full edge from line 9.",
-        )
         assertEquals(
             dLine9,
             dfgTodB.start,
+            "We expect two incoming DFG edges: The full edge from line 9.",
+        )
+        val dfgToInit =
+            printD.prevDFGEdges.singleOrNull { it.granularity is FullDataflowGranularity }
+        assertNotNull(dfgToInit, "We expect two incoming DFG edges: The full edge from line 9.")
+        assertEquals(
+            dLine2,
+            dfgToInit.start,
             "We expect two incoming DFG edges: The full edge from line 9.",
         )
     }

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DFGTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DFGTest.kt
@@ -611,6 +611,9 @@ class DFGTest {
 
         // Test the DFG edges for the reference d and the access d[1] printed in line 10 of the
         // file.
+        val dLine2 = result.refs("d").first()
+        assertNotNull(dLine2)
+
         val printDLine10 =
             result.refs[{ it.name.localName == "d" && it.location?.region?.startLine == 10 }]
         assertIs<Reference>(
@@ -618,23 +621,34 @@ class DFGTest {
             "We expect that there is a reference called \"d\" in line 10 of the file.",
         )
         assertEquals(
-            1,
+            2,
             printDLine10.prevDFGEdges.size,
-            "We expect one incoming DFG edges: The full edge from line 9.",
+            "We expect two incoming DFG edges: The full edge from line 2 and the partial one from line 9.",
         )
-        val dfgToInitializationLine10 = printDLine10.prevDFGEdges.singleOrNull()
+        val dfgToInitializationLine10 =
+            printDLine10.prevDFGEdges.singleOrNull { it.granularity is FullDataflowGranularity }
         assertNotNull(
             dfgToInitializationLine10,
-            "We expect one incoming DFG edges: The full edge from line 9.",
+            "We expect one incoming DFG edges: The full edge from line 2.",
         )
-        assertIs<FullDataflowGranularity>(
-            dfgToInitializationLine10.granularity,
-            "We expect one incoming DFG edges: The full edge from line 9.",
+        assertEquals(
+            dLine2,
+            dfgToInitializationLine10.start,
+            "We expect one incoming DFG edges: The full edge from line 2.",
+        )
+        val dfgToPartialLine10 =
+            printDLine10.prevDFGEdges.singleOrNull {
+                ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Literal<*>)
+                    ?.value == 1L
+            }
+        assertNotNull(
+            dfgToPartialLine10,
+            "We expect one incoming DFG edges: The partial edge from line 9.",
         )
         assertEquals(
             dLine9,
-            dfgToInitializationLine10.start,
-            "We expect one incoming DFG edges: The full edge from line 9.",
+            dfgToPartialLine10.start,
+            "We expect one incoming DFG edges: The partial edge from line 9.",
         )
 
         val subscriptLine10 =
@@ -692,22 +706,33 @@ class DFGTest {
             "We expect that there is a reference called \"d\" in line 11 of the file.",
         )
         assertEquals(
-            1,
+            2,
             printDLine11.prevDFGEdges.size,
             "We expect one incoming DFG edges: The full edge from the initialization and the partial edge from line 9.",
         )
-        val dfgToPartialWriteLine11 = printDLine11.prevDFGEdges.singleOrNull()
+        val dfgToPartialWriteLine11 =
+            printDLine11.prevDFGEdges.singleOrNull {
+                ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Literal<*>)
+                    ?.value == 1L
+            }
         assertNotNull(
             dfgToPartialWriteLine11,
             "We expect two incoming DFG edges: The full edge from the initialization and the partial edge from line 9.",
         )
-        assertIs<FullDataflowGranularity>(
-            dfgToPartialWriteLine11.granularity,
-            "We expect one incoming DFG edges: The full edge from the initialization and the partial edge from line 9.",
-        )
         assertEquals(
             dLine9,
             dfgToPartialWriteLine11.start,
+            "We expect two incoming DFG edges: The full edge from the initialization and the partial edge from line 9.",
+        )
+        val dfgToFullLine11 =
+            printDLine11.prevDFGEdges.singleOrNull { it.granularity is FullDataflowGranularity }
+        assertNotNull(
+            dfgToFullLine11,
+            "We expect two incoming DFG edges: The full edge from the initialization and the partial edge from line 9.",
+        )
+        assertEquals(
+            dLine2,
+            dfgToFullLine11.start,
             "We expect two incoming DFG edges: The full edge from the initialization and the partial edge from line 9.",
         )
 
@@ -746,20 +771,30 @@ class DFGTest {
             "We expect that there is a reference called \"d\" in line 12 of the file.",
         )
         assertEquals(
-            1,
+            2,
             printD.prevDFGEdges.size,
+            "We expect two incoming DFG edges: The full edge from line 2 and the partial one from line 9.",
+        )
+        val dfgToD = printD.prevDFGEdges.singleOrNull { it.granularity is FullDataflowGranularity }
+        assertNotNull(dfgToD, "We expect two incoming DFG edges: The full edge from line 9.")
+        assertEquals(
+            dLine2,
+            dfgToD.start,
             "We expect two incoming DFG edges: The full edge from line 9.",
         )
-        val dfgToD = printD.prevDFGEdges.singleOrNull()
-        assertNotNull(dfgToD, "We expect two incoming DFG edges: The full edge from line 9.")
-        assertIs<FullDataflowGranularity>(
-            dfgToD.granularity,
-            "We expect two incoming DFG edges: The full edge from line 9.",
+        val dfgToPartial =
+            printD.prevDFGEdges.singleOrNull {
+                ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Literal<*>)
+                    ?.value == 1L
+            }
+        assertNotNull(
+            dfgToPartial,
+            "We expect two incoming DFG edges: The full edge from line 2 and the partial one from line 9.",
         )
         assertEquals(
             dLine9,
-            dfgToD.start,
-            "We expect two incoming DFG edges: The full edge from line 9.",
+            dfgToPartial.start,
+            "We expect two incoming DFG edges: The full edge from line 2 and the partial one from line 9.",
         )
     }
 

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DFGTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/DFGTest.kt
@@ -348,24 +348,39 @@ class DFGTest {
             printDLine10,
             "We expect that there is a reference called \"d\" in line 10 of the file.",
         )
+        // We have 2 prevDFG edges: The full one to the declaration and a partial one to the write
+        // in line 9
+        val dLine2 = result.refs("d").first()
+        assertNotNull(dLine2)
         assertEquals(
-            1,
+            2,
             printDLine10.prevDFGEdges.size,
-            "We expect one incoming DFG edges: The full edge from line 9.",
+            "We expect two incoming DFG edges: The full edge from line 2 and a partial one from line 9.",
         )
-        val dfgToInitializationLine10 = printDLine10.prevDFGEdges.singleOrNull()
+        val dfgToInitializationLine10 =
+            printDLine10.prevDFGEdges.singleOrNull { it.granularity is FullDataflowGranularity }
         assertNotNull(
             dfgToInitializationLine10,
-            "We expect one incoming DFG edges: The full edge from line 9.",
+            "We expect one full incoming DFG edge: The full edge from line 2.",
         )
-        assertIs<FullDataflowGranularity>(
-            dfgToInitializationLine10.granularity,
-            "We expect one incoming DFG edges: The full edge from line 9.",
+        assertEquals(
+            dLine2,
+            dfgToInitializationLine10.start,
+            "We expect one incoming full DFG edges: The full edge from line 9.",
+        )
+        val dfgToPartialLine10 =
+            printDLine10.prevDFGEdges.singleOrNull {
+                ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Literal<*>)
+                    ?.value == "b"
+            }
+        assertNotNull(
+            dfgToPartialLine10,
+            "We expect one partial incoming DFG edge: The edge to line 9.",
         )
         assertEquals(
             dLine9,
-            dfgToInitializationLine10.start,
-            "We expect one incoming DFG edges: The full edge from line 9.",
+            dfgToPartialLine10.start,
+            "We expect one incoming partial DFG edge: The partial edge from line 9.",
         )
 
         val subscriptLine10 =
@@ -423,22 +438,33 @@ class DFGTest {
             "We expect that there is a reference called \"d\" in line 11 of the file.",
         )
         assertEquals(
-            1,
+            2,
             printDLine11.prevDFGEdges.size,
-            "We expect one incoming DFG edges: The full edge from the initialization and the partial edge from line 9.",
+            "We expect two incoming DFG edges: The full edge from the initialization and the partial edge from line 9.",
         )
-        val dfgToPartialWriteLine11 = printDLine11.prevDFGEdges.singleOrNull()
+        val dfgToPartialWriteLine11 =
+            printDLine11.prevDFGEdges.singleOrNull {
+                ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Literal<*>)
+                    ?.value == "b"
+            }
+        val dfgToFullLine11 =
+            printDLine11.prevDFGEdges.singleOrNull { it.granularity is FullDataflowGranularity }
+        assertNotNull(
+            dfgToFullLine11,
+            "We expect two incoming DFG edges: The full edge from the initialization and the partial edge from line 9.",
+        )
         assertNotNull(
             dfgToPartialWriteLine11,
             "We expect two incoming DFG edges: The full edge from the initialization and the partial edge from line 9.",
         )
-        assertIs<FullDataflowGranularity>(
-            dfgToPartialWriteLine11.granularity,
-            "We expect one incoming DFG edges: The full edge from the initialization and the partial edge from line 9.",
-        )
         assertEquals(
             dLine9,
             dfgToPartialWriteLine11.start,
+            "We expect two incoming DFG edges: The full edge from the initialization and the partial edge from line 9.",
+        )
+        assertEquals(
+            dLine2,
+            dfgToFullLine11.start,
             "We expect two incoming DFG edges: The full edge from the initialization and the partial edge from line 9.",
         )
 
@@ -477,19 +503,27 @@ class DFGTest {
             "We expect that there is a reference called \"d\" in line 12 of the file.",
         )
         assertEquals(
-            1,
+            2,
             printD.prevDFGEdges.size,
             "We expect two incoming DFG edges: The full edge from line 9.",
         )
-        val dfgTodB = printD.prevDFGEdges.singleOrNull()
-        assertNotNull(dfgTodB, "We expect two incoming DFG edges: The full edge from line 9.")
-        assertIs<FullDataflowGranularity>(
-            dfgTodB.granularity,
-            "We expect two incoming DFG edges: The full edge from line 9.",
-        )
+        val dfgTodB =
+            printD.prevDFGEdges.singleOrNull {
+                ((it.granularity as? PartialDataflowGranularity<*>)?.partialTarget as? Literal<*>)
+                    ?.value == "b"
+            }
+        val dfgToLine2 =
+            printD.prevDFGEdges.singleOrNull { it.granularity is FullDataflowGranularity }
+        assertNotNull(dfgToLine2, "We expect two incoming DFG edges: The full edge from line 2.")
+        assertNotNull(dfgTodB, "We expect two incoming DFG edges: The partial edge from line 9.")
         assertEquals(
             dLine9,
             dfgTodB.start,
+            "We expect two incoming DFG edges: The full edge from line 9.",
+        )
+        assertEquals(
+            dLine2,
+            dfgToLine2.start,
             "We expect two incoming DFG edges: The full edge from line 9.",
         )
     }


### PR DESCRIPTION
+ Fixes #2758 
+ Reduces functionSummary size
+ Replaces most PointerGranularity granularities with derefDepth property to be able to combine it with partialGranularity
+ General better handling of member/offset writes
+ No dfg-edges were harmed, only new ones were added