### PR TITLE
Revert "Update dependency io.ktor.plugin to v3.5.0 (#2742)"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ slf4j = "2.0.16"
 clikt = "5.1.0"
 kaml = "0.104.0"
 sarif4k = "0.7.0"
-ktor = "3.5.0"
+ktor = "3.3.3"
 node = "22.14.0"
 deno-plugin = "0.1.5"
 


### PR DESCRIPTION
This reverts commit d601daa43b2947032ec05cecd601f13021119367.

MCP needs ktor 3.3.3. See https://github.com/Fraunhofer-AISEC/cpg/pull/2668#issuecomment-4197336999