### PR TITLE
Fix phantom argument attachment in Fluent DSL member expressions

### DIFF
--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/testcases/Passes.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/testcases/Passes.kt
@@ -60,7 +60,9 @@ class Passes {
                                         thenStmt { ref("y").inc() }
                                         elseStmt { ref("y").dec() }
                                     }
-                                    memberCall("println", member("out", ref("System"))) { ref("y") }
+                                    memberCall("println", member("out") { ref("System") }) {
+                                        ref("y")
+                                    }
                                     returnStmt {}
                                 }
                             }
@@ -79,7 +81,9 @@ class Passes {
                                         thenStmt { ref("y").inc() }
                                         elseStmt { ref("y").dec() }
                                     }
-                                    memberCall("println", member("out", ref("System"))) { ref("y") }
+                                    memberCall("println", member("out") { ref("System") }) {
+                                        ref("y")
+                                    }
                                     returnStmt {}
                                 }
                             }
@@ -98,7 +102,9 @@ class Passes {
                                         thenStmt { ref("y").inc() }
                                         elseStmt { ref("y").dec() }
                                     }
-                                    memberCall("println", member("out", ref("System"))) { ref("y") }
+                                    memberCall("println", member("out") { ref("System") }) {
+                                        ref("y")
+                                    }
                                     returnStmt {}
                                 }
                             }
@@ -117,7 +123,9 @@ class Passes {
                                         thenStmt { ref("y").inc() }
                                         elseStmt { ref("y").dec() }
                                     }
-                                    memberCall("println", member("out", ref("System"))) { ref("y") }
+                                    memberCall("println", member("out") { ref("System") }) {
+                                        ref("y")
+                                    }
                                     returnStmt {}
                                 }
                             }
@@ -138,7 +146,9 @@ class Passes {
                                         elseStmt { ref("y").dec() }
                                     }
                                     ref("z") assign literal(10, t("int"))
-                                    memberCall("println", member("out", ref("System"))) { ref("y") }
+                                    memberCall("println", member("out") { ref("System") }) {
+                                        ref("y")
+                                    }
                                     returnStmt {}
                                 }
                             }
@@ -159,7 +169,9 @@ class Passes {
                                         elseStmt { ref("y").dec() }
                                     }
                                     ref("z") assign literal(3, t("int"))
-                                    memberCall("println", member("out", ref("System"))) { ref("y") }
+                                    memberCall("println", member("out") { ref("System") }) {
+                                        ref("y")
+                                    }
                                     returnStmt {}
                                 }
                             }
@@ -178,7 +190,9 @@ class Passes {
                                         thenStmt { ref("y").inc() }
                                         elseStmt { ref("y").dec() }
                                     }
-                                    memberCall("println", member("out", ref("System"))) { ref("y") }
+                                    memberCall("println", member("out") { ref("System") }) {
+                                        ref("y")
+                                    }
                                     returnStmt {}
                                 }
                             }
