### PR TITLE
Refactor expression handling in PointsToPass

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
@@ -1143,7 +1143,7 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                 is Return -> handleReturn(lattice, currentNode, doubleState)
 
                 is Expression -> {
-                    if (currentNode.usedAsExpression || currentNode is BinaryOperator)
+                    if (currentNode.usedAsExpression)
                         handleExpression(lattice, currentNode, doubleState)
                     else doubleState
                 }


### PR DESCRIPTION
The default of a BinaryOperator is usedAsExpression = true now, so this should no longer be necessary.