### PR TITLE
[renovate] Add minimum release age preset for NPM packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,8 @@
   "extends": [
     "config:recommended",
     "schedule:weekly",
-    ":enableVulnerabilityAlerts"
+    ":enableVulnerabilityAlerts",
+    "security:minimumReleaseAgeNpm"
   ],
   "patch": {
     "enabled": false


### PR DESCRIPTION
We include Renovate's security preset for NPM packages. It enforces a minimum release age for NPM packages. It's currently 3 days.

This also fixes failed builds with `pnpm`. It applies its own minimum release age policy of 1 day by default.