@@ -192,13 +206,13 @@ class Passes {
                                     whileStmt {
                                         whileCondition { ref("x") }
                                         loopBody {
-                                            memberCall("println", member("out", ref("System"))) {
+                                            memberCall("println", member("out") { ref("System") }) {
                                                 literal("Cool loop", t("string"))
                                             }
                                         }
                                     }
 
-                                    memberCall("println", member("out", ref("System"))) {
+                                    memberCall("println", member("out") { ref("System") }) {
                                         literal("After cool loop", t("string"))
                                     }
                                     returnStmt {}
@@ -214,14 +228,14 @@ class Passes {
                                     whileStmt {
                                         whileCondition { ref("x") }
                                         loopBody {
-                                            memberCall("println", member("out", ref("System"))) {
+                                            memberCall("println", member("out") { ref("System") }) {
                                                 literal("Cool loop", t("string"))
                                             }
                                             ref("x") assign literal(false, t("boolean"))
                                         }
                                     }
 
-                                    memberCall("println", member("out", ref("System"))) {
+                                    memberCall("println", member("out") { ref("System") }) {
                                         literal("After cool loop", t("string"))
                                     }
                                     returnStmt {}
@@ -233,13 +247,13 @@ class Passes {
                                     whileStmt {
                                         whileCondition { literal(false, t("boolean")) }
                                         loopBody {
-                                            memberCall("println", member("out", ref("System"))) {
+                                            memberCall("println", member("out") { ref("System") }) {
                                                 literal("Cool loop", t("string"))
                                             }
                                         }
                                     }
 
-                                    memberCall("println", member("out", ref("System"))) {
+                                    memberCall("println", member("out") { ref("System") }) {
                                         literal("After cool loop", t("string"))
                                     }
                                     returnStmt {}
@@ -253,13 +267,13 @@ class Passes {
                                     whileStmt {
                                         whileCondition { ref("x") le literal(2, t("int")) }
                                         loopBody {
-                                            memberCall("println", member("out", ref("System"))) {
+                                            memberCall("println", member("out") { ref("System") }) {
                                                 literal("Cool loop", t("string"))
                                             }
                                         }
                                     }
 
-                                    memberCall("println", member("out", ref("System"))) {
+                                    memberCall("println", member("out") { ref("System") }) {
                                         literal("After cool loop", t("string"))
                                     }
                                     returnStmt {}
@@ -273,13 +287,13 @@ class Passes {
                                     whileStmt {
                                         whileCondition { ref("x") gt literal(3, t("int")) }
                                         loopBody {
-                                            memberCall("println", member("out", ref("System"))) {
+                                            memberCall("println", member("out") { ref("System") }) {
                                                 literal("Cool loop", t("string"))
                                             }
                                         }
                                     }
 
-                                    memberCall("println", member("out", ref("System"))) {
+                                    memberCall("println", member("out") { ref("System") }) {
                                         literal("After cool loop", t("string"))
                                     }
                                     returnStmt {}
@@ -297,14 +311,14 @@ class Passes {
                                     whileStmt {
                                         whileCondition { ref("y") le literal(2, t("int")) }
                                         loopBody {
-                                            memberCall("println", member("out", ref("System"))) {
+                                            memberCall("println", member("out") { ref("System") }) {
                                                 literal("Cool loop", t("string"))
                                             }
                                             ref("y") assign memberCall("nextUInt", ref("URandomKt"))
                                         }
                                     }
 
-                                    memberCall("println", member("out", ref("System"))) {
+                                    memberCall("println", member("out") { ref("System") }) {
                                         literal("After cool loop", t("string"))
                                     }
                                     returnStmt {}

--- a/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/testcases/Query.kt
+++ b/cpg-analysis/src/test/kotlin/de/fraunhofer/aisec/cpg/testcases/Query.kt
@@ -63,7 +63,9 @@ class Query {
                             method("print", void()) {
                                 param("s", t("string"))
                                 body {
-                                    memberCall("println", member("out", ref("System"))) { ref("s") }
+                                    memberCall("println", member("out") { ref("System") }) {
+                                        ref("s")
+                                    }
                                     returnStmt {}
                                 }
                             }
@@ -84,9 +86,7 @@ class Query {
                                         }
                                     }
                                     memberCall("print", ref("sc")) { ref("s") }
-                                    memberCall("print", ref("sc")) {
-                                        memberCall("test", ref("sc", makeMagic = false))
-                                    }
+                                    memberCall("print", ref("sc")) { memberCall("test", ref("sc")) }
                                 }
                             }
                         }
@@ -120,7 +120,9 @@ class Query {
                                 isStatic = true
                                 param("s", t("string"))
                                 body {
-                                    memberCall("println", member("out", ref("System"))) { ref("s") }
+                                    memberCall("println", member("out") { ref("System") }) {
+                                        ref("s")
+                                    }
                                     returnStmt {}
                                 }
                             }
@@ -135,7 +137,7 @@ class Query {
                                         }
                                     }
 
-                                    member("a", ref("sc")) assign literal(5, t("int"))
+                                    member("a") { ref("sc") } assign literal(5, t("int"))
 
                                     memberCall(
                                         "highlyCriticalOperation",
@@ -145,21 +147,18 @@ class Query {
                                         },
                                     ) {
                                         this@memberCall.isStatic = true
-                                        memberCall(
-                                            "toString",
-                                            ref("Integer", t("Integer"), makeMagic = false),
-                                        ) {
+                                        memberCall("toString", ref("Integer", t("Integer"))) {
                                             this.type = t("string")
                                             this@memberCall.isStatic = true
                                             isStatic = true
-                                            member("a", ref("sc", makeMagic = false))
+                                            member("a") { ref("sc") }
                                         }
                                     }
 
                                     memberCall("log", ref("logger")) {
-                                        member("INFO", ref("Level", makeMagic = false))
+                                        member("INFO") { ref("Level") }
                                         literal("put ", t("string")) +
-                                            member("a", ref("sc", makeMagic = false)) +
+                                            member("a") { ref("sc") } +
                                             literal(" into highlyCriticalOperation()", t("string"))
                                     }
                                     returnStmt {}
@@ -198,7 +197,9 @@ class Query {
                                 isStatic = true
                                 param("s", t("string"))
                                 body {
-                                    memberCall("println", member("out", ref("System"))) { ref("s") }
+                                    memberCall("println", member("out") { ref("System") }) {
+                                        ref("s")
+                                    }
                                     returnStmt {}
                                 }
                             }
@@ -213,12 +214,12 @@ class Query {
                                         }
                                     }
 
-                                    member("a", ref("sc")) assign literal(5, t("int"))
+                                    member("a") { ref("sc") } assign literal(5, t("int"))
 
                                     memberCall("log", ref("logger")) {
-                                        member("INFO", ref("Level", makeMagic = false))
+                                        member("INFO") { ref("Level") }
                                         literal("put ", t("string")) +
-                                            member("a", ref("sc", makeMagic = false)) +
+                                            member("a") { ref("sc") } +
                                             literal(" into highlyCriticalOperation()", t("string"))
                                     }
 
@@ -230,14 +231,11 @@ class Query {
                                         },
                                     ) {
                                         this@memberCall.isStatic = true
-                                        memberCall(
-                                            "toString",
-                                            ref("Integer", t("Integer"), makeMagic = false),
-                                        ) {
+                                        memberCall("toString", ref("Integer", t("Integer"))) {
                                             this.type = t("string")
                                             this@memberCall.isStatic = true
                                             isStatic = true
-                                            member("a", ref("sc", makeMagic = false))
+                                            member("a") { ref("sc") }
                                         }
                                     }
                                     returnStmt {}
@@ -273,7 +271,9 @@ class Query {
                                 isStatic = true
                                 param("s", t("string"))
                                 body {
-                                    memberCall("println", member("out", ref("System"))) { ref("s") }
+                                    memberCall("println", member("out") { ref("System") }) {
+                                        ref("s")
+                                    }
                                     returnStmt {}
                                 }
                             }
@@ -288,16 +288,16 @@ class Query {
                                         }
                                     }
 
-                                    member("a", ref("sc")) assign literal(5, t("int"))
+                                    member("a") { ref("sc") } assign literal(5, t("int"))
 
                                     memberCall("log", ref("logger")) {
-                                        member("INFO", ref("Level", makeMagic = false))
+                                        member("INFO") { ref("Level") }
                                         literal("put ", t("string")) +
-                                            member("a", ref("a", makeMagic = false)) +
+                                            member("a") { ref("a") } +
                                             literal(" into highlyCriticalOperation()", t("string"))
                                     }
 
-                                    member("a", ref("sc")) assign literal(3, t("int"))
+                                    member("a") { ref("sc") } assign literal(3, t("int"))
 
                                     memberCall(
                                         "highlyCriticalOperation",
@@ -307,14 +307,11 @@ class Query {
                                         },
                                     ) {
                                         this@memberCall.isStatic = true
-                                        memberCall(
-                                            "toString",
-                                            ref("Integer", t("Integer"), makeMagic = false),
-                                        ) {
+                                        memberCall("toString", ref("Integer", t("Integer"))) {
                                             this.type = t("string")
                                             this@memberCall.isStatic = true
                                             isStatic = true
-                                            member("a", ref("sc", makeMagic = false))
+                                            member("a") { ref("sc") }
                                         }
                                     }
                                     returnStmt {}

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
@@ -1103,20 +1103,25 @@ fun Expression.line(i: Int): Expression {
     return this
 }
 
+private object DiscardHolder : Holder<Expression> {
+    override fun replace(old: Expression, new: Expression) = false
+
+    override fun plusAssign(node: Expression) {}
+}
+
 /**
  * Creates a new [MemberAccess] in the Fluent Node DSL and invokes [ArgumentHolder.addArgument] of
  * the nearest enclosing [Holder], but only if it is an [ArgumentHolder]. If the [name] doesn't
  * already contain a fqn, we add an implicit "this" as base.
- *
- * The [base] is an optional lambda that produces the base expression. Using a lambda defers
- * evaluation so the base expression is produced after [member] has started executing, preventing it
- * from eagerly attaching to the wrong [ArgumentHolder].
  */
 context(holder: Holder<out Expression>)
 fun LanguageFrontend<*, *>.member(
     name: CharSequence,
     operatorCode: String = ".",
-    base: (() -> Expression)? = null,
+    base:
+        (context(Holder<out Expression>)
+        () -> Expression)? =
+        null,
 ): MemberAccess {
     val parsedName = parseName(name)
     val type =
@@ -1131,7 +1136,8 @@ fun LanguageFrontend<*, *>.member(
             scopeType
         }
     val memberBase =
-        base?.invoke() ?: this.memberOrRef(parsedName.parent ?: this.parseName("this"), type)
+        base?.let { with(DiscardHolder) { it() } }
+            ?: this.memberOrRef(parsedName.parent ?: this.parseName("this"), type)
 
     val node =
         newMemberAccess(name, memberBase, operatorCode = operatorCode).apply {
@@ -1140,11 +1146,6 @@ fun LanguageFrontend<*, *>.member(
 
     if (holder is ArgumentHolder) {
         holder += node
-        // base?.invoke() runs with the outer holder in context, so ref() / member() inside
-        // the lambda eagerly attach memberBase to holder. Remove that phantom attachment.
-        if (base != null) {
-            holder -= memberBase
-        }
     }
 
     return node

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/builder/Fluent.kt
@@ -547,6 +547,7 @@ fun LanguageFrontend<*, *>.memberCall(
         holder += node
     } else if (holder is ArgumentHolder) {
         holder += node
+        holder -= base
     }
 
     return node
@@ -1066,7 +1067,6 @@ context(holder: Holder<out Expression>)
 fun LanguageFrontend<*, *>.ref(
     name: CharSequence,
     type: Type = unknownType(),
-    makeMagic: Boolean = true,
     init: (Reference.() -> Unit)? = null,
 ): Reference {
     val node = newReference(name).apply { this.location = getCallerFileAndLine() }
@@ -1077,11 +1077,9 @@ fun LanguageFrontend<*, *>.ref(
         init(node)
     }
 
-    if (makeMagic) {
-        // Only add this to an argument holder if the nearest holder is an argument holder
-        if (holder is ArgumentHolder) {
-            holder += node
-        }
+    // Only add this to an argument holder if the nearest holder is an argument holder
+    if (holder is ArgumentHolder) {
+        holder += node
     }
 
     return node
@@ -1109,12 +1107,16 @@ fun Expression.line(i: Int): Expression {
  * Creates a new [MemberAccess] in the Fluent Node DSL and invokes [ArgumentHolder.addArgument] of
  * the nearest enclosing [Holder], but only if it is an [ArgumentHolder]. If the [name] doesn't
  * already contain a fqn, we add an implicit "this" as base.
+ *
+ * The [base] is an optional lambda that produces the base expression. Using a lambda defers
+ * evaluation so the base expression is produced after [member] has started executing, preventing it
+ * from eagerly attaching to the wrong [ArgumentHolder].
  */
 context(holder: Holder<out Expression>)
 fun LanguageFrontend<*, *>.member(
     name: CharSequence,
-    base: Expression? = null,
     operatorCode: String = ".",
+    base: (() -> Expression)? = null,
 ): MemberAccess {
     val parsedName = parseName(name)
     val type =
@@ -1128,16 +1130,21 @@ fun LanguageFrontend<*, *>.member(
             val scopeType = scope?.name?.let { this.t(it) } ?: unknownType()
             scopeType
         }
-    val memberBase = base ?: this.memberOrRef(parsedName.parent ?: this.parseName("this"), type)
+    val memberBase =
+        base?.invoke() ?: this.memberOrRef(parsedName.parent ?: this.parseName("this"), type)
 
     val node =
         newMemberAccess(name, memberBase, operatorCode = operatorCode).apply {
             this.location = getCallerFileAndLine()
         }
 
-    // Only add this to an argument holder if the nearest holder is an argument holder
     if (holder is ArgumentHolder) {
         holder += node
+        // base?.invoke() runs with the outer holder in context, so ref() / member() inside
+        // the lambda eagerly attach memberBase to holder. Remove that phantom attachment.
+        if (base != null) {
+            holder -= memberBase
+        }
     }
 
     return node

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluationTests.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluationTests.kt
@@ -69,10 +69,12 @@ class ValueEvaluationTests {
                                                 variable("i", t("int")) { literal(0, t("int")) }
                                             }
                                         }
-                                        forCondition { ref("i") lt member("length", ref("array")) }
+                                        forCondition {
+                                            ref("i") lt member("length") { ref("array") }
+                                        }
                                         forIteration { ref("i").inc() }
                                     }
-                                    memberCall("println", member("out", ref("System"))) {
+                                    memberCall("println", member("out") { ref("System") }) {
                                         subscriptExpr {
                                             ref("array")
                                             literal(1, t("int"))
@@ -85,7 +87,7 @@ class ValueEvaluationTests {
                                         }
                                     }
 
-                                    memberCall("println", member("out", ref("System"))) {
+                                    memberCall("println", member("out") { ref("System") }) {
                                         ref("str")
                                     }
                                     returnStmt {}
@@ -126,9 +128,13 @@ class ValueEvaluationTests {
 
                                     ref("i").inc()
 
-                                    memberCall("println", member("out", ref("System"))) { ref("s") }
+                                    memberCall("println", member("out") { ref("System") }) {
+                                        ref("s")
+                                    }
 
-                                    memberCall("println", member("out", ref("System"))) { ref("i") }
+                                    memberCall("println", member("out") { ref("System") }) {
+                                        ref("i")
+                                    }
                                     returnStmt {}
                                 }
                             }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/FluentTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/FluentTest.kt
@@ -39,6 +39,7 @@ import de.fraunhofer.aisec.cpg.graph.expressions.Comprehension
 import de.fraunhofer.aisec.cpg.graph.expressions.DeclarationStatement
 import de.fraunhofer.aisec.cpg.graph.expressions.IfElse
 import de.fraunhofer.aisec.cpg.graph.expressions.Literal
+import de.fraunhofer.aisec.cpg.graph.expressions.MemberAccess
 import de.fraunhofer.aisec.cpg.graph.expressions.MemberCall
 import de.fraunhofer.aisec.cpg.graph.expressions.Reference
 import de.fraunhofer.aisec.cpg.graph.expressions.Return
@@ -359,6 +360,54 @@ class FluentTest {
         assertIs<Reference>(compExpr.iterable)
         assertLocalName("someIterable", compExpr.iterable)
         assertNotNull(compExpr.predicate)
+    }
+
+    @Test
+    fun testMemberWithBaseAttachesExactlyOnce() {
+        val result =
+            testFrontend { it.registerLanguage<TestLanguage>() }
+                .build {
+                    translationResult {
+                        translationUnit("member_test.c") {
+                            function("main", t("void")) {
+                                body {
+                                    call("doSomething") { member("field1") { ref("s1") } }
+
+                                    call("useNested") {
+                                        member("field") { member("in") { ref("o") } }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+        val main = result.functions["main"]
+        assertNotNull(main)
+
+        val doSomething = (main.body as? Block)?.statements?.filterIsInstance<Call>()?.get(0)
+        assertNotNull(doSomething)
+        assertEquals(
+            1,
+            doSomething.arguments.size,
+            "doSomething must have exactly 1 argument (the MemberAccess, no phantom ref)",
+        )
+        val fieldAccess = doSomething.arguments.single()
+        assertIs<MemberAccess>(fieldAccess)
+        assertLocalName("field1", fieldAccess)
+        val s1Ref = fieldAccess.base
+        assertIs<Reference>(s1Ref)
+        assertLocalName("s1", s1Ref)
+
+        val useNested = (main.body as? Block)?.statements?.filterIsInstance<Call>()?.get(1)
+        assertNotNull(useNested)
+        assertEquals(1, useNested.arguments.size, "useNested must have exactly 1 argument")
+        val outerMember = useNested.arguments.single()
+        assertIs<MemberAccess>(outerMember)
+        assertLocalName("field", outerMember)
+        val innerMember = outerMember.base
+        assertIs<MemberAccess>(innerMember)
+        assertLocalName("in", innerMember)
     }
 
     @Test

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/UnresolvedDFGPassTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/UnresolvedDFGPassTest.kt
@@ -160,14 +160,14 @@ class UnresolvedDFGPassTest {
                                 receiver = newVariable("this", t("DfgUnresolvedCalls"))
                                 param("i", t("int"))
                                 body {
-                                    member("i", ref("this")) assign { ref("i") }
+                                    member("i") { ref("this") } assign { ref("i") }
                                     returnStmt { isImplicit = true }
                                 }
                             }
                             method("knownFunction", t("int")) {
                                 receiver = newVariable("this", t("DfgUnresolvedCalls"))
                                 param("arg", t("int"))
-                                body { returnStmt { member("i", ref("this")) + ref("arg") } }
+                                body { returnStmt { member("i") { ref("this") } + ref("arg") } }
                             }
 
                             // The main method

--- a/cpg-core/src/testFixtures/kotlin/de/fraunhofer/aisec/cpg/test/GraphExamples.kt
+++ b/cpg-core/src/testFixtures/kotlin/de/fraunhofer/aisec/cpg/test/GraphExamples.kt
@@ -395,8 +395,8 @@ class GraphExamples {
                                         t("T").reference(PointerType.PointerOrigin.POINTER),
                                     )
                                 }
-                                member("value", ref("node"), "->") assign literal(42, t("int"))
-                                member("next", ref("node"), "->") assign ref("node")
+                                member("value", "->") { ref("node") } assign literal(42, t("int"))
+                                member("next", "->") { ref("node") } assign ref("node")
                                 memberCall(
                                     "dump",
                                     ref("node"),
@@ -425,8 +425,8 @@ class GraphExamples {
                         function("main", t("int")) {
                             body {
                                 declare { variable("node", t("T")) }
-                                member("value", ref("node")) assign literal(42, t("int"))
-                                member("next", ref("node")) assign { reference(ref("node")) }
+                                member("value") { ref("node") } assign literal(42, t("int"))
+                                member("next") { ref("node") } assign { reference(ref("node")) }
                                 returnStmt { isImplicit = true }
                             }
                         }
@@ -577,7 +577,7 @@ class GraphExamples {
                                     declare {
                                         variable("field", t("int")) { literal(43, t("int")) }
                                     }
-                                    returnStmt { member("field", ref("this")) }
+                                    returnStmt { member("field") { ref("this") } }
                                 }
                             }
                         }
@@ -823,16 +823,15 @@ class GraphExamples {
                                     declare { variable("a", t("int")) { literal(1, t("int")) } }
                                     ifStmt {
                                         condition {
-                                            member("length", ref("args")) gt literal(3, t("int"))
+                                            member("length") { ref("args") } gt literal(3, t("int"))
                                         }
                                         thenStmt { ref("a") assign literal(2, t("int")) }
                                         elseStmt {
                                             memberCall(
                                                 "println",
-                                                member(
-                                                    "out",
-                                                    ref("System") { isStaticAccess = true },
-                                                ),
+                                                member("out") {
+                                                    ref("System") { isStaticAccess = true }
+                                                },
                                             ) {
                                                 ref("a")
                                             }
@@ -854,7 +853,7 @@ class GraphExamples {
                                             new { construct("ControlFlowSensitiveDFGIfMerge") }
                                         }
                                     }
-                                    member("bla", ref("obj")) assign literal(3, t("int"))
+                                    member("bla") { ref("obj") } assign literal(3, t("int"))
                                     returnStmt { isImplicit = true }
                                 }
                             }
@@ -913,10 +912,9 @@ class GraphExamples {
                                             default()
                                             memberCall(
                                                 "println",
-                                                member(
-                                                    "out",
-                                                    ref("System") { isStaticAccess = true },
-                                                ),
+                                                member("out") {
+                                                    ref("System") { isStaticAccess = true }
+                                                },
                                             ) {
                                                 ref("a")
                                             }
@@ -952,7 +950,7 @@ class GraphExamples {
                                     declare { variable("a", t("int")) { literal(1, t("int")) } }
                                     ifStmt {
                                         condition {
-                                            member("length", ref("args")) gt literal(3, t("int"))
+                                            member("length") { ref("args") } gt literal(3, t("int"))
                                         }
                                         thenStmt { ref("a") assign literal(2, t("int")) }
                                         elseStmt {
@@ -1005,12 +1003,11 @@ class GraphExamples {
                                                             elseStmt {
                                                                 memberCall(
                                                                     "println",
-                                                                    member(
-                                                                        "out",
+                                                                    member("out") {
                                                                         ref("System") {
                                                                             isStaticAccess = true
-                                                                        },
-                                                                    ),
+                                                                        }
+                                                                    },
                                                                 ) {
                                                                     ref("a")
                                                                 }
@@ -1023,10 +1020,9 @@ class GraphExamples {
                                                 }
                                                 memberCall(
                                                     "println",
-                                                    member(
-                                                        "out",
-                                                        ref("System") { isStaticAccess = true },
-                                                    ),
+                                                    member("out") {
+                                                        ref("System") { isStaticAccess = true }
+                                                    },
                                                 ) {
                                                     ref("a")
                                                 }
@@ -1037,7 +1033,7 @@ class GraphExamples {
 
                                     memberCall(
                                         "println",
-                                        member("out", ref("System") { isStaticAccess = true }),
+                                        member("out") { ref("System") { isStaticAccess = true } },
                                     ) {
                                         ref("a")
                                     }
@@ -1078,10 +1074,9 @@ class GraphExamples {
                                                 elseStmt {
                                                     memberCall(
                                                         "println",
-                                                        member(
-                                                            "out",
-                                                            ref("System") { isStaticAccess = true },
-                                                        ),
+                                                        member("out") {
+                                                            ref("System") { isStaticAccess = true }
+                                                        },
                                                     ) {
                                                         ref("a")
                                                     }
@@ -1194,7 +1189,9 @@ class GraphExamples {
                                     body {
                                         memberCall(
                                             "println",
-                                            member("out", ref("System") { isStaticAccess = true }),
+                                            member("out") {
+                                                ref("System") { isStaticAccess = true }
+                                            },
                                         ) {
                                             literal("Hello world")
                                         }
@@ -1253,7 +1250,7 @@ class GraphExamples {
                                 body {
                                     memberCall(
                                         "println",
-                                        member("out", ref("System") { isStaticAccess = true }),
+                                        member("out") { ref("System") { isStaticAccess = true } },
                                     ) {
                                         ref("s")
                                     }
@@ -1310,7 +1307,7 @@ class GraphExamples {
                                 body {
                                     memberCall(
                                         "println",
-                                        member("out", ref("System") { isStaticAccess = true }),
+                                        member("out") { ref("System") { isStaticAccess = true } },
                                     ) {
                                         call("this.toString")
                                     }
@@ -1477,26 +1474,21 @@ class GraphExamples {
 
                                 // Call doSomething on field1 of s1
                                 call("doSomething") {
-                                        member("field1", ref("s1", makeMagic = false).line(11))
-                                            .line(11)
+                                        member("field1") { ref("s1").line(11) }.line(11)
                                     }
                                     .line(11)
 
                                 // Set field1 of both s1 and s2, to literal 1 and 2 respectively
-                                member("field1", ref("s1", makeMagic = false).line(13))
-                                    .line(13) assign literal(1)
-                                member("field1", ref("s2", makeMagic = false).line(14))
-                                    .line(14) assign literal(2)
+                                member("field1") { ref("s1").line(13) }.line(13) assign literal(1)
+                                member("field1") { ref("s2").line(14) }.line(14) assign literal(2)
 
                                 // Call doSomething on field1 of s1 and s2
                                 call("doSomething") {
-                                        member("field1", ref("s1", makeMagic = false).line(15))
-                                            .line(15)
+                                        member("field1") { ref("s1").line(15) }.line(15)
                                     }
                                     .line(15)
                                 call("doSomething") {
-                                        member("field1", ref("s2", makeMagic = false).line(16))
-                                            .line(16)
+                                        member("field1") { ref("s2").line(16) }.line(16)
                                     }
                                     .line(16)
                             }
@@ -1543,18 +1535,13 @@ class GraphExamples {
                             body {
                                 declare { variable("o", t("outer")) }
 
-                                member(
-                                        "field",
-                                        member("in", ref("o", makeMagic = false).line(13)).line(13),
-                                    )
+                                member("field") { member("in") { ref("o").line(13) }.line(13) }
                                     .line(13) assign literal(1)
 
                                 call("doSomething") {
-                                        member(
-                                                "field",
-                                                member("in", ref("o", makeMagic = false).line(15))
-                                                    .line(15),
-                                            )
+                                        member("field") {
+                                                member("in") { ref("o").line(15) }.line(15)
+                                            }
                                             .line(15)
                                     }
                                     .line(15)


### PR DESCRIPTION
## Summary

`member()` with an explicit `base` lambda (e.g. `call("doSomething") { member("field1") { ref("s1") } }`) attached the base expression to the wrong `ArgumentHolder`. A plain lambda resolves its enclosing holder from where it's written, not where it's invoked, so `ref("s1")` resolved to the outer `Call` and added itself as a phantom second argument.

`base` now declares its own `Holder` context parameter, bound at invocation rather than capture. Calling it under a no-op `DiscardHolder` means any `ref()`/`member()` inside it attaches there instead of leaking into the real outer holder.

Removes the `makeMagic` per-callsite flag previously needed as a workaround at `ref()` call sites.

## Test plan

- [x] `cpg-core:test` (`FluentTest.testMemberWithBaseAttachesExactlyOnce`)
- [x] `cpg-analysis:test` (`QueryTest`)
- [x] `cpg-core:compileKotlin`