### PR TITLE
Fix loop in type listener when writing to unary operators

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/DFGPass.kt
@@ -418,6 +418,9 @@ open class DFGPass(ctx: TranslationContext) : ComponentPass(ctx) {
      */
     protected fun handleUnaryOperator(node: UnaryOperator) {
         if ((node.input as? Reference)?.access == AccessValues.WRITE) {
+            // The unary operator should no longer be a type observer of the input. This is the
+            // default case but could cause loops
+            (node.input as? Reference)?.let { it.unregisterTypeObserver(node) }
             node.input.let { node.nextDFGEdges += it }
         } else {
             node.input.let {

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/ExpressionHandler.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/ExpressionHandler.kt
@@ -34,6 +34,7 @@ import de.fraunhofer.aisec.cpg.graph.expressions.KeyValue
 import de.fraunhofer.aisec.cpg.graph.expressions.Lambda
 import de.fraunhofer.aisec.cpg.graph.expressions.Literal
 import de.fraunhofer.aisec.cpg.graph.expressions.MemberAccess
+import de.fraunhofer.aisec.cpg.graph.expressions.PointerDereference
 import de.fraunhofer.aisec.cpg.graph.expressions.ProblemExpression
 import de.fraunhofer.aisec.cpg.graph.expressions.Range
 import de.fraunhofer.aisec.cpg.graph.expressions.Reference
@@ -392,11 +393,11 @@ class ExpressionHandler(frontend: GoLanguageFrontend) :
         return ase
     }
 
-    private fun handleStarExpr(starExpr: GoStandardLibrary.Ast.StarExpr): UnaryOperator {
-        val op = newUnaryOperator("*", postfix = false, prefix = false, rawNode = starExpr)
-        op.input = handle(starExpr.x)
-
-        return op
+    private fun handleStarExpr(starExpr: GoStandardLibrary.Ast.StarExpr): PointerDereference {
+        val input = handle(starExpr.x)
+        return newPointerDereference(input.name, unknownType(), rawNode = starExpr).apply {
+            this.input = input
+        }
     }
 
     private fun handleTypeAssertExpr(


### PR DESCRIPTION
When we write to `*x` in go, this is still handled as `UnaryOperator` and causes a loop in the type listener system because `*` observes `x` and `x` observes `*`. This PR removes `*` as the type listener of `x` to remove the loop.