### PR TITLE
Reduce memory footprint of `Node` classes

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/MultiValueEvaluator.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/MultiValueEvaluator.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.evaluation
 
+import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.Field
 import de.fraunhofer.aisec.cpg.graph.declarations.Variable
@@ -297,8 +298,11 @@ class MultiValueEvaluator : ValueEvaluator() {
         if (loop == null || loop.condition !is BinaryOperator) return setOf()
 
         var loopVar: Any? =
-            evaluateInternal(loop.initializerStatement?.declarations?.first(), depth) as? Number
-                ?: return setOf()
+            evaluateInternal(
+                (loop.initializerStatement as? DeclarationHolder)?.declarations?.first(),
+                depth,
+            )
+                as? Number ?: return setOf()
 
         val cond = loop.condition as BinaryOperator
         val result = mutableSetOf<Any?>()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationHolder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/DeclarationHolder.kt
@@ -31,6 +31,55 @@ import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
 import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdges
 import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeList
 
+fun <T> addIfNotContains(collection: MutableCollection<T>, declaration: T) {
+    if (!collection.contains(declaration)) {
+        collection.add(declaration)
+    }
+}
+
+fun <T : AstNode, P : AstEdge<T>> addIfNotContains(collection: AstEdges<T, P>, declaration: T) {
+    addIfNotContains(collection, declaration, true)
+}
+
+fun <T : AstNode, P : Edge<T>> addIfNotContains(collection: EdgeList<T, P>, declaration: T) {
+    addIfNotContains(collection, declaration, true)
+}
+
+/**
+ * Adds a declaration to a collection of property edges, which contain the declarations
+ *
+ * @param collection the collection
+ * @param declaration the declaration
+ * @param <T> the type of the declaration
+ * @param outgoing whether the property is outgoing </T>
+ */
+fun <T : Node, P : Edge<T>> addIfNotContains(
+    collection: EdgeList<T, out P>,
+    declaration: T,
+    outgoing: Boolean,
+) {
+    var contains = false
+    for (element in collection) {
+        if (outgoing) {
+            if (element.end == declaration) {
+                contains = true
+                break
+            }
+        } else {
+            if (element.start == declaration) {
+                contains = true
+                break
+            }
+        }
+    }
+
+    if (contains) {
+        return
+    }
+
+    collection.add(declaration)
+}
+
 interface DeclarationHolder {
     /**
      * Adds the specified declaration to this declaration holder. Ideally, the declaration holder
@@ -39,55 +88,6 @@ interface DeclarationHolder {
      * @param declaration the declaration
      */
     fun addDeclaration(declaration: Declaration)
-
-    fun <T : Declaration> addIfNotContains(collection: MutableCollection<T>, declaration: T) {
-        if (!collection.contains(declaration)) {
-            collection.add(declaration)
-        }
-    }
-
-    fun <T : AstNode, P : AstEdge<T>> addIfNotContains(collection: AstEdges<T, P>, declaration: T) {
-        addIfNotContains(collection, declaration, true)
-    }
-
-    fun <T : AstNode, P : Edge<T>> addIfNotContains(collection: EdgeList<T, P>, declaration: T) {
-        addIfNotContains(collection, declaration, true)
-    }
-
-    /**
-     * Adds a declaration to a collection of property edges, which contain the declarations
-     *
-     * @param collection the collection
-     * @param declaration the declaration
-     * @param <T> the type of the declaration
-     * @param outgoing whether the property is outgoing </T>
-     */
-    fun <T : Node, P : Edge<T>> addIfNotContains(
-        collection: EdgeList<T, out P>,
-        declaration: T,
-        outgoing: Boolean,
-    ) {
-        var contains = false
-        for (element in collection) {
-            if (outgoing) {
-                if (element.end == declaration) {
-                    contains = true
-                    break
-                }
-            } else {
-                if (element.start == declaration) {
-                    contains = true
-                    break
-                }
-            }
-        }
-
-        if (contains) {
-            return
-        }
-
-        collection.add(declaration)
-    }
 
     val declarations: List<Declaration>
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilder.kt
@@ -645,7 +645,6 @@ fun <T> Literal<T>.duplicate(implicit: Boolean): Literal<T> {
     duplicate.assignedTypes = this.assignedTypes
     duplicate.code = this.code
     duplicate.location = this.location
-    duplicate.locals = this.locals
     duplicate.argumentIndex = this.argumentIndex
     duplicate.annotations = this.annotations
     duplicate.comment = this.comment

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -554,7 +554,12 @@ class Context(
     var steps: Int = 0,
 ) : HasAssumptions {
 
-    override val assumptions: MutableSet<Assumption> = mutableSetOf()
+    private var assumptionsStorage: MutableSet<Assumption>? = null
+
+    override val assumptions: MutableSet<Assumption>
+        get() {
+            return assumptionsStorage ?: mutableSetOf<Assumption>().also { assumptionsStorage = it }
+        }
 
     fun clone(): Context {
         return Context(indexStack = indexStack.clone(), callStack = callStack.clone(), steps)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -1580,13 +1580,12 @@ inline fun <reified T : Scope> Scope.firstScopeParentOrNull(
  */
 val AstNode?.problems: List<ProblemNode>
     get() {
-        val relevantNodes =
-            this.allChildren<Node> { it is ProblemNode || it.additionalProblems.isNotEmpty() }
+        val relevantNodes = this.allChildren<Node> { it is ProblemNode || it.hasAdditionalProblems }
 
         val result = mutableListOf<ProblemNode>()
 
         relevantNodes.forEach {
-            if (it.additionalProblems.isNotEmpty()) {
+            if (it.hasAdditionalProblems) {
                 result += it.additionalProblems
             }
             if (it is ProblemNode) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Interfaces.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Interfaces.kt
@@ -29,8 +29,11 @@ import de.fraunhofer.aisec.cpg.PopulatedByPass
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.declarations.Method
 import de.fraunhofer.aisec.cpg.graph.declarations.Operator
+import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.Variable
 import de.fraunhofer.aisec.cpg.graph.edges.MemoryAddressEdges
+import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
+import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdges
 import de.fraunhofer.aisec.cpg.graph.edges.flows.Dataflows
 import de.fraunhofer.aisec.cpg.graph.edges.flows.FullDataflowGranularity
 import de.fraunhofer.aisec.cpg.graph.expressions.BinaryOperator
@@ -45,7 +48,21 @@ import de.fraunhofer.aisec.cpg.passes.DFGPass
 import de.fraunhofer.aisec.cpg.passes.PointsToPass
 import de.fraunhofer.aisec.cpg.passes.SymbolResolver
 import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
+import de.fraunhofer.aisec.cpg.persistence.Relationship
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
+
+interface HasLocals {
+    /**
+     * A list of local variables (or other values) associated to this statement, defined by their
+     * [ValueDeclaration] extracted from Block because `for`, `while`, `if`, and `switch` can
+     * declare locals in their condition or initializers.
+     */
+    @Relationship(value = "LOCALS", direction = Relationship.Direction.OUTGOING)
+    var localEdges: AstEdges<ValueDeclaration, AstEdge<ValueDeclaration>>
+
+    /** Virtual property to access [localEdges] without property edges. */
+    var locals: MutableList<ValueDeclaration>
+}
 
 /**
  * Represents that this node (potentially) makes use of the given memory addresses e.g. to load or

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Name.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Name.kt
@@ -69,8 +69,16 @@ class Name(
      * this is basically a cache for [toString]. Otherwise, we would need to call [toString] a lot
      * of times, to implement the necessary functions for [CharSequence].
      */
-    private val fullName: String by lazy {
-        (if (parent != null) parent.toString() + delimiter else "") + localName
+    private var qualifiedFullNameCache: String? = null
+
+    private fun fullName(): String {
+        // Most names are unqualified, so avoid any extra cache object/value in this hot case.
+        if (parent == null) {
+            return localName
+        }
+
+        return qualifiedFullNameCache
+            ?: (parent.toString() + delimiter + localName).also { qualifiedFullNameCache = it }
     }
 
     public override fun clone(): Name = Name(localName, parent?.clone(), delimiter)
@@ -93,13 +101,14 @@ class Name(
      * Returns the string representation of this name using a fully qualified name notation with the
      * specified [delimiter].
      */
-    override fun toString() = fullName
+    override fun toString() = fullName()
 
-    override val length = fullName.length
+    override val length: Int
+        get() = fullName().length
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (other is String) return this.fullName == other
+        if (other is String) return this.toString() == other
         if (other is Name)
             return localName == other.localName &&
                 parent == other.parent &&
@@ -108,12 +117,12 @@ class Name(
         return false
     }
 
-    override fun get(index: Int) = fullName[index]
+    override fun get(index: Int) = fullName()[index]
 
     override fun hashCode() = Objects.hash(localName, parent, delimiter)
 
     override fun subSequence(startIndex: Int, endIndex: Int): CharSequence =
-        fullName.subSequence(startIndex, endIndex)
+        fullName().subSequence(startIndex, endIndex)
 
     /**
      * Determines if this name ends with the [ending] (i.e., the localNames match until the [ending]
@@ -141,7 +150,7 @@ class Name(
         Name(localName.replace(oldValue, newValue), parent, delimiter)
 
     /** Compare names according to the string representation of the [fullName]. */
-    override fun compareTo(other: Name) = fullName.compareTo(other.toString())
+    override fun compareTo(other: Name) = toString().compareTo(other.toString())
 
     /**
      * A name can be considered as "qualified", if it has any specified [parent]. Otherwise, only

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -251,7 +251,13 @@ abstract class Node() :
 
     var prevPDG by unwrapping(Node::prevPDGEdges)
 
-    @DoNotPersist override val assumptions: MutableSet<Assumption> = mutableSetOf()
+    @DoNotPersist @JsonIgnore private var assumptionsStorage: MutableSet<Assumption>? = null
+
+    @DoNotPersist
+    override val assumptions: MutableSet<Assumption>
+        get() {
+            return assumptionsStorage ?: mutableSetOf<Assumption>().also { assumptionsStorage = it }
+        }
 
     /**
      * If a node is marked as being inferred, it means that it was created artificially and does not
@@ -292,7 +298,16 @@ abstract class Node() :
      * Additional problem nodes. These nodes represent problems which occurred during processing of
      * a node (i.e. only partially processed).
      */
-    val additionalProblems: MutableSet<ProblemNode> = mutableSetOf()
+    @DoNotPersist @JsonIgnore private var additionalProblemsStorage: MutableSet<ProblemNode>? = null
+
+    val additionalProblems: MutableSet<ProblemNode>
+        get() {
+            return additionalProblemsStorage
+                ?: mutableSetOf<ProblemNode>().also { additionalProblemsStorage = it }
+        }
+
+    val hasAdditionalProblems: Boolean
+        get() = additionalProblemsStorage?.isNotEmpty() == true
 
     @Relationship(value = "OVERLAY", direction = Relationship.Direction.OUTGOING)
     val overlayEdges: Overlays =
@@ -308,7 +323,8 @@ abstract class Node() :
      * Currently, of the [Component].
      */
     override fun relevantAssumptions(): Set<Assumption> {
-        return super.relevantAssumptions() + (component?.relevantAssumptions() ?: emptySet())
+        val localAssumptions = assumptionsStorage?.toSet() ?: emptySet()
+        return localAssumptions + (component?.relevantAssumptions() ?: emptySet())
     }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -111,21 +111,25 @@ abstract class Node() :
     @Relationship(value = "EOG", direction = Relationship.Direction.INCOMING)
     @PopulatedByPass(EvaluationOrderGraphPass::class)
     var prevEOGEdges: EvaluationOrders<Node> =
-        EvaluationOrders<Node>(this, mirrorProperty = Node::nextEOGEdges, outgoing = false)
+        EvaluationOrders<Node>(this, mirroredCollection = { it.nextEOGEdges }, outgoing = false)
         protected set
 
     /** Outgoing control flow edges. */
     @Relationship(value = "EOG", direction = Relationship.Direction.OUTGOING)
     @PopulatedByPass(EvaluationOrderGraphPass::class)
     var nextEOGEdges: EvaluationOrders<Node> =
-        EvaluationOrders<Node>(this, mirrorProperty = Node::prevEOGEdges, outgoing = true)
+        EvaluationOrders<Node>(this, mirroredCollection = { it.prevEOGEdges }, outgoing = true)
         protected set
 
     /** The [BasicBlockEdgeList] leading to the basic block this node belongs to. */
     @Relationship(value = "BB", direction = Relationship.Direction.OUTGOING)
     @PopulatedByPass(BasicBlockCollectorPass::class)
     var basicBlockEdges: BasicBlockEdgeList<Node> =
-        BasicBlockEdgeList<Node>(this, mirrorProperty = BasicBlock::nodeEdges, outgoing = true)
+        BasicBlockEdgeList<Node>(
+            this,
+            mirroredCollection = { (it as BasicBlock).nodeEdges },
+            outgoing = true,
+        )
         protected set
 
     /** The basic block this node belongs to. */
@@ -138,7 +142,7 @@ abstract class Node() :
     @PopulatedByPass(ControlDependenceGraphPass::class)
     @Relationship(value = "CDG", direction = Relationship.Direction.OUTGOING)
     var nextCDGEdges: ControlDependences<Node> =
-        ControlDependences(this, mirrorProperty = Node::prevCDGEdges, outgoing = true)
+        ControlDependences(this, mirroredCollection = { it.prevCDGEdges }, outgoing = true)
         protected set
 
     var nextCDG by unwrapping(Node::nextCDGEdges)
@@ -150,7 +154,7 @@ abstract class Node() :
     @PopulatedByPass(ControlDependenceGraphPass::class)
     @Relationship(value = "CDG", direction = Relationship.Direction.INCOMING)
     var prevCDGEdges: ControlDependences<Node> =
-        ControlDependences<Node>(this, mirrorProperty = Node::nextCDGEdges, outgoing = false)
+        ControlDependences<Node>(this, mirroredCollection = { it.nextCDGEdges }, outgoing = false)
         protected set
 
     var prevCDG by unwrapping(Node::prevCDGEdges)
@@ -167,7 +171,7 @@ abstract class Node() :
     @Relationship(value = "DFG", direction = Relationship.Direction.INCOMING)
     @PopulatedByPass(DFGPass::class, PointsToPass::class)
     var prevDFGEdges: Dataflows<Node> =
-        Dataflows<Node>(this, mirrorProperty = Node::nextDFGEdges, outgoing = false)
+        Dataflows<Node>(this, mirroredCollection = { it.nextDFGEdges }, outgoing = false)
         protected set
 
     /** Virtual property for accessing [prevDFGEdges] without property edges. */
@@ -200,7 +204,7 @@ abstract class Node() :
     @PopulatedByPass(DFGPass::class, PointsToPass::class)
     @Relationship(value = "DFG", direction = Relationship.Direction.OUTGOING)
     var nextDFGEdges: Dataflows<Node> =
-        Dataflows<Node>(this, mirrorProperty = Node::prevDFGEdges, outgoing = true)
+        Dataflows<Node>(this, mirroredCollection = { it.prevDFGEdges }, outgoing = true)
         protected set
 
     /** Virtual property for accessing [nextDFGEdges] without property edges. */
@@ -233,7 +237,7 @@ abstract class Node() :
     @PopulatedByPass(ProgramDependenceGraphPass::class)
     @Relationship(value = "PDG", direction = Relationship.Direction.OUTGOING)
     var nextPDGEdges: ProgramDependences<Node> =
-        ProgramDependences<Node>(this, mirrorProperty = Node::prevPDGEdges, outgoing = true)
+        ProgramDependences<Node>(this, mirroredCollection = { it.prevPDGEdges }, outgoing = true)
         protected set
 
     var nextPDG by unwrapping(Node::nextPDGEdges)
@@ -242,7 +246,7 @@ abstract class Node() :
     @PopulatedByPass(ProgramDependenceGraphPass::class)
     @Relationship(value = "PDG", direction = Relationship.Direction.INCOMING)
     var prevPDGEdges: ProgramDependences<Node> =
-        ProgramDependences<Node>(this, mirrorProperty = Node::nextPDGEdges, outgoing = false)
+        ProgramDependences<Node>(this, mirroredCollection = { it.nextPDGEdges }, outgoing = false)
         protected set
 
     var prevPDG by unwrapping(Node::prevPDGEdges)
@@ -292,7 +296,11 @@ abstract class Node() :
 
     @Relationship(value = "OVERLAY", direction = Relationship.Direction.OUTGOING)
     val overlayEdges: Overlays =
-        Overlays(this, mirrorProperty = OverlayNode::underlyingNodeEdge, outgoing = true)
+        Overlays(
+            this,
+            mirroredCollection = { (it as OverlayNode).underlyingNodeEdge },
+            outgoing = true,
+        )
     var overlays by unwrapping(Node::overlayEdges)
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -306,6 +306,7 @@ abstract class Node() :
                 ?: mutableSetOf<ProblemNode>().also { additionalProblemsStorage = it }
         }
 
+    @DoNotPersist
     val hasAdditionalProblems: Boolean
         get() = additionalProblemsStorage?.isNotEmpty() == true
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilder.kt
@@ -35,6 +35,7 @@ import de.fraunhofer.aisec.cpg.graph.Node.Companion.EMPTY_NAME
 import de.fraunhofer.aisec.cpg.graph.NodeBuilder.LOGGER
 import de.fraunhofer.aisec.cpg.graph.NodeBuilder.log
 import de.fraunhofer.aisec.cpg.graph.expressions.Expression
+import de.fraunhofer.aisec.cpg.graph.expressions.Reference
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.graph.types.HasType
 import de.fraunhofer.aisec.cpg.helpers.getCodeOfSubregion
@@ -154,6 +155,18 @@ fun Node.applyMetadata(
                 defaultNamespace
             }
         this.name = this.newName(name, doNotPrependNamespace, namespace)
+
+        // For most references, code and name are the same token. If their textual value matches,
+        // reuse the name string instance to avoid duplicate string objects.
+        if (this is Reference) {
+            val currentCode = this.code
+            if (currentCode != null) {
+                val nameAsString = this.name.toString()
+                if (currentCode == nameAsString) {
+                    this.code = nameAsString
+                }
+            }
+        }
     }
 
     // Disable the type observer if the config says so.

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/OverlayNode.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/OverlayNode.kt
@@ -48,7 +48,7 @@ abstract class OverlayNode() : Node() {
         OverlaySingleEdge(
             this,
             of = null,
-            mirrorProperty = Node::overlayEdges,
+            mirroredCollection = { it.overlayEdges },
             outgoing = false,
             onChange = this::propagateNodePropertiesFromUnderlyingNode,
         )

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Declaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Declaration.kt
@@ -64,7 +64,7 @@ abstract class Declaration : AstNode(), HasModifiers, HasMemoryAddress, HasMemor
     @Relationship
     override var memoryAddressEdges: MemoryAddressEdges =
         memoryAddressEdgesOf(
-            mirrorProperty = MemoryAddress::usageEdges,
+            mirroredCollection = { (it as MemoryAddress).usageEdges },
             outgoing = true,
             onAdd = { toAdd ->
                 if (this.memoryAddressEdges.size > 1) {
@@ -79,7 +79,11 @@ abstract class Declaration : AstNode(), HasModifiers, HasMemoryAddress, HasMemor
     /** Where the memory value of this declaration is used. */
     @Relationship
     override var memoryValueUsageEdges =
-        Dataflows<Node>(this, mirrorProperty = HasMemoryValue::memoryValueEdges, outgoing = true)
+        Dataflows<Node>(
+            this,
+            mirroredCollection = { (it as HasMemoryValue).memoryValueEdges },
+            outgoing = true,
+        )
     override var memoryValueUsages by unwrapping(Declaration::memoryValueUsageEdges)
 
     /** Each Declaration can also have a MemoryValue. */
@@ -87,7 +91,7 @@ abstract class Declaration : AstNode(), HasModifiers, HasMemoryAddress, HasMemor
     override var memoryValueEdges =
         Dataflows<Node>(
             this,
-            mirrorProperty = HasMemoryValue::memoryValueUsageEdges,
+            mirroredCollection = { (it as HasMemoryValue).memoryValueUsageEdges },
             outgoing = false,
         )
     override var memoryValues by unwrapping(Declaration::memoryValueEdges)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/DeclarationSequence.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/DeclarationSequence.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.graph.declarations
 
 import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
+import de.fraunhofer.aisec.cpg.graph.addIfNotContains
 
 /**
  * This represents a sequence of one or more declaration(s). The purpose of this node is primarily

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Extension.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Extension.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.graph.declarations
 
 import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.addIfNotContains
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import java.util.Objects

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Function.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Function.kt
@@ -85,7 +85,7 @@ open class Function :
      */
     @Relationship(value = "INVOKES", direction = Relationship.Direction.INCOMING)
     val calledByEdges: Invokes<Function> =
-        Invokes<Function>(this, Call::invokeEdges, outgoing = false)
+        Invokes<Function>(this, mirroredCollection = { (it as Call).invokeEdges }, outgoing = false)
 
     /** Virtual property for accessing [calledByEdges] without property edges. */
     val calledBy: MutableList<Call> by unwrappingIncoming(Function::calledByEdges)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/FunctionTemplate.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/FunctionTemplate.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.graph.declarations
 
+import de.fraunhofer.aisec.cpg.graph.addIfNotContains
 import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/RecordTemplate.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/RecordTemplate.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.graph.declarations
 
+import de.fraunhofer.aisec.cpg.graph.addIfNotContains
 import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/Edge.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/Edge.kt
@@ -57,7 +57,13 @@ abstract class Edge<NodeType : Node> : Persistable, Cloneable, HasAssumptions {
     // Node where the edge is ingoing
     @JsonBackReference var end: NodeType
 
-    @DoNotPersist override val assumptions: MutableSet<Assumption> = mutableSetOf()
+    @DoNotPersist @JsonIgnore private var assumptionsStorage: MutableSet<Assumption>? = null
+
+    @DoNotPersist
+    override val assumptions: MutableSet<Assumption>
+        get() {
+            return assumptionsStorage ?: mutableSetOf<Assumption>().also { assumptionsStorage = it }
+        }
 
     constructor(start: Node, end: NodeType) {
         this.start = start

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/MemoryAddress.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/MemoryAddress.kt
@@ -29,7 +29,6 @@ import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeSet
 import de.fraunhofer.aisec.cpg.graph.edges.collections.MirroredEdgeCollection
 import de.fraunhofer.aisec.cpg.graph.expressions.MemoryAddress
-import kotlin.reflect.KProperty
 
 /** This edge class defines that [end] is a (possible) memory address of [start]. */
 open class MemoryAddressEdge(start: Node, end: MemoryAddress, var outgoing: Boolean) :
@@ -50,7 +49,7 @@ open class MemoryAddressEdge(start: Node, end: MemoryAddress, var outgoing: Bool
 /** This class represents a container of [MemoryAddressEdge] property edges in a [thisRef]. */
 class MemoryAddressEdges(
     thisRef: Node,
-    override var mirrorProperty: KProperty<MutableCollection<MemoryAddressEdge>>,
+    override var mirroredCollection: (Node) -> MutableCollection<MemoryAddressEdge>,
     outgoing: Boolean,
     onAdd: ((MemoryAddressEdge) -> Unit)? = null,
 ) :
@@ -64,13 +63,13 @@ class MemoryAddressEdges(
 
 /** Creates an [Node] container starting from this node. */
 fun Node.memoryAddressEdgesOf(
-    mirrorProperty: KProperty<MutableCollection<MemoryAddressEdge>>,
+    mirroredCollection: (Node) -> MutableCollection<MemoryAddressEdge>,
     outgoing: Boolean,
     onAdd: ((MemoryAddressEdge) -> Unit)? = null,
 ): MemoryAddressEdges {
     return MemoryAddressEdges(
         thisRef = this,
-        mirrorProperty = mirrorProperty,
+        mirroredCollection = mirroredCollection,
         outgoing = outgoing,
         onAdd = onAdd,
     )

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/CompactEdgeStorage.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/CompactEdgeStorage.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.graph.edges.collections
+
+/**
+ * Shared helper for compact 0/1/many edge storage.
+ *
+ * In the common singleton case we avoid allocating a full list/set object and only materialize a
+ * collection when we transition to "many" elements.
+ */
+internal class CompactEdgeStorage<EdgeType, ManyType : MutableCollection<EdgeType>>(
+    private val createMany: (capacity: Int) -> ManyType
+) {
+    var first: EdgeType? = null
+    var many: ManyType? = null
+
+    val size: Int
+        get() = many?.size ?: if (first == null) 0 else 1
+
+    fun ensureMany(minCapacity: Int = 2): ManyType {
+        val existing = many
+        if (existing != null) {
+            return existing
+        }
+
+        val created = createMany(minCapacity)
+        first?.let { created.add(it) }
+        first = null
+        many = created
+        return created
+    }
+
+    fun clearAndSnapshot(): List<EdgeType> {
+        val snapshot = many?.toList() ?: first?.let { listOf(it) } ?: emptyList()
+        first = null
+        many = null
+        return snapshot
+    }
+
+    fun compactManyToSingleton(singleExtractor: (ManyType) -> EdgeType?) {
+        val current = many ?: return
+        when (current.size) {
+            0 -> many = null
+            1 -> {
+                first = singleExtractor(current)
+                many = null
+            }
+        }
+    }
+}

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeCollection.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeCollection.kt
@@ -116,6 +116,24 @@ interface EdgeCollection<NodeType : Node, EdgeType : Edge<NodeType>> : MutableCo
         return any { if (outgoing) it.end == target else it.start == target }
     }
 
+    /** Identity-based variant of [contains], matching only the same edge instance. */
+    fun containsByIdentity(edge: EdgeType): Boolean {
+        return this.any { it === edge }
+    }
+
+    /** Identity-based variant of [remove], removing only the same edge instance. */
+    fun removeByIdentity(edge: EdgeType): Boolean {
+        val iterator = this.iterator()
+        while (iterator.hasNext()) {
+            if (iterator.next() === edge) {
+                iterator.remove()
+                return true
+            }
+        }
+
+        return false
+    }
+
     operator fun plusAssign(end: NodeType) {
         add(end)
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeList.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeList.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.graph.edges.collections
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.edges.Edge
 import java.util.function.Predicate
+import kotlin.collections.AbstractMutableList
 
 /** This class extends a list of edges. This allows us to use lists of edges more conveniently. */
 abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
@@ -44,50 +45,165 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
      * operations to a larger list.
      */
     initialCapacity: Int = 1,
-) : ArrayList<EdgeType>(initialCapacity), EdgeCollection<NodeType, EdgeType> {
+) : AbstractMutableList<EdgeType>(), EdgeCollection<NodeType, EdgeType> {
+
+    // Draft: compact 0/1/many storage to avoid allocating an ArrayList per node in the common case.
+    private var first: EdgeType? = null
+    private var many: MutableList<EdgeType>? = null
+    private var cachedCapacity: Int = initialCapacity
+
+    override val size: Int
+        get() = many?.size ?: if (first == null) 0 else 1
+
+    override fun get(index: Int): EdgeType {
+        return when {
+            many != null -> many!![index]
+            index == 0 && first != null -> first!!
+            else -> throw IndexOutOfBoundsException("Index: $index, Size: $size")
+        }
+    }
 
     override fun add(element: EdgeType): Boolean {
-        // Make sure, the index is always set
         if (element.index == null) {
             element.index = this.size
         }
 
-        val ok = super<ArrayList>.add(element)
-        if (ok) {
-            handleOnAdd(element)
+        when {
+            many != null -> many!!.add(element)
+            first == null -> first = element
+            else -> {
+                many =
+                    ArrayList<EdgeType>(maxOf(cachedCapacity, 2)).also {
+                        it.add(first!!)
+                        it.add(element)
+                    }
+                first = null
+            }
         }
-        return ok
+
+        handleOnAdd(element)
+        return true
     }
 
-    override fun remove(element: EdgeType): Boolean {
-        val ok = super<ArrayList>.remove(element)
-        if (ok) {
-            handleOnRemove(element)
+    override fun add(index: Int, element: EdgeType) {
+        if (index < 0 || index > size) {
+            throw IndexOutOfBoundsException("Index: $index, Size: $size")
         }
-        return ok
-    }
 
-    override fun removeAll(elements: Collection<EdgeType>): Boolean {
-        val ok = super.removeAll(elements.toSet())
-        if (ok) {
-            elements.forEach { handleOnRemove(it) }
+        when {
+            many != null -> many!!.add(index, element)
+            first == null -> {
+                if (index != 0) throw IndexOutOfBoundsException("Index: $index, Size: $size")
+                first = element
+            }
+            else -> {
+                val prev = first!!
+                many =
+                    ArrayList<EdgeType>(maxOf(cachedCapacity, 2)).also {
+                        if (index == 0) {
+                            it.add(element)
+                            it.add(prev)
+                        } else {
+                            it.add(prev)
+                            it.add(element)
+                        }
+                    }
+                first = null
+            }
         }
-        return ok
+
+        handleOnAdd(element)
+        updateIndicesFrom(index)
     }
 
     override fun removeAt(index: Int): EdgeType {
-        val edge = super.removeAt(index)
-        handleOnRemove(edge)
-        return edge
+        if (index < 0 || index >= size) {
+            throw IndexOutOfBoundsException("Index: $index, Size: $size")
+        }
+
+        val removed =
+            when {
+                many != null -> {
+                    val r = many!!.removeAt(index)
+                    if (many!!.size == 1) {
+                        first = many!![0]
+                        many = null
+                    }
+                    r
+                }
+                else -> {
+                    val r = first!!
+                    first = null
+                    r
+                }
+            }
+
+        handleOnRemove(removed)
+        updateIndicesFrom(index)
+        return removed
+    }
+
+    override fun set(index: Int, element: EdgeType): EdgeType {
+        if (index < 0 || index >= size) {
+            throw IndexOutOfBoundsException("Index: $index, Size: $size")
+        }
+
+        return when {
+            many != null -> {
+                val prev = many!![index]
+                many!![index] = element
+                prev
+            }
+            else -> {
+                val prev = first!!
+                first = element
+                prev
+            }
+        }
+    }
+
+    override fun remove(element: EdgeType): Boolean {
+        val idx = indexOf(element)
+        if (idx == -1) {
+            return false
+        }
+
+        removeAt(idx)
+        return true
+    }
+
+    override fun removeAll(elements: Collection<EdgeType>): Boolean {
+        if (elements.isEmpty() || isEmpty()) {
+            return false
+        }
+
+        val toRemove = elements.toSet()
+        var changed = false
+
+        for (i in size - 1 downTo 0) {
+            if (this[i] in toRemove) {
+                removeAt(i)
+                changed = true
+            }
+        }
+
+        return changed
+    }
+
+    override fun clear() {
+        if (isEmpty()) {
+            return
+        }
+
+        val edges = this.toList()
+        first = null
+        many = null
+        edges.forEach { handleOnRemove(it) }
     }
 
     override fun removeIf(predicate: Predicate<in EdgeType>): Boolean {
-        val edges = filter { predicate.test(it) }
-        val ok = super<ArrayList>.removeIf(predicate)
-        if (ok) {
-            edges.forEach { handleOnRemove(it) }
-        }
-        return ok
+        val toRemove = this.filter { predicate.test(it) }
+        return removeAll(toRemove)
     }
 
     /** Replaces the first occurrence of an edge with [old] with a new edge to [new]. */
@@ -101,13 +217,6 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
         return false
     }
 
-    override fun clear() {
-        // Make a copy of our edges so we can pass a copy to our on-remove handler
-        val edges = this.toList()
-        super.clear()
-        edges.forEach { handleOnRemove(it) }
-    }
-
     /**
      * This function creates a new edge (of [EdgeType]) to/from the specified node [target]
      * (depending on [outgoing]) and adds it to the specified index in the list.
@@ -116,20 +225,6 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
         val edge = createEdge(target, init, this.outgoing)
 
         return add(index, edge)
-    }
-
-    override fun add(index: Int, element: EdgeType) {
-        // Make sure, the index is always set
-        element.index = this.size
-
-        super<ArrayList>.add(index, element)
-
-        handleOnAdd(element)
-
-        // We need to re-compute all edges with an index > inserted index
-        for (i in index until this.size) {
-            this[i].index = i
-        }
     }
 
     override fun toNodeCollection(predicate: ((EdgeType) -> Boolean)?): List<NodeType> {
@@ -162,5 +257,15 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
 
     override fun hashCode(): Int {
         return internalHashcode(this, outgoing)
+    }
+
+    private fun updateIndicesFrom(startIndex: Int) {
+        if (startIndex < 0) {
+            return
+        }
+
+        for (i in startIndex until size) {
+            this[i].index = i
+        }
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeList.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeList.kt
@@ -77,7 +77,7 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
             return false
         }
 
-        addWithoutHooks(element)
+        add(element)
         return true
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeList.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeList.kt
@@ -45,7 +45,10 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
      * operations to a larger list.
      */
     initialCapacity: Int = 1,
-) : AbstractMutableList<EdgeType>(), EdgeCollection<NodeType, EdgeType> {
+) :
+    AbstractMutableList<EdgeType>(),
+    EdgeCollection<NodeType, EdgeType>,
+    MirrorBacklinkCollection<EdgeType> {
 
     // Draft: compact 0/1/many storage to avoid allocating an ArrayList per node in the common case.
     private val storage =
@@ -64,6 +67,35 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
     }
 
     override fun add(element: EdgeType): Boolean {
+        addWithoutHooks(element)
+        handleOnAdd(element)
+        return true
+    }
+
+    override fun addMirrorBacklink(element: EdgeType): Boolean {
+        if (containsMirrorBacklinkByIdentity(element)) {
+            return false
+        }
+
+        addWithoutHooks(element)
+        return true
+    }
+
+    override fun containsMirrorBacklinkByIdentity(element: EdgeType): Boolean {
+        return indexOfIdentity(element) != -1
+    }
+
+    override fun removeMirrorBacklink(element: EdgeType): Boolean {
+        val idx = indexOfIdentity(element)
+        if (idx == -1) {
+            return false
+        }
+
+        removeAtWithoutHooks(idx)
+        return true
+    }
+
+    private fun addWithoutHooks(element: EdgeType) {
         if (element.index == null) {
             element.index = this.size
         }
@@ -75,9 +107,6 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
                 storage.ensureMany(maxOf(cachedCapacity, 2)).add(element)
             }
         }
-
-        handleOnAdd(element)
-        return true
     }
 
     override fun add(index: Int, element: EdgeType) {
@@ -110,6 +139,13 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
             throw IndexOutOfBoundsException("Index: $index, Size: $size")
         }
 
+        val removed = removeAtWithoutHooks(index)
+
+        handleOnRemove(removed)
+        return removed
+    }
+
+    private fun removeAtWithoutHooks(index: Int): EdgeType {
         val removed =
             when {
                 storage.many != null -> {
@@ -127,7 +163,6 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
                 }
             }
 
-        handleOnRemove(removed)
         updateIndicesFrom(index)
         return removed
     }
@@ -244,6 +279,14 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
 
     override fun hashCode(): Int {
         return internalHashcode(this, outgoing)
+    }
+
+    private fun indexOfIdentity(element: EdgeType): Int {
+        return when {
+            storage.many != null -> storage.many!!.indexOfFirst { it === element }
+            storage.first === element -> 0
+            else -> -1
+        }
     }
 
     private fun updateIndicesFrom(startIndex: Int) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeList.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeList.kt
@@ -85,6 +85,10 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
         return indexOfIdentity(element) != -1
     }
 
+    override fun containsByIdentity(edge: EdgeType): Boolean {
+        return indexOfIdentity(edge) != -1
+    }
+
     override fun removeMirrorBacklink(element: EdgeType): Boolean {
         val idx = indexOfIdentity(element)
         if (idx == -1) {
@@ -92,6 +96,16 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
         }
 
         removeAtWithoutHooks(idx)
+        return true
+    }
+
+    override fun removeByIdentity(edge: EdgeType): Boolean {
+        val idx = indexOfIdentity(edge)
+        if (idx == -1) {
+            return false
+        }
+
+        removeAt(idx)
         return true
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeList.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeList.kt
@@ -48,17 +48,17 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
 ) : AbstractMutableList<EdgeType>(), EdgeCollection<NodeType, EdgeType> {
 
     // Draft: compact 0/1/many storage to avoid allocating an ArrayList per node in the common case.
-    private var first: EdgeType? = null
-    private var many: MutableList<EdgeType>? = null
+    private val storage =
+        CompactEdgeStorage<EdgeType, MutableList<EdgeType>> { cap -> ArrayList(cap) }
     private var cachedCapacity: Int = initialCapacity
 
     override val size: Int
-        get() = many?.size ?: if (first == null) 0 else 1
+        get() = storage.size
 
     override fun get(index: Int): EdgeType {
         return when {
-            many != null -> many!![index]
-            index == 0 && first != null -> first!!
+            storage.many != null -> storage.many!![index]
+            index == 0 && storage.first != null -> storage.first!!
             else -> throw IndexOutOfBoundsException("Index: $index, Size: $size")
         }
     }
@@ -69,15 +69,10 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
         }
 
         when {
-            many != null -> many!!.add(element)
-            first == null -> first = element
+            storage.many != null -> storage.many!!.add(element)
+            storage.first == null -> storage.first = element
             else -> {
-                many =
-                    ArrayList<EdgeType>(maxOf(cachedCapacity, 2)).also {
-                        it.add(first!!)
-                        it.add(element)
-                    }
-                first = null
+                storage.ensureMany(maxOf(cachedCapacity, 2)).add(element)
             }
         }
 
@@ -91,24 +86,18 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
         }
 
         when {
-            many != null -> many!!.add(index, element)
-            first == null -> {
+            storage.many != null -> storage.many!!.add(index, element)
+            storage.first == null -> {
                 if (index != 0) throw IndexOutOfBoundsException("Index: $index, Size: $size")
-                first = element
+                storage.first = element
             }
             else -> {
-                val prev = first!!
-                many =
-                    ArrayList<EdgeType>(maxOf(cachedCapacity, 2)).also {
-                        if (index == 0) {
-                            it.add(element)
-                            it.add(prev)
-                        } else {
-                            it.add(prev)
-                            it.add(element)
-                        }
-                    }
-                first = null
+                val created = storage.ensureMany(maxOf(cachedCapacity, 2))
+                if (index == 0) {
+                    created.add(0, element)
+                } else {
+                    created.add(element)
+                }
             }
         }
 
@@ -123,17 +112,17 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
 
         val removed =
             when {
-                many != null -> {
-                    val r = many!!.removeAt(index)
-                    if (many!!.size == 1) {
-                        first = many!![0]
-                        many = null
+                storage.many != null -> {
+                    val r = storage.many!!.removeAt(index)
+                    if (storage.many!!.size == 1) {
+                        storage.first = storage.many!![0]
+                        storage.many = null
                     }
                     r
                 }
                 else -> {
-                    val r = first!!
-                    first = null
+                    val r = storage.first!!
+                    storage.first = null
                     r
                 }
             }
@@ -149,14 +138,14 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
         }
 
         return when {
-            many != null -> {
-                val prev = many!![index]
-                many!![index] = element
+            storage.many != null -> {
+                val prev = storage.many!![index]
+                storage.many!![index] = element
                 prev
             }
             else -> {
-                val prev = first!!
-                first = element
+                val prev = storage.first!!
+                storage.first = element
                 prev
             }
         }
@@ -195,9 +184,7 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
             return
         }
 
-        val edges = this.toList()
-        first = null
-        many = null
+        val edges = storage.clearAndSnapshot()
         edges.forEach { handleOnRemove(it) }
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSet.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSet.kt
@@ -63,7 +63,7 @@ abstract class EdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
     }
 
     override fun addMirrorBacklink(element: EdgeType): Boolean {
-        return addWithoutHooks(element)
+        return add(element)
     }
 
     override fun containsMirrorBacklinkByIdentity(element: EdgeType): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSet.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSet.kt
@@ -46,34 +46,28 @@ abstract class EdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
 ) : AbstractMutableSet<EdgeType>(), EdgeCollection<NodeType, EdgeType> {
 
     // Draft: compact 0/1/many storage to avoid eagerly allocating a HashSet for singleton cases.
-    private var first: EdgeType? = null
-    private var many: MutableSet<EdgeType>? = null
+    private val storage = CompactEdgeStorage<EdgeType, MutableSet<EdgeType>> { cap -> HashSet(cap) }
 
     override val size: Int
-        get() = many?.size ?: if (first == null) 0 else 1
+        get() = storage.size
 
     override fun add(element: EdgeType): Boolean {
         return when {
-            many != null -> {
-                val ok = many!!.add(element)
+            storage.many != null -> {
+                val ok = storage.many!!.add(element)
                 if (ok) {
                     handleOnAdd(element)
                 }
                 ok
             }
-            first == null -> {
-                first = element
+            storage.first == null -> {
+                storage.first = element
                 handleOnAdd(element)
                 true
             }
-            first == element -> false
+            storage.first == element -> false
             else -> {
-                many =
-                    HashSet<EdgeType>(2).also {
-                        it.add(first!!)
-                        it.add(element)
-                    }
-                first = null
+                storage.ensureMany(2).add(element)
                 handleOnAdd(element)
                 true
             }
@@ -81,30 +75,30 @@ abstract class EdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
     }
 
     override fun iterator(): MutableIterator<EdgeType> {
-        val singleton = first
-        return if (many != null) {
-            ManyIterator(many!!.iterator())
+        val singleton = storage.first
+        return if (storage.many != null) {
+            ManyIterator(storage.many!!.iterator())
         } else {
             SingletonIterator(singleton)
         }
     }
 
     override fun contains(element: EdgeType): Boolean {
-        return many?.contains(element) ?: (first == element)
+        return storage.many?.contains(element) ?: (storage.first == element)
     }
 
     override fun remove(element: EdgeType): Boolean {
         return when {
-            many != null -> {
-                val ok = many!!.remove(element)
+            storage.many != null -> {
+                val ok = storage.many!!.remove(element)
                 if (ok) {
                     handleOnRemove(element)
                     compactManyIfPossible()
                 }
                 ok
             }
-            first == element -> {
-                first = null
+            storage.first == element -> {
+                storage.first = null
                 handleOnRemove(element)
                 true
             }
@@ -143,9 +137,7 @@ abstract class EdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
         }
 
         // Make a copy of our edges so we can pass a copy to our on-remove handler
-        val edges = this.toSet()
-        first = null
-        many = null
+        val edges = storage.clearAndSnapshot()
         edges.forEach { handleOnRemove(it) }
     }
 
@@ -174,14 +166,7 @@ abstract class EdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
     }
 
     private fun compactManyIfPossible() {
-        val current = many ?: return
-        when (current.size) {
-            0 -> many = null
-            1 -> {
-                first = current.first()
-                many = null
-            }
-        }
+        storage.compactManyToSingleton { it.firstOrNull() }
     }
 
     private inner class ManyIterator(private val delegate: MutableIterator<EdgeType>) :
@@ -229,7 +214,7 @@ abstract class EdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
                 throw IllegalStateException("next() must be called before remove()")
             }
 
-            first = null
+            storage.first = null
             handleOnRemove(edge)
             canRemove = false
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSet.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSet.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.graph.edges.collections
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.edges.Edge
 import java.util.function.Predicate
+import kotlin.collections.AbstractMutableSet
 
 /**
  * This class extends a list of property edges. This allows us to use list of property edges more
@@ -42,44 +43,109 @@ abstract class EdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
     // We explicitly set the capacity to 1, as we expect that most nodes will only have one edge of
     // a given type. This is a common case for many edge types in the CPG, and setting the initial
     // capacity to 1 can save memory in these cases.
-) : HashSet<EdgeType>(1), EdgeCollection<NodeType, EdgeType> {
+) : AbstractMutableSet<EdgeType>(), EdgeCollection<NodeType, EdgeType> {
+
+    // Draft: compact 0/1/many storage to avoid eagerly allocating a HashSet for singleton cases.
+    private var first: EdgeType? = null
+    private var many: MutableSet<EdgeType>? = null
+
+    override val size: Int
+        get() = many?.size ?: if (first == null) 0 else 1
+
     override fun add(element: EdgeType): Boolean {
-        val ok = super<HashSet>.add(element)
-        if (ok) {
-            handleOnAdd(element)
+        return when {
+            many != null -> {
+                val ok = many!!.add(element)
+                if (ok) {
+                    handleOnAdd(element)
+                }
+                ok
+            }
+            first == null -> {
+                first = element
+                handleOnAdd(element)
+                true
+            }
+            first == element -> false
+            else -> {
+                many =
+                    HashSet<EdgeType>(2).also {
+                        it.add(first!!)
+                        it.add(element)
+                    }
+                first = null
+                handleOnAdd(element)
+                true
+            }
         }
-        return ok
     }
 
-    override fun removeIf(predicate: Predicate<in EdgeType>): Boolean {
-        val edges = filter { predicate.test(it) }
-        val ok = super<HashSet>.removeIf(predicate)
-        if (ok) {
-            edges.forEach { handleOnRemove(it) }
+    override fun iterator(): MutableIterator<EdgeType> {
+        val singleton = first
+        return if (many != null) {
+            ManyIterator(many!!.iterator())
+        } else {
+            SingletonIterator(singleton)
         }
-        return ok
     }
 
-    override fun removeAll(elements: Collection<EdgeType>): Boolean {
-        val ok = super.removeAll(elements.toSet())
-        if (ok) {
-            elements.forEach { handleOnRemove(it) }
-        }
-        return ok
+    override fun contains(element: EdgeType): Boolean {
+        return many?.contains(element) ?: (first == element)
     }
 
     override fun remove(element: EdgeType): Boolean {
-        val ok = super<HashSet>.remove(element)
-        if (ok) {
-            handleOnRemove(element)
+        return when {
+            many != null -> {
+                val ok = many!!.remove(element)
+                if (ok) {
+                    handleOnRemove(element)
+                    compactManyIfPossible()
+                }
+                ok
+            }
+            first == element -> {
+                first = null
+                handleOnRemove(element)
+                true
+            }
+            else -> false
         }
-        return ok
+    }
+
+    override fun removeIf(predicate: Predicate<in EdgeType>): Boolean {
+        val toRemove = this.filter { predicate.test(it) }
+        return removeAll(toRemove)
+    }
+
+    override fun removeAll(elements: Collection<EdgeType>): Boolean {
+        if (elements.isEmpty() || isEmpty()) {
+            return false
+        }
+
+        var changed = false
+        val toRemove = elements.toSet()
+        val it = iterator()
+
+        while (it.hasNext()) {
+            val edge = it.next()
+            if (edge in toRemove) {
+                it.remove()
+                changed = true
+            }
+        }
+
+        return changed
     }
 
     override fun clear() {
+        if (isEmpty()) {
+            return
+        }
+
         // Make a copy of our edges so we can pass a copy to our on-remove handler
         val edges = this.toSet()
-        super.clear()
+        first = null
+        many = null
         edges.forEach { handleOnRemove(it) }
     }
 
@@ -105,5 +171,67 @@ abstract class EdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
 
     override fun hashCode(): Int {
         return internalHashcode(this, outgoing)
+    }
+
+    private fun compactManyIfPossible() {
+        val current = many ?: return
+        when (current.size) {
+            0 -> many = null
+            1 -> {
+                first = current.first()
+                many = null
+            }
+        }
+    }
+
+    private inner class ManyIterator(private val delegate: MutableIterator<EdgeType>) :
+        MutableIterator<EdgeType> {
+        private var last: EdgeType? = null
+
+        override fun hasNext(): Boolean {
+            return delegate.hasNext()
+        }
+
+        override fun next(): EdgeType {
+            return delegate.next().also { last = it }
+        }
+
+        override fun remove() {
+            val removed =
+                last ?: throw IllegalStateException("next() must be called before remove()")
+            delegate.remove()
+            handleOnRemove(removed)
+            compactManyIfPossible()
+            last = null
+        }
+    }
+
+    private inner class SingletonIterator(private val edge: EdgeType?) : MutableIterator<EdgeType> {
+        private var consumed = false
+        private var canRemove = false
+
+        override fun hasNext(): Boolean {
+            return !consumed && edge != null
+        }
+
+        override fun next(): EdgeType {
+            if (!hasNext()) {
+                throw NoSuchElementException()
+            }
+
+            consumed = true
+            canRemove = true
+            return edge!!
+        }
+
+        override fun remove() {
+            if (!canRemove || edge == null) {
+                throw IllegalStateException("next() must be called before remove()")
+            }
+
+            first = null
+            handleOnRemove(edge)
+            canRemove = false
+        }
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSet.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSet.kt
@@ -43,7 +43,10 @@ abstract class EdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
     // We explicitly set the capacity to 1, as we expect that most nodes will only have one edge of
     // a given type. This is a common case for many edge types in the CPG, and setting the initial
     // capacity to 1 can save memory in these cases.
-) : AbstractMutableSet<EdgeType>(), EdgeCollection<NodeType, EdgeType> {
+) :
+    AbstractMutableSet<EdgeType>(),
+    EdgeCollection<NodeType, EdgeType>,
+    MirrorBacklinkCollection<EdgeType> {
 
     // Draft: compact 0/1/many storage to avoid eagerly allocating a HashSet for singleton cases.
     private val storage = CompactEdgeStorage<EdgeType, MutableSet<EdgeType>> { cap -> HashSet(cap) }
@@ -52,23 +55,40 @@ abstract class EdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
         get() = storage.size
 
     override fun add(element: EdgeType): Boolean {
+        val ok = addWithoutHooks(element)
+        if (ok) {
+            handleOnAdd(element)
+        }
+        return ok
+    }
+
+    override fun addMirrorBacklink(element: EdgeType): Boolean {
+        return addWithoutHooks(element)
+    }
+
+    override fun containsMirrorBacklinkByIdentity(element: EdgeType): Boolean {
+        return when {
+            storage.many != null -> storage.many!!.any { it === element }
+            else -> storage.first === element
+        }
+    }
+
+    override fun removeMirrorBacklink(element: EdgeType): Boolean {
+        return removeByIdentityWithoutHooks(element)
+    }
+
+    private fun addWithoutHooks(element: EdgeType): Boolean {
         return when {
             storage.many != null -> {
-                val ok = storage.many!!.add(element)
-                if (ok) {
-                    handleOnAdd(element)
-                }
-                ok
+                storage.many!!.add(element)
             }
             storage.first == null -> {
                 storage.first = element
-                handleOnAdd(element)
                 true
             }
             storage.first == element -> false
             else -> {
                 storage.ensureMany(2).add(element)
-                handleOnAdd(element)
                 true
             }
         }
@@ -88,18 +108,51 @@ abstract class EdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
     }
 
     override fun remove(element: EdgeType): Boolean {
+        val ok = removeByEqualityWithoutHooks(element)
+        if (ok) {
+            handleOnRemove(element)
+        }
+        return ok
+    }
+
+    private fun removeByEqualityWithoutHooks(element: EdgeType): Boolean {
         return when {
             storage.many != null -> {
                 val ok = storage.many!!.remove(element)
                 if (ok) {
-                    handleOnRemove(element)
                     compactManyIfPossible()
                 }
                 ok
             }
             storage.first == element -> {
                 storage.first = null
-                handleOnRemove(element)
+                true
+            }
+            else -> false
+        }
+    }
+
+    private fun removeByIdentityWithoutHooks(element: EdgeType): Boolean {
+        return when {
+            storage.many != null -> {
+                val it = storage.many!!.iterator()
+                var removed = false
+                while (it.hasNext()) {
+                    if (it.next() === element) {
+                        it.remove()
+                        removed = true
+                        break
+                    }
+                }
+
+                if (removed) {
+                    compactManyIfPossible()
+                }
+
+                removed
+            }
+            storage.first === element -> {
+                storage.first = null
                 true
             }
             else -> false

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSet.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSet.kt
@@ -73,8 +73,20 @@ abstract class EdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
         }
     }
 
+    override fun containsByIdentity(edge: EdgeType): Boolean {
+        return containsMirrorBacklinkByIdentity(edge)
+    }
+
     override fun removeMirrorBacklink(element: EdgeType): Boolean {
         return removeByIdentityWithoutHooks(element)
+    }
+
+    override fun removeByIdentity(edge: EdgeType): Boolean {
+        val removed = removeByIdentityWithoutHooks(edge)
+        if (removed) {
+            handleOnRemove(edge)
+        }
+        return removed
     }
 
     private fun addWithoutHooks(element: EdgeType): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSingletonList.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSingletonList.kt
@@ -44,7 +44,7 @@ open class EdgeSingletonList<
     var onChanged: ((old: EdgeType?, new: EdgeType?) -> Unit)? = null,
     override var outgoing: Boolean,
     of: NullableNodeType,
-) : EdgeCollection<NodeType, EdgeType> {
+) : EdgeCollection<NodeType, EdgeType>, MirrorBacklinkCollection<EdgeType> {
 
     var element: EdgeType? =
         if (of == null) {
@@ -82,6 +82,35 @@ open class EdgeSingletonList<
                 "We cannot 'add' to a singleton edge list, that is already populated"
             )
         }
+    }
+
+    override fun addMirrorBacklink(element: EdgeType): Boolean {
+        if (this.element === element) {
+            return false
+        }
+
+        if (this.element != null) {
+            return false
+        }
+
+        this.element = element
+        onChanged?.invoke(null, this.element)
+        return true
+    }
+
+    override fun removeMirrorBacklink(element: EdgeType): Boolean {
+        if (this.element !== element) {
+            return false
+        }
+
+        val old = this.element
+        this.element = null
+        onChanged?.invoke(old, null)
+        return true
+    }
+
+    override fun containsMirrorBacklinkByIdentity(element: EdgeType): Boolean {
+        return this.element === element
     }
 
     override fun addAll(elements: Collection<EdgeType>): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/MirroredEdgeCollection.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/MirroredEdgeCollection.kt
@@ -27,7 +27,15 @@ package de.fraunhofer.aisec.cpg.graph.edges.collections
 
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.edges.Edge
-import kotlin.reflect.KProperty
+
+/** Internal operations for mirroring without recursively triggering hooks. */
+internal interface MirrorBacklinkCollection<ElementType> {
+    fun addMirrorBacklink(element: ElementType): Boolean
+
+    fun removeMirrorBacklink(element: ElementType): Boolean
+
+    fun containsMirrorBacklinkByIdentity(element: ElementType): Boolean
+}
 
 /**
  * This interface can be used for edge collections, which "mirror" its content to another property.
@@ -35,20 +43,18 @@ import kotlin.reflect.KProperty
  */
 interface MirroredEdgeCollection<NodeType : Node, PropertyEdgeType : Edge<NodeType>> :
     EdgeCollection<NodeType, PropertyEdgeType> {
-    var mirrorProperty: KProperty<MutableCollection<PropertyEdgeType>>
+    /** Provides direct access to the mirrored collection without reflection. */
+    var mirroredCollection: (Node) -> MutableCollection<PropertyEdgeType>
 
     override fun handleOnRemove(edge: PropertyEdgeType) {
         // Handle our mirror property.
-        if (outgoing) {
-            var prevOfNext = mirrorProperty.call(edge.end)
-            if (edge in prevOfNext) {
-                prevOfNext.remove(edge)
-            }
-        } else {
-            var nextOfPrev = mirrorProperty.call(edge.start)
-            if (edge in nextOfPrev) {
-                nextOfPrev.remove(edge)
-            }
+        val mirror = if (outgoing) mirroredCollection(edge.end) else mirroredCollection(edge.start)
+
+        @Suppress("UNCHECKED_CAST")
+        if (mirror is MirrorBacklinkCollection<*>) {
+            (mirror as MirrorBacklinkCollection<PropertyEdgeType>).removeMirrorBacklink(edge)
+        } else if (edge in mirror) {
+            mirror.remove(edge)
         }
 
         // Execute any remaining pre actions
@@ -56,22 +62,21 @@ interface MirroredEdgeCollection<NodeType : Node, PropertyEdgeType : Edge<NodeTy
     }
 
     /**
-     * Adds this particular edge to its [mirrorProperty]. We need the information if this is an
+     * Adds this particular edge to its mirror collection. We need the information if this is an
      * [outgoing] or incoming edge collection.
      */
     override fun handleOnAdd(edge: PropertyEdgeType) {
-        // Handle our mirror property. We add some extra "in" checks here, otherwise things will
-        // loop.
-        if (outgoing) {
-            var prevOfNext = mirrorProperty.call(edge.end)
-            if (edge !in prevOfNext) {
-                prevOfNext.add(edge)
+        // Handle our mirror collection.
+        val mirror = if (outgoing) mirroredCollection(edge.end) else mirroredCollection(edge.start)
+
+        @Suppress("UNCHECKED_CAST")
+        if (mirror is MirrorBacklinkCollection<*>) {
+            val backlink = mirror as MirrorBacklinkCollection<PropertyEdgeType>
+            if (!backlink.containsMirrorBacklinkByIdentity(edge)) {
+                backlink.addMirrorBacklink(edge)
             }
-        } else {
-            var nextOfPrev = mirrorProperty.call(edge.start)
-            if (edge !in nextOfPrev) {
-                nextOfPrev.add(edge)
-            }
+        } else if (edge !in mirror) {
+            mirror.add(edge)
         }
 
         // Execute any remaining post actions

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/MirroredEdgeCollection.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/MirroredEdgeCollection.kt
@@ -82,8 +82,6 @@ interface MirroredEdgeCollection<NodeType : Node, PropertyEdgeType : Edge<NodeTy
             if (!edgeCollection.containsByIdentity(edge)) {
                 edgeCollection.add(edge)
             }
-        } else if (edge !in mirror) {
-            mirror.add(edge)
         }
 
         // Execute any remaining post actions

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/MirroredEdgeCollection.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/MirroredEdgeCollection.kt
@@ -53,6 +53,8 @@ interface MirroredEdgeCollection<NodeType : Node, PropertyEdgeType : Edge<NodeTy
         @Suppress("UNCHECKED_CAST")
         if (mirror is MirrorBacklinkCollection<*>) {
             (mirror as MirrorBacklinkCollection<PropertyEdgeType>).removeMirrorBacklink(edge)
+        } else if (mirror is EdgeCollection<*, *>) {
+            (mirror as EdgeCollection<NodeType, PropertyEdgeType>).removeByIdentity(edge)
         } else if (edge in mirror) {
             mirror.remove(edge)
         }
@@ -74,6 +76,11 @@ interface MirroredEdgeCollection<NodeType : Node, PropertyEdgeType : Edge<NodeTy
             val backlink = mirror as MirrorBacklinkCollection<PropertyEdgeType>
             if (!backlink.containsMirrorBacklinkByIdentity(edge)) {
                 backlink.addMirrorBacklink(edge)
+            }
+        } else if (mirror is EdgeCollection<*, *>) {
+            val edgeCollection = mirror as EdgeCollection<NodeType, PropertyEdgeType>
+            if (!edgeCollection.containsByIdentity(edge)) {
+                edgeCollection.add(edge)
             }
         } else if (edge !in mirror) {
             mirror.add(edge)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/ControlDependence.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/ControlDependence.kt
@@ -29,7 +29,6 @@ import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeList
 import de.fraunhofer.aisec.cpg.graph.edges.collections.MirroredEdgeCollection
 import de.fraunhofer.aisec.cpg.passes.ControlDependenceGraphPass
-import kotlin.reflect.KProperty
 
 /**
  * An edge in a Control Dependence Graph (CDG). Denotes that the [start] node exercises control
@@ -66,13 +65,13 @@ class ControlDependence(
 class ControlDependences<NodeType : Node> :
     EdgeList<Node, ControlDependence>, MirroredEdgeCollection<Node, ControlDependence> {
 
-    override var mirrorProperty: KProperty<MutableCollection<ControlDependence>>
+    override var mirroredCollection: (Node) -> MutableCollection<ControlDependence>
 
     constructor(
         thisRef: Node,
-        mirrorProperty: KProperty<MutableCollection<ControlDependence>>,
+        mirroredCollection: (Node) -> MutableCollection<ControlDependence>,
         outgoing: Boolean,
     ) : super(thisRef = thisRef, init = ::ControlDependence, outgoing = outgoing) {
-        this.mirrorProperty = mirrorProperty
+        this.mirroredCollection = mirroredCollection
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Dataflow.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Dataflow.kt
@@ -39,7 +39,6 @@ import de.fraunhofer.aisec.cpg.graph.types.HasType
 import de.fraunhofer.aisec.cpg.persistence.Convert
 import de.fraunhofer.aisec.cpg.persistence.converters.DataflowGranularityConverter
 import java.util.Objects
-import kotlin.reflect.KProperty
 
 /**
  * The granularity of the data-flow, e.g., whether the flow contains the whole object, or just a
@@ -272,7 +271,7 @@ class ContextSensitiveDataflow(
 /** This class represents a container of [Dataflow] property edges in a [thisRef]. */
 class Dataflows<T : Node>(
     thisRef: Node,
-    override var mirrorProperty: KProperty<MutableCollection<Dataflow>>,
+    override var mirroredCollection: (Node) -> MutableCollection<Dataflow>,
     outgoing: Boolean,
 ) :
     EdgeSet<Node, Dataflow>(thisRef = thisRef, init = ::Dataflow, outgoing = outgoing),

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/EvaluationOrder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/EvaluationOrder.kt
@@ -30,7 +30,6 @@ import de.fraunhofer.aisec.cpg.graph.edges.Edge
 import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeList
 import de.fraunhofer.aisec.cpg.graph.edges.collections.MirroredEdgeCollection
 import de.fraunhofer.aisec.cpg.passes.EvaluationOrderGraphPass
-import kotlin.reflect.KProperty
 
 /**
  * An edge in our Evaluation Order Graph (EOG). It considers the order in which our AST statements
@@ -89,7 +88,7 @@ class EvaluationOrder(
  */
 class EvaluationOrders<NodeType : Node>(
     thisRef: Node,
-    override var mirrorProperty: KProperty<MutableCollection<EvaluationOrder>>,
+    override var mirroredCollection: (Node) -> MutableCollection<EvaluationOrder>,
     outgoing: Boolean = true,
 ) :
     EdgeList<Node, EvaluationOrder>(

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Invoke.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Invoke.kt
@@ -31,7 +31,6 @@ import de.fraunhofer.aisec.cpg.graph.edges.Edge
 import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeList
 import de.fraunhofer.aisec.cpg.graph.edges.collections.MirroredEdgeCollection
 import de.fraunhofer.aisec.cpg.graph.expressions.Call
-import kotlin.reflect.KProperty
 
 /** This edge class denotes the invocation of a [Function] by a [Call]. */
 class Invoke(
@@ -61,7 +60,7 @@ class Invoke(
 /** A container for [Usage] edges. [NodeType] is necessary for type safety. */
 class Invokes<NodeType : Function>(
     thisRef: Node,
-    override var mirrorProperty: KProperty<MutableCollection<Invoke>>,
+    override var mirroredCollection: (Node) -> MutableCollection<Invoke>,
     outgoing: Boolean = true,
 ) :
     EdgeList<Function, Invoke>(thisRef = thisRef, init = ::Invoke, outgoing = outgoing),

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/ProgramDependence.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/ProgramDependence.kt
@@ -30,7 +30,6 @@ import de.fraunhofer.aisec.cpg.graph.edges.Edge
 import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeSet
 import de.fraunhofer.aisec.cpg.graph.edges.collections.MirroredEdgeCollection
 import de.fraunhofer.aisec.cpg.passes.ProgramDependenceGraphPass
-import kotlin.reflect.KProperty
 
 /** The types of dependences that might be represented in the CPG */
 enum class DependenceType {
@@ -49,11 +48,11 @@ enum class DependenceType {
  */
 class ProgramDependences<NodeType : Node> :
     EdgeSet<NodeType, Edge<NodeType>>, MirroredEdgeCollection<NodeType, Edge<NodeType>> {
-    override var mirrorProperty: KProperty<MutableCollection<Edge<NodeType>>>
+    override var mirroredCollection: (Node) -> MutableCollection<Edge<NodeType>>
 
     constructor(
         thisRef: Node,
-        mirrorProperty: KProperty<MutableCollection<Edge<NodeType>>>,
+        mirroredCollection: (Node) -> MutableCollection<Edge<NodeType>>,
         outgoing: Boolean,
     ) : super(
         thisRef,
@@ -64,7 +63,7 @@ class ProgramDependences<NodeType : Node> :
         },
         outgoing,
     ) {
-        this.mirrorProperty = mirrorProperty
+        this.mirroredCollection = mirroredCollection
     }
 
     override fun add(element: Edge<NodeType>): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/overlay/BasicBlockEdge.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/overlay/BasicBlockEdge.kt
@@ -30,7 +30,6 @@ import de.fraunhofer.aisec.cpg.graph.edges.Edge
 import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeList
 import de.fraunhofer.aisec.cpg.graph.edges.collections.MirroredEdgeCollection
 import de.fraunhofer.aisec.cpg.graph.overlays.BasicBlock
-import kotlin.reflect.KProperty
 
 /**
  * An edge representing that a [Node] belongs to a [BasicBlock] or the basic block contains the
@@ -56,7 +55,7 @@ class BasicBlockEdge(start: Node, end: Node) : Edge<Node>(start, end) {
  */
 class BasicBlockEdgeList<NodeType : Node>(
     thisRef: Node,
-    override var mirrorProperty: KProperty<MutableCollection<BasicBlockEdge>>,
+    override var mirroredCollection: (Node) -> MutableCollection<BasicBlockEdge>,
     outgoing: Boolean = true,
 ) :
     EdgeList<Node, BasicBlockEdge>(thisRef = thisRef, init = ::BasicBlockEdge, outgoing = outgoing),

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/overlay/Overlay.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/overlay/Overlay.kt
@@ -30,7 +30,6 @@ import de.fraunhofer.aisec.cpg.graph.edges.Edge
 import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeSet
 import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeSingletonList
 import de.fraunhofer.aisec.cpg.graph.edges.collections.MirroredEdgeCollection
-import kotlin.reflect.KProperty
 
 /**
  * Represents an edge in a graph specifically used for overlay purposes.
@@ -50,14 +49,14 @@ class OverlayEdge(start: Node, end: Node) : Edge<Node>(start, end) {
  *
  * @param thisRef The current node that the edge originates from or is associated with.
  * @param of The optional target node of the edge.
- * @param mirrorProperty The property representing a mutable collection of mirrored overlay edges.
+ * @param mirroredCollection Accessor for the mirrored collection of overlay edges.
  * @param outgoing A flag indicating whether the edge is outgoing (default is true).
  * @constructor Initializes the [OverlaySingleEdge] instance with the provided parameters.
  */
 class OverlaySingleEdge(
     thisRef: Node,
     of: Node?,
-    override var mirrorProperty: KProperty<MutableCollection<OverlayEdge>>,
+    override var mirroredCollection: (Node) -> MutableCollection<OverlayEdge>,
     outgoing: Boolean = true,
     onChange: ((old: OverlayEdge?, new: OverlayEdge?) -> Unit)? = null,
 ) :
@@ -76,14 +75,14 @@ class OverlaySingleEdge(
  * incoming edge handling capabilities.
  *
  * @param thisRef The reference node that the overlays are associated with.
- * @param mirrorProperty A reference to a property that mirrors the collection of overlay edges.
+ * @param mirroredCollection Accessor for the mirrored collection of overlay edges.
  * @param outgoing A boolean indicating whether the edges managed by this collection are outgoing.
  * @constructor Initializes the [Overlays] object with a reference node, a property for edge
  *   mirroring, and a direction to specify outgoing or incoming edges.
  */
 class Overlays(
     thisRef: Node,
-    override var mirrorProperty: KProperty<MutableCollection<OverlayEdge>>,
+    override var mirroredCollection: (Node) -> MutableCollection<OverlayEdge>,
     outgoing: Boolean,
 ) :
     EdgeSet<Node, OverlayEdge>(thisRef = thisRef, init = ::OverlayEdge, outgoing = outgoing),

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/scopes/Import.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/scopes/Import.kt
@@ -32,7 +32,6 @@ import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeSet
 import de.fraunhofer.aisec.cpg.graph.edges.collections.MirroredEdgeCollection
 import de.fraunhofer.aisec.cpg.graph.scopes.NamespaceScope
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
-import kotlin.reflect.KProperty
 
 /**
  * The style of the import. This can be used to distinguish between different import modes, such as
@@ -85,7 +84,7 @@ class Import(start: Scope, end: NamespaceScope, var declaration: ImportNode? = n
 /** A container to manage [Import] edges. */
 class Imports(
     thisRef: Node,
-    override var mirrorProperty: KProperty<MutableCollection<Import>>,
+    override var mirroredCollection: (Node) -> MutableCollection<Import>,
     outgoing: Boolean = true,
 ) :
     EdgeSet<NamespaceScope, Import>(

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/ArrayConstruction.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/ArrayConstruction.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.graph.expressions
 
 import de.fraunhofer.aisec.cpg.graph.HasInitializer
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.addIfNotContains
 import de.fraunhofer.aisec.cpg.graph.declarations.Variable
 import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Assign.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Assign.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.graph.expressions
 
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.Variable
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
@@ -56,7 +57,12 @@ import org.slf4j.LoggerFactory
  * from the (first) rhs to the [Assign] itself.
  */
 class Assign :
-    Expression(false), AssignmentHolder, ArgumentHolder, HasType.TypeObserver, HasOperatorCode {
+    Expression(false),
+    AssignmentHolder,
+    ArgumentHolder,
+    HasType.TypeObserver,
+    DeclarationHolder,
+    HasOperatorCode {
 
     override var operatorCode: String = "="
 
@@ -154,6 +160,11 @@ class Assign :
         }
 
     @Relationship("DECLARATIONS") var declarationEdges = astEdgesOf<Variable>()
+
+    override fun addDeclaration(declaration: Declaration) {
+        (declaration as? Variable)?.let { this.declarations.add(it) }
+    }
+
     /**
      * Some languages, such as Go explicitly allow the definition / declaration of variables in the
      * assignment (known as a "short assignment"). Some languages, such as Python even implicitly

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Block.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Block.kt
@@ -29,6 +29,7 @@ import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
 import de.fraunhofer.aisec.cpg.graph.HasLocals
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.StatementHolder
+import de.fraunhofer.aisec.cpg.graph.addIfNotContains
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.Function
 import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Block.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Block.kt
@@ -25,10 +25,16 @@
  */
 package de.fraunhofer.aisec.cpg.graph.expressions
 
+import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
+import de.fraunhofer.aisec.cpg.graph.HasLocals
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.StatementHolder
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.Function
+import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Variable
 import de.fraunhofer.aisec.cpg.graph.edges.Edge
+import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import de.fraunhofer.aisec.cpg.persistence.Relationship
@@ -39,7 +45,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder
  * A statement which contains a list of statements. A common example is a function body within a
  * [Function].
  */
-open class Block : Expression(false), StatementHolder {
+open class Block : Expression(false), StatementHolder, DeclarationHolder, HasLocals {
 
     /** The list of statements. */
     @Relationship(value = "STATEMENTS", direction = Relationship.Direction.OUTGOING)
@@ -61,10 +67,12 @@ open class Block : Expression(false), StatementHolder {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is Block) return false
-        return super.equals(other) && Edge.propertyEqualsList(statementEdges, other.statementEdges)
+        return super.equals(other) &&
+            Edge.propertyEqualsList(statementEdges, other.statementEdges) &&
+            propertyEqualsList(localEdges, other.localEdges)
     }
 
-    override fun hashCode() = Objects.hash(super.hashCode())
+    override fun hashCode() = Objects.hash(super.hashCode(), locals)
 
     /** Returns the [n]-th statement in this list of statements. */
     operator fun get(n: Int): Expression {
@@ -74,4 +82,21 @@ open class Block : Expression(false), StatementHolder {
     override fun getStartingPrevEOG(): Collection<Node> {
         return this.statements.firstOrNull()?.getStartingPrevEOG() ?: this.prevEOG
     }
+
+    @Relationship(value = "LOCALS", direction = Relationship.Direction.OUTGOING)
+    override var localEdges = astEdgesOf<ValueDeclaration>()
+
+    /** Virtual property to access [localEdges] without property edges. */
+    override var locals by unwrapping(Block::localEdges)
+
+    override fun addDeclaration(declaration: Declaration) {
+        if (declaration is Variable) {
+            addIfNotContains(localEdges, declaration)
+        } else if (declaration is Function) {
+            addIfNotContains(localEdges, declaration)
+        }
+    }
+
+    override val declarations: List<Declaration>
+        get() = locals
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Call.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Call.kt
@@ -60,7 +60,11 @@ open class Call :
     @PopulatedByPass(SymbolResolver::class)
     @Relationship(value = "INVOKES", direction = Relationship.Direction.OUTGOING)
     var invokeEdges: Invokes<Function> =
-        Invokes<Function>(this, mirrorProperty = Function::calledByEdges, outgoing = true)
+        Invokes<Function>(
+            this,
+            mirroredCollection = { (it as Function).calledByEdges },
+            outgoing = true,
+        )
         protected set
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Comprehension.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Comprehension.kt
@@ -27,9 +27,17 @@ package de.fraunhofer.aisec.cpg.graph.expressions
 
 import de.fraunhofer.aisec.cpg.graph.AccessValues
 import de.fraunhofer.aisec.cpg.graph.ArgumentHolder
+import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
+import de.fraunhofer.aisec.cpg.graph.HasLocals
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.allChildren
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Function
+import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Variable
+import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgeOf
+import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astOptionalEdgeOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import de.fraunhofer.aisec.cpg.persistence.Relationship
@@ -37,7 +45,7 @@ import java.util.Objects
 import org.apache.commons.lang3.builder.ToStringBuilder
 
 /** This class holds the variable, iterable and predicate of the [CollectionComprehension]. */
-class Comprehension : Expression(), ArgumentHolder {
+class Comprehension : Expression(), ArgumentHolder, DeclarationHolder, HasLocals {
     @Relationship("VARIABLE")
     var variableEdge =
         astEdgeOf<Expression>(
@@ -80,10 +88,11 @@ class Comprehension : Expression(), ArgumentHolder {
         return super.equals(other) &&
             variable == other.variable &&
             iterable == other.iterable &&
-            predicate == other.predicate
+            predicate == other.predicate &&
+            propertyEqualsList(localEdges, other.localEdges)
     }
 
-    override fun hashCode() = Objects.hash(super.hashCode(), variable, iterable, predicate)
+    override fun hashCode() = Objects.hash(super.hashCode(), variable, iterable, predicate, locals)
 
     override fun addArgument(expression: Expression) {
         if (this.variable is ProblemExpression) {
@@ -126,4 +135,21 @@ class Comprehension : Expression(), ArgumentHolder {
     override fun getExitNextEOG(): Collection<Node> {
         return this.nextEOG.filter { it !in iterable.allChildren<Node> { true } }
     }
+
+    @Relationship(value = "LOCALS", direction = Relationship.Direction.OUTGOING)
+    override var localEdges = astEdgesOf<ValueDeclaration>()
+
+    /** Virtual property to access [localEdges] without property edges. */
+    override var locals by unwrapping(Comprehension::localEdges)
+
+    override fun addDeclaration(declaration: Declaration) {
+        if (declaration is Variable) {
+            addIfNotContains(localEdges, declaration)
+        } else if (declaration is Function) {
+            addIfNotContains(localEdges, declaration)
+        }
+    }
+
+    override val declarations: List<Declaration>
+        get() = locals
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Comprehension.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Comprehension.kt
@@ -30,6 +30,7 @@ import de.fraunhofer.aisec.cpg.graph.ArgumentHolder
 import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
 import de.fraunhofer.aisec.cpg.graph.HasLocals
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.addIfNotContains
 import de.fraunhofer.aisec.cpg.graph.allChildren
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.Function
@@ -50,7 +51,7 @@ class Comprehension : Expression(), ArgumentHolder, DeclarationHolder, HasLocals
     var variableEdge =
         astEdgeOf<Expression>(
             of = ProblemExpression("Missing variableEdge in ${this::class}"),
-            onChanged = { _, new -> (new?.end as? Expression)?.access = AccessValues.WRITE },
+            onChanged = { _, new -> new?.end?.access = AccessValues.WRITE },
         )
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/DeclarationStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/DeclarationStatement.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.graph.expressions
 
+import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
@@ -40,7 +41,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder
  * contain other statements, but not declarations. Therefore, declarations are wrapped in a
  * [DeclarationStatement].
  */
-open class DeclarationStatement : Expression(false) {
+open class DeclarationStatement : Expression(false), DeclarationHolder {
 
     /**
      * The list of declarations declared or defined by this statement. It is always a list, even if

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/DeclarationStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/DeclarationStatement.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.graph.expressions
 
 import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.addIfNotContains
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/DoWhile.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/DoWhile.kt
@@ -26,8 +26,16 @@
 package de.fraunhofer.aisec.cpg.graph.expressions
 
 import de.fraunhofer.aisec.cpg.graph.ArgumentHolder
+import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
+import de.fraunhofer.aisec.cpg.graph.HasLocals
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.allChildren
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Function
+import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Variable
+import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
+import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astOptionalEdgeOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import de.fraunhofer.aisec.cpg.persistence.Relationship
@@ -38,7 +46,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder
  * Represents a conditional loop statement of the form: `do{...}while(...)`. Where the body, usually
  * a [Block], is executed and re-executed if the [condition] evaluates to true.
  */
-class DoWhile : Loop(), ArgumentHolder {
+class DoWhile : Loop(), ArgumentHolder, DeclarationHolder, HasLocals {
     @Relationship("CONDITION") var conditionEdge = astOptionalEdgeOf<Expression>()
     /**
      * The loop condition that is evaluated after the loop statement and may trigger reevaluation.
@@ -70,10 +78,12 @@ class DoWhile : Loop(), ArgumentHolder {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is DoWhile) return false
-        return super.equals(other) && condition == other.condition
+        return super.equals(other) &&
+            condition == other.condition &&
+            propertyEqualsList(localEdges, other.localEdges)
     }
 
-    override fun hashCode() = Objects.hash(super.hashCode(), condition)
+    override fun hashCode() = Objects.hash(super.hashCode(), condition, locals)
 
     override fun getStartingPrevEOG(): Collection<Node> {
         return statement?.getStartingPrevEOG()?.filter { it != this }
@@ -84,4 +94,21 @@ class DoWhile : Loop(), ArgumentHolder {
     override fun getExitNextEOG(): Collection<Node> {
         return this.nextEOG.filter { it !in statement.allChildren<Node> { true } }
     }
+
+    @Relationship(value = "LOCALS", direction = Relationship.Direction.OUTGOING)
+    override var localEdges = astEdgesOf<ValueDeclaration>()
+
+    /** Virtual property to access [localEdges] without property edges. */
+    override var locals by unwrapping(DoWhile::localEdges)
+
+    override fun addDeclaration(declaration: Declaration) {
+        if (declaration is Variable) {
+            addIfNotContains(localEdges, declaration)
+        } else if (declaration is Function) {
+            addIfNotContains(localEdges, declaration)
+        }
+    }
+
+    override val declarations: List<Declaration>
+        get() = locals
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/DoWhile.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/DoWhile.kt
@@ -29,6 +29,7 @@ import de.fraunhofer.aisec.cpg.graph.ArgumentHolder
 import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
 import de.fraunhofer.aisec.cpg.graph.HasLocals
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.addIfNotContains
 import de.fraunhofer.aisec.cpg.graph.allChildren
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.Function

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Expression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Expression.kt
@@ -121,7 +121,7 @@ abstract class Expression(usedAsExpression: Boolean = true) :
     override var memoryValueEdges =
         Dataflows<Node>(
             this,
-            mirrorProperty = HasMemoryValue::memoryValueUsageEdges,
+            mirroredCollection = { (it as HasMemoryValue).memoryValueUsageEdges },
             outgoing = false,
         )
     override var memoryValues by unwrapping(Expression::memoryValueEdges)
@@ -129,13 +129,20 @@ abstract class Expression(usedAsExpression: Boolean = true) :
     /** Where the memory value of this Expression is used. */
     @Relationship
     override var memoryValueUsageEdges =
-        Dataflows<Node>(this, mirrorProperty = HasMemoryValue::memoryValueEdges, outgoing = true)
+        Dataflows<Node>(
+            this,
+            mirroredCollection = { (it as HasMemoryValue).memoryValueEdges },
+            outgoing = true,
+        )
     override var memoryValueUsages by unwrapping(Expression::memoryValueUsageEdges)
 
     /** Each Expression also has a MemoryAddress. */
     @Relationship
     override var memoryAddressEdges =
-        memoryAddressEdgesOf(mirrorProperty = MemoryAddress::usageEdges, outgoing = true)
+        memoryAddressEdgesOf(
+            mirroredCollection = { (it as MemoryAddress).usageEdges },
+            outgoing = true,
+        )
     override var memoryAddresses by unwrapping(Expression::memoryAddressEdges)
 
     override fun toString(): String {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Expression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Expression.kt
@@ -30,14 +30,7 @@ import de.fraunhofer.aisec.cpg.frontends.UnknownLanguage
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.AccessValues
 import de.fraunhofer.aisec.cpg.graph.AstNode
-import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
-import de.fraunhofer.aisec.cpg.graph.declarations.Function
-import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
-import de.fraunhofer.aisec.cpg.graph.declarations.Variable
-import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
-import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.flows.Dataflows
 import de.fraunhofer.aisec.cpg.graph.edges.memoryAddressEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
@@ -62,7 +55,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder
  * executable code.
  */
 abstract class Expression(usedAsExpression: Boolean = true) :
-    AstNode(), DeclarationHolder, HasType, HasMemoryAddress, HasMemoryValue {
+    AstNode(), HasType, HasMemoryAddress, HasMemoryValue {
 
     /**
      * This property specifies that this node is used as an expression. Depending on the language,
@@ -83,19 +76,6 @@ abstract class Expression(usedAsExpression: Boolean = true) :
      * modeling and determine the dataflow direction
      */
     open var access: AccessValues = AccessValues.READ
-
-    /**
-     * A list of local variables (or other values) associated to this statement, defined by their
-     * [ValueDeclaration] extracted from Block because `for`, `while`, `if`, and `switch` can
-     * declare locals in their condition or initializers.
-     *
-     * TODO: This is actually an AST node just for a subset of nodes, i.e. initializers in for-loops
-     */
-    @Relationship(value = "LOCALS", direction = Relationship.Direction.OUTGOING)
-    var localEdges = astEdgesOf<ValueDeclaration>()
-
-    /** Virtual property to access [localEdges] without property edges. */
-    var locals by unwrapping(Expression::localEdges)
 
     @DoNotPersist override val typeObservers: MutableSet<HasType.TypeObserver> = identitySetOf()
 
@@ -168,22 +148,8 @@ abstract class Expression(usedAsExpression: Boolean = true) :
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is Expression) return false
-        return super.equals(other) &&
-            locals == other.locals &&
-            propertyEqualsList(localEdges, other.localEdges) &&
-            type == other.type
+        return super.equals(other) && type == other.type
     }
 
-    override fun hashCode() = Objects.hash(super.hashCode(), locals)
-
-    override fun addDeclaration(declaration: Declaration) {
-        if (declaration is Variable) {
-            addIfNotContains(localEdges, declaration)
-        } else if (declaration is Function) {
-            addIfNotContains(localEdges, declaration)
-        }
-    }
-
-    override val declarations: List<Declaration>
-        get() = locals
+    override fun hashCode() = super.hashCode()
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/ExpressionList.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/ExpressionList.kt
@@ -25,14 +25,16 @@
  */
 package de.fraunhofer.aisec.cpg.graph.expressions
 
+import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import de.fraunhofer.aisec.cpg.persistence.Relationship
 import java.util.*
 
-class ExpressionList : Expression() {
+class ExpressionList : Expression(), DeclarationHolder {
     @Relationship(value = "SUBEXPR", direction = Relationship.Direction.OUTGOING)
     var expressionEdges = astEdgesOf<Expression>()
     var expressions by unwrapping(ExpressionList::expressionEdges)
@@ -56,4 +58,10 @@ class ExpressionList : Expression() {
     override fun getStartingPrevEOG(): Collection<Node> {
         return this.expressions.firstOrNull()?.getStartingPrevEOG() ?: this.prevEOG
     }
+
+    override fun addDeclaration(declaration: Declaration) {
+        declarations.add(declaration)
+    }
+
+    override val declarations: MutableList<Declaration> = mutableListOf()
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/For.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/For.kt
@@ -27,6 +27,10 @@ package de.fraunhofer.aisec.cpg.graph.expressions
 
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Function
+import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Variable
+import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
 import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdges
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
@@ -41,7 +45,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder
  * that declares variables, can change them in an iteration statement and is executed until the
  * condition evaluates to false.
  */
-class For : Loop(), BranchingNode, StatementHolder {
+class For : Loop(), BranchingNode, StatementHolder, DeclarationHolder, HasLocals {
 
     @Relationship("INITIALIZER_STATEMENT")
     var initializerStatementEdge = astOptionalEdgeOf<Expression>()
@@ -99,7 +103,8 @@ class For : Loop(), BranchingNode, StatementHolder {
             initializerStatement == other.initializerStatement &&
             conditionDeclaration == other.conditionDeclaration &&
             condition == other.condition &&
-            iterationStatement == other.iterationStatement
+            iterationStatement == other.iterationStatement &&
+            propertyEqualsList(localEdges, other.localEdges)
     }
 
     override fun hashCode(): Int {
@@ -108,6 +113,7 @@ class For : Loop(), BranchingNode, StatementHolder {
             this.initializerStatement,
             this.conditionDeclaration,
             this.iterationStatement,
+            locals,
         )
     }
 
@@ -122,4 +128,21 @@ class For : Loop(), BranchingNode, StatementHolder {
     override fun getExitNextEOG(): Collection<Node> {
         return this.nextEOG.filter { it !in statement.allChildren<Node> { true } }
     }
+
+    @Relationship(value = "LOCALS", direction = Relationship.Direction.OUTGOING)
+    override var localEdges = astEdgesOf<ValueDeclaration>()
+
+    /** Virtual property to access [localEdges] without property edges. */
+    override var locals by unwrapping(For::localEdges)
+
+    override fun addDeclaration(declaration: Declaration) {
+        if (declaration is Variable) {
+            addIfNotContains(localEdges, declaration)
+        } else if (declaration is Function) {
+            addIfNotContains(localEdges, declaration)
+        }
+    }
+
+    override val declarations: List<Declaration>
+        get() = locals
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/ForEach.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/ForEach.kt
@@ -26,6 +26,11 @@
 package de.fraunhofer.aisec.cpg.graph.expressions
 
 import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Function
+import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Variable
+import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
 import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdges
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
@@ -39,7 +44,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder
  * Represent a for statement of the form `for(variable ... iterable){...}` that executes the loop
  * body for each instance of an element in `iterable` that is temporarily stored in `variable`.
  */
-class ForEach : Loop(), BranchingNode, StatementHolder {
+class ForEach : Loop(), BranchingNode, StatementHolder, DeclarationHolder, HasLocals {
 
     @Relationship("VARIABLE")
     var variableEdge =
@@ -93,10 +98,13 @@ class ForEach : Loop(), BranchingNode, StatementHolder {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is ForEach) return false
-        return super.equals(other) && variable == other.variable && iterable == other.iterable
+        return super.equals(other) &&
+            variable == other.variable &&
+            iterable == other.iterable &&
+            propertyEqualsList(localEdges, other.localEdges)
     }
 
-    override fun hashCode() = Objects.hash(super.hashCode(), variable, iterable)
+    override fun hashCode() = Objects.hash(super.hashCode(), variable, iterable, locals)
 
     override fun getStartingPrevEOG(): Collection<Node> {
         val astChildren = this.allChildren<Node> { true }
@@ -108,4 +116,21 @@ class ForEach : Loop(), BranchingNode, StatementHolder {
     override fun getExitNextEOG(): Collection<Node> {
         return this.nextEOG.filter { it !in statement.allChildren<Node> { true } }
     }
+
+    @Relationship(value = "LOCALS", direction = Relationship.Direction.OUTGOING)
+    override var localEdges = astEdgesOf<ValueDeclaration>()
+
+    /** Virtual property to access [localEdges] without property edges. */
+    override var locals by unwrapping(ForEach::localEdges)
+
+    override fun addDeclaration(declaration: Declaration) {
+        if (declaration is Variable) {
+            addIfNotContains(localEdges, declaration)
+        } else if (declaration is Function) {
+            addIfNotContains(localEdges, declaration)
+        }
+    }
+
+    override val declarations: List<Declaration>
+        get() = locals
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Lambda.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Lambda.kt
@@ -26,8 +26,11 @@
 package de.fraunhofer.aisec.cpg.graph.expressions
 
 import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.Function
 import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Variable
+import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astOptionalEdgeOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import de.fraunhofer.aisec.cpg.graph.types.FunctionType
@@ -39,7 +42,15 @@ import de.fraunhofer.aisec.cpg.persistence.Relationship
  * This expression denotes the usage of an anonymous / lambda function. It connects the inner
  * anonymous function to the user of a lambda function with an expression.
  */
-class Lambda : Expression(), HasType.TypeObserver {
+class Lambda : Expression(), DeclarationHolder, HasType.TypeObserver {
+
+    @Relationship("DECLARATIONS") var declarationEdges = astEdgesOf<Variable>()
+
+    override fun addDeclaration(declaration: Declaration) {
+        (declaration as? Variable)?.let { this.declarations.add(it) }
+    }
+
+    override var declarations by unwrapping(Lambda::declarationEdges)
 
     /**
      * If [areVariablesMutable] is false, only the (outer) variables in this list can be modified

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/MemoryAddress.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/MemoryAddress.kt
@@ -44,7 +44,7 @@ open class MemoryAddress(override var name: Name, open var isGlobal: Boolean = f
     @Relationship
     open var usageEdges =
         memoryAddressEdgesOf(
-            mirrorProperty = HasMemoryAddress::memoryAddressEdges,
+            mirroredCollection = { (it as HasMemoryAddress).memoryAddressEdges },
             outgoing = false,
         )
     open var usages by unwrapping(MemoryAddress::usageEdges)
@@ -65,14 +65,18 @@ open class MemoryAddress(override var name: Name, open var isGlobal: Boolean = f
     override var memoryValueEdges =
         Dataflows<Node>(
             this,
-            mirrorProperty = HasMemoryValue::memoryValueUsageEdges,
+            mirroredCollection = { (it as HasMemoryValue).memoryValueUsageEdges },
             outgoing = false,
         )
     override var memoryValues by unwrapping(MemoryAddress::memoryValueEdges)
 
     @Relationship
     override var memoryValueUsageEdges =
-        Dataflows<Node>(this, mirrorProperty = HasMemoryValue::memoryValueEdges, outgoing = true)
+        Dataflows<Node>(
+            this,
+            mirroredCollection = { (it as HasMemoryValue).memoryValueEdges },
+            outgoing = true,
+        )
     override var memoryValueUsages by unwrapping(MemoryAddress::memoryValueUsageEdges)
 }
 
@@ -88,7 +92,10 @@ class ParameterMemoryValue(override var name: Name) : MemoryAddress(name), HasMe
      * get to the parameter's address
      */
     override var memoryAddressEdges =
-        memoryAddressEdgesOf(mirrorProperty = MemoryAddress::usageEdges, outgoing = true)
+        memoryAddressEdgesOf(
+            mirroredCollection = { (it as MemoryAddress).usageEdges },
+            outgoing = true,
+        )
 
     override var memoryAddresses by unwrapping(ParameterMemoryValue::memoryAddressEdges)
 }
@@ -114,7 +121,10 @@ class UnknownMemoryValue(
     }
 
     override var memoryAddressEdges =
-        memoryAddressEdgesOf(mirrorProperty = MemoryAddress::usageEdges, outgoing = true)
+        memoryAddressEdgesOf(
+            mirroredCollection = { (it as MemoryAddress).usageEdges },
+            outgoing = true,
+        )
 
     override var memoryAddresses by unwrapping(UnknownMemoryValue::memoryAddressEdges)
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Switch.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Switch.kt
@@ -26,8 +26,15 @@
 package de.fraunhofer.aisec.cpg.graph.expressions
 
 import de.fraunhofer.aisec.cpg.graph.BranchingNode
+import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
+import de.fraunhofer.aisec.cpg.graph.HasLocals
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Function
+import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Variable
+import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
+import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astOptionalEdgeOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import de.fraunhofer.aisec.cpg.persistence.Relationship
@@ -38,7 +45,7 @@ import java.util.Objects
  * and default statements. Break statements break out of the switch and labeled breaks in Java are
  * handled properly.
  */
-class Switch : Expression(false), BranchingNode {
+class Switch : Expression(false), BranchingNode, DeclarationHolder, HasLocals {
 
     @Relationship(value = "SELECTOR") var selectorEdge = astOptionalEdgeOf<Expression>()
     /** Selector that determines the case/default statement of the subsequent execution */
@@ -71,7 +78,8 @@ class Switch : Expression(false), BranchingNode {
             initializerStatement == other.initializerStatement &&
             selectorDeclaration == other.selectorDeclaration &&
             selector == other.selector &&
-            statement == other.statement
+            statement == other.statement &&
+            propertyEqualsList(localEdges, other.localEdges)
     }
 
     override fun hashCode() =
@@ -81,6 +89,7 @@ class Switch : Expression(false), BranchingNode {
             selectorDeclaration,
             selector,
             statement,
+            locals,
         )
 
     override fun getStartingPrevEOG(): Collection<Node> {
@@ -93,4 +102,21 @@ class Switch : Expression(false), BranchingNode {
     override fun getExitNextEOG(): Collection<Node> {
         return this.statement?.getExitNextEOG() ?: this.nextEOG
     }
+
+    @Relationship(value = "LOCALS", direction = Relationship.Direction.OUTGOING)
+    override var localEdges = astEdgesOf<ValueDeclaration>()
+
+    /** Virtual property to access [localEdges] without property edges. */
+    override var locals by unwrapping(Switch::localEdges)
+
+    override fun addDeclaration(declaration: Declaration) {
+        if (declaration is Variable) {
+            addIfNotContains(localEdges, declaration)
+        } else if (declaration is Function) {
+            addIfNotContains(localEdges, declaration)
+        }
+    }
+
+    override val declarations: List<Declaration>
+        get() = locals
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Switch.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Switch.kt
@@ -29,6 +29,7 @@ import de.fraunhofer.aisec.cpg.graph.BranchingNode
 import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
 import de.fraunhofer.aisec.cpg.graph.HasLocals
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.addIfNotContains
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.Function
 import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Try.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Try.kt
@@ -25,7 +25,13 @@
  */
 package de.fraunhofer.aisec.cpg.graph.expressions
 
+import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
+import de.fraunhofer.aisec.cpg.graph.HasLocals
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Function
+import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Variable
 import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astOptionalEdgeOf
@@ -34,7 +40,7 @@ import de.fraunhofer.aisec.cpg.persistence.Relationship
 import java.util.*
 
 /** A [Expression] which represents a try/catch block, primarily used for exception handling. */
-class Try : Expression(false) {
+class Try : Expression(false), DeclarationHolder, HasLocals {
 
     /**
      * This represents some kind of resource which is typically opened (or similar) while entering
@@ -88,11 +94,20 @@ class Try : Expression(false) {
             finallyBlock == other.finallyBlock &&
             catchClauses == other.catchClauses &&
             elseBlock == other.elseBlock &&
-            propertyEqualsList(catchClauseEdges, other.catchClauseEdges))
+            propertyEqualsList(catchClauseEdges, other.catchClauseEdges)) &&
+            propertyEqualsList(localEdges, other.localEdges)
     }
 
     override fun hashCode() =
-        Objects.hash(super.hashCode(), resources, tryBlock, finallyBlock, catchClauses, elseBlock)
+        Objects.hash(
+            super.hashCode(),
+            resources,
+            tryBlock,
+            finallyBlock,
+            catchClauses,
+            elseBlock,
+            locals,
+        )
 
     override fun getStartingPrevEOG(): Collection<Node> {
         return this.resources.firstOrNull()?.getStartingPrevEOG()
@@ -100,4 +115,21 @@ class Try : Expression(false) {
             ?: this.finallyBlock?.getStartingPrevEOG()
             ?: this.prevEOG
     }
+
+    @Relationship(value = "LOCALS", direction = Relationship.Direction.OUTGOING)
+    override var localEdges = astEdgesOf<ValueDeclaration>()
+
+    /** Virtual property to access [localEdges] without property edges. */
+    override var locals by unwrapping(Try::localEdges)
+
+    override fun addDeclaration(declaration: Declaration) {
+        if (declaration is Variable) {
+            addIfNotContains(localEdges, declaration)
+        } else if (declaration is Function) {
+            addIfNotContains(localEdges, declaration)
+        }
+    }
+
+    override val declarations: List<Declaration>
+        get() = locals
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Try.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Try.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.graph.expressions
 import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
 import de.fraunhofer.aisec.cpg.graph.HasLocals
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.addIfNotContains
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.Function
 import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/While.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/While.kt
@@ -28,9 +28,16 @@ package de.fraunhofer.aisec.cpg.graph.expressions
 import de.fraunhofer.aisec.cpg.graph.ArgumentHolder
 import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.BranchingNode
+import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
+import de.fraunhofer.aisec.cpg.graph.HasLocals
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.allChildren
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Function
+import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Variable
+import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
+import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astOptionalEdgeOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import de.fraunhofer.aisec.cpg.persistence.Relationship
@@ -41,7 +48,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder
  * Represents a conditional loop statement of the form: `while(...){...}`. The loop body is executed
  * until condition evaluates to false for the first time.
  */
-class While : Loop(), BranchingNode, ArgumentHolder {
+class While : Loop(), BranchingNode, ArgumentHolder, DeclarationHolder, HasLocals {
     @Relationship(value = "CONDITION_DECLARATION")
     var conditionDeclarationEdge = astOptionalEdgeOf<Declaration>()
     /** C++ allows defining a declaration instead of a pure logical expression as condition */
@@ -81,10 +88,12 @@ class While : Loop(), BranchingNode, ArgumentHolder {
 
         return super.equals(other) &&
             conditionDeclaration == other.conditionDeclaration &&
-            condition == other.condition
+            condition == other.condition &&
+            propertyEqualsList(localEdges, other.localEdges)
     }
 
-    override fun hashCode() = Objects.hash(super.hashCode(), conditionDeclaration, condition)
+    override fun hashCode() =
+        Objects.hash(super.hashCode(), conditionDeclaration, condition, locals)
 
     override fun getStartingPrevEOG(): Collection<Node> {
         val astChildren = this.allChildren<Node> { true }
@@ -96,4 +105,21 @@ class While : Loop(), BranchingNode, ArgumentHolder {
     override fun getExitNextEOG(): Collection<Node> {
         return this.nextEOG.filter { it !in statement.allChildren<Node> { true } }
     }
+
+    @Relationship(value = "LOCALS", direction = Relationship.Direction.OUTGOING)
+    override var localEdges = astEdgesOf<ValueDeclaration>()
+
+    /** Virtual property to access [localEdges] without property edges. */
+    override var locals by unwrapping(While::localEdges)
+
+    override fun addDeclaration(declaration: Declaration) {
+        if (declaration is Variable) {
+            addIfNotContains(localEdges, declaration)
+        } else if (declaration is Function) {
+            addIfNotContains(localEdges, declaration)
+        }
+    }
+
+    override val declarations: List<Declaration>
+        get() = locals
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/While.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/While.kt
@@ -31,6 +31,7 @@ import de.fraunhofer.aisec.cpg.graph.BranchingNode
 import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
 import de.fraunhofer.aisec.cpg.graph.HasLocals
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.addIfNotContains
 import de.fraunhofer.aisec.cpg.graph.allChildren
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.Function

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/overlays/BasicBlock.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/overlays/BasicBlock.kt
@@ -59,7 +59,7 @@ class BasicBlock() : OverlayNode() {
     @Relationship(value = "BB", direction = Relationship.Direction.INCOMING)
     @PopulatedByPass(BasicBlockCollectorPass::class)
     var nodeEdges: BasicBlockEdgeList<Node> =
-        BasicBlockEdgeList(this, mirrorProperty = Node::basicBlockEdges, outgoing = false)
+        BasicBlockEdgeList(this, mirroredCollection = { it.basicBlockEdges }, outgoing = false)
         protected set
 
     /** The nodes contained in this basic block. */

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/NamespaceScope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/NamespaceScope.kt
@@ -50,7 +50,7 @@ class NamespaceScope(astNode: Namespace) : NameScope(astNode) {
      */
     @Relationship(value = "IMPORTS_SCOPE", direction = Relationship.Direction.INCOMING)
     val importedByEdges: Imports =
-        Imports(this, mirrorProperty = Scope::importedScopeEdges, outgoing = false)
+        Imports(this, mirroredCollection = { (it as Scope).importedScopeEdges }, outgoing = false)
 
     /** Virtual property for accessing [importedScopeEdges] without property edges. */
     val importedBy: MutableSet<Scope> by unwrappingIncoming(NamespaceScope::importedByEdges)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
@@ -103,7 +103,11 @@ sealed class Scope(
     @Relationship(value = "IMPORTS_SCOPE", direction = Relationship.Direction.OUTGOING)
     @PopulatedByPass(ImportResolver::class)
     val importedScopeEdges =
-        Imports(this, mirrorProperty = NamespaceScope::importedByEdges, outgoing = true)
+        Imports(
+            this,
+            mirroredCollection = { (it as NamespaceScope).importedByEdges },
+            outgoing = true,
+        )
 
     /** Virtual property for accessing [importedScopeEdges] without property edges. */
     val importedScopes by unwrapping(Scope::importedScopeEdges)

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/assumptions/AssumptionTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/assumptions/AssumptionTest.kt
@@ -36,12 +36,12 @@ class AssumptionTest {
     @Test
     fun testAssumptionStatus() {
         with(TestLanguageFrontend()) {
-            Assumption.states[{ it.id == Uuid.parse("00000000-0000-0000-0000-000072023357") }] =
+            Assumption.states[{ it.id == Uuid.parse("00000000-0000-0000-0000-000066e9d78f") }] =
                 AssumptionStatus.Accepted
 
             val lit = newLiteral(1).assume(AssumptionType.SoundnessAssumption, "We assume 1 is 1")
-            assertEquals(1107044270, lit.hashCode())
-            assertEquals("00000000-0000-0000-0000-000041fc27ae", lit.id.toString())
+            assertEquals(1698279030, lit.hashCode())
+            assertEquals("00000000-0000-0000-0000-00006539ae76", lit.id.toString())
 
             val assumption = lit.assumptions.firstOrNull()
             assertNotNull(assumption)
@@ -52,8 +52,8 @@ class AssumptionTest {
                 "de.fraunhofer.aisec.cpg.assumptions.Assumption",
                 assumption.javaClass.name,
             )
-            assertEquals(1912746839, assumption.hashCode())
-            assertEquals("00000000-0000-0000-0000-000072023357", assumption.id.toString())
+            assertEquals(1726601103, assumption.hashCode())
+            assertEquals("00000000-0000-0000-0000-000066e9d78f", assumption.id.toString())
             assertEquals(AssumptionStatus.Accepted, assumption.status)
         }
     }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilderTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/NodeBuilderTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.graph
+
+import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.expressions.Reference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class NodeBuilderTest {
+    @Test
+    fun testReferenceCodeReusesNameStringWhenEqual() {
+        with(TestLanguageFrontend()) {
+            val ref = Reference()
+            ref.code = buildString { append("foo") }
+
+            // applyMetadata sets a Name and should canonicalize matching Reference.code strings
+            ref.applyMetadata(this, name = "foo", rawNode = null, doNotPrependNamespace = true)
+
+            assertEquals("foo", ref.code)
+            assertSame(ref.name.toString(), ref.code)
+        }
+    }
+}

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeListTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeListTest.kt
@@ -67,4 +67,33 @@ class EdgeListTest {
             assertEquals<List<Node>>(listOf(node2, node4, node3), unwrapped)
         }
     }
+
+    @Test
+    fun testCompactStorageTransitions() {
+        with(TestLanguageFrontend()) {
+            val owner = newLiteral(0)
+            val n1 = newLiteral(1)
+            val n2 = newLiteral(2)
+            val n3 = newLiteral(3)
+
+            val list = AstEdges<AstNode, AstEdge<AstNode>>(thisRef = owner)
+            assertEquals(0, list.size)
+
+            list += n1
+            assertEquals<List<Node>>(listOf(n1), list.unwrap())
+
+            list += n2
+            assertEquals<List<Node>>(listOf(n1, n2), list.unwrap())
+
+            list.removeAt(0)
+            assertEquals<List<Node>>(listOf(n2), list.unwrap())
+
+            list += n3
+            assertEquals<List<Node>>(listOf(n2, n3), list.unwrap())
+
+            list.clear()
+            assertEquals(0, list.size)
+            assertEquals(emptyList(), list.unwrap())
+        }
+    }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeListTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeListTest.kt
@@ -30,9 +30,12 @@ import de.fraunhofer.aisec.cpg.graph.AstNode
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
 import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdges
+import de.fraunhofer.aisec.cpg.graph.edges.flows.EvaluationOrder
 import de.fraunhofer.aisec.cpg.graph.newLiteral
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class EdgeListTest {
     @Test
@@ -94,6 +97,30 @@ class EdgeListTest {
             list.clear()
             assertEquals(0, list.size)
             assertEquals(emptyList(), list.unwrap())
+        }
+    }
+
+    @Test
+    fun testIdentityBasedOperations() {
+        with(TestLanguageFrontend()) {
+            val owner = newLiteral(0)
+            val target = newLiteral(1)
+
+            val list = owner.nextEOGEdges
+            val edge1 = EvaluationOrder(owner, target)
+            val edge2 = EvaluationOrder(owner, target)
+
+            list.add(edge1)
+
+            // Identity checks must distinguish object instances.
+            assertTrue(list.containsByIdentity(edge1))
+            assertFalse(list.containsByIdentity(edge2))
+
+            assertFalse(list.removeByIdentity(edge2))
+            assertEquals(1, list.size)
+
+            assertTrue(list.removeByIdentity(edge1))
+            assertEquals(0, list.size)
         }
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeSetTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeSetTest.kt
@@ -49,4 +49,36 @@ class UnwrappedEdgeSetTest {
             assertEquals(dfgSet, nodeSet)
         }
     }
+
+    @Test
+    fun testCompactStorageTransitions() {
+        with(TestLanguageFrontend()) {
+            val node1 = newLiteral(1)
+            val node2 = newLiteral(2)
+            val node3 = newLiteral(3)
+
+            assertEquals(0, node1.nextDFGEdges.size)
+            assertEquals(0, node1.nextDFG.size)
+
+            node1.nextDFG += node2
+            assertEquals(1, node1.nextDFGEdges.size)
+            assertEquals(setOf<Node>(node2), node1.nextDFG.toSet())
+            assertEquals(setOf<Node>(node1), node2.prevDFG.toSet())
+
+            node1.nextDFG += node3
+            assertEquals(2, node1.nextDFGEdges.size)
+            assertEquals(setOf<Node>(node2, node3), node1.nextDFG.toSet())
+            assertEquals(setOf<Node>(node1), node2.prevDFG.toSet())
+            assertEquals(setOf<Node>(node1), node3.prevDFG.toSet())
+
+            node1.nextDFG.remove(node2)
+            assertEquals(1, node1.nextDFGEdges.size)
+            assertEquals(setOf<Node>(node3), node1.nextDFG.toSet())
+            assertEquals(0, node2.prevDFG.size)
+
+            node1.nextDFG.clear()
+            assertEquals(0, node1.nextDFGEdges.size)
+            assertEquals(0, node3.prevDFG.size)
+        }
+    }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeSetTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/UnwrappedEdgeSetTest.kt
@@ -27,9 +27,12 @@ package de.fraunhofer.aisec.cpg.graph.edges.collections
 
 import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.edges.flows.Dataflow
 import de.fraunhofer.aisec.cpg.graph.newLiteral
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class UnwrappedEdgeSetTest {
     @Test
@@ -79,6 +82,30 @@ class UnwrappedEdgeSetTest {
             node1.nextDFG.clear()
             assertEquals(0, node1.nextDFGEdges.size)
             assertEquals(0, node3.prevDFG.size)
+        }
+    }
+
+    @Test
+    fun testIdentityBasedOperations() {
+        with(TestLanguageFrontend()) {
+            val node1 = newLiteral(1)
+            val node2 = newLiteral(2)
+
+            val edge1 = Dataflow(node1, node2)
+            val edge2 = Dataflow(node1, node2)
+
+            node1.nextDFGEdges.add(edge1)
+
+            // Equality matches by start/end+properties, identity must still distinguish instances.
+            assertTrue(node1.nextDFGEdges.contains(edge2))
+            assertTrue(node1.nextDFGEdges.containsByIdentity(edge1))
+            assertFalse(node1.nextDFGEdges.containsByIdentity(edge2))
+
+            assertFalse(node1.nextDFGEdges.removeByIdentity(edge2))
+            assertEquals(1, node1.nextDFGEdges.size)
+
+            assertTrue(node1.nextDFGEdges.removeByIdentity(edge1))
+            assertEquals(0, node1.nextDFGEdges.size)
         }
     }
 }

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
@@ -383,30 +383,35 @@ internal class CXXLanguageFrontendTest : BaseTest() {
             )
 
             val declFromMultiplicateExpression =
-                (statements[0] as DeclarationStatement).getSingleDeclarationAs(Variable::class.java)
+                (statements[0] as? DeclarationStatement)?.getSingleDeclarationAs(
+                    Variable::class.java
+                )
             assertEquals(
                 assertResolvedType("SSL_CTX").pointer(),
-                declFromMultiplicateExpression.type,
+                declFromMultiplicateExpression?.type,
             )
             assertLocalName("ptr", declFromMultiplicateExpression)
 
             val withInitializer =
-                (statements[1] as DeclarationStatement).getSingleDeclarationAs(Variable::class.java)
-            var initializer = withInitializer.initializer
+                (statements[1] as? DeclarationStatement)?.getSingleDeclarationAs(
+                    Variable::class.java
+                )
+            var initializer = withInitializer?.initializer
             assertNotNull(initializer)
             assertTrue(initializer is Literal<*>)
             assertEquals(1, initializer.value)
 
-            val twoDeclarations = statements[2].declarations
+            val twoDeclarations = (statements[2] as? DeclarationHolder)?.declarations
+            assertNotNull(twoDeclarations)
             assertEquals(2, twoDeclarations.size)
 
-            val b = twoDeclarations[0] as Variable
-            assertNotNull(b)
+            val b = twoDeclarations[0]
+            assertIs<Variable>(b)
             assertLocalName("b", b)
             assertEquals(primitiveType("int").reference(POINTER), b.type)
 
-            val c = twoDeclarations[1] as Variable
-            assertNotNull(c)
+            val c = twoDeclarations[1]
+            assertIs<Variable>(c)
             assertLocalName("c", c)
             assertEquals(primitiveType("int"), c.type)
 
@@ -430,15 +435,16 @@ internal class CXXLanguageFrontendTest : BaseTest() {
             assertLocalName("ptr2", pointerWithAssign)
             assertLiteralValue(null, pointerWithAssign.initializer)
 
-            val classWithVariable = statements[6].declarations
+            val classWithVariable = (statements[6] as? DeclarationHolder)?.declarations
+            assertNotNull(classWithVariable)
             assertEquals(2, classWithVariable.size)
 
-            val classA = classWithVariable[0] as Record
-            assertNotNull(classA)
+            val classA = classWithVariable[0]
+            assertIs<Record>(classA)
             assertLocalName("A", classA)
 
-            val myA = classWithVariable[1] as Variable
-            assertNotNull(myA)
+            val myA = classWithVariable[1]
+            assertIs<Variable>(myA)
             assertLocalName("myA", myA)
             assertEquals(classA, (myA.type as ObjectType).recordDeclaration)
         }

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/StatementHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/StatementHandler.kt
@@ -1206,7 +1206,7 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
         val newArrayDecl = declarationOrNot(frontend.getOperandValueAtIndex(instr, 0), instr)
         compoundStatement.statements += newArrayDecl
 
-        val decl = newArrayDecl.declarations[0] as? Variable
+        val decl = (newArrayDecl as? DeclarationHolder)?.declarations?.firstOrNull() as? Variable
         val arrayExpr = newSubscription(rawNode = instr)
         arrayExpr.arrayExpression =
             newReference(

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -352,7 +352,8 @@ class LLVMIRLanguageFrontendTest {
 
         // Check that the first statement is "literal_i32_i1 val_success = literal_i32_i1(*ptr, *ptr
         // == 5)"
-        val declaration = cmpxchgStatement.statements[0].declarations[0]
+        val declaration =
+            (cmpxchgStatement.statements[0] as? DeclarationHolder)?.declarations?.firstOrNull()
         assertIs<Variable>(declaration)
         assertLocalName("val_success", declaration)
         assertLocalName("literal_i32_i1", declaration.type)

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/StatementHandlerTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/StatementHandlerTest.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.frontends.llvm
 
+import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
 import de.fraunhofer.aisec.cpg.graph.bodyOrNull
 import de.fraunhofer.aisec.cpg.graph.declarations.Variable
 import de.fraunhofer.aisec.cpg.graph.expressions.Assign
@@ -846,7 +847,8 @@ class StatementHandlerTest {
         requiresUintCast: Boolean,
     ) {
         // Check that the value is assigned to
-        val declaration = atomicrmwStatement.statements[0].declarations[0]
+        val declaration =
+            (atomicrmwStatement.statements[0] as? DeclarationHolder)?.declarations?.firstOrNull()
         assertIs<Variable>(declaration)
         assertLocalName(variableName, declaration)
         assertLocalName("i32", declaration.type)
@@ -897,7 +899,8 @@ class StatementHandlerTest {
         variableName: String,
     ) {
         // Check that the value is assigned to
-        val declaration = atomicrmwStatement.statements[0].declarations[0]
+        val declaration =
+            (atomicrmwStatement.statements[0] as? DeclarationHolder)?.declarations?.firstOrNull()
         assertIs<Variable>(declaration)
         assertLocalName(variableName, declaration)
         assertLocalName("i32", declaration.type)

--- a/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/statementHandler/WithStatementTest.kt
+++ b/cpg-language-python/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/python/statementHandler/WithStatementTest.kt
@@ -80,7 +80,7 @@ class WithStatementTest : BaseTest() {
         val blockStmts =
             result.statements.filterIsInstance<Block>().filter { it.astParent is Namespace }
 
-        val ref = result.refs["contextManager_00000000-11a2-7efe-0000-00000958dca6"]
+        val ref = result.refs["contextManager_00000000-11a2-7efe-0000-00000958dc87"]
         assertNotNull(
             ref,
             "Expected to find a reference to the context manager with a deterministic ID.",


### PR DESCRIPTION
We allocate a significant amount of memory in the `Node` classes. Partially because we have a lot of attributes (which may not even be used), partially due to inefficient datastructures. This PR implements a couple of things:

* It extracts `locals` from all `Expression`s and adds it where necessary.
* It changes the `EdgeList` and `EdgeSet` implementations as they often hold a single value but are always a `List`/`Set`.
* Lazy initialization of unused properties in `Node`s and `Edge`s (e.g. `additionalProblems`, `assumptions`).
* Reuse `name` as `code` for `Reference`s which is the case most of the time
* Minor improvements in `Name` class
* Identity-based management in `EdgeList` and `EdgeSet` to speed up the runtime

This seems to have a positive impact - if my tests were correct this may reduce it from ~10 to ~8.5 GB for a 300k LOC project and also helped to reduce the run-time from ~20min to ~16-18min.