### PR TITLE
 Reduce CPG memory footprint and pass/frontend runtime

### DIFF
--- a/cpg-core/build.gradle.kts
+++ b/cpg-core/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     implementation(libs.kotlin.reflect)
     implementation(libs.jacksonyml)
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.collections.immutable)
 
     testImplementation(libs.junit.params)
     integrationTestImplementation(libs.kotlin.reflect)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -77,6 +77,44 @@ class ScopeManager(override var ctx: TranslationContext) : ScopeProvider, Contex
      */
     private val nameScopeMap: MutableMap<Name, NameScope> = mutableMapOf()
 
+    /**
+     * Caches the result of [lookupSymbolByName] (for calls without a custom [predicate], which
+     * cannot be cached safely). [lookupSymbolByName] can be called repeatedly for the same symbol
+     * (e.g. once per reference to the same variable, or once per candidate scope during ambiguous
+     * call/member resolution), and walking the scope chain for every single call is unnecessarily
+     * expensive.
+     *
+     * The cache is invalidated wholesale (see [symbolTableGeneration]) whenever a symbol table is
+     * mutated (see [invalidateSymbolLookupCache]), rather than per-entry, to keep invalidation
+     * trivially correct. This is cheap in practice because virtually all symbol table mutations
+     * happen while the language frontend is still building the AST, before any of the passes that
+     * call [lookupSymbolByName] (e.g. [SymbolResolver]) run.
+     */
+    private val symbolLookupCache: MutableMap<SymbolLookupCacheKey, List<Declaration>> =
+        mutableMapOf()
+
+    /** See [symbolLookupCache]. Bumped by [invalidateSymbolLookupCache]. */
+    private var symbolTableGeneration: Int = 0
+
+    /** The [symbolTableGeneration] that [symbolLookupCache] was last cleared for. */
+    private var symbolLookupCacheGeneration: Int = -1
+
+    /**
+     * Must be called whenever a symbol table (i.e. [Scope.symbols] or [Scope.wildcardImports]) is
+     * mutated, so that [symbolLookupCache] does not serve stale results.
+     */
+    internal fun invalidateSymbolLookupCache() {
+        symbolTableGeneration++
+    }
+
+    private data class SymbolLookupCacheKey(
+        val scope: Scope?,
+        val symbol: Symbol,
+        val language: Language<*>,
+        val qualifiedLookup: Boolean,
+        val replaceImports: Boolean,
+    )
+
     /** True, if the scope manager is currently in a [FunctionScope]. */
     val isInFunction: Boolean
         get() = this.firstScopeOrNull { it is FunctionScope } != null
@@ -129,6 +167,10 @@ class ScopeManager(override var ctx: TranslationContext) : ScopeProvider, Contex
      * @param toMerge The scope managers to merge into this one
      */
     fun mergeFrom(toMerge: Collection<ScopeManager>) {
+        // Merging combines symbol tables from several scope managers into this one, so any cached
+        // lookups may no longer be valid.
+        invalidateSymbolLookupCache()
+
         val globalScopes = toMerge.map { it.globalScope }
         val currGlobalScope = scopeMap[null]
         if (currGlobalScope !is GlobalScope) {
@@ -786,6 +828,31 @@ class ScopeManager(override var ctx: TranslationContext) : ScopeProvider, Contex
             n = extractedScope.adjustedName
         }
 
+        // A custom predicate is a per-call lambda and cannot be safely used as (or compared
+        // through)
+        // a cache key, so we only cache the common case where no predicate is given.
+        val cacheKey =
+            if (predicate == null) {
+                SymbolLookupCacheKey(
+                    scope = scope ?: startScope,
+                    symbol = n.localName,
+                    language = language,
+                    qualifiedLookup = scope != null,
+                    replaceImports = replaceImports,
+                )
+            } else {
+                null
+            }
+        if (cacheKey != null) {
+            if (symbolLookupCacheGeneration != symbolTableGeneration) {
+                symbolLookupCache.clear()
+                symbolLookupCacheGeneration = symbolTableGeneration
+            }
+            symbolLookupCache[cacheKey]?.let {
+                return it
+            }
+        }
+
         // We need to differentiate between a qualified and unqualified lookup. We have a qualified
         // lookup, if the scope is not null. In this case we need to stay within the specified scope
         val list =
@@ -826,6 +893,10 @@ class ScopeManager(override var ctx: TranslationContext) : ScopeProvider, Contex
                     it.remove()
                 }
             }
+        }
+
+        if (cacheKey != null) {
+            symbolLookupCache[cacheKey] = list
         }
 
         return list

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/ScopeManager.kt
@@ -107,6 +107,7 @@ class ScopeManager(override var ctx: TranslationContext) : ScopeProvider, Contex
         symbolTableGeneration++
     }
 
+    /** The key identifying a cached [lookupSymbolByName] result in [symbolLookupCache]. */
     private data class SymbolLookupCacheKey(
         val scope: Scope?,
         val symbol: Symbol,

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationContext.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationContext.kt
@@ -31,8 +31,11 @@ import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.ContextProvider
+import de.fraunhofer.aisec.cpg.graph.scopes.Scope
+import de.fraunhofer.aisec.cpg.graph.types.ObjectType
 import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * The translation context holds all necessary managers and configurations needed during the
@@ -62,6 +65,23 @@ open class TranslationContext(
      * (through individual contexts) and then finally merged into a final one.
      */
     val scopeManager: ScopeManager = ScopeManager(this)
+
+    /**
+     * A per-context cache of non-generic [ObjectType]s, keyed by their defining [Scope] and (local)
+     * name. It lets the frontend reuse a single [ObjectType] instance for repeated references to
+     * the same named type within the same scope, instead of allocating a fresh one per use (see
+     * [de.fraunhofer.aisec.cpg.graph.objectType]).
+     *
+     * Sharing is sound because a type's resolution (its [ObjectType.recordDeclaration], fully
+     * qualified name and supertypes, set by the [de.fraunhofer.aisec.cpg.passes.TypeResolver]) is
+     * fully determined by its name and [Scope]; all references with the same `(scope, name)`
+     * resolve identically. It is conservatively scoped: distinct scopes never share, and because
+     * each parallel translation context has its own global scope, types are never shared across
+     * contexts or, for non-global scopes, across translation units.
+     */
+    @DoNotPersist
+    val objectTypeCache: ConcurrentHashMap<Scope, ConcurrentHashMap<String, ObjectType>> =
+        ConcurrentHashMap()
 
     /**
      * Set of files, that are available for additional analysis. They are not the primary subjects

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationContext.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TranslationContext.kt
@@ -31,11 +31,8 @@ import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.graph.Component
 import de.fraunhofer.aisec.cpg.graph.ContextProvider
-import de.fraunhofer.aisec.cpg.graph.scopes.Scope
-import de.fraunhofer.aisec.cpg.graph.types.ObjectType
 import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
 import java.io.File
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  * The translation context holds all necessary managers and configurations needed during the
@@ -65,23 +62,6 @@ open class TranslationContext(
      * (through individual contexts) and then finally merged into a final one.
      */
     val scopeManager: ScopeManager = ScopeManager(this)
-
-    /**
-     * A per-context cache of non-generic [ObjectType]s, keyed by their defining [Scope] and (local)
-     * name. It lets the frontend reuse a single [ObjectType] instance for repeated references to
-     * the same named type within the same scope, instead of allocating a fresh one per use (see
-     * [de.fraunhofer.aisec.cpg.graph.objectType]).
-     *
-     * Sharing is sound because a type's resolution (its [ObjectType.recordDeclaration], fully
-     * qualified name and supertypes, set by the [de.fraunhofer.aisec.cpg.passes.TypeResolver]) is
-     * fully determined by its name and [Scope]; all references with the same `(scope, name)`
-     * resolve identically. It is conservatively scoped: distinct scopes never share, and because
-     * each parallel translation context has its own global scope, types are never shared across
-     * contexts or, for non-global scopes, across translation units.
-     */
-    @DoNotPersist
-    val objectTypeCache: ConcurrentHashMap<Scope, ConcurrentHashMap<String, ObjectType>> =
-        ConcurrentHashMap()
 
     /**
      * Set of files, that are available for additional analysis. They are not the primary subjects

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/MultiValueEvaluator.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/MultiValueEvaluator.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.evaluation
 
+import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.Field
 import de.fraunhofer.aisec.cpg.graph.declarations.Variable
@@ -297,8 +298,11 @@ class MultiValueEvaluator : ValueEvaluator() {
         if (loop == null || loop.condition !is BinaryOperator) return setOf()
 
         var loopVar: Any? =
-            evaluateInternal(loop.initializerStatement?.declarations?.first(), depth) as? Number
-                ?: return setOf()
+            evaluateInternal(
+                (loop.initializerStatement as? DeclarationHolder)?.declarations?.first(),
+                depth,
+            )
+                as? Number ?: return setOf()
 
         val cond = loop.condition as BinaryOperator
         val result = mutableSetOf<Any?>()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/AstNode.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/AstNode.kt
@@ -27,10 +27,12 @@ package de.fraunhofer.aisec.cpg.graph
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
+import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
+import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdges
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
-import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import de.fraunhofer.aisec.cpg.graph.expressions.Expression
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
+import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
 import de.fraunhofer.aisec.cpg.persistence.Relationship
 
 /**
@@ -55,9 +57,28 @@ abstract class AstNode : Node() {
     var astChildren: List<AstNode> = listOf()
         get() = SubgraphWalker.getAstChildren(this)
 
-    /** List of [Annotation]s associated with that node. */
-    @Relationship("ANNOTATIONS") var annotationEdges = astEdgesOf<Annotation>()
-    var annotations by unwrapping(AstNode::annotationEdges)
+    /**
+     * List of [Annotation]s associated with that node.
+     *
+     * Backed lazily: annotations are absent on the overwhelming majority of nodes, and [astEdgesOf]
+     * eagerly allocates a backing array. Allocating the edge container only on first use avoids
+     * that cost per node.
+     */
+    private var _annotationEdges: AstEdges<Annotation, AstEdge<Annotation>>? = null
+
+    @Relationship("ANNOTATIONS")
+    var annotationEdges: AstEdges<Annotation, AstEdge<Annotation>>
+        get() = _annotationEdges ?: astEdgesOf<Annotation>().also { _annotationEdges = it }
+        set(value) {
+            _annotationEdges = value
+        }
+
+    @DoNotPersist
+    var annotations: MutableList<Annotation>
+        get() = annotationEdges.unwrap()
+        set(value) {
+            annotationEdges.resetTo(value)
+        }
 
     override fun disconnectFromGraph() {
         super.disconnectFromGraph()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/AstNode.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/AstNode.kt
@@ -57,15 +57,15 @@ abstract class AstNode : Node() {
     var astChildren: List<AstNode> = listOf()
         get() = SubgraphWalker.getAstChildren(this)
 
+    /** Lazy backing field for [annotationEdges]. */
+    private var _annotationEdges: AstEdges<Annotation, AstEdge<Annotation>>? = null
+
     /**
      * List of [Annotation]s associated with that node.
      *
-     * Backed lazily: annotations are absent on the overwhelming majority of nodes, and [astEdgesOf]
-     * eagerly allocates a backing array. Allocating the edge container only on first use avoids
-     * that cost per node.
+     * The backing container is allocated lazily on first access: annotations are absent on the
+     * overwhelming majority of nodes, and [astEdgesOf] eagerly allocates a backing array.
      */
-    private var _annotationEdges: AstEdges<Annotation, AstEdge<Annotation>>? = null
-
     @Relationship("ANNOTATIONS")
     var annotationEdges: AstEdges<Annotation, AstEdge<Annotation>>
         get() = _annotationEdges ?: astEdgesOf<Annotation>().also { _annotationEdges = it }
@@ -73,6 +73,7 @@ abstract class AstNode : Node() {
             _annotationEdges = value
         }
 
+    /** Virtual property for accessing [annotationEdges] as plain nodes. */
     @DoNotPersist
     var annotations: MutableList<Annotation>
         get() = annotationEdges.unwrap()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/ExpressionBuilder.kt
@@ -645,7 +645,6 @@ fun <T> Literal<T>.duplicate(implicit: Boolean): Literal<T> {
     duplicate.assignedTypes = this.assignedTypes
     duplicate.code = this.code
     duplicate.location = this.location
-    duplicate.locals = this.locals
     duplicate.argumentIndex = this.argumentIndex
     duplicate.annotations = this.annotations
     duplicate.comment = this.comment

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -47,6 +47,7 @@ import de.fraunhofer.aisec.cpg.graph.scopes.GlobalScope
 import de.fraunhofer.aisec.cpg.graph.scopes.RecordScope
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.helpers.mapFiltered
+import de.fraunhofer.aisec.cpg.helpers.smallMutableSetOf
 import de.fraunhofer.aisec.cpg.passes.*
 import de.fraunhofer.aisec.cpg.persistence.Convert
 import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
@@ -247,7 +248,7 @@ abstract class Node() :
 
     var prevPDG by unwrapping(Node::prevPDGEdges)
 
-    @DoNotPersist override val assumptions: MutableSet<Assumption> = mutableSetOf()
+    @DoNotPersist override val assumptions: MutableSet<Assumption> = smallMutableSetOf()
 
     /**
      * If a node is marked as being inferred, it means that it was created artificially and does not
@@ -288,7 +289,7 @@ abstract class Node() :
      * Additional problem nodes. These nodes represent problems which occurred during processing of
      * a node (i.e. only partially processed).
      */
-    val additionalProblems: MutableSet<ProblemNode> = mutableSetOf()
+    val additionalProblems: MutableSet<ProblemNode> = smallMutableSetOf()
 
     @Relationship(value = "OVERLAY", direction = Relationship.Direction.OUTGOING)
     val overlayEdges: Overlays =

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -73,8 +73,23 @@ abstract class Node() :
     HasScope,
     HasAssumptions {
 
+    /**
+     * Caches the (structural) [hashCode]. A value of `0` means "not yet computed" (a genuine
+     * hashCode of `0` is harmless: it simply recomputes on the next call). [hashCode] depends only
+     * on [name], [location] and the constant runtime class, so the [name] and [location] setters
+     * invalidate this cache. This is safe because [Name] is immutable and no [PhysicalLocation] is
+     * mutated in place in the codebase, so those setters observe every change. With the cache, the
+     * value returned is always identical to the live computation.
+     */
+    @DoNotPersist @JsonIgnore private var cachedHashCode: Int = 0
+
     /** This property holds the full name using our new [Name] class. */
-    @Convert(NameConverter::class) override var name: Name = Name(EMPTY_NAME)
+    @Convert(NameConverter::class)
+    override var name: Name = Name(EMPTY_NAME)
+        set(value) {
+            field = value
+            cachedHashCode = 0
+        }
 
     /**
      * Original code snippet of this node. Most nodes will have a corresponding "code", but in cases
@@ -106,7 +121,12 @@ abstract class Node() :
     /** Optional comment of this node. */
     var comment: String? = null
 
-    @Convert(LocationConverter::class) override var location: PhysicalLocation? = null
+    @Convert(LocationConverter::class)
+    override var location: PhysicalLocation? = null
+        set(value) {
+            field = value
+            cachedHashCode = 0
+        }
 
     /** Incoming control flow edges. */
     @Relationship(value = "EOG", direction = Relationship.Direction.INCOMING)
@@ -439,7 +459,16 @@ abstract class Node() :
      * location already when creating the node.
      */
     override fun hashCode(): Int {
-        return Objects.hash(name, location, this.javaClass.name)
+        // Cached (see [cachedHashCode]); invalidated by the [name]/[location] setters. This is
+        // called very frequently (every structural HashMap/HashSet operation on a node), so
+        // avoiding
+        // the recomputation - and the varargs array [Objects.hash] allocates - is worthwhile.
+        var h = cachedHashCode
+        if (h == 0) {
+            h = Objects.hash(name, location, this.javaClass.name)
+            cachedHashCode = h
+        }
+        return h
     }
 
     /** Returns the starting point of the EOG outside this node and its children. */

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -152,16 +152,17 @@ abstract class Node() :
     /** The basic block this node belongs to. */
     var basicBlock by unwrapping(Node::basicBlockEdges)
 
+    /** Lazy backing field for [nextCDGEdges]. */
+    private var _nextCDGEdges: ControlDependences<Node>? = null
+
     /**
      * The nodes which are control-flow dominated, i.e., the children of the Control Dependence
      * Graph (CDG).
+     *
+     * The backing container is allocated lazily on first access: CDG edges are only populated by
+     * the optional [ControlDependenceGraphPass] and stay empty on the vast majority of nodes. The
+     * container is not part of [equals]/[hashCode], so lazy-on-access is safe.
      */
-    // CDG/PDG/overlay edge containers are backed lazily: they are only populated by optional passes
-    // (CDG/PDG passes, concept/overlay passes) and stay empty on the vast majority of nodes.
-    // Allocating the container only on first use avoids that per-node cost. They are not part of
-    // [equals]/[hashCode], so lazy-on-access is safe.
-    private var _nextCDGEdges: ControlDependences<Node>? = null
-
     @PopulatedByPass(ControlDependenceGraphPass::class)
     @Relationship(value = "CDG", direction = Relationship.Direction.OUTGOING)
     var nextCDGEdges: ControlDependences<Node>
@@ -177,16 +178,20 @@ abstract class Node() :
             _nextCDGEdges = value
         }
 
+    /** Virtual property for accessing [nextCDGEdges] as plain nodes. */
     @DoNotPersist
     val nextCDG: MutableList<Node>
         get() = nextCDGEdges.unwrap()
 
+    /** Lazy backing field for [prevCDGEdges]. */
+    private var _prevCDGEdges: ControlDependences<Node>? = null
+
     /**
      * The nodes which dominate this node via the control-flow, i.e., the parents of the Control
      * Dependence Graph (CDG).
+     *
+     * The backing container is allocated lazily on first access (see [nextCDGEdges]).
      */
-    private var _prevCDGEdges: ControlDependences<Node>? = null
-
     @PopulatedByPass(ControlDependenceGraphPass::class)
     @Relationship(value = "CDG", direction = Relationship.Direction.INCOMING)
     var prevCDGEdges: ControlDependences<Node>
@@ -202,6 +207,7 @@ abstract class Node() :
             _prevCDGEdges = value
         }
 
+    /** Virtual property for accessing [prevCDGEdges] as plain nodes. */
     @DoNotPersist
     val prevCDG: MutableList<Node>
         get() = prevCDGEdges.unwrap()
@@ -280,9 +286,16 @@ abstract class Node() :
             return nextDFGEdges.mapFiltered({ it.functionSummary }) { it.end }
         }
 
-    /** Outgoing Program Dependence Edges. */
+    /** Lazy backing field for [nextPDGEdges]. */
     private var _nextPDGEdges: ProgramDependences<Node>? = null
 
+    /**
+     * Outgoing Program Dependence Edges.
+     *
+     * The backing container is allocated lazily on first access: PDG edges are only populated by
+     * the optional [ProgramDependenceGraphPass] and stay empty on the vast majority of nodes. The
+     * container is not part of [equals]/[hashCode], so lazy-on-access is safe.
+     */
     @PopulatedByPass(ProgramDependenceGraphPass::class)
     @Relationship(value = "PDG", direction = Relationship.Direction.OUTGOING)
     var nextPDGEdges: ProgramDependences<Node>
@@ -298,13 +311,19 @@ abstract class Node() :
             _nextPDGEdges = value
         }
 
+    /** Virtual property for accessing [nextPDGEdges] as plain nodes. */
     @DoNotPersist
     val nextPDG: MutableSet<Node>
         get() = nextPDGEdges.unwrap()
 
-    /** Incoming Program Dependence Edges. */
+    /** Lazy backing field for [prevPDGEdges]. */
     private var _prevPDGEdges: ProgramDependences<Node>? = null
 
+    /**
+     * Incoming Program Dependence Edges.
+     *
+     * The backing container is allocated lazily on first access (see [nextPDGEdges]).
+     */
     @PopulatedByPass(ProgramDependenceGraphPass::class)
     @Relationship(value = "PDG", direction = Relationship.Direction.INCOMING)
     var prevPDGEdges: ProgramDependences<Node>
@@ -320,6 +339,7 @@ abstract class Node() :
             _prevPDGEdges = value
         }
 
+    /** Virtual property for accessing [prevPDGEdges] as plain nodes. */
     @DoNotPersist
     val prevPDG: MutableSet<Node>
         get() = prevPDGEdges.unwrap()
@@ -367,8 +387,15 @@ abstract class Node() :
      */
     val additionalProblems: MutableSet<ProblemNode> = smallMutableSetOf()
 
+    /** Lazy backing field for [overlayEdges]. */
     private var _overlayEdges: Overlays? = null
 
+    /**
+     * The [OverlayNode]s attached to this node.
+     *
+     * The backing container is allocated lazily on first access: overlays are only added by
+     * (optional) concept/overlay passes and stay empty on the vast majority of nodes.
+     */
     @Relationship(value = "OVERLAY", direction = Relationship.Direction.OUTGOING)
     val overlayEdges: Overlays
         get() =
@@ -376,6 +403,7 @@ abstract class Node() :
                 ?: Overlays(this, mirrorProperty = OverlayNode::underlyingNodeEdge, outgoing = true)
                     .also { _overlayEdges = it }
 
+    /** Virtual property for accessing [overlayEdges] as plain nodes. */
     @DoNotPersist
     val overlays: MutableSet<Node>
         get() = overlayEdges.unwrap()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -142,12 +142,30 @@ abstract class Node() :
         EvaluationOrders<Node>(this, mirrorProperty = Node::prevEOGEdges, outgoing = true)
         protected set
 
-    /** The [BasicBlockEdgeList] leading to the basic block this node belongs to. */
+    /** Lazy backing field for [basicBlockEdges]. */
+    private var _basicBlockEdges: BasicBlockEdgeList<Node>? = null
+
+    /**
+     * The [BasicBlockEdgeList] leading to the basic block this node belongs to.
+     *
+     * The backing container is allocated lazily on first access: basic blocks are only populated by
+     * the optional [BasicBlockCollectorPass] and stay empty on the vast majority of nodes. The
+     * container is not part of [equals]/[hashCode], so lazy-on-access is safe.
+     */
     @Relationship(value = "BB", direction = Relationship.Direction.OUTGOING)
     @PopulatedByPass(BasicBlockCollectorPass::class)
-    var basicBlockEdges: BasicBlockEdgeList<Node> =
-        BasicBlockEdgeList<Node>(this, mirrorProperty = BasicBlock::nodeEdges, outgoing = true)
-        protected set
+    var basicBlockEdges: BasicBlockEdgeList<Node>
+        get() =
+            _basicBlockEdges
+                ?: BasicBlockEdgeList<Node>(
+                        this,
+                        mirrorProperty = BasicBlock::nodeEdges,
+                        outgoing = true,
+                    )
+                    .also { _basicBlockEdges = it }
+        protected set(value) {
+            _basicBlockEdges = value
+        }
 
     /** The basic block this node belongs to. */
     var basicBlock by unwrapping(Node::basicBlockEdges)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Node.kt
@@ -136,25 +136,55 @@ abstract class Node() :
      * The nodes which are control-flow dominated, i.e., the children of the Control Dependence
      * Graph (CDG).
      */
+    // CDG/PDG/overlay edge containers are backed lazily: they are only populated by optional passes
+    // (CDG/PDG passes, concept/overlay passes) and stay empty on the vast majority of nodes.
+    // Allocating the container only on first use avoids that per-node cost. They are not part of
+    // [equals]/[hashCode], so lazy-on-access is safe.
+    private var _nextCDGEdges: ControlDependences<Node>? = null
+
     @PopulatedByPass(ControlDependenceGraphPass::class)
     @Relationship(value = "CDG", direction = Relationship.Direction.OUTGOING)
-    var nextCDGEdges: ControlDependences<Node> =
-        ControlDependences(this, mirrorProperty = Node::prevCDGEdges, outgoing = true)
-        protected set
+    var nextCDGEdges: ControlDependences<Node>
+        get() =
+            _nextCDGEdges
+                ?: ControlDependences<Node>(
+                        this,
+                        mirrorProperty = Node::prevCDGEdges,
+                        outgoing = true,
+                    )
+                    .also { _nextCDGEdges = it }
+        protected set(value) {
+            _nextCDGEdges = value
+        }
 
-    var nextCDG by unwrapping(Node::nextCDGEdges)
+    @DoNotPersist
+    val nextCDG: MutableList<Node>
+        get() = nextCDGEdges.unwrap()
 
     /**
      * The nodes which dominate this node via the control-flow, i.e., the parents of the Control
      * Dependence Graph (CDG).
      */
+    private var _prevCDGEdges: ControlDependences<Node>? = null
+
     @PopulatedByPass(ControlDependenceGraphPass::class)
     @Relationship(value = "CDG", direction = Relationship.Direction.INCOMING)
-    var prevCDGEdges: ControlDependences<Node> =
-        ControlDependences<Node>(this, mirrorProperty = Node::nextCDGEdges, outgoing = false)
-        protected set
+    var prevCDGEdges: ControlDependences<Node>
+        get() =
+            _prevCDGEdges
+                ?: ControlDependences<Node>(
+                        this,
+                        mirrorProperty = Node::nextCDGEdges,
+                        outgoing = false,
+                    )
+                    .also { _prevCDGEdges = it }
+        protected set(value) {
+            _prevCDGEdges = value
+        }
 
-    var prevCDG by unwrapping(Node::prevCDGEdges)
+    @DoNotPersist
+    val prevCDG: MutableList<Node>
+        get() = prevCDGEdges.unwrap()
 
     @DoNotPersist @JsonIgnore var astParent: AstNode? = null
 
@@ -231,22 +261,48 @@ abstract class Node() :
         }
 
     /** Outgoing Program Dependence Edges. */
+    private var _nextPDGEdges: ProgramDependences<Node>? = null
+
     @PopulatedByPass(ProgramDependenceGraphPass::class)
     @Relationship(value = "PDG", direction = Relationship.Direction.OUTGOING)
-    var nextPDGEdges: ProgramDependences<Node> =
-        ProgramDependences<Node>(this, mirrorProperty = Node::prevPDGEdges, outgoing = true)
-        protected set
+    var nextPDGEdges: ProgramDependences<Node>
+        get() =
+            _nextPDGEdges
+                ?: ProgramDependences<Node>(
+                        this,
+                        mirrorProperty = Node::prevPDGEdges,
+                        outgoing = true,
+                    )
+                    .also { _nextPDGEdges = it }
+        protected set(value) {
+            _nextPDGEdges = value
+        }
 
-    var nextPDG by unwrapping(Node::nextPDGEdges)
+    @DoNotPersist
+    val nextPDG: MutableSet<Node>
+        get() = nextPDGEdges.unwrap()
 
     /** Incoming Program Dependence Edges. */
+    private var _prevPDGEdges: ProgramDependences<Node>? = null
+
     @PopulatedByPass(ProgramDependenceGraphPass::class)
     @Relationship(value = "PDG", direction = Relationship.Direction.INCOMING)
-    var prevPDGEdges: ProgramDependences<Node> =
-        ProgramDependences<Node>(this, mirrorProperty = Node::nextPDGEdges, outgoing = false)
-        protected set
+    var prevPDGEdges: ProgramDependences<Node>
+        get() =
+            _prevPDGEdges
+                ?: ProgramDependences<Node>(
+                        this,
+                        mirrorProperty = Node::nextPDGEdges,
+                        outgoing = false,
+                    )
+                    .also { _prevPDGEdges = it }
+        protected set(value) {
+            _prevPDGEdges = value
+        }
 
-    var prevPDG by unwrapping(Node::prevPDGEdges)
+    @DoNotPersist
+    val prevPDG: MutableSet<Node>
+        get() = prevPDGEdges.unwrap()
 
     @DoNotPersist override val assumptions: MutableSet<Assumption> = smallMutableSetOf()
 
@@ -291,10 +347,18 @@ abstract class Node() :
      */
     val additionalProblems: MutableSet<ProblemNode> = smallMutableSetOf()
 
+    private var _overlayEdges: Overlays? = null
+
     @Relationship(value = "OVERLAY", direction = Relationship.Direction.OUTGOING)
-    val overlayEdges: Overlays =
-        Overlays(this, mirrorProperty = OverlayNode::underlyingNodeEdge, outgoing = true)
-    var overlays by unwrapping(Node::overlayEdges)
+    val overlayEdges: Overlays
+        get() =
+            _overlayEdges
+                ?: Overlays(this, mirrorProperty = OverlayNode::underlyingNodeEdge, outgoing = true)
+                    .also { _overlayEdges = it }
+
+    @DoNotPersist
+    val overlays: MutableSet<Node>
+        get() = overlayEdges.unwrap()
 
     /**
      * Adds the [assumptions] attached to the [Node] and of relevant supernodes in the AST.
@@ -316,10 +380,12 @@ abstract class Node() :
     open fun disconnectFromGraph() {
         nextDFGEdges.clear()
         prevDFGEdges.clear()
-        prevCDGEdges.clear()
-        nextCDGEdges.clear()
-        prevPDGEdges.clear()
-        nextPDGEdges.clear()
+        // The CDG/PDG/overlay containers are lazily allocated; only clear them if they were ever
+        // populated, so disconnecting does not allocate empty containers just to clear them.
+        _prevCDGEdges?.clear()
+        _nextCDGEdges?.clear()
+        _prevPDGEdges?.clear()
+        _nextPDGEdges?.clear()
         nextEOGEdges.clear()
         prevEOGEdges.clear()
 
@@ -327,7 +393,7 @@ abstract class Node() :
             underlyingNodeEdge.clear()
         }
 
-        this.overlayEdges.clear()
+        _overlayEdges?.clear()
     }
 
     override fun toString(): String {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/TypeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/TypeBuilder.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg.graph
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.TranslationException
 import de.fraunhofer.aisec.cpg.graph.types.*
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Creates a new [UnknownType] and sets the appropriate language, if this [MetadataProvider]
@@ -92,8 +93,36 @@ fun LanguageProvider.objectType(
         return builtIn
     }
 
-    // Otherwise, we either need to create the type because of the generics or because we do not
-    // know the type yet.
+    // Conservative interning: for a non-generic named type we reuse a single ObjectType instance
+    // per
+    // (scope, name) within the current translation context (see
+    // TranslationContext.objectTypeCache).
+    // Every reference to the same named type in the same scope resolves identically, so sharing one
+    // instance avoids allocating a fresh, redundant ObjectType for each use. Types with generics,
+    // or
+    // created without a scope/context, keep their previous fresh-per-call behavior.
+    val scope = (this as? ScopeProvider)?.scope
+    val ctx = (this as? ContextProvider)?.ctx
+    if (generics.isEmpty() && scope != null && ctx != null) {
+        return ctx.objectTypeCache
+            .computeIfAbsent(scope) { ConcurrentHashMap() }
+            .computeIfAbsent(name.toString()) { createObjectType(name, generics, rawNode) }
+    }
+
+    return createObjectType(name, generics, rawNode)
+}
+
+/**
+ * Creates a fresh [ObjectType] with the given [name] and [generics] and applies the usual metadata
+ * (scope, code, location). We only refer to the type by its local name, because we treat types as
+ * sort of references when creating them and resolve them later. Callers should prefer [objectType],
+ * which additionally interns simple named types.
+ */
+private fun LanguageProvider.createObjectType(
+    name: CharSequence,
+    generics: List<Type>,
+    rawNode: Any?,
+): ObjectType {
     val type =
         ObjectType(
             typeName = name,
@@ -102,11 +131,7 @@ fun LanguageProvider.objectType(
             mutable = true,
             language = language,
         )
-    // Apply our usual metadata, such as scope, code, location, if we have any. Make sure only
-    // to refer by the local name because we will treat types as sort of references when
-    // creating them and resolve them later.
     type.applyMetadata(this, name, rawNode = rawNode, doNotPrependNamespace = true)
-
     return type
 }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/TypeBuilder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/TypeBuilder.kt
@@ -28,7 +28,6 @@ package de.fraunhofer.aisec.cpg.graph
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.TranslationException
 import de.fraunhofer.aisec.cpg.graph.types.*
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Creates a new [UnknownType] and sets the appropriate language, if this [MetadataProvider]
@@ -94,19 +93,16 @@ fun LanguageProvider.objectType(
     }
 
     // Conservative interning: for a non-generic named type we reuse a single ObjectType instance
-    // per
-    // (scope, name) within the current translation context (see
-    // TranslationContext.objectTypeCache).
-    // Every reference to the same named type in the same scope resolves identically, so sharing one
-    // instance avoids allocating a fresh, redundant ObjectType for each use. Types with generics,
-    // or
-    // created without a scope/context, keep their previous fresh-per-call behavior.
+    // per (scope, name), stored on the defining scope (see Scope.objectTypeCache). Every reference
+    // to the same named type in the same scope resolves identically, so sharing one instance avoids
+    // allocating a fresh, redundant ObjectType for each use. Types with generics, or created
+    // without a scope/context, keep their previous fresh-per-call behavior.
     val scope = (this as? ScopeProvider)?.scope
     val ctx = (this as? ContextProvider)?.ctx
     if (generics.isEmpty() && scope != null && ctx != null) {
-        return ctx.objectTypeCache
-            .computeIfAbsent(scope) { ConcurrentHashMap() }
-            .computeIfAbsent(name.toString()) { createObjectType(name, generics, rawNode) }
+        return scope.objectTypeCache.computeIfAbsent(name.toString()) {
+            createObjectType(name, generics, rawNode)
+        }
     }
 
     return createObjectType(name, generics, rawNode)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Declaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Declaration.kt
@@ -56,15 +56,17 @@ abstract class Declaration : AstNode(), HasModifiers, HasMemoryAddress, HasMemor
             return this.name.localName
         }
 
-    // The memory-model edge containers below are backed lazily: only populated by the DFG/PointsTo
-    // passes and empty on most declarations, yet were eagerly constructed (3 wrapper objects per
-    // declaration). Not part of equals/hashCode, so lazy-on-access is safe. The unwrapped views are
-    // @DoNotPersist, matching the previous `by unwrapping` delegates.
+    /** Lazy backing field for [memoryAddressEdges]. */
     private var _memoryAddressEdges: MemoryAddressEdges? = null
 
     /**
      * Each Declaration allocates new memory, AKA a new address, so we create a new MemoryAddress
      * node. Should only be a single address!
+     *
+     * This and the other two memory-model containers ([memoryValueUsageEdges], [memoryValueEdges])
+     * are only populated by the DFG and points-to passes and stay empty on most declarations. Their
+     * backing containers are therefore allocated lazily on first access. They are not part of
+     * [equals]/[hashCode], so lazy-on-access is safe.
      */
     @Relationship
     override var memoryAddressEdges: MemoryAddressEdges
@@ -86,6 +88,7 @@ abstract class Declaration : AstNode(), HasModifiers, HasMemoryAddress, HasMemor
             _memoryAddressEdges = value
         }
 
+    /** Virtual property for accessing [memoryAddressEdges] as plain nodes. */
     @DoNotPersist
     override var memoryAddresses: MutableSet<MemoryAddress>
         get() = memoryAddressEdges.unwrap()
@@ -93,9 +96,13 @@ abstract class Declaration : AstNode(), HasModifiers, HasMemoryAddress, HasMemor
             memoryAddressEdges.resetTo(value)
         }
 
+    /** Lazy backing field for [memoryValueUsageEdges]. */
     private var _memoryValueUsageEdges: Dataflows<Node>? = null
 
-    /** Where the memory value of this declaration is used. */
+    /**
+     * Where the memory value of this declaration is used (allocated lazily, see
+     * [memoryAddressEdges]).
+     */
     @Relationship
     override var memoryValueUsageEdges: Dataflows<Node>
         get() =
@@ -110,6 +117,7 @@ abstract class Declaration : AstNode(), HasModifiers, HasMemoryAddress, HasMemor
             _memoryValueUsageEdges = value
         }
 
+    /** Virtual property for accessing [memoryValueUsageEdges] as plain nodes. */
     @DoNotPersist
     override var memoryValueUsages: MutableSet<Node>
         get() = memoryValueUsageEdges.unwrap()
@@ -117,9 +125,12 @@ abstract class Declaration : AstNode(), HasModifiers, HasMemoryAddress, HasMemor
             memoryValueUsageEdges.resetTo(value)
         }
 
+    /** Lazy backing field for [memoryValueEdges]. */
     private var _memoryValueEdges: Dataflows<Node>? = null
 
-    /** Each Declaration can also have a MemoryValue. */
+    /**
+     * Each Declaration can also have a MemoryValue (allocated lazily, see [memoryAddressEdges]).
+     */
     @Relationship
     override var memoryValueEdges: Dataflows<Node>
         get() =
@@ -134,6 +145,7 @@ abstract class Declaration : AstNode(), HasModifiers, HasMemoryAddress, HasMemor
             _memoryValueEdges = value
         }
 
+    /** Virtual property for accessing [memoryValueEdges] as plain nodes. */
     @DoNotPersist
     override var memoryValues: MutableSet<Node>
         get() = memoryValueEdges.unwrap()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Declaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Declaration.kt
@@ -26,20 +26,12 @@
 package de.fraunhofer.aisec.cpg.graph.declarations
 
 import de.fraunhofer.aisec.cpg.graph.AstNode
-import de.fraunhofer.aisec.cpg.graph.HasMemoryAddress
-import de.fraunhofer.aisec.cpg.graph.HasMemoryValue
 import de.fraunhofer.aisec.cpg.graph.HasModifiers
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.edges.MemoryAddressEdges
-import de.fraunhofer.aisec.cpg.graph.edges.flows.Dataflows
-import de.fraunhofer.aisec.cpg.graph.edges.flows.dataflowsOf
-import de.fraunhofer.aisec.cpg.graph.edges.memoryAddressEdgesOf
-import de.fraunhofer.aisec.cpg.graph.expressions.MemoryAddress
 import de.fraunhofer.aisec.cpg.graph.scopes.RecordScope
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.graph.scopes.Symbol
 import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
-import de.fraunhofer.aisec.cpg.persistence.Relationship
 
 /**
  * Represents a single declaration or definition, i.e. of a variable ([Variable]) or function
@@ -50,102 +42,11 @@ import de.fraunhofer.aisec.cpg.persistence.Relationship
  * currently have two [Function] nodes. This is very similar to the behaviour of clang, however
  * clang does establish a connection between those nodes, we currently do not.
  */
-abstract class Declaration : AstNode(), HasModifiers, HasMemoryAddress, HasMemoryValue {
+abstract class Declaration : AstNode(), HasModifiers {
     @DoNotPersist
     val symbol: Symbol
         get() {
             return this.name.localName
-        }
-
-    /** Lazy backing field for [memoryAddressEdges]. */
-    private var _memoryAddressEdges: MemoryAddressEdges? = null
-
-    /**
-     * Each Declaration allocates new memory, AKA a new address, so we create a new MemoryAddress
-     * node. Should only be a single address!
-     *
-     * This and the other two memory-model containers ([memoryValueUsageEdges], [memoryValueEdges])
-     * are only populated by the DFG and points-to passes and stay empty on most declarations. Their
-     * backing containers are therefore allocated lazily on first access. They are not part of
-     * [equals]/[hashCode], so lazy-on-access is safe.
-     */
-    @Relationship
-    override var memoryAddressEdges: MemoryAddressEdges
-        get() =
-            _memoryAddressEdges
-                ?: memoryAddressEdgesOf(
-                        mirrorProperty = MemoryAddress::usageEdges,
-                        outgoing = true,
-                        onAdd = { toAdd ->
-                            if (this.memoryAddressEdges.size > 1) {
-                                log.error(
-                                    "A declaration should have only a single address but we have ${this.memoryAddressEdges.size}."
-                                )
-                            }
-                        },
-                    )
-                    .also { _memoryAddressEdges = it }
-        set(value) {
-            _memoryAddressEdges = value
-        }
-
-    /** Virtual property for accessing [memoryAddressEdges] as plain nodes. */
-    @DoNotPersist
-    override var memoryAddresses: MutableSet<MemoryAddress>
-        get() = memoryAddressEdges.unwrap()
-        set(value) {
-            memoryAddressEdges.resetTo(value)
-        }
-
-    /** Lazy backing field for [memoryValueUsageEdges]. */
-    private var _memoryValueUsageEdges: Dataflows<Node>? = null
-
-    /**
-     * Where the memory value of this declaration is used (allocated lazily, see
-     * [memoryAddressEdges]).
-     */
-    @Relationship
-    override var memoryValueUsageEdges: Dataflows<Node>
-        get() =
-            _memoryValueUsageEdges
-                ?: dataflowsOf(HasMemoryValue::memoryValueEdges, outgoing = true).also {
-                    _memoryValueUsageEdges = it
-                }
-        set(value) {
-            _memoryValueUsageEdges = value
-        }
-
-    /** Virtual property for accessing [memoryValueUsageEdges] as plain nodes. */
-    @DoNotPersist
-    override var memoryValueUsages: MutableSet<Node>
-        get() = memoryValueUsageEdges.unwrap()
-        set(value) {
-            memoryValueUsageEdges.resetTo(value)
-        }
-
-    /** Lazy backing field for [memoryValueEdges]. */
-    private var _memoryValueEdges: Dataflows<Node>? = null
-
-    /**
-     * Each Declaration can also have a MemoryValue (allocated lazily, see [memoryAddressEdges]).
-     */
-    @Relationship
-    override var memoryValueEdges: Dataflows<Node>
-        get() =
-            _memoryValueEdges
-                ?: dataflowsOf(HasMemoryValue::memoryValueUsageEdges, outgoing = false).also {
-                    _memoryValueEdges = it
-                }
-        set(value) {
-            _memoryValueEdges = value
-        }
-
-    /** Virtual property for accessing [memoryValueEdges] as plain nodes. */
-    @DoNotPersist
-    override var memoryValues: MutableSet<Node>
-        get() = memoryValueEdges.unwrap()
-        set(value) {
-            memoryValueEdges.resetTo(value)
         }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Declaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Declaration.kt
@@ -32,6 +32,7 @@ import de.fraunhofer.aisec.cpg.graph.HasModifiers
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.edges.MemoryAddressEdges
 import de.fraunhofer.aisec.cpg.graph.edges.flows.Dataflows
+import de.fraunhofer.aisec.cpg.graph.edges.flows.dataflowsOf
 import de.fraunhofer.aisec.cpg.graph.edges.memoryAddressEdgesOf
 import de.fraunhofer.aisec.cpg.graph.expressions.MemoryAddress
 import de.fraunhofer.aisec.cpg.graph.scopes.RecordScope
@@ -107,12 +108,9 @@ abstract class Declaration : AstNode(), HasModifiers, HasMemoryAddress, HasMemor
     override var memoryValueUsageEdges: Dataflows<Node>
         get() =
             _memoryValueUsageEdges
-                ?: Dataflows<Node>(
-                        this,
-                        mirrorProperty = HasMemoryValue::memoryValueEdges,
-                        outgoing = true,
-                    )
-                    .also { _memoryValueUsageEdges = it }
+                ?: dataflowsOf(HasMemoryValue::memoryValueEdges, outgoing = true).also {
+                    _memoryValueUsageEdges = it
+                }
         set(value) {
             _memoryValueUsageEdges = value
         }
@@ -135,12 +133,9 @@ abstract class Declaration : AstNode(), HasModifiers, HasMemoryAddress, HasMemor
     override var memoryValueEdges: Dataflows<Node>
         get() =
             _memoryValueEdges
-                ?: Dataflows<Node>(
-                        this,
-                        mirrorProperty = HasMemoryValue::memoryValueUsageEdges,
-                        outgoing = false,
-                    )
-                    .also { _memoryValueEdges = it }
+                ?: dataflowsOf(HasMemoryValue::memoryValueUsageEdges, outgoing = false).also {
+                    _memoryValueEdges = it
+                }
         set(value) {
             _memoryValueEdges = value
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Declaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Declaration.kt
@@ -33,7 +33,6 @@ import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.edges.MemoryAddressEdges
 import de.fraunhofer.aisec.cpg.graph.edges.flows.Dataflows
 import de.fraunhofer.aisec.cpg.graph.edges.memoryAddressEdgesOf
-import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import de.fraunhofer.aisec.cpg.graph.expressions.MemoryAddress
 import de.fraunhofer.aisec.cpg.graph.scopes.RecordScope
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
@@ -57,40 +56,90 @@ abstract class Declaration : AstNode(), HasModifiers, HasMemoryAddress, HasMemor
             return this.name.localName
         }
 
+    // The memory-model edge containers below are backed lazily: only populated by the DFG/PointsTo
+    // passes and empty on most declarations, yet were eagerly constructed (3 wrapper objects per
+    // declaration). Not part of equals/hashCode, so lazy-on-access is safe. The unwrapped views are
+    // @DoNotPersist, matching the previous `by unwrapping` delegates.
+    private var _memoryAddressEdges: MemoryAddressEdges? = null
+
     /**
      * Each Declaration allocates new memory, AKA a new address, so we create a new MemoryAddress
      * node. Should only be a single address!
      */
     @Relationship
-    override var memoryAddressEdges: MemoryAddressEdges =
-        memoryAddressEdgesOf(
-            mirrorProperty = MemoryAddress::usageEdges,
-            outgoing = true,
-            onAdd = { toAdd ->
-                if (this.memoryAddressEdges.size > 1) {
-                    log.error(
-                        "A declaration should have only a single address but we have ${this.memoryAddressEdges.size}."
+    override var memoryAddressEdges: MemoryAddressEdges
+        get() =
+            _memoryAddressEdges
+                ?: memoryAddressEdgesOf(
+                        mirrorProperty = MemoryAddress::usageEdges,
+                        outgoing = true,
+                        onAdd = { toAdd ->
+                            if (this.memoryAddressEdges.size > 1) {
+                                log.error(
+                                    "A declaration should have only a single address but we have ${this.memoryAddressEdges.size}."
+                                )
+                            }
+                        },
                     )
-                }
-            },
-        )
-    override var memoryAddresses by unwrapping(Declaration::memoryAddressEdges)
+                    .also { _memoryAddressEdges = it }
+        set(value) {
+            _memoryAddressEdges = value
+        }
+
+    @DoNotPersist
+    override var memoryAddresses: MutableSet<MemoryAddress>
+        get() = memoryAddressEdges.unwrap()
+        set(value) {
+            memoryAddressEdges.resetTo(value)
+        }
+
+    private var _memoryValueUsageEdges: Dataflows<Node>? = null
 
     /** Where the memory value of this declaration is used. */
     @Relationship
-    override var memoryValueUsageEdges =
-        Dataflows<Node>(this, mirrorProperty = HasMemoryValue::memoryValueEdges, outgoing = true)
-    override var memoryValueUsages by unwrapping(Declaration::memoryValueUsageEdges)
+    override var memoryValueUsageEdges: Dataflows<Node>
+        get() =
+            _memoryValueUsageEdges
+                ?: Dataflows<Node>(
+                        this,
+                        mirrorProperty = HasMemoryValue::memoryValueEdges,
+                        outgoing = true,
+                    )
+                    .also { _memoryValueUsageEdges = it }
+        set(value) {
+            _memoryValueUsageEdges = value
+        }
+
+    @DoNotPersist
+    override var memoryValueUsages: MutableSet<Node>
+        get() = memoryValueUsageEdges.unwrap()
+        set(value) {
+            memoryValueUsageEdges.resetTo(value)
+        }
+
+    private var _memoryValueEdges: Dataflows<Node>? = null
 
     /** Each Declaration can also have a MemoryValue. */
     @Relationship
-    override var memoryValueEdges =
-        Dataflows<Node>(
-            this,
-            mirrorProperty = HasMemoryValue::memoryValueUsageEdges,
-            outgoing = false,
-        )
-    override var memoryValues by unwrapping(Declaration::memoryValueEdges)
+    override var memoryValueEdges: Dataflows<Node>
+        get() =
+            _memoryValueEdges
+                ?: Dataflows<Node>(
+                        this,
+                        mirrorProperty = HasMemoryValue::memoryValueUsageEdges,
+                        outgoing = false,
+                    )
+                    .also { _memoryValueEdges = it }
+        set(value) {
+            _memoryValueEdges = value
+        }
+
+    @DoNotPersist
+    override var memoryValues: MutableSet<Node>
+        get() = memoryValueEdges.unwrap()
+        set(value) {
+            memoryValueEdges.resetTo(value)
+        }
 
     /**
      * Returns the [Scope] that this [Declaration] declares (if it does). For example, for a

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Record.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Record.kt
@@ -93,10 +93,16 @@ open class Record :
     /** Virtual property to directly access the nodes in [recordEdges]. */
     var records by unwrapping(Record::recordEdges)
 
-    // Backed lazily: templates are rare, and [astEdgesOf] eagerly allocates a backing array. The
-    // container is not part of [equals]/[hashCode], so lazy-on-access is safe.
+    /** Lazy backing field for [templateEdges]. */
     private var _templateEdges: AstEdges<Template, AstEdge<Template>>? = null
 
+    /**
+     * The [Template]s declared in this record.
+     *
+     * The backing container is allocated lazily on first access: templates are rare, and
+     * [astEdgesOf] eagerly allocates a backing array. The container is not part of
+     * [equals]/[hashCode], so lazy-on-access is safe.
+     */
     @Relationship(value = "TEMPLATES", direction = Relationship.Direction.OUTGOING)
     var templateEdges: AstEdges<Template, AstEdge<Template>>
         get() = _templateEdges ?: astEdgesOf<Template>().also { _templateEdges = it }
@@ -104,6 +110,7 @@ open class Record :
             _templateEdges = value
         }
 
+    /** Virtual property for accessing [templateEdges] as plain nodes. */
     @DoNotPersist
     val templates: MutableList<Template>
         get() = templateEdges.unwrap()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Record.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Record.kt
@@ -28,6 +28,8 @@ package de.fraunhofer.aisec.cpg.graph.declarations
 import de.fraunhofer.aisec.cpg.frontends.TranslationException
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
+import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
+import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdges
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import de.fraunhofer.aisec.cpg.graph.expressions.Expression
@@ -91,9 +93,20 @@ open class Record :
     /** Virtual property to directly access the nodes in [recordEdges]. */
     var records by unwrapping(Record::recordEdges)
 
+    // Backed lazily: templates are rare, and [astEdgesOf] eagerly allocates a backing array. The
+    // container is not part of [equals]/[hashCode], so lazy-on-access is safe.
+    private var _templateEdges: AstEdges<Template, AstEdge<Template>>? = null
+
     @Relationship(value = "TEMPLATES", direction = Relationship.Direction.OUTGOING)
-    var templateEdges = astEdgesOf<Template>()
-    var templates by unwrapping(Record::templateEdges)
+    var templateEdges: AstEdges<Template, AstEdge<Template>>
+        get() = _templateEdges ?: astEdgesOf<Template>().also { _templateEdges = it }
+        set(value) {
+            _templateEdges = value
+        }
+
+    @DoNotPersist
+    val templates: MutableList<Template>
+        get() = templateEdges.unwrap()
 
     /** The list of statements. */
     @Relationship(value = "STATEMENTS", direction = Relationship.Direction.OUTGOING)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ValueDeclaration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/ValueDeclaration.kt
@@ -29,8 +29,13 @@ import de.fraunhofer.aisec.cpg.PopulatedByPass
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.frontends.UnknownLanguage
 import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.edges.MemoryAddressEdges
+import de.fraunhofer.aisec.cpg.graph.edges.flows.Dataflows
 import de.fraunhofer.aisec.cpg.graph.edges.flows.Usages
+import de.fraunhofer.aisec.cpg.graph.edges.flows.dataflowsOf
+import de.fraunhofer.aisec.cpg.graph.edges.memoryAddressEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
+import de.fraunhofer.aisec.cpg.graph.expressions.MemoryAddress
 import de.fraunhofer.aisec.cpg.graph.expressions.Reference
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.helpers.identitySetOf
@@ -40,7 +45,7 @@ import de.fraunhofer.aisec.cpg.persistence.Relationship
 import org.apache.commons.lang3.builder.ToStringBuilder
 
 /** A declaration who has a type. */
-abstract class ValueDeclaration : Declaration(), HasType {
+abstract class ValueDeclaration : Declaration(), HasType, HasMemoryAddress, HasMemoryValue {
 
     @DoNotPersist override var observerEnabled: Boolean = true
 
@@ -82,6 +87,100 @@ abstract class ValueDeclaration : Declaration(), HasType {
 
             field = value
             informObservers(HasType.TypeObserver.ChangeType.ASSIGNED_TYPE)
+        }
+
+    /** Lazy backing field for [memoryAddressEdges]. */
+    private var _memoryAddressEdges: MemoryAddressEdges? = null
+
+    /**
+     * Each value declaration allocates new memory, AKA a new address, so we create a new
+     * MemoryAddress node. Should only be a single address!
+     *
+     * This and the other two memory-model containers ([memoryValueUsageEdges], [memoryValueEdges])
+     * are only populated by the DFG and points-to passes and stay empty on most declarations. Their
+     * backing containers are therefore allocated lazily on first access. They are not part of
+     * [equals]/[hashCode], so lazy-on-access is safe. These members live on [ValueDeclaration] (not
+     * the more general [Declaration]) because only value-carrying declarations ever hold a memory
+     * address or value.
+     */
+    @Relationship
+    override var memoryAddressEdges: MemoryAddressEdges
+        get() =
+            _memoryAddressEdges
+                ?: memoryAddressEdgesOf(
+                        mirrorProperty = MemoryAddress::usageEdges,
+                        outgoing = true,
+                        onAdd = { toAdd ->
+                            if (this.memoryAddressEdges.size > 1) {
+                                log.error(
+                                    "A declaration should have only a single address but we have ${this.memoryAddressEdges.size}."
+                                )
+                            }
+                        },
+                    )
+                    .also { _memoryAddressEdges = it }
+        set(value) {
+            _memoryAddressEdges = value
+        }
+
+    /** Virtual property for accessing [memoryAddressEdges] as plain nodes. */
+    @DoNotPersist
+    override var memoryAddresses: MutableSet<MemoryAddress>
+        get() = memoryAddressEdges.unwrap()
+        set(value) {
+            memoryAddressEdges.resetTo(value)
+        }
+
+    /** Lazy backing field for [memoryValueUsageEdges]. */
+    private var _memoryValueUsageEdges: Dataflows<Node>? = null
+
+    /**
+     * Where the memory value of this declaration is used (allocated lazily, see
+     * [memoryAddressEdges]).
+     */
+    @Relationship
+    override var memoryValueUsageEdges: Dataflows<Node>
+        get() =
+            _memoryValueUsageEdges
+                ?: dataflowsOf(HasMemoryValue::memoryValueEdges, outgoing = true).also {
+                    _memoryValueUsageEdges = it
+                }
+        set(value) {
+            _memoryValueUsageEdges = value
+        }
+
+    /** Virtual property for accessing [memoryValueUsageEdges] as plain nodes. */
+    @DoNotPersist
+    override var memoryValueUsages: MutableSet<Node>
+        get() = memoryValueUsageEdges.unwrap()
+        set(value) {
+            memoryValueUsageEdges.resetTo(value)
+        }
+
+    /** Lazy backing field for [memoryValueEdges]. */
+    private var _memoryValueEdges: Dataflows<Node>? = null
+
+    /**
+     * Each value declaration can also have a MemoryValue (allocated lazily, see
+     * [memoryAddressEdges]).
+     */
+    @Relationship
+    override var memoryValueEdges: Dataflows<Node>
+        get() =
+            _memoryValueEdges
+                ?: dataflowsOf(HasMemoryValue::memoryValueUsageEdges, outgoing = false).also {
+                    _memoryValueEdges = it
+                }
+        set(value) {
+            _memoryValueEdges = value
+        }
+
+    /** Virtual property for accessing [memoryValueEdges] as plain nodes. */
+    @DoNotPersist
+    override var memoryValues: MutableSet<Node>
+        get() = memoryValueEdges.unwrap()
+        set(value) {
+            memoryValueEdges.resetTo(value)
         }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Variable.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Variable.kt
@@ -26,6 +26,8 @@
 package de.fraunhofer.aisec.cpg.graph.declarations
 
 import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
+import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdges
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astOptionalEdgeOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
@@ -38,6 +40,7 @@ import de.fraunhofer.aisec.cpg.graph.types.AutoType
 import de.fraunhofer.aisec.cpg.graph.types.HasType
 import de.fraunhofer.aisec.cpg.graph.types.TupleType
 import de.fraunhofer.aisec.cpg.graph.types.Type
+import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
 import de.fraunhofer.aisec.cpg.persistence.Relationship
 import org.apache.commons.lang3.builder.ToStringBuilder
 
@@ -48,9 +51,24 @@ open class Variable : ValueDeclaration(), HasInitializer, HasType.TypeObserver {
      * We need a way to store the templateParameters that a [Variable] might have before the
      * [Construction] is created.
      */
+    // Backed lazily: template parameters are rare, and [astEdgesOf] eagerly allocates a backing
+    // array. The container is not part of [equals]/[hashCode], so lazy-on-access is safe.
+    private var _templateParameterEdges: AstEdges<AstNode, AstEdge<AstNode>>? = null
+
     @Relationship(value = "TEMPLATE_PARAMETERS", direction = Relationship.Direction.OUTGOING)
-    var templateParameterEdges = astEdgesOf<AstNode>()
-    var templateParameters by unwrapping(Variable::templateParameterEdges)
+    var templateParameterEdges: AstEdges<AstNode, AstEdge<AstNode>>
+        get() =
+            _templateParameterEdges ?: astEdgesOf<AstNode>().also { _templateParameterEdges = it }
+        set(value) {
+            _templateParameterEdges = value
+        }
+
+    @DoNotPersist
+    var templateParameters: MutableList<AstNode>
+        get() = templateParameterEdges.unwrap()
+        set(value) {
+            templateParameterEdges.resetTo(value)
+        }
 
     /** Determines if this is a global variable. */
     val isGlobal: Boolean

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Variable.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/declarations/Variable.kt
@@ -47,14 +47,17 @@ import org.apache.commons.lang3.builder.ToStringBuilder
 /** Represents the declaration of a local variable. */
 open class Variable : ValueDeclaration(), HasInitializer, HasType.TypeObserver {
 
+    /** Lazy backing field for [templateParameterEdges]. */
+    private var _templateParameterEdges: AstEdges<AstNode, AstEdge<AstNode>>? = null
+
     /**
      * We need a way to store the templateParameters that a [Variable] might have before the
      * [Construction] is created.
+     *
+     * The backing container is allocated lazily on first access: template parameters are rare, and
+     * [astEdgesOf] eagerly allocates a backing array. The container is not part of
+     * [equals]/[hashCode], so lazy-on-access is safe.
      */
-    // Backed lazily: template parameters are rare, and [astEdgesOf] eagerly allocates a backing
-    // array. The container is not part of [equals]/[hashCode], so lazy-on-access is safe.
-    private var _templateParameterEdges: AstEdges<AstNode, AstEdge<AstNode>>? = null
-
     @Relationship(value = "TEMPLATE_PARAMETERS", direction = Relationship.Direction.OUTGOING)
     var templateParameterEdges: AstEdges<AstNode, AstEdge<AstNode>>
         get() =
@@ -63,6 +66,7 @@ open class Variable : ValueDeclaration(), HasInitializer, HasType.TypeObserver {
             _templateParameterEdges = value
         }
 
+    /** Virtual property for accessing [templateParameterEdges] as plain nodes. */
     @DoNotPersist
     var templateParameters: MutableList<AstNode>
         get() = templateParameterEdges.unwrap()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/Edge.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/Edge.kt
@@ -57,12 +57,17 @@ abstract class Edge<NodeType : Node> : Persistable, Cloneable, HasAssumptions {
     // Node where the edge is ingoing
     @JsonBackReference var end: NodeType
 
-    // Backed lazily: edges are the most numerous objects in the graph and almost none of them
-    // carry assumptions (which are only populated/read by the opt-in assumption analysis, never on
-    // the hot edge-construction path). Allocating the set only on first use avoids a per-edge
-    // allocation. Not part of equals/hashCode.
+    /** Lazy backing field for [assumptions]. */
     private var _assumptions: MutableSet<Assumption>? = null
 
+    /**
+     * The assumptions attached to this edge.
+     *
+     * The backing set is allocated lazily on first access: edges are the most numerous objects in
+     * the graph and almost none of them carry assumptions (which are only populated/read by the
+     * opt-in assumption analysis, never on the hot edge-construction path). Not part of
+     * [equals]/[hashCode].
+     */
     @DoNotPersist
     override val assumptions: MutableSet<Assumption>
         get() = _assumptions ?: mutableSetOf<Assumption>().also { _assumptions = it }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/Edge.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/Edge.kt
@@ -57,7 +57,15 @@ abstract class Edge<NodeType : Node> : Persistable, Cloneable, HasAssumptions {
     // Node where the edge is ingoing
     @JsonBackReference var end: NodeType
 
-    @DoNotPersist override val assumptions: MutableSet<Assumption> = mutableSetOf()
+    // Backed lazily: edges are the most numerous objects in the graph and almost none of them
+    // carry assumptions (which are only populated/read by the opt-in assumption analysis, never on
+    // the hot edge-construction path). Allocating the set only on first use avoids a per-edge
+    // allocation. Not part of equals/hashCode.
+    private var _assumptions: MutableSet<Assumption>? = null
+
+    @DoNotPersist
+    override val assumptions: MutableSet<Assumption>
+        get() = _assumptions ?: mutableSetOf<Assumption>().also { _assumptions = it }
 
     constructor(start: Node, end: NodeType) {
         this.start = start

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/MemoryAddress.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/MemoryAddress.kt
@@ -34,7 +34,12 @@ import kotlin.reflect.KProperty
 /** This edge class defines that [end] is a (possible) memory address of [start]. */
 open class MemoryAddressEdge(start: Node, end: MemoryAddress, var outgoing: Boolean) :
     Edge<MemoryAddress>(start, end) {
-    override var labels = setOf("MemoryAddress")
+    override var labels = LABELS
+
+    companion object {
+        /** Shared, immutable label set for all [MemoryAddressEdge]s (see [Edge.labels]). */
+        val LABELS = setOf("MemoryAddress")
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/ast/AstEdge.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/ast/AstEdge.kt
@@ -37,7 +37,12 @@ open class AstEdge<T : AstNode>(start: AstNode, end: T) : Edge<T>(start, end) {
         end.astParent = start
     }
 
-    override var labels: Set<String> = setOf("AST")
+    override var labels: Set<String> = LABELS
+
+    companion object {
+        /** Shared, immutable label set for all [AstEdge]s (see [Edge.labels]). */
+        val LABELS = setOf("AST")
+    }
 }
 
 /** Creates an [AstEdges] container starting from this node. */

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeList.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeList.kt
@@ -37,13 +37,16 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
     override var onAdd: ((EdgeType) -> Unit)? = null,
     override var onRemove: ((EdgeType) -> Unit)? = null,
     /**
-     * We allow to explicitly set the capacity. In most cases, 1 is fine as we expect that most
-     * nodes will only have one edge of a given type. This is a common case for many edge types in
-     * the CPG, and setting the initial capacity to 1 can save memory in these cases. In cases where
-     * we expect more edges, we can increase the capacity to avoid unnecessary and expensive copy
-     * operations to a larger list.
+     * We allow to explicitly set the capacity. The default of 0 defers the backing array allocation
+     * until the first element is added: [ArrayList]'s constructor allocates a real backing array
+     * immediately for any capacity > 0, so a supposedly cheap "capacity 1" default still paid for
+     * an array allocation on every single node, even for the majority of edge types that stay empty
+     * for most nodes (e.g. control- and program-dependence edges). With capacity 0, [ArrayList]
+     * uses a shared empty backing array until something is actually added. In cases where we expect
+     * many edges, we can increase the capacity to avoid unnecessary and expensive copy operations
+     * to a larger list.
      */
-    initialCapacity: Int = 1,
+    initialCapacity: Int = 0,
 ) : ArrayList<EdgeType>(initialCapacity), EdgeCollection<NodeType, EdgeType> {
 
     override fun add(element: EdgeType): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeList.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeList.kt
@@ -71,10 +71,13 @@ abstract class EdgeList<NodeType : Node, EdgeType : Edge<NodeType>>(
     }
 
     override fun removeAll(elements: Collection<EdgeType>): Boolean {
-        val ok = super.removeAll(elements.toSet())
-        if (ok) {
-            elements.forEach { handleOnRemove(it) }
-        }
+        // Only notify for edges that were actually present and removed. Firing onRemove for
+        // elements that were not in this list (or for duplicates in the input) would corrupt
+        // mirror-property bookkeeping and other onRemove side effects.
+        val toRemove = elements.toSet()
+        val removed = toRemove.filter { contains(it) }
+        val ok = super.removeAll(toRemove)
+        removed.forEach { handleOnRemove(it) }
         return ok
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSet.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSet.kt
@@ -30,8 +30,17 @@ import de.fraunhofer.aisec.cpg.graph.edges.Edge
 import java.util.function.Predicate
 
 /**
- * This class extends a list of property edges. This allows us to use list of property edges more
+ * This class extends a set of property edges. This allows us to use sets of property edges more
  * conveniently.
+ *
+ * Measurements across representative test corpora show that the overwhelming majority of edge sets
+ * (evaluation order, dataflow, control- and program-dependence, overlays, ...) hold either 0, 1 or
+ * 2 elements per node, with a long tail of much larger sets for a small minority of nodes (e.g. a
+ * branch condition that control-depends hundreds of statements). A plain [HashSet] pays for a full
+ * hash table entry ([java.util.HashMap.Node], i.e. hash + key + value + next pointer) per element
+ * even when there is only one. To avoid that overhead for the common case, this class stores up to
+ * two elements directly in fields and only falls back to a real [HashSet] once a third distinct
+ * element is added.
  */
 abstract class EdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
     override var thisRef: Node,
@@ -39,21 +48,93 @@ abstract class EdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
     override var outgoing: Boolean = true,
     override var onAdd: ((EdgeType) -> Unit)? = null,
     override var onRemove: ((EdgeType) -> Unit)? = null,
-    // We explicitly set the capacity to 1, as we expect that most nodes will only have one edge of
-    // a given type. This is a common case for many edge types in the CPG, and setting the initial
-    // capacity to 1 can save memory in these cases.
-) : HashSet<EdgeType>(1), EdgeCollection<NodeType, EdgeType> {
+) : AbstractMutableSet<EdgeType>(), EdgeCollection<NodeType, EdgeType> {
+
+    private var elem0: EdgeType? = null
+    private var elem1: EdgeType? = null
+    private var overflow: HashSet<EdgeType>? = null
+
+    override val size: Int
+        get() {
+            var count = 0
+            if (elem0 != null) count++
+            if (elem1 != null) count++
+            return count + (overflow?.size ?: 0)
+        }
+
+    override fun isEmpty(): Boolean {
+        return elem0 == null && elem1 == null && overflow.isNullOrEmpty()
+    }
+
+    override fun contains(element: EdgeType): Boolean {
+        return elem0 == element || elem1 == element || overflow?.contains(element) == true
+    }
+
+    override fun iterator(): MutableIterator<EdgeType> = EdgeSetIterator()
+
+    /** Mutates the backing storage only, without triggering [onAdd]/[onRemove] notifications. */
+    private fun addInternal(element: EdgeType): Boolean {
+        if (contains(element)) return false
+        return when {
+            elem0 == null -> {
+                elem0 = element
+                true
+            }
+            elem1 == null -> {
+                elem1 = element
+                true
+            }
+            else -> {
+                val of = overflow ?: HashSet<EdgeType>().also { overflow = it }
+                of.add(element)
+            }
+        }
+    }
+
+    private fun removeInternal(element: EdgeType): Boolean {
+        return when {
+            elem0 == element -> {
+                elem0 = null
+                true
+            }
+            elem1 == element -> {
+                elem1 = null
+                true
+            }
+            else -> {
+                val removed = overflow?.remove(element) == true
+                if (overflow?.isEmpty() == true) {
+                    overflow = null
+                }
+                removed
+            }
+        }
+    }
+
     override fun add(element: EdgeType): Boolean {
-        val ok = super<HashSet>.add(element)
+        val ok = addInternal(element)
         if (ok) {
             handleOnAdd(element)
         }
         return ok
     }
 
+    override fun remove(element: EdgeType): Boolean {
+        val ok = removeInternal(element)
+        if (ok) {
+            handleOnRemove(element)
+        }
+        return ok
+    }
+
     override fun removeIf(predicate: Predicate<in EdgeType>): Boolean {
         val edges = filter { predicate.test(it) }
-        val ok = super<HashSet>.removeIf(predicate)
+        var ok = false
+        for (edge in edges) {
+            if (removeInternal(edge)) {
+                ok = true
+            }
+        }
         if (ok) {
             edges.forEach { handleOnRemove(it) }
         }
@@ -61,17 +142,14 @@ abstract class EdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
     }
 
     override fun removeAll(elements: Collection<EdgeType>): Boolean {
-        val ok = super.removeAll(elements.toSet())
+        var ok = false
+        for (edge in elements.toSet()) {
+            if (removeInternal(edge)) {
+                ok = true
+            }
+        }
         if (ok) {
             elements.forEach { handleOnRemove(it) }
-        }
-        return ok
-    }
-
-    override fun remove(element: EdgeType): Boolean {
-        val ok = super<HashSet>.remove(element)
-        if (ok) {
-            handleOnRemove(element)
         }
         return ok
     }
@@ -79,7 +157,9 @@ abstract class EdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
     override fun clear() {
         // Make a copy of our edges so we can pass a copy to our on-remove handler
         val edges = this.toSet()
-        super.clear()
+        elem0 = null
+        elem1 = null
+        overflow = null
         edges.forEach { handleOnRemove(it) }
     }
 
@@ -105,5 +185,82 @@ abstract class EdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
 
     override fun hashCode(): Int {
         return internalHashcode(this, outgoing)
+    }
+
+    private inner class EdgeSetIterator : MutableIterator<EdgeType> {
+        /** 0: about to yield [elem0], 1: about to yield [elem1], 2: yielding [overflow]. */
+        private var stage = 0
+        private var overflowIterator: MutableIterator<EdgeType>? = null
+        private var lastReturned: EdgeType? = null
+        private var lastFromOverflow = false
+
+        private fun skipEmptyStages() {
+            if (stage == 0 && elem0 == null) stage = 1
+            if (stage == 1 && elem1 == null) stage = 2
+        }
+
+        private fun ensureOverflowIterator(): MutableIterator<EdgeType>? {
+            var it = overflowIterator
+            if (it == null) {
+                it = overflow?.iterator()
+                overflowIterator = it
+            }
+            return it
+        }
+
+        override fun hasNext(): Boolean {
+            skipEmptyStages()
+            return when (stage) {
+                0 -> elem0 != null
+                1 -> elem1 != null
+                else -> ensureOverflowIterator()?.hasNext() == true
+            }
+        }
+
+        override fun next(): EdgeType {
+            skipEmptyStages()
+            return when (stage) {
+                0 -> {
+                    val value = elem0 ?: throw NoSuchElementException()
+                    lastReturned = value
+                    lastFromOverflow = false
+                    stage = 1
+                    value
+                }
+                1 -> {
+                    val value = elem1 ?: throw NoSuchElementException()
+                    lastReturned = value
+                    lastFromOverflow = false
+                    stage = 2
+                    value
+                }
+                else -> {
+                    val it = ensureOverflowIterator() ?: throw NoSuchElementException()
+                    val value = it.next()
+                    lastReturned = value
+                    lastFromOverflow = true
+                    value
+                }
+            }
+        }
+
+        override fun remove() {
+            // Note: like the previous HashSet-based implementation, removal via the iterator does
+            // not trigger the onRemove notification (unlike remove()/removeAll()/clear() below,
+            // which do) - this matches the behavior of java.util.HashSet's iterator, which
+            // EdgeSet used to inherit from directly.
+            val value = lastReturned ?: throw IllegalStateException("next() has not been called")
+            if (lastFromOverflow) {
+                overflowIterator?.remove()
+                if (overflow?.isEmpty() == true) {
+                    overflow = null
+                }
+            } else if (elem0 == value) {
+                elem0 = null
+            } else if (elem1 == value) {
+                elem1 = null
+            }
+            lastReturned = null
+        }
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSet.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSet.kt
@@ -142,16 +142,18 @@ abstract class EdgeSet<NodeType : Node, EdgeType : Edge<NodeType>>(
     }
 
     override fun removeAll(elements: Collection<EdgeType>): Boolean {
-        var ok = false
+        // Only notify for edges that were actually present and removed. Firing onRemove for
+        // elements that were not in this set (or for duplicates in the input) would corrupt
+        // mirror-property bookkeeping and other onRemove side effects. This mirrors the precise
+        // behavior of removeIf above.
+        val removed = ArrayList<EdgeType>()
         for (edge in elements.toSet()) {
             if (removeInternal(edge)) {
-                ok = true
+                removed.add(edge)
             }
         }
-        if (ok) {
-            elements.forEach { handleOnRemove(it) }
-        }
-        return ok
+        removed.forEach { handleOnRemove(it) }
+        return removed.isNotEmpty()
     }
 
     override fun clear() {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/ControlDependence.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/ControlDependence.kt
@@ -38,16 +38,20 @@ import kotlin.reflect.KProperty
 class ControlDependence(
     start: Node,
     end: Node,
-    /** A set of [EvaluationOrder.branch] values. */
-    var branches: Set<Boolean> =
-        HashSet(
-            1
-        ), // We set the capacity to 1, as the node depends on the true or false branch, never both.
-    // This means, the maximum size of the set is 1, and we can save some memory by setting
-    // the initial capacity to 1.
+    /**
+     * A set of [EvaluationOrder.branch] values. Defaults to the shared empty set: the [branches] a
+     * CDG edge actually depends on are assigned via the edge builder, so most default instances
+     * would otherwise pay for an empty [HashSet].
+     */
+    var branches: Set<Boolean> = emptySet(),
 ) : ProgramDependence(start, end, DependenceType.CONTROL) {
 
-    override var labels = super.labels.plus("CDG")
+    override var labels = LABELS
+
+    companion object {
+        /** Shared, immutable label set for all [ControlDependence] edges (see [Edge.labels]). */
+        val LABELS = ProgramDependence.LABELS + "CDG"
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Dataflow.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Dataflow.kt
@@ -334,3 +334,13 @@ class Dataflows<T : Node>(
         }
     }
 }
+
+/**
+ * Creates a [Dataflows] container starting from this node, mirrored to [mirrorProperty]. This is
+ * the counterpart of [memoryAddressEdgesOf] and keeps the lazily-allocated memory-model dataflow
+ * getters (e.g. `memoryValueEdges`) to a single line.
+ */
+fun Node.dataflowsOf(
+    mirrorProperty: KProperty<MutableCollection<Dataflow>>,
+    outgoing: Boolean,
+): Dataflows<Node> = Dataflows(thisRef = this, mirrorProperty = mirrorProperty, outgoing = outgoing)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Dataflow.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Dataflow.kt
@@ -174,7 +174,12 @@ open class Dataflow(
     open val functionSummary: Boolean = false,
     open val derefDepth: PointerAccess? = null,
 ) : ProgramDependence(start, end, DependenceType.DATA) {
-    override var labels = super.labels.plus("DFG")
+    override var labels = LABELS
+
+    companion object {
+        /** Shared, immutable label set for all [Dataflow] edges (see [Edge.labels]). */
+        val LABELS = ProgramDependence.LABELS + "DFG"
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/EvaluationOrder.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/EvaluationOrder.kt
@@ -76,7 +76,12 @@ class EvaluationOrder(
         return result
     }
 
-    override var labels = setOf("EOG")
+    override var labels = LABELS
+
+    companion object {
+        /** Shared, immutable label set for all [EvaluationOrder] edges (see [Edge.labels]). */
+        val LABELS = setOf("EOG")
+    }
 }
 
 /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Invoke.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Invoke.kt
@@ -43,7 +43,12 @@ class Invoke(
      */
     var dynamicInvoke: Boolean = false,
 ) : Edge<Function>(start, end) {
-    override var labels = setOf("INVOKES")
+    override var labels = LABELS
+
+    companion object {
+        /** Shared, immutable label set for all [Invoke] edges (see [Edge.labels]). */
+        val LABELS = setOf("INVOKES")
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/ProgramDependence.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/ProgramDependence.kt
@@ -86,7 +86,12 @@ open class ProgramDependence(
     var dependence: DependenceType,
 ) : Edge<Node>(start, end) {
 
-    override var labels = setOf("PDG")
+    override var labels = LABELS
+
+    companion object {
+        /** Shared, immutable label set for all [ProgramDependence] edges (see [Edge.labels]). */
+        val LABELS = setOf("PDG")
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Usage.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/flows/Usage.kt
@@ -51,7 +51,12 @@ class Usage(
         return result
     }
 
-    override var labels = setOf("USAGE")
+    override var labels = LABELS
+
+    companion object {
+        /** Shared, immutable label set for all [Usage] edges (see [Edge.labels]). */
+        val LABELS = setOf("USAGE")
+    }
 }
 
 /** A container for [Usage] edges. [NodeType] is necessary for type safety. */

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/overlay/BasicBlockEdge.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/overlay/BasicBlockEdge.kt
@@ -47,7 +47,12 @@ class BasicBlockEdge(start: Node, end: Node) : Edge<Node>(start, end) {
         return super.hashCode()
     }
 
-    override var labels = setOf("BB")
+    override var labels = LABELS
+
+    companion object {
+        /** Shared, immutable label set for all [BasicBlockEdge]s (see [Edge.labels]). */
+        val LABELS = setOf("BB")
+    }
 }
 
 /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/overlay/Overlay.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/overlay/Overlay.kt
@@ -42,7 +42,12 @@ import kotlin.reflect.KProperty
  * @constructor Constructs an [OverlayEdge] with a specified [start] and [end] node.
  */
 class OverlayEdge(start: Node, end: Node) : Edge<Node>(start, end) {
-    override var labels: Set<String> = setOf("OVERLAY")
+    override var labels: Set<String> = LABELS
+
+    companion object {
+        /** Shared, immutable label set for all [OverlayEdge]s (see [Edge.labels]). */
+        val LABELS = setOf("OVERLAY")
+    }
 }
 
 /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/scopes/Import.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/scopes/Import.kt
@@ -72,7 +72,12 @@ enum class ImportStyle {
 class Import(start: Scope, end: NamespaceScope, var declaration: ImportNode? = null) :
     Edge<NamespaceScope>(start, end) {
 
-    override var labels = setOf("SCOPE_IMPORT")
+    override var labels = LABELS
+
+    companion object {
+        /** Shared, immutable label set for all [Import] edges (see [Edge.labels]). */
+        val LABELS = setOf("SCOPE_IMPORT")
+    }
 
     val style: ImportStyle?
         get() = declaration?.style

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/ArrayConstruction.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/ArrayConstruction.kt
@@ -62,7 +62,9 @@ class ArrayConstruction : Expression(), HasInitializer {
 
     /** Adds an [Expression] to the existing [dimensions]. */
     fun addDimension(expression: Expression) {
-        addIfNotContains(dimensionEdges, expression)
+        if (dimensionEdges.none { it.end == expression }) {
+            dimensionEdges += expression
+        }
     }
 
     override fun equals(other: Any?): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Assign.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Assign.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.graph.expressions
 
 import de.fraunhofer.aisec.cpg.frontends.Language
 import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.Variable
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
@@ -56,7 +57,12 @@ import org.slf4j.LoggerFactory
  * from the (first) rhs to the [Assign] itself.
  */
 class Assign :
-    Expression(false), AssignmentHolder, ArgumentHolder, HasType.TypeObserver, HasOperatorCode {
+    Expression(false),
+    AssignmentHolder,
+    ArgumentHolder,
+    HasType.TypeObserver,
+    HasOperatorCode,
+    DeclarationHolder {
 
     override var operatorCode: String = "="
 
@@ -163,6 +169,12 @@ class Assign :
      * [declarations].
      */
     override var declarations by unwrapping(Assign::declarationEdges)
+
+    override fun addDeclaration(declaration: Declaration) {
+        if (declaration is Variable) {
+            addIfNotContains(declarationEdges, declaration)
+        }
+    }
 
     /** Finds the value (of [rhs]) that is assigned to the particular [lhs] expression. */
     fun findValue(lhsExpression: HasType): Expression? {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Comprehension.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Comprehension.kt
@@ -27,17 +27,47 @@ package de.fraunhofer.aisec.cpg.graph.expressions
 
 import de.fraunhofer.aisec.cpg.graph.AccessValues
 import de.fraunhofer.aisec.cpg.graph.ArgumentHolder
+import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.allChildren
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Function
+import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Variable
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgeOf
+import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astOptionalEdgeOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
+import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
 import de.fraunhofer.aisec.cpg.persistence.Relationship
 import java.util.Objects
 import org.apache.commons.lang3.builder.ToStringBuilder
 
 /** This class holds the variable, iterable and predicate of the [CollectionComprehension]. */
-class Comprehension : Expression(), ArgumentHolder {
+class Comprehension : Expression(), ArgumentHolder, DeclarationHolder {
+
+    /**
+     * The local [ValueDeclaration]s (the comprehension's iteration variable(s)) declared by this
+     * node. These members were moved down from [Expression] because only a few expression types
+     * actually hold locals; see [DeclarationHolder].
+     */
+    @Relationship(value = "LOCALS", direction = Relationship.Direction.OUTGOING)
+    var localEdges = astEdgesOf<ValueDeclaration>()
+
+    /** Virtual property to access [localEdges] without property edges. */
+    @DoNotPersist var locals by unwrapping(Comprehension::localEdges)
+
+    override fun addDeclaration(declaration: Declaration) {
+        if (declaration is Variable) {
+            addIfNotContains(localEdges, declaration)
+        } else if (declaration is Function) {
+            addIfNotContains(localEdges, declaration)
+        }
+    }
+
+    override val declarations: List<Declaration>
+        get() = locals
+
     @Relationship("VARIABLE")
     var variableEdge =
         astEdgeOf<Expression>(

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/DeclarationStatement.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/DeclarationStatement.kt
@@ -25,6 +25,7 @@
  */
 package de.fraunhofer.aisec.cpg.graph.expressions
 
+import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
@@ -40,7 +41,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder
  * contain other statements, but not declarations. Therefore, declarations are wrapped in a
  * [DeclarationStatement].
  */
-open class DeclarationStatement : Expression(false) {
+open class DeclarationStatement : Expression(false), DeclarationHolder {
 
     /**
      * The list of declarations declared or defined by this statement. It is always a list, even if

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Expression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Expression.kt
@@ -30,17 +30,8 @@ import de.fraunhofer.aisec.cpg.frontends.UnknownLanguage
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.AccessValues
 import de.fraunhofer.aisec.cpg.graph.AstNode
-import de.fraunhofer.aisec.cpg.graph.DeclarationHolder
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
-import de.fraunhofer.aisec.cpg.graph.declarations.Function
-import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
-import de.fraunhofer.aisec.cpg.graph.declarations.Variable
-import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
 import de.fraunhofer.aisec.cpg.graph.edges.MemoryAddressEdges
-import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
-import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdges
-import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.flows.Dataflows
 import de.fraunhofer.aisec.cpg.graph.edges.flows.dataflowsOf
 import de.fraunhofer.aisec.cpg.graph.edges.memoryAddressEdgesOf
@@ -53,7 +44,6 @@ import de.fraunhofer.aisec.cpg.graph.unknownType
 import de.fraunhofer.aisec.cpg.helpers.identitySetOf
 import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
 import de.fraunhofer.aisec.cpg.persistence.Relationship
-import java.util.*
 import org.apache.commons.lang3.builder.ToStringBuilder
 
 /**
@@ -65,7 +55,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder
  * executable code.
  */
 abstract class Expression(usedAsExpression: Boolean = true) :
-    AstNode(), DeclarationHolder, HasType, HasMemoryAddress, HasMemoryValue {
+    AstNode(), HasType, HasMemoryAddress, HasMemoryValue {
 
     /**
      * This property specifies that this node is used as an expression. Depending on the language,
@@ -86,35 +76,6 @@ abstract class Expression(usedAsExpression: Boolean = true) :
      * modeling and determine the dataflow direction
      */
     open var access: AccessValues = AccessValues.READ
-
-    /** Lazy backing field for [localEdges]. */
-    private var _localEdges: AstEdges<ValueDeclaration, AstEdge<ValueDeclaration>>? = null
-
-    /**
-     * A list of local variables (or other values) associated to this statement, defined by their
-     * [ValueDeclaration] extracted from Block because `for`, `while`, `if`, and `switch` can
-     * declare locals in their condition or initializers.
-     *
-     * The backing container is allocated lazily on first access: most expressions declare no
-     * locals, and [astEdgesOf] eagerly allocates a backing array. See [localsEqual] and [hashCode],
-     * which avoid forcing this allocation during structural comparisons.
-     *
-     * TODO: This is actually an AST node just for a subset of nodes, i.e. initializers in for-loops
-     */
-    @Relationship(value = "LOCALS", direction = Relationship.Direction.OUTGOING)
-    var localEdges: AstEdges<ValueDeclaration, AstEdge<ValueDeclaration>>
-        get() = _localEdges ?: astEdgesOf<ValueDeclaration>().also { _localEdges = it }
-        set(value) {
-            _localEdges = value
-        }
-
-    /** Virtual property to access [localEdges] without property edges. */
-    @DoNotPersist
-    var locals: MutableList<ValueDeclaration>
-        get() = localEdges.unwrap()
-        set(value) {
-            localEdges.resetTo(value)
-        }
 
     @DoNotPersist override val typeObservers: MutableSet<HasType.TypeObserver> = identitySetOf()
 
@@ -242,37 +203,16 @@ abstract class Expression(usedAsExpression: Boolean = true) :
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is Expression) return false
-        return super.equals(other) && localsEqual(other) && type == other.type
-    }
-
-    /**
-     * Compares the locals of `this` and [other] without forcing allocation of the lazily-created
-     * [localEdges] container when both sides are empty (the common case).
-     */
-    private fun localsEqual(other: Expression): Boolean {
-        val thisEmpty = _localEdges?.isEmpty() != false
-        val otherEmpty = other._localEdges?.isEmpty() != false
-        if (thisEmpty && otherEmpty) return true
-        return locals == other.locals && propertyEqualsList(localEdges, other.localEdges)
+        return super.equals(other) && type == other.type
     }
 
     override fun hashCode(): Int {
-        // Exactly matches the previous `Objects.hash(super.hashCode(), locals)`. An empty unwrapped
-        // locals collection hashes to `Objects.hash(collection.size)` == `Objects.hash(0)` == 31
-        // (see UnwrappedEdgeCollection.hashCode); using that constant for the empty case avoids
-        // forcing the lazy [localEdges] container to be allocated during hashing.
-        val localsHash = if (_localEdges?.isEmpty() != false) 31 else locals.hashCode()
-        return 31 * (31 + super.hashCode()) + localsHash
+        // `locals` moved to the few DeclarationHolder subclasses and is no longer part of the
+        // generic expression identity. This reproduces the historical value
+        // `Objects.hash(super.hashCode(), locals)` for the (now universal) empty-locals case, so
+        // expression node ids stay stable across this refactor. `type` is part of equals but
+        // deliberately excluded from the hash because it is mutated by the type passes, and a
+        // node's hash must stay stable while it is used as a map key.
+        return 31 * (31 + super.hashCode()) + 31
     }
-
-    override fun addDeclaration(declaration: Declaration) {
-        if (declaration is Variable) {
-            addIfNotContains(localEdges, declaration)
-        } else if (declaration is Function) {
-            addIfNotContains(localEdges, declaration)
-        }
-    }
-
-    override val declarations: List<Declaration>
-        get() = locals
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Expression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Expression.kt
@@ -37,6 +37,8 @@ import de.fraunhofer.aisec.cpg.graph.declarations.Function
 import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.Variable
 import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
+import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
+import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdges
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.flows.Dataflows
 import de.fraunhofer.aisec.cpg.graph.edges.memoryAddressEdgesOf
@@ -91,11 +93,25 @@ abstract class Expression(usedAsExpression: Boolean = true) :
      *
      * TODO: This is actually an AST node just for a subset of nodes, i.e. initializers in for-loops
      */
+    // Backed lazily: most expressions declare no locals, and [astEdgesOf] eagerly allocates a
+    // backing array. See [localsEqual]/[hashCode], which avoid forcing this allocation during
+    // structural comparisons.
+    private var _localEdges: AstEdges<ValueDeclaration, AstEdge<ValueDeclaration>>? = null
+
     @Relationship(value = "LOCALS", direction = Relationship.Direction.OUTGOING)
-    var localEdges = astEdgesOf<ValueDeclaration>()
+    var localEdges: AstEdges<ValueDeclaration, AstEdge<ValueDeclaration>>
+        get() = _localEdges ?: astEdgesOf<ValueDeclaration>().also { _localEdges = it }
+        set(value) {
+            _localEdges = value
+        }
 
     /** Virtual property to access [localEdges] without property edges. */
-    var locals by unwrapping(Expression::localEdges)
+    @DoNotPersist
+    var locals: MutableList<ValueDeclaration>
+        get() = localEdges.unwrap()
+        set(value) {
+            localEdges.resetTo(value)
+        }
 
     @DoNotPersist override val typeObservers: MutableSet<HasType.TypeObserver> = identitySetOf()
 
@@ -168,13 +184,28 @@ abstract class Expression(usedAsExpression: Boolean = true) :
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is Expression) return false
-        return super.equals(other) &&
-            locals == other.locals &&
-            propertyEqualsList(localEdges, other.localEdges) &&
-            type == other.type
+        return super.equals(other) && localsEqual(other) && type == other.type
     }
 
-    override fun hashCode() = Objects.hash(super.hashCode(), locals)
+    /**
+     * Compares the locals of `this` and [other] without forcing allocation of the lazily-created
+     * [localEdges] container when both sides are empty (the common case).
+     */
+    private fun localsEqual(other: Expression): Boolean {
+        val thisEmpty = _localEdges?.isEmpty() != false
+        val otherEmpty = other._localEdges?.isEmpty() != false
+        if (thisEmpty && otherEmpty) return true
+        return locals == other.locals && propertyEqualsList(localEdges, other.localEdges)
+    }
+
+    override fun hashCode(): Int {
+        // Exactly matches the previous `Objects.hash(super.hashCode(), locals)`. An empty unwrapped
+        // locals collection hashes to `Objects.hash(collection.size)` == `Objects.hash(0)` == 31
+        // (see UnwrappedEdgeCollection.hashCode); using that constant for the empty case avoids
+        // forcing the lazy [localEdges] container to be allocated during hashing.
+        val localsHash = if (_localEdges?.isEmpty() != false) 31 else locals.hashCode()
+        return 31 * (31 + super.hashCode()) + localsHash
+    }
 
     override fun addDeclaration(declaration: Declaration) {
         if (declaration is Variable) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Expression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Expression.kt
@@ -37,12 +37,12 @@ import de.fraunhofer.aisec.cpg.graph.declarations.Function
 import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.Variable
 import de.fraunhofer.aisec.cpg.graph.edges.Edge.Companion.propertyEqualsList
+import de.fraunhofer.aisec.cpg.graph.edges.MemoryAddressEdges
 import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
 import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdges
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.flows.Dataflows
 import de.fraunhofer.aisec.cpg.graph.edges.memoryAddressEdgesOf
-import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.graph.types.AutoType
 import de.fraunhofer.aisec.cpg.graph.types.HasType
@@ -152,27 +152,78 @@ abstract class Expression(usedAsExpression: Boolean = true) :
             informObservers(HasType.TypeObserver.ChangeType.ASSIGNED_TYPE)
         }
 
+    // The memory-model edge containers below are backed lazily: they are only populated by the
+    // DFG/PointsTo passes and stay empty on the majority of expressions, yet were eagerly
+    // constructed (3 wrapper objects per expression). They are not part of equals/hashCode, so
+    // lazy-on-access is safe. The unwrapped views are @DoNotPersist, matching the previous
+    // `by unwrapping` delegates.
+    private var _memoryValueEdges: Dataflows<Node>? = null
+
     /** Each Expression also has a MemoryValue. */
     @Relationship
-    override var memoryValueEdges =
-        Dataflows<Node>(
-            this,
-            mirrorProperty = HasMemoryValue::memoryValueUsageEdges,
-            outgoing = false,
-        )
-    override var memoryValues by unwrapping(Expression::memoryValueEdges)
+    override var memoryValueEdges: Dataflows<Node>
+        get() =
+            _memoryValueEdges
+                ?: Dataflows<Node>(
+                        this,
+                        mirrorProperty = HasMemoryValue::memoryValueUsageEdges,
+                        outgoing = false,
+                    )
+                    .also { _memoryValueEdges = it }
+        set(value) {
+            _memoryValueEdges = value
+        }
+
+    @DoNotPersist
+    override var memoryValues: MutableSet<Node>
+        get() = memoryValueEdges.unwrap()
+        set(value) {
+            memoryValueEdges.resetTo(value)
+        }
+
+    private var _memoryValueUsageEdges: Dataflows<Node>? = null
 
     /** Where the memory value of this Expression is used. */
     @Relationship
-    override var memoryValueUsageEdges =
-        Dataflows<Node>(this, mirrorProperty = HasMemoryValue::memoryValueEdges, outgoing = true)
-    override var memoryValueUsages by unwrapping(Expression::memoryValueUsageEdges)
+    override var memoryValueUsageEdges: Dataflows<Node>
+        get() =
+            _memoryValueUsageEdges
+                ?: Dataflows<Node>(
+                        this,
+                        mirrorProperty = HasMemoryValue::memoryValueEdges,
+                        outgoing = true,
+                    )
+                    .also { _memoryValueUsageEdges = it }
+        set(value) {
+            _memoryValueUsageEdges = value
+        }
+
+    @DoNotPersist
+    override var memoryValueUsages: MutableSet<Node>
+        get() = memoryValueUsageEdges.unwrap()
+        set(value) {
+            memoryValueUsageEdges.resetTo(value)
+        }
+
+    private var _memoryAddressEdges: MemoryAddressEdges? = null
 
     /** Each Expression also has a MemoryAddress. */
     @Relationship
-    override var memoryAddressEdges =
-        memoryAddressEdgesOf(mirrorProperty = MemoryAddress::usageEdges, outgoing = true)
-    override var memoryAddresses by unwrapping(Expression::memoryAddressEdges)
+    override var memoryAddressEdges: MemoryAddressEdges
+        get() =
+            _memoryAddressEdges
+                ?: memoryAddressEdgesOf(mirrorProperty = MemoryAddress::usageEdges, outgoing = true)
+                    .also { _memoryAddressEdges = it }
+        set(value) {
+            _memoryAddressEdges = value
+        }
+
+    @DoNotPersist
+    override var memoryAddresses: MutableSet<MemoryAddress>
+        get() = memoryAddressEdges.unwrap()
+        set(value) {
+            memoryAddressEdges.resetTo(value)
+        }
 
     override fun toString(): String {
         return ToStringBuilder(this, TO_STRING_STYLE)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Expression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Expression.kt
@@ -86,18 +86,20 @@ abstract class Expression(usedAsExpression: Boolean = true) :
      */
     open var access: AccessValues = AccessValues.READ
 
+    /** Lazy backing field for [localEdges]. */
+    private var _localEdges: AstEdges<ValueDeclaration, AstEdge<ValueDeclaration>>? = null
+
     /**
      * A list of local variables (or other values) associated to this statement, defined by their
      * [ValueDeclaration] extracted from Block because `for`, `while`, `if`, and `switch` can
      * declare locals in their condition or initializers.
      *
+     * The backing container is allocated lazily on first access: most expressions declare no
+     * locals, and [astEdgesOf] eagerly allocates a backing array. See [localsEqual] and [hashCode],
+     * which avoid forcing this allocation during structural comparisons.
+     *
      * TODO: This is actually an AST node just for a subset of nodes, i.e. initializers in for-loops
      */
-    // Backed lazily: most expressions declare no locals, and [astEdgesOf] eagerly allocates a
-    // backing array. See [localsEqual]/[hashCode], which avoid forcing this allocation during
-    // structural comparisons.
-    private var _localEdges: AstEdges<ValueDeclaration, AstEdge<ValueDeclaration>>? = null
-
     @Relationship(value = "LOCALS", direction = Relationship.Direction.OUTGOING)
     var localEdges: AstEdges<ValueDeclaration, AstEdge<ValueDeclaration>>
         get() = _localEdges ?: astEdgesOf<ValueDeclaration>().also { _localEdges = it }
@@ -152,14 +154,17 @@ abstract class Expression(usedAsExpression: Boolean = true) :
             informObservers(HasType.TypeObserver.ChangeType.ASSIGNED_TYPE)
         }
 
-    // The memory-model edge containers below are backed lazily: they are only populated by the
-    // DFG/PointsTo passes and stay empty on the majority of expressions, yet were eagerly
-    // constructed (3 wrapper objects per expression). They are not part of equals/hashCode, so
-    // lazy-on-access is safe. The unwrapped views are @DoNotPersist, matching the previous
-    // `by unwrapping` delegates.
+    /** Lazy backing field for [memoryValueEdges]. */
     private var _memoryValueEdges: Dataflows<Node>? = null
 
-    /** Each Expression also has a MemoryValue. */
+    /**
+     * Each Expression also has a MemoryValue.
+     *
+     * This and the other two memory-model containers ([memoryValueUsageEdges],
+     * [memoryAddressEdges]) are only populated by the DFG and points-to passes and stay empty on
+     * the majority of expressions. Their backing containers are therefore allocated lazily on first
+     * access. They are not part of [equals]/[hashCode], so lazy-on-access is safe.
+     */
     @Relationship
     override var memoryValueEdges: Dataflows<Node>
         get() =
@@ -174,6 +179,7 @@ abstract class Expression(usedAsExpression: Boolean = true) :
             _memoryValueEdges = value
         }
 
+    /** Virtual property for accessing [memoryValueEdges] as plain nodes. */
     @DoNotPersist
     override var memoryValues: MutableSet<Node>
         get() = memoryValueEdges.unwrap()
@@ -181,9 +187,12 @@ abstract class Expression(usedAsExpression: Boolean = true) :
             memoryValueEdges.resetTo(value)
         }
 
+    /** Lazy backing field for [memoryValueUsageEdges]. */
     private var _memoryValueUsageEdges: Dataflows<Node>? = null
 
-    /** Where the memory value of this Expression is used. */
+    /**
+     * Where the memory value of this Expression is used (allocated lazily, see [memoryValueEdges]).
+     */
     @Relationship
     override var memoryValueUsageEdges: Dataflows<Node>
         get() =
@@ -198,6 +207,7 @@ abstract class Expression(usedAsExpression: Boolean = true) :
             _memoryValueUsageEdges = value
         }
 
+    /** Virtual property for accessing [memoryValueUsageEdges] as plain nodes. */
     @DoNotPersist
     override var memoryValueUsages: MutableSet<Node>
         get() = memoryValueUsageEdges.unwrap()
@@ -205,9 +215,10 @@ abstract class Expression(usedAsExpression: Boolean = true) :
             memoryValueUsageEdges.resetTo(value)
         }
 
+    /** Lazy backing field for [memoryAddressEdges]. */
     private var _memoryAddressEdges: MemoryAddressEdges? = null
 
-    /** Each Expression also has a MemoryAddress. */
+    /** Each Expression also has a MemoryAddress (allocated lazily, see [memoryValueEdges]). */
     @Relationship
     override var memoryAddressEdges: MemoryAddressEdges
         get() =
@@ -218,6 +229,7 @@ abstract class Expression(usedAsExpression: Boolean = true) :
             _memoryAddressEdges = value
         }
 
+    /** Virtual property for accessing [memoryAddressEdges] as plain nodes. */
     @DoNotPersist
     override var memoryAddresses: MutableSet<MemoryAddress>
         get() = memoryAddressEdges.unwrap()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Expression.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Expression.kt
@@ -42,6 +42,7 @@ import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
 import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdges
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.flows.Dataflows
+import de.fraunhofer.aisec.cpg.graph.edges.flows.dataflowsOf
 import de.fraunhofer.aisec.cpg.graph.edges.memoryAddressEdgesOf
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.graph.types.AutoType
@@ -169,12 +170,9 @@ abstract class Expression(usedAsExpression: Boolean = true) :
     override var memoryValueEdges: Dataflows<Node>
         get() =
             _memoryValueEdges
-                ?: Dataflows<Node>(
-                        this,
-                        mirrorProperty = HasMemoryValue::memoryValueUsageEdges,
-                        outgoing = false,
-                    )
-                    .also { _memoryValueEdges = it }
+                ?: dataflowsOf(HasMemoryValue::memoryValueUsageEdges, outgoing = false).also {
+                    _memoryValueEdges = it
+                }
         set(value) {
             _memoryValueEdges = value
         }
@@ -197,12 +195,9 @@ abstract class Expression(usedAsExpression: Boolean = true) :
     override var memoryValueUsageEdges: Dataflows<Node>
         get() =
             _memoryValueUsageEdges
-                ?: Dataflows<Node>(
-                        this,
-                        mirrorProperty = HasMemoryValue::memoryValueEdges,
-                        outgoing = true,
-                    )
-                    .also { _memoryValueUsageEdges = it }
+                ?: dataflowsOf(HasMemoryValue::memoryValueEdges, outgoing = true).also {
+                    _memoryValueUsageEdges = it
+                }
         set(value) {
             _memoryValueUsageEdges = value
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/ForEach.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/ForEach.kt
@@ -26,11 +26,16 @@
 package de.fraunhofer.aisec.cpg.graph.expressions
 
 import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Function
+import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Variable
 import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
 import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdges
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astOptionalEdgeOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
+import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
 import de.fraunhofer.aisec.cpg.persistence.Relationship
 import java.util.Objects
 import org.apache.commons.lang3.builder.ToStringBuilder
@@ -39,7 +44,29 @@ import org.apache.commons.lang3.builder.ToStringBuilder
  * Represent a for statement of the form `for(variable ... iterable){...}` that executes the loop
  * body for each instance of an element in `iterable` that is temporarily stored in `variable`.
  */
-class ForEach : Loop(), BranchingNode, StatementHolder {
+class ForEach : Loop(), BranchingNode, StatementHolder, DeclarationHolder {
+
+    /**
+     * The local [ValueDeclaration]s (the loop's iteration variable) declared by this node. These
+     * members were moved down from [Expression] because only a few expression types actually hold
+     * locals; see [DeclarationHolder].
+     */
+    @Relationship(value = "LOCALS", direction = Relationship.Direction.OUTGOING)
+    var localEdges = astEdgesOf<ValueDeclaration>()
+
+    /** Virtual property to access [localEdges] without property edges. */
+    @DoNotPersist var locals by unwrapping(ForEach::localEdges)
+
+    override fun addDeclaration(declaration: Declaration) {
+        if (declaration is Variable) {
+            addIfNotContains(localEdges, declaration)
+        } else if (declaration is Function) {
+            addIfNotContains(localEdges, declaration)
+        }
+    }
+
+    override val declarations: List<Declaration>
+        get() = locals
 
     @Relationship("VARIABLE")
     var variableEdge =

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Lambda.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/expressions/Lambda.kt
@@ -26,20 +26,46 @@
 package de.fraunhofer.aisec.cpg.graph.expressions
 
 import de.fraunhofer.aisec.cpg.graph.*
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.Function
 import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
+import de.fraunhofer.aisec.cpg.graph.declarations.Variable
+import de.fraunhofer.aisec.cpg.graph.edges.ast.astEdgesOf
 import de.fraunhofer.aisec.cpg.graph.edges.ast.astOptionalEdgeOf
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
 import de.fraunhofer.aisec.cpg.graph.types.FunctionType
 import de.fraunhofer.aisec.cpg.graph.types.HasType
 import de.fraunhofer.aisec.cpg.graph.types.Type
+import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
 import de.fraunhofer.aisec.cpg.persistence.Relationship
 
 /**
  * This expression denotes the usage of an anonymous / lambda function. It connects the inner
  * anonymous function to the user of a lambda function with an expression.
  */
-class Lambda : Expression(), HasType.TypeObserver {
+class Lambda : Expression(), HasType.TypeObserver, DeclarationHolder {
+
+    /**
+     * The local [ValueDeclaration]s (e.g. init-capture variables) declared by this lambda. These
+     * members were moved down from [Expression] because only a few expression types actually hold
+     * locals; see [DeclarationHolder].
+     */
+    @Relationship(value = "LOCALS", direction = Relationship.Direction.OUTGOING)
+    var localEdges = astEdgesOf<ValueDeclaration>()
+
+    /** Virtual property to access [localEdges] without property edges. */
+    @DoNotPersist var locals by unwrapping(Lambda::localEdges)
+
+    override fun addDeclaration(declaration: Declaration) {
+        if (declaration is Variable) {
+            addIfNotContains(localEdges, declaration)
+        } else if (declaration is Function) {
+            addIfNotContains(localEdges, declaration)
+        }
+    }
+
+    override val declarations: List<Declaration>
+        get() = locals
 
     /**
      * If [areVariablesMutable] is false, only the (outer) variables in this list can be modified

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
@@ -146,6 +146,10 @@ sealed class Scope(
             val list = symbols.computeIfAbsent(symbol) { mutableListOf() }
             list += declaration
         }
+
+        // This scope's symbol table changed, so any cached ScopeManager.lookupSymbolByName results
+        // may no longer be valid.
+        provider.ctx.scopeManager.invalidateSymbolLookupCache()
     }
 
     /**

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/scopes/Scope.kt
@@ -44,9 +44,11 @@ import de.fraunhofer.aisec.cpg.graph.expressions.Label
 import de.fraunhofer.aisec.cpg.graph.expressions.LookupScope
 import de.fraunhofer.aisec.cpg.graph.expressions.Reference
 import de.fraunhofer.aisec.cpg.graph.firstScopeParentOrNull
+import de.fraunhofer.aisec.cpg.graph.types.ObjectType
 import de.fraunhofer.aisec.cpg.passes.ImportResolver
 import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
 import de.fraunhofer.aisec.cpg.persistence.Relationship
+import java.util.concurrent.ConcurrentHashMap
 import org.apache.commons.lang3.builder.ToStringBuilder
 
 /**
@@ -123,6 +125,38 @@ sealed class Scope(
      * completely redesign the alias / typedef system.
      */
     @DoNotPersist val typedefs = mutableMapOf<Name, Typedef>()
+
+    /** Lazy backing field for [objectTypeCache]. */
+    @DoNotPersist
+    @Volatile
+    private var _objectTypeCache: ConcurrentHashMap<String, ObjectType>? = null
+
+    /**
+     * A per-scope cache of non-generic [ObjectType]s, keyed by their (local) name. It lets the
+     * frontend reuse a single [ObjectType] instance for repeated references to the same named type
+     * within this scope (see [de.fraunhofer.aisec.cpg.graph.objectType]), instead of allocating a
+     * fresh, redundant [ObjectType] for each use.
+     *
+     * Sharing is sound because a type's resolution (its [ObjectType.recordDeclaration], fully
+     * qualified name and supertypes) is fully determined by its name and scope; all references to
+     * the same name within this scope resolve identically.
+     *
+     * The cache is stored directly on the scope instead of in a map keyed by the scope on purpose:
+     * [Scope.equals]/[hashCode] are derived from mutable fields ([astNode], [name]), so using a
+     * [Scope] as a map key would strand entries (and silently stop interning) if those fields ever
+     * changed after insertion. Keying by the scope's own identity — i.e. hanging the cache off the
+     * instance — sidesteps that entirely, and, because each translation context has its own scopes,
+     * it preserves the previous per-context isolation. The container is allocated lazily on first
+     * use.
+     */
+    @DoNotPersist
+    val objectTypeCache: ConcurrentHashMap<String, ObjectType>
+        get() =
+            _objectTypeCache
+                ?: synchronized(this) {
+                    _objectTypeCache
+                        ?: ConcurrentHashMap<String, ObjectType>().also { _objectTypeCache = it }
+                }
 
     /**
      * Adds a [typedef] declaration to the scope. This is used to store typedefs in the scope, so

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/EOGWorklist.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/EOGWorklist.kt
@@ -166,8 +166,14 @@ class Worklist<K : Any, N : Any, V>() {
     /**
      * The actual worklist, i.e., elements which still have to be analyzed and the state which
      * should be considered there.
+     *
+     * A [LinkedHashMap] preserves insertion order (like the list-based implementation this
+     * replaces) while making the by-node lookup in [push] O(1) on average instead of the O(n)
+     * linear scan a list would require. Removing and re-inserting a key moves it to the end of the
+     * iteration order, which is exactly the "move updated entries to the back of the queue"
+     * behavior the previous implementation had.
      */
-    private val nodeOrder: MutableList<Pair<K, State<N, V>>> = mutableListOf()
+    private val nodeOrder: LinkedHashMap<K, State<N, V>> = LinkedHashMap()
 
     /**
      * Adds [newNode] and the [state] to the [globalState] (i.e., computes the [State.lub] of the
@@ -187,21 +193,21 @@ class Worklist<K : Any, N : Any, V>() {
      * If it returns `false`, the [newNode] wasn't added to the worklist as the state didn't change.
      */
     fun push(newNode: K, state: State<N, V>): Boolean {
-        val currentEntry = nodeOrder.find { it.first == newNode }
+        val currentState = nodeOrder[newNode]
         val update: Boolean
-        val newEntry =
-            if (currentEntry != null) {
-                val (newState, update2) = currentEntry.second.lub(state)
-                update = update2
-                if (update) {
-                    nodeOrder.remove(currentEntry)
-                }
-                Pair(currentEntry.first, newState)
-            } else {
-                update = true
-                Pair(newNode, state)
+        val newState: State<N, V>
+        if (currentState != null) {
+            val (lubState, changed) = currentState.lub(state)
+            update = changed
+            newState = lubState
+            if (update) {
+                nodeOrder.remove(newNode)
             }
-        if (update) nodeOrder.add(newEntry)
+        } else {
+            update = true
+            newState = state
+        }
+        if (update) nodeOrder[newNode] = newState
         return update
     }
 
@@ -213,9 +219,11 @@ class Worklist<K : Any, N : Any, V>() {
 
     /** Removes a [Node] from the worklist and returns the [Node] together with its [State] */
     fun pop(): Pair<K, State<N, V>> {
-        val node = nodeOrder.removeFirst()
-        alreadySeen.add(node.first)
-        return node
+        val iterator = nodeOrder.entries.iterator()
+        val entry = iterator.next()
+        iterator.remove()
+        alreadySeen.add(entry.key)
+        return Pair(entry.key, entry.value)
     }
 
     /** Computes the meet over paths for all the states in [globalState]. */

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/IdentitySet.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/IdentitySet.kt
@@ -48,22 +48,31 @@ import java.util.function.Predicate
  * The magic size of 16 comes from the implementation of Java and is randomly chosen. The
  * [expectedMaxSize] should be 2^n but this will be enforced internally anyway.
  */
-open class IdentitySet<T>(expectedMaxSize: Int = 16) : MutableSet<T> {
+open class IdentitySet<T>(private val expectedMaxSize: Int = 16) : MutableSet<T> {
     /**
      * The backing hashmap for our set. The [IdentityHashMap] offers reference-equality for keys and
      * values. In this case we use it to determine, if a node is already in our set or not. The
      * value of the map is not used and is always true. A [Boolean] is used because it seems to be
      * the smallest data type possible.
      *
-     * The map is twice the [expectedMaxSize] to avoid resizing too often which is expensive.
+     * It is allocated lazily on the first insertion: a great many [IdentitySet]s (e.g. every node's
+     * `typeObservers`) stay empty for their whole lifetime, and an [IdentityHashMap] eagerly
+     * allocates its backing table in its constructor. Keeping this `null` until something is added
+     * avoids that allocation for the empty case. The map is sized to twice the [expectedMaxSize] to
+     * avoid resizing too often, which is expensive.
      */
-    private val map: IdentityHashMap<T, Int> = IdentityHashMap(expectedMaxSize * 2)
+    private var map: IdentityHashMap<T, Int>? = null
     private val counter = AtomicInteger()
+
+    /** Returns the backing map, allocating it on first use. */
+    private fun ensureMap(): IdentityHashMap<T, Int> {
+        return map ?: IdentityHashMap<T, Int>(expectedMaxSize * 2).also { map = it }
+    }
 
     override operator fun contains(element: T): Boolean {
         // We are using the backing reference-equality based map to check, if the element is already
         // in the set.
-        return map.containsKey(element)
+        return map?.containsKey(element) == true
     }
 
     override fun equals(other: Any?): Boolean {
@@ -75,7 +84,7 @@ open class IdentitySet<T>(expectedMaxSize: Int = 16) : MutableSet<T> {
     override fun add(element: T): Boolean {
         // Since we are a Set, we only want to add elements that are not already there
         if (!contains(element)) {
-            map[element] = counter.addAndGet(1)
+            ensureMap()[element] = counter.addAndGet(1)
             return true
         }
 
@@ -87,23 +96,29 @@ open class IdentitySet<T>(expectedMaxSize: Int = 16) : MutableSet<T> {
      * should only be used if this set is empty!
      */
     open fun addAllWithoutCheck(elements: IdentitySet<T>) {
+        if (elements.isEmpty()) {
+            return
+        }
         // We rely on the input set and add everything without checking if an element is already
         // present.
+        val backing = ensureMap()
         for (element in elements) {
-            map[element] = counter.addAndGet(1)
+            backing[element] = counter.addAndGet(1)
         }
     }
 
     override fun containsAll(elements: Collection<T>): Boolean {
-        return elements.all { map.containsKey(it) }
+        val backing = map ?: return elements.isEmpty()
+        return elements.all { backing.containsKey(it) }
     }
 
     override fun isEmpty(): Boolean {
-        return map.isEmpty()
+        return map?.isEmpty() != false
     }
 
     override fun iterator(): MutableIterator<T> {
-        return map.keys.iterator()
+        @Suppress("UNCHECKED_CAST")
+        return map?.keys?.iterator() ?: (EmptyMutableIterator as MutableIterator<T>)
     }
 
     /**
@@ -112,7 +127,7 @@ open class IdentitySet<T>(expectedMaxSize: Int = 16) : MutableSet<T> {
      * according to their "closeness" to the root AST node.
      */
     open fun toSortedList(): List<T> {
-        return map.entries.sortedBy { it.value }.map { it.key }
+        return map?.entries?.sortedBy { it.value }?.map { it.key } ?: listOf()
     }
 
     override fun addAll(elements: Collection<T>): Boolean {
@@ -129,11 +144,11 @@ open class IdentitySet<T>(expectedMaxSize: Int = 16) : MutableSet<T> {
     }
 
     override fun clear() {
-        map.clear()
+        map?.clear()
     }
 
     override fun remove(element: T): Boolean {
-        return map.remove(element) != null
+        return map?.remove(element) != null
     }
 
     override fun removeAll(elements: Collection<T>): Boolean {
@@ -154,11 +169,11 @@ open class IdentitySet<T>(expectedMaxSize: Int = 16) : MutableSet<T> {
     }
 
     override fun hashCode(): Int {
-        return map.hashCode()
+        return map?.hashCode() ?: 0
     }
 
     override val size: Int
-        get() = map.size
+        get() = map?.size ?: 0
 }
 
 open class ConcurrentIdentitySet<T>(expectedMaxSize: Int = 16) : MutableSet<T> {
@@ -275,6 +290,15 @@ open class ConcurrentIdentitySet<T>(expectedMaxSize: Int = 16) : MutableSet<T> {
 
     override val size: Int
         get() = map.size
+}
+
+/** A shared, allocation-free empty [MutableIterator], used for empty [IdentitySet]s. */
+private object EmptyMutableIterator : MutableIterator<Any?> {
+    override fun hasNext() = false
+
+    override fun next(): Any? = throw NoSuchElementException()
+
+    override fun remove() = throw IllegalStateException()
 }
 
 fun <T> identitySetOf(vararg elements: T): IdentitySet<T> {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SmallMutableSet.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/SmallMutableSet.kt
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.helpers
+
+/**
+ * A [MutableSet] optimized for fields that are empty for the overwhelming majority of instances and
+ * hold only one or two elements otherwise (e.g. [de.fraunhofer.aisec.cpg.graph.Node.assumptions] or
+ * [de.fraunhofer.aisec.cpg.graph.Node.additionalProblems], which measurements show are empty for
+ * 98%+ of nodes). Elements are stored directly in two fields, avoiding the overhead of a
+ * [HashMap.Node] hash-table entry per element that a plain [HashSet] would pay even for a single
+ * element. Only once a third distinct element is added does this fall back to a real [HashSet].
+ */
+class SmallMutableSet<T : Any> : MutableSet<T> {
+    private var elem0: T? = null
+    private var elem1: T? = null
+    private var overflow: HashSet<T>? = null
+
+    override val size: Int
+        get() {
+            var count = 0
+            if (elem0 != null) count++
+            if (elem1 != null) count++
+            return count + (overflow?.size ?: 0)
+        }
+
+    override fun isEmpty(): Boolean {
+        return elem0 == null && elem1 == null && overflow.isNullOrEmpty()
+    }
+
+    override fun contains(element: T): Boolean {
+        return elem0 == element || elem1 == element || overflow?.contains(element) == true
+    }
+
+    override fun containsAll(elements: Collection<T>): Boolean {
+        return elements.all { contains(it) }
+    }
+
+    override fun add(element: T): Boolean {
+        if (contains(element)) return false
+        return when {
+            elem0 == null -> {
+                elem0 = element
+                true
+            }
+            elem1 == null -> {
+                elem1 = element
+                true
+            }
+            else -> (overflow ?: HashSet<T>().also { overflow = it }).add(element)
+        }
+    }
+
+    override fun addAll(elements: Collection<T>): Boolean {
+        var modified = false
+        for (e in elements) {
+            if (add(e)) {
+                modified = true
+            }
+        }
+        return modified
+    }
+
+    override fun remove(element: T): Boolean {
+        return when {
+            elem0 == element -> {
+                elem0 = null
+                true
+            }
+            elem1 == element -> {
+                elem1 = null
+                true
+            }
+            else -> {
+                val removed = overflow?.remove(element) == true
+                if (overflow?.isEmpty() == true) {
+                    overflow = null
+                }
+                removed
+            }
+        }
+    }
+
+    override fun removeAll(elements: Collection<T>): Boolean {
+        var modified = false
+        for (e in elements) {
+            if (remove(e)) {
+                modified = true
+            }
+        }
+        return modified
+    }
+
+    override fun retainAll(elements: Collection<T>): Boolean {
+        var modified = false
+        val it = iterator()
+        while (it.hasNext()) {
+            if (it.next() !in elements) {
+                it.remove()
+                modified = true
+            }
+        }
+        return modified
+    }
+
+    override fun clear() {
+        elem0 = null
+        elem1 = null
+        overflow = null
+    }
+
+    override fun iterator(): MutableIterator<T> = SmallMutableSetIterator()
+
+    override fun equals(other: Any?): Boolean {
+        if (other === this) return true
+        if (other !is Set<*>) return false
+        return this.size == other.size && this.containsAll(other)
+    }
+
+    override fun hashCode(): Int {
+        var hash = 0
+        for (e in this) {
+            hash += e.hashCode()
+        }
+        return hash
+    }
+
+    private inner class SmallMutableSetIterator : MutableIterator<T> {
+        /** 0: about to yield [elem0], 1: about to yield [elem1], 2: yielding [overflow]. */
+        private var stage = 0
+        private var overflowIterator: MutableIterator<T>? = null
+        private var lastReturned: T? = null
+        private var lastFromOverflow = false
+
+        private fun skipEmptyStages() {
+            if (stage == 0 && elem0 == null) stage = 1
+            if (stage == 1 && elem1 == null) stage = 2
+        }
+
+        private fun ensureOverflowIterator(): MutableIterator<T>? {
+            var it = overflowIterator
+            if (it == null) {
+                it = overflow?.iterator()
+                overflowIterator = it
+            }
+            return it
+        }
+
+        override fun hasNext(): Boolean {
+            skipEmptyStages()
+            return when (stage) {
+                0 -> elem0 != null
+                1 -> elem1 != null
+                else -> ensureOverflowIterator()?.hasNext() == true
+            }
+        }
+
+        override fun next(): T {
+            skipEmptyStages()
+            return when (stage) {
+                0 -> {
+                    val value = elem0 ?: throw NoSuchElementException()
+                    lastReturned = value
+                    lastFromOverflow = false
+                    stage = 1
+                    value
+                }
+                1 -> {
+                    val value = elem1 ?: throw NoSuchElementException()
+                    lastReturned = value
+                    lastFromOverflow = false
+                    stage = 2
+                    value
+                }
+                else -> {
+                    val it = ensureOverflowIterator() ?: throw NoSuchElementException()
+                    val value = it.next()
+                    lastReturned = value
+                    lastFromOverflow = true
+                    value
+                }
+            }
+        }
+
+        override fun remove() {
+            val value = lastReturned ?: throw IllegalStateException("next() has not been called")
+            if (lastFromOverflow) {
+                overflowIterator?.remove()
+                if (overflow?.isEmpty() == true) {
+                    overflow = null
+                }
+            } else if (elem0 == value) {
+                elem0 = null
+            } else if (elem1 == value) {
+                elem1 = null
+            }
+            lastReturned = null
+        }
+    }
+}
+
+/** Returns a new empty [SmallMutableSet]. See its documentation for the intended use case. */
+fun <T : Any> smallMutableSetOf(): MutableSet<T> = SmallMutableSet()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/functional/PersistentLattices.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/functional/PersistentLattices.kt
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.helpers.functional
+
+import de.fraunhofer.aisec.cpg.helpers.ConcurrentIdentitySet
+import de.fraunhofer.aisec.cpg.passes.PointsToPass
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.persistentHashMapOf
+
+/**
+ * Like [ConcurrentMapLattice], a [Lattice] over a map of [K] to another lattice represented by
+ * [innerLattice], but backed by a [PersistentMap] (structural sharing, from
+ * `kotlinx.collections.immutable`) instead of a mutable hash map.
+ *
+ * This makes [Element.duplicate] O(1) instead of O(n): since the backing map is never mutated in
+ * place, two [Element]s can safely share the same underlying [PersistentMap], and [lub] builds a
+ * new, structurally-shared map via [PersistentMap.put] rather than copying entry by entry. This
+ * matters because [Lattice.iterateEogInternal] calls [Lattice.Element.duplicate] on essentially
+ * every EOG edge near a branch; for state that is large and changes little between iterations (e.g.
+ * in [de.fraunhofer.aisec.cpg.passes.ControlDependenceGraphPass], where a single branch condition
+ * can dominate hundreds of statements), the previous deep-copy-per-branch cost dominated runtime.
+ *
+ * To preserve this safety property, [lub] always computes updated values via `innerLattice.lub(
+ * ..., allowModify = false, ...)`, regardless of the [allowModify] argument passed to [lub]: since
+ * values already stored in a [PersistentMap] may be shared by multiple [Element]s (via
+ * [Element.duplicate] or a prior [lub]), mutating one in place could silently corrupt the other.
+ * [allowModify] is therefore accepted (to match the [Lattice] interface) but has no effect here.
+ *
+ * Keys are compared by reference identity (like [ConcurrentMapLattice]), not by [Any.equals], since
+ * [de.fraunhofer.aisec.cpg.graph.Node] (and its subclasses, e.g.
+ * [de.fraunhofer.aisec.cpg.graph.overlays.BasicBlock]) define structural equals/hashCode, and two
+ * distinct nodes that happen to compare structurally equal must not collide as the same key.
+ */
+open class PersistentMapLattice<K, V : Lattice.Element>(val innerLattice: Lattice<V>) :
+    Lattice<PersistentMapLattice.Element<K, V>> {
+    override lateinit var elements: ConcurrentIdentitySet<Element<K, V>>
+
+    open class Element<K, V : Lattice.Element>(
+        internal val map: PersistentMap<PointsToPass.IdKey<K>, V>
+    ) : Lattice.Element {
+
+        constructor() : this(persistentHashMapOf())
+
+        constructor(
+            m: Map<K, V>
+        ) : this(
+            m.entries.fold(persistentHashMapOf<PointsToPass.IdKey<K>, V>()) { acc, (k, v) ->
+                acc.put(PointsToPass.IdKey(k), v)
+            }
+        )
+
+        constructor(entries: Collection<Pair<K, V>>) : this(entries.toMap())
+
+        constructor(vararg entries: Pair<K, V>) : this(entries.toMap())
+
+        /** Copy-constructs from another [Element], reusing its [PersistentMap] (this is O(1)). */
+        constructor(other: Element<K, V>) : this(other.map)
+
+        val size: Int
+            get() = map.size
+
+        val keys: Set<K>
+            get() = map.keys.mapTo(LinkedHashSet()) { it.ref }
+
+        val entries: List<Pair<K, V>>
+            get() = map.entries.map { it.key.ref to it.value }
+
+        operator fun get(key: K): V? = map[PointsToPass.IdKey(key)]
+
+        operator fun iterator(): Iterator<Pair<K, V>> = entries.iterator()
+
+        /** Returns a new [Element] with [key] mapped to [value]; does not modify this [Element]. */
+        fun put(key: K, value: V): Element<K, V> = Element(map.put(PointsToPass.IdKey(key), value))
+
+        /** Returns the entries (as `(K, V)` pairs) for which [predicate] holds. */
+        fun filter(predicate: (Pair<K, V>) -> Boolean): List<Pair<K, V>> {
+            return entries.filter(predicate)
+        }
+
+        override fun equals(other: Any?): Boolean {
+            return other is Element<*, *> && this.compare(other) == Order.EQUAL
+        }
+
+        override fun compare(other: Lattice.Element): Order {
+            if (this === other) return Order.EQUAL
+
+            if (other !is Element<*, *>)
+                throw IllegalArgumentException(
+                    "$other should be of type PersistentMapLattice.Element<K, V> but is of type ${other.javaClass}"
+                )
+            @Suppress("UNCHECKED_CAST") val otherMap = other as Element<K, V>
+
+            val otherKeySetIsBigger = otherMap.map.keys.any { it !in this.map.keys }
+
+            var someGreater = false
+            var someLesser = otherKeySetIsBigger
+            for ((k, v) in this.map) {
+                val otherV = otherMap.map[k]
+                if (otherV != null) {
+                    when (v.compare(otherV)) {
+                        Order.EQUAL -> {
+                            /* Nothing to do*/
+                        }
+                        Order.GREATER -> {
+                            if (someLesser) return Order.UNEQUAL
+                            someGreater = true
+                        }
+                        Order.LESSER -> {
+                            if (someGreater) return Order.UNEQUAL
+                            someLesser = true
+                        }
+                        Order.UNEQUAL -> return Order.UNEQUAL
+                    }
+                } else {
+                    if (someLesser) return Order.UNEQUAL
+                    someGreater = true
+                }
+            }
+            return if (!someGreater && !someLesser) {
+                Order.EQUAL
+            } else if (someLesser && !someGreater) {
+                Order.LESSER
+            } else if (!someLesser && someGreater) {
+                Order.GREATER
+            } else {
+                Order.UNEQUAL
+            }
+        }
+
+        // O(1): the underlying PersistentMap is never mutated in place (see the class-level
+        // documentation), so it is always safe for the duplicate to share it with the original.
+        override fun duplicate(): Element<K, V> = Element(map)
+
+        override fun hashCode(): Int = map.hashCode()
+    }
+
+    override val bottom: Element<K, V>
+        get() = Element()
+
+    override suspend fun lub(
+        one: Element<K, V>,
+        two: Element<K, V>,
+        allowModify: Boolean,
+        widen: Boolean,
+        concurrencyCounter: Int,
+    ): Element<K, V> {
+        var result = one.map
+        for ((key, v) in two.map) {
+            val existing = result[key]
+            val newValue =
+                if (existing != null) {
+                    if (existing === v) {
+                        existing
+                    } else {
+                        innerLattice.lub(existing, v, allowModify = false, widen = widen, 1)
+                    }
+                } else {
+                    v
+                }
+            result = result.put(key, newValue)
+        }
+        return Element(result)
+    }
+
+    override suspend fun glb(one: Element<K, V>, two: Element<K, V>): Element<K, V> {
+        var result = persistentHashMapOf<PointsToPass.IdKey<K>, V>()
+        for ((key, v) in one.map) {
+            val otherValue = two.map[key]
+            if (otherValue != null) {
+                result = result.put(key, innerLattice.glb(v, otherValue))
+            }
+        }
+        return Element(result)
+    }
+
+    override fun compare(one: Element<K, V>, two: Element<K, V>): Order {
+        return one.compare(two)
+    }
+
+    override fun duplicate(one: Element<K, V>): Element<K, V> {
+        return one.duplicate()
+    }
+}

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/functional/PersistentLattices.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/functional/PersistentLattices.kt
@@ -82,6 +82,9 @@ open class PersistentMapLattice<K, V : Lattice.Element>(val innerLattice: Lattic
         val size: Int
             get() = map.size
 
+        /** Returns `true` if this [Element] contains no entries. */
+        fun isEmpty(): Boolean = map.isEmpty()
+
         val keys: Set<K>
             get() = map.keys.mapTo(LinkedHashSet()) { it.ref }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlDependenceGraphPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlDependenceGraphPass.kt
@@ -42,8 +42,8 @@ import de.fraunhofer.aisec.cpg.graph.expressions.Return
 import de.fraunhofer.aisec.cpg.graph.expressions.ShortCircuitOperator
 import de.fraunhofer.aisec.cpg.graph.overlays.BasicBlock
 import de.fraunhofer.aisec.cpg.helpers.flatMapNotNull
-import de.fraunhofer.aisec.cpg.helpers.functional.ConcurrentMapLattice
 import de.fraunhofer.aisec.cpg.helpers.functional.Lattice
+import de.fraunhofer.aisec.cpg.helpers.functional.PersistentMapLattice
 import de.fraunhofer.aisec.cpg.helpers.functional.PowersetLattice
 import de.fraunhofer.aisec.cpg.helpers.identitySetOf
 import de.fraunhofer.aisec.cpg.helpers.mapFilteredTo
@@ -437,13 +437,13 @@ private fun IfElse.allBranchesFromMyThenBranchGoThrough(node: Node?): Boolean {
 }
 
 typealias PrevEOGLatticeElement =
-    ConcurrentMapLattice.Element<Node, PowersetLattice.Element<BasicBlock>>
+    PersistentMapLattice.Element<Node, PowersetLattice.Element<BasicBlock>>
 
-typealias PrevEOGLattice = ConcurrentMapLattice<Node, PowersetLattice.Element<BasicBlock>>
+typealias PrevEOGLattice = PersistentMapLattice<Node, PowersetLattice.Element<BasicBlock>>
 
-typealias PrevEOGStateElement = ConcurrentMapLattice.Element<BasicBlock, PrevEOGLatticeElement>
+typealias PrevEOGStateElement = PersistentMapLattice.Element<BasicBlock, PrevEOGLatticeElement>
 
-typealias PrevEOGState = ConcurrentMapLattice<BasicBlock, PrevEOGLatticeElement>
+typealias PrevEOGState = PersistentMapLattice<BasicBlock, PrevEOGLatticeElement>
 
 suspend fun PrevEOGState.push(
     currentElement: PrevEOGStateElement,

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlFlowSensitiveDFGPass.kt
@@ -489,11 +489,14 @@ open class ControlFlowSensitiveDFGPass(ctx: TranslationContext) : EOGStarterPass
             if (writtenTo is Reference) {
                 // This is a special case: We add the nextEOGEdge which goes out of the loop but
                 // with the old previousWrites map.
+                // Hoisted out of the filter: allChildren() flattens the whole statement subtree, so
+                // recomputing it for every nextEOGEdge was O(edges x subtree).
+                val statementChildren = currentNode.statement.allChildren<Node>()
                 val nodesOutsideTheLoop =
                     currentNode.nextEOGEdges.filter {
                         it.unreachable != true &&
                             it.end != currentNode.statement &&
-                            it.end !in currentNode.statement.allChildren<Node>()
+                            it.end !in statementChildren
                     }
                 nodesOutsideTheLoop.forEach { worklist.push(it, state.duplicate()) }
             }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ImportResolver.kt
@@ -421,4 +421,8 @@ fun ScopeManager.updateImportedSymbols(import: Import) {
                 .toMutableList()
         import.importedSymbols = mutableMapOf(import.symbol to list)
     }
+
+    // Import.importedSymbols is read by Scope.lookupSymbol (via replaceImports), so any cached
+    // ScopeManager.lookupSymbolByName results may no longer be valid.
+    invalidateSymbolLookupCache()
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
@@ -3799,8 +3799,9 @@ fun PointsToState.Element.getValues(
             }
             retVal
         }
-        is Declaration -> {
-            /* For Declarations, we have to look up the last value written to it.
+        is ValueDeclaration -> {
+            /* For value declarations, we have to look up the last value written to it. Only
+             * value declarations carry a memory address (see HasMemoryAddress on ValueDeclaration).
              */
             if (node.memoryAddresses.isEmpty()) {
                 node.memoryAddresses += MemoryAddress(node.name, isGlobal(node))
@@ -3907,9 +3908,10 @@ fun PointsToState.Element.getValues(
 
 fun PointsToState.Element.getAddresses(node: Node, startNode: Node): IdentitySet<Node> {
     return when (node) {
-        is Declaration -> {
+        is ValueDeclaration -> {
             /*
-             * For declarations, we created a new MemoryAddress node, so that's the one we use here
+             * For value declarations, we created a new MemoryAddress node, so that's the one we use
+             * here. Only value declarations carry a memory address.
              */
             if (node.memoryAddresses.isEmpty()) {
                 node.memoryAddresses += MemoryAddress(node.name, isGlobal(node))
@@ -3982,7 +3984,7 @@ fun PointsToState.Element.getAddresses(node: Node, startNode: Node): IdentitySet
                 if (refersTo is Function) {
                     globalDerefs.put(refersTo, PowersetLattice.Element(Pair(refersTo, false)))
                     identitySetOf(refersTo)
-                } else {
+                } else if (refersTo is ValueDeclaration) {
                     /* In some cases, the refersTo might not yet have an initialized MemoryAddress, for example if it's a Function. So let's do this here */
                     if (refersTo.memoryAddresses.isEmpty()) {
                         val newAddress = MemoryAddress(node.name, isGlobal(node))
@@ -3990,6 +3992,9 @@ fun PointsToState.Element.getAddresses(node: Node, startNode: Node): IdentitySet
                     }
 
                     refersTo.memoryAddresses.toIdentitySet()
+                } else {
+                    /* Only value declarations carry a memory address. */
+                    identitySetOf()
                 }
             } ?: identitySetOf()
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ProgramDependenceGraphPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ProgramDependenceGraphPass.kt
@@ -32,10 +32,12 @@ import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
 import de.fraunhofer.aisec.cpg.graph.edges.flows.Dataflow
 import de.fraunhofer.aisec.cpg.graph.edges.flows.DependenceType
 import de.fraunhofer.aisec.cpg.graph.expressions.Reference
+import de.fraunhofer.aisec.cpg.helpers.IdentitySet
 import de.fraunhofer.aisec.cpg.helpers.identitySetOf
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
 import de.fraunhofer.aisec.cpg.processing.IVisitor
 import de.fraunhofer.aisec.cpg.processing.strategy.Strategy
+import java.util.IdentityHashMap
 
 /**
  * This pass collects the dependence information of each node into a Program Dependence Graph (PDG)
@@ -107,34 +109,73 @@ class ProgramDependenceGraphPass(ctx: TranslationContext) : TranslationUnitPass(
             }
         }
 
+    /**
+     * Caches, per `from` node, a map from a `through` node to the set of nodes reachable from
+     * `from` via [Node.nextEOG] without ever stepping into `through` (see
+     * [computeReachableExcluding]). This lets [allEOGsFromToFlowThrough] answer the question for
+     * every `to` with a single O(1) set lookup, instead of running a fresh EOG traversal per
+     * `(from, to, through)` triple. The same `(from, through)` pair recurs across all references
+     * that share a data-flow predecessor and a control-dependence condition, so this is a
+     * substantial saving on functions with many references.
+     *
+     * Keys use reference identity ([IdentityHashMap]). The cache is cleared per translation unit in
+     * [accept] to bound its memory footprint.
+     */
+    private val reachableExcludingCache =
+        IdentityHashMap<Node, IdentityHashMap<Node, IdentitySet<Node>>>()
+
+    /**
+     * Returns `true` if every EOG path from [from] to [to] flows through [through]. Equivalently,
+     * it returns `false` iff [to] is reachable from [from] following [Node.nextEOG] edges without
+     * ever stepping into [through].
+     *
+     * The reachable set depends only on `(from, through)` and is memoized in
+     * [reachableExcludingCache], so repeated queries with different [to] values are answered by a
+     * set membership check.
+     */
     private fun allEOGsFromToFlowThrough(from: Node, to: Node, through: Node): Boolean {
+        val reachable =
+            reachableExcludingCache
+                .getOrPut(from) { IdentityHashMap() }
+                .getOrPut(through) { computeReachableExcluding(from, through) }
+        return to !in reachable
+    }
+
+    /**
+     * Computes the set of nodes that are reachable as a [Node.nextEOG] successor of any node
+     * reachable from [from], where paths never step into [through]. A node `n` is in the result iff
+     * there is an EOG path from [from] to `n` that does not pass through [through]; this is exactly
+     * the set of `to` values for which [allEOGsFromToFlowThrough] returns `false`.
+     */
+    private fun computeReachableExcluding(from: Node, through: Node): IdentitySet<Node> {
         val worklist = mutableListOf(from)
         val alreadySeenNodes = identitySetOf<Node>()
+        val reachable = identitySetOf<Node>()
 
         while (worklist.isNotEmpty()) {
             val currentStatus = worklist.removeFirst()
             if (!alreadySeenNodes.add(currentStatus)) {
                 continue
             }
-            val nextEOG = currentStatus.nextEOG.filter { it != through }
-            if (nextEOG.isEmpty()) {
-                // This path always flows through "through" or has not seen "to", so we're good
-                continue
-            } else if (nextEOG.any { it == to }) {
-                // We reached "to". This means that "through" has not been on the path for this EOG
-                // path.
-                return false
-            } else {
-                worklist.addAll(nextEOG.filter { it !in alreadySeenNodes })
+            for (next in currentStatus.nextEOG) {
+                if (next == through) {
+                    continue
+                }
+                reachable.add(next)
+                if (next !in alreadySeenNodes) {
+                    worklist.add(next)
+                }
             }
         }
-        return true
+        return reachable
     }
 
     override fun accept(tu: TranslationUnit) {
+        reachableExcludingCache.clear()
         tu.statements.forEach(::handle)
         tu.namespaces.forEach(::handle)
         tu.declarations.forEach(::handle)
+        reachableExcludingCache.clear()
     }
 
     override fun cleanup() {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ProgramDependenceGraphPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ProgramDependenceGraphPass.kt
@@ -63,6 +63,15 @@ class ProgramDependenceGraphPass(ctx: TranslationContext) : TranslationUnitPass(
                     // We filter all prevDFGEdges if the condition affects the variable of t and
                     // if there's a flow from the prevDFGEdge's node through the condition to t.
                     val prevDFGToConsider = mutableListOf<Dataflow>()
+                    // The reference children of the branching conditions depend only on t.prevCDG,
+                    // which is constant across all of t's prevDFG edges. Compute them once
+                    // (unfiltered)
+                    // and apply the per-prevDFG-node filter below, instead of re-walking each
+                    // condition's subtree for every prevDFG edge.
+                    val conditionReferences =
+                        t.prevCDG.flatMap {
+                            (it as? BranchingNode)?.branchedBy?.allChildren<Reference>() ?: listOf()
+                        }
                     t.prevDFGEdges.forEach { prevDfgEdge ->
                         val prevDfgNode = prevDfgEdge.start
                         // The prevDfgNode also flows into the condition. This is suspicious because
@@ -70,12 +79,7 @@ class ProgramDependenceGraphPass(ctx: TranslationContext) : TranslationUnitPass(
                         // is more relevant.
                         if (prevDfgNode is Reference || prevDfgNode is ValueDeclaration) {
                             val cdgConditionChildren =
-                                t.prevCDG.flatMap {
-                                    (it as? BranchingNode)?.branchedBy?.allChildren<Reference> { c
-                                        ->
-                                        c in prevDfgNode.nextDFG
-                                    } ?: listOf()
-                                }
+                                conditionReferences.filter { c -> c in prevDfgNode.nextDFG }
                             if (
                                 cdgConditionChildren.isNotEmpty() &&
                                     cdgConditionChildren.all {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/sarif/PhysicalLocation.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/sarif/PhysicalLocation.kt
@@ -29,6 +29,7 @@ import java.io.File
 import java.net.URI
 import java.nio.file.Path
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 
 /** A SARIF compatible location referring to a location, i.e. file and region within the file. */
 class PhysicalLocation(uri: URI?, region: Region) {
@@ -52,13 +53,28 @@ class PhysicalLocation(uri: URI?, region: Region) {
         }
 
         override fun hashCode() = Objects.hashCode(fileName)
+
+        companion object {
+            private val unknown = ArtifactLocation(null)
+            private val cache = ConcurrentHashMap<URI, ArtifactLocation>()
+
+            /**
+             * Returns a (shared) [ArtifactLocation] for [uri]. Since an [ArtifactLocation] is
+             * immutable and value-equal by [uri], and every node in a file shares the same URI, we
+             * intern one instance per URI instead of reconstructing a wrapper (and recomputing
+             * [fileName]) for every located node. The cache is bounded by the number of distinct
+             * files, not nodes.
+             */
+            fun of(uri: URI?): ArtifactLocation =
+                if (uri == null) unknown else cache.computeIfAbsent(uri) { ArtifactLocation(it) }
+        }
     }
 
     var artifactLocation: ArtifactLocation
     var region: Region
 
     init {
-        artifactLocation = ArtifactLocation(uri)
+        artifactLocation = ArtifactLocation.of(uri)
         this.region = region
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/sarif/PhysicalLocation.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/sarif/PhysicalLocation.kt
@@ -59,14 +59,30 @@ class PhysicalLocation(uri: URI?, region: Region) {
             private val cache = ConcurrentHashMap<URI, ArtifactLocation>()
 
             /**
+             * Upper bound on the number of interned [ArtifactLocation]s. The interning only needs
+             * to help within the working set of files currently being analyzed; because an
+             * [ArtifactLocation] is value-equal and cheap to rebuild, dropping cached entries only
+             * forgoes sharing, never correctness. Bounding the cache prevents unbounded growth in
+             * long-lived processes (e.g. server mode) that analyze many distinct files over time.
+             */
+            private const val MAX_CACHE_SIZE = 50_000
+
+            /**
              * Returns a (shared) [ArtifactLocation] for [uri]. Since an [ArtifactLocation] is
              * immutable and value-equal by [uri], and every node in a file shares the same URI, we
              * intern one instance per URI instead of reconstructing a wrapper (and recomputing
-             * [fileName]) for every located node. The cache is bounded by the number of distinct
-             * files, not nodes.
+             * [fileName]) for every located node. The cache is bounded by [MAX_CACHE_SIZE] distinct
+             * URIs; once that limit is reached it is cleared and repopulated on demand.
              */
-            fun of(uri: URI?): ArtifactLocation =
-                if (uri == null) unknown else cache.computeIfAbsent(uri) { ArtifactLocation(it) }
+            fun of(uri: URI?): ArtifactLocation {
+                if (uri == null) return unknown
+                // Cheap, racy bound. Occasional over-shoot or double-clear across threads is
+                // harmless: entries are pure caches and any dropped instance is simply rebuilt.
+                if (cache.size >= MAX_CACHE_SIZE) {
+                    cache.clear()
+                }
+                return cache.computeIfAbsent(uri) { ArtifactLocation(it) }
+            }
         }
     }
 

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/LazyEdgeDelegatePocTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/LazyEdgeDelegatePocTest.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.graph.edges
+
+import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+import kotlin.reflect.jvm.javaField
+import kotlin.test.*
+
+/**
+ * Proof-of-concept and feasibility check for "option 1b": replacing the manual three-member edge
+ * pattern
+ *
+ * ```
+ * private var _fooEdges: FooEdges? = null           // backing field
+ * @Relationship var fooEdges: FooEdges get()/set()  // persisted edge property
+ * @DoNotPersist var foos: MutableSet<Node> get()/set() // unwrapped view
+ * ```
+ *
+ * with a single-line Kotlin property delegate (`var fooEdges by lazyEdge { ... }`).
+ *
+ * The delegate is attractive: it is one line and it is genuinely lazy (the container is only built
+ * on first access). This test exists to answer, empirically, whether it can actually be adopted,
+ * because two independent reflection mechanisms read these members and they read them differently:
+ * - **Persistence** ([de.fraunhofer.aisec.cpg.persistence], `isRelationship`) keys off the Kotlin
+ *   *property return type*. A delegated edge property therefore still looks like a relationship —
+ *   *except* that `isRelationship` explicitly drops any property whose backing field type name
+ *   contains `"Delegate"`.
+ * - **AST/DFG traversal** ([SubgraphWalker.getAllEdgeFields]) reads the raw Java *field* whose name
+ *   contains `"Edge"` and expects it to hold an `EdgeCollection`. A delegated property's backing
+ *   field holds the *delegate object*, not the container.
+ *
+ * The assertions below confirm the conclusion: a delegate is transparent to persistence but opaque
+ * to `getAllEdgeFields`, so it silently removes the edges from AST/DFG traversal. That is why the
+ * production code keeps the manual field and only shortens the getter via a factory (option 1a). A
+ * delegate could only be adopted if [SubgraphWalker.getAllEdgeFields] were first taught to unwrap
+ * delegates.
+ */
+class LazyEdgeDelegatePocTest {
+
+    /**
+     * Minimal lazy read/write delegate: build the value via [factory] on first read, cache it, and
+     * allow it to be overwritten. This is the shape a real `lazyEdge` delegate would take.
+     */
+    private class LazyEdge<T : Any>(val factory: () -> T) : ReadWriteProperty<Any?, T> {
+        var backing: T? = null
+            private set
+
+        override fun getValue(thisRef: Any?, property: KProperty<*>): T =
+            backing ?: factory().also { backing = it }
+
+        override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+            backing = value
+        }
+    }
+
+    /** Sample using the delegate. Note the single-line declaration that replaces the triplet. */
+    private class DelegatedSample(counter: IntArray) {
+        var fooEdges: MutableList<String> by LazyEdge {
+            counter[0]++
+            mutableListOf()
+        }
+    }
+
+    /** Sample using the manual backing-field pattern that the real nodes use today. */
+    @Suppress("unused")
+    private class ManualSample {
+        private var _fooEdges: MutableList<String>? = null
+        var fooEdges: MutableList<String>
+            get() = _fooEdges ?: mutableListOf<String>().also { _fooEdges = it }
+            set(value) {
+                _fooEdges = value
+            }
+    }
+
+    @Test
+    fun testDelegateIsLazyAndCached() {
+        val counter = intArrayOf(0)
+        val sample = DelegatedSample(counter)
+
+        // The container is not built until first access.
+        assertEquals(0, counter[0])
+
+        sample.fooEdges.add("a")
+        assertEquals(1, counter[0])
+
+        // Second access reuses the cached container instead of rebuilding it.
+        sample.fooEdges.add("b")
+        assertEquals(1, counter[0])
+        assertEquals(listOf("a", "b"), sample.fooEdges)
+    }
+
+    @Test
+    fun testTraversalCannotSeeDelegatedContainer() {
+        // getAllEdgeFields selects Java fields whose *name* contains "Edge".
+        val fooField =
+            SubgraphWalker.getAllEdgeFields(DelegatedSample::class.java).single {
+                it.name.startsWith("fooEdges")
+            }
+
+        // The backing field is the synthetic delegate holder, not the container itself...
+        assertEquals("fooEdges\$delegate", fooField.name)
+        // ...and its type is the delegate, so getAstChildren's `is EdgeCollection` branch would not
+        // match (it throws AnnotationFormatError for a field that is not an edge/edge collection).
+        assertEquals(LazyEdge::class.java, fooField.type)
+        assertNotEquals(MutableList::class.java, fooField.type)
+
+        // By contrast, the manual pattern exposes a field that directly holds the container, which
+        // is exactly what the traversal expects.
+        val manualField =
+            SubgraphWalker.getAllEdgeFields(ManualSample::class.java).single {
+                it.name.contains("Edge")
+            }
+        assertEquals("_fooEdges", manualField.name)
+    }
+
+    @Test
+    fun testPersistenceSeesReturnTypeNotDelegate() {
+        val prop = DelegatedSample::fooEdges
+
+        // Persistence's isRelationship keys off the property's RETURN type, which is transparent to
+        // the delegate: it sees MutableList (a Collection), not the LazyEdge wrapper. So the
+        // relationship path itself is unaffected by delegation.
+        assertNotEquals(LazyEdge::class, prop.returnType.classifier)
+
+        // The decisive guard is the *backing field* type: isRelationship drops any property whose
+        // field type simpleName contains "Delegate". Our delegate is deliberately not named
+        // "*Delegate" (so this assertion passes), but it shows what that guard keys on: naming the
+        // delegate class conventionally (…Delegate) would silently drop the relationship.
+        val fieldTypeName = prop.javaField?.type?.simpleName
+        assertEquals("LazyEdge", fieldTypeName)
+        assertFalse(
+            fieldTypeName!!.contains("Delegate"),
+            "a delegate named *Delegate would be excluded from persistence by isRelationship",
+        )
+    }
+}

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSetTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSetTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.graph.edges.collections
+
+import de.fraunhofer.aisec.cpg.frontends.TestLanguageFrontend
+import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.newLiteral
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Exercises [EdgeSet]'s inline (0/1/2 element) storage and its [HashSet] overflow (3+ elements)
+ * through a concrete [de.fraunhofer.aisec.cpg.graph.edges.flows.Dataflows] set.
+ */
+class EdgeSetTest {
+    @Test
+    fun testInlineOverflowAndDeduplicate() {
+        with(TestLanguageFrontend()) {
+            val n = newLiteral(0)
+            val t1 = newLiteral(1)
+            val t2 = newLiteral(2)
+            val t3 = newLiteral(3)
+            val t4 = newLiteral(4)
+
+            // Two inline elements.
+            n.nextDFG += t1
+            n.nextDFG += t2
+            assertEquals(2, n.nextDFGEdges.size)
+
+            // Third and fourth spill into the overflow set.
+            n.nextDFG += t3
+            n.nextDFG += t4
+            assertEquals(4, n.nextDFGEdges.size)
+            assertEquals(setOf<Node>(t1, t2, t3, t4), n.nextDFG)
+
+            // Adding an already-present target (equal edge) is a no-op.
+            n.nextDFG += t3
+            assertEquals(4, n.nextDFGEdges.size)
+        }
+    }
+
+    @Test
+    fun testRemoveShrinksInlineAndOverflow() {
+        with(TestLanguageFrontend()) {
+            val n = newLiteral(0)
+            val targets = (1..4).map { newLiteral(it) }
+            targets.forEach { n.nextDFG += it }
+            assertEquals(4, n.nextDFGEdges.size)
+
+            // Remove an overflow element.
+            assertTrue(n.nextDFG.remove(targets[3]))
+            assertEquals(3, n.nextDFGEdges.size)
+
+            // Remove an inline element.
+            assertTrue(n.nextDFG.remove(targets[0]))
+            assertEquals(2, n.nextDFGEdges.size)
+            assertFalse(targets[0] in n.nextDFG)
+
+            // Removing an absent target.
+            assertFalse(n.nextDFG.remove(newLiteral(99)))
+        }
+    }
+
+    @Test
+    fun testIteratorAndIteratorRemove() {
+        with(TestLanguageFrontend()) {
+            val n = newLiteral(0)
+            (1..4).forEach { n.nextDFG += newLiteral(it) }
+
+            // The edge iterator visits every element (inline + overflow).
+            assertEquals(4, n.nextDFGEdges.iterator().asSequence().count())
+
+            // Remove everything via the iterator.
+            val it = n.nextDFGEdges.iterator()
+            while (it.hasNext()) {
+                it.next()
+                it.remove()
+            }
+            assertEquals(0, n.nextDFGEdges.size)
+        }
+    }
+
+    @Test
+    fun testRemoveIfAndClear() {
+        with(TestLanguageFrontend()) {
+            val n = newLiteral(0)
+            val keep = newLiteral(1)
+            val drop2 = newLiteral(2)
+            val drop3 = newLiteral(3)
+            listOf(keep, drop2, drop3).forEach { n.nextDFG += it }
+
+            assertTrue(n.nextDFGEdges.removeIf { it.end == drop2 || it.end == drop3 })
+            assertEquals(setOf<Node>(keep), n.nextDFG)
+
+            n.nextDFGEdges.clear()
+            assertTrue(n.nextDFGEdges.isEmpty())
+        }
+    }
+}

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSetTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/graph/edges/collections/EdgeSetTest.kt
@@ -121,4 +121,45 @@ class EdgeSetTest {
             assertTrue(n.nextDFGEdges.isEmpty())
         }
     }
+
+    /**
+     * [EdgeSet.removeAll] must only fire `onRemove` for edges it actually removed. Notifying an
+     * edge that is not a member (or a duplicate in the input) would run the mirror-property
+     * bookkeeping ([de.fraunhofer.aisec.cpg.graph.edges.collections.MirroredEdgeCollection]) for an
+     * edge that still legitimately lives elsewhere, evicting it from the mirror and corrupting the
+     * next/prev DFG invariant.
+     */
+    @Test
+    fun testRemoveAllOnlyNotifiesActuallyRemovedEdges() {
+        with(TestLanguageFrontend()) {
+            val n = newLiteral(0)
+            val m = newLiteral(10)
+            val t1 = newLiteral(1)
+            val t2 = newLiteral(2)
+
+            // n -> t1, n -> t2
+            n.nextDFG += t1
+            n.nextDFG += t2
+            // m -> t1 shares the target t1 but is NOT part of n's edge set. Its mirror lives in
+            // t1.prevDFGEdges.
+            m.nextDFG += t1
+
+            val foreignEdge = m.nextDFGEdges.single { it.end == t1 }
+            assertTrue(foreignEdge in t1.prevDFGEdges)
+
+            // Remove n -> t1 together with the foreign edge that is not a member of n.nextDFGEdges.
+            // Only n -> t1 must actually be removed and notified.
+            val ownEdge = n.nextDFGEdges.single { it.end == t1 }
+            assertTrue(n.nextDFGEdges.removeAll(listOf(ownEdge, foreignEdge)))
+
+            // n -> t1 is gone, n -> t2 remains.
+            assertEquals(setOf<Node>(t2), n.nextDFG)
+
+            // The foreign edge m -> t1 must be untouched on both sides of the mirror. With the
+            // previous (buggy) behavior, notifying foreignEdge here would have evicted it from
+            // t1.prevDFGEdges while leaving it in m.nextDFG.
+            assertTrue(t1 in m.nextDFG)
+            assertTrue(foreignEdge in t1.prevDFGEdges)
+        }
+    }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/helpers/IdentitySetTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/helpers/IdentitySetTest.kt
@@ -122,4 +122,33 @@ class IdentitySetTest {
 
         assertEquals(listOf(1, 2, 3, 4, 5, 6), set.toSortedList())
     }
+
+    /**
+     * The backing map is allocated lazily; these operations must all behave correctly while it is
+     * still `null` (i.e. before anything was added).
+     */
+    @Test
+    fun testEmptyBeforeFirstAdd() {
+        val set = IdentitySet<Int>()
+
+        assertEquals(0, set.size)
+        assertTrue(set.isEmpty())
+        assertFalse(set.contains(1))
+        assertFalse(set.iterator().hasNext())
+        assertTrue(set.containsAll(emptyList()))
+        assertFalse(set.containsAll(listOf(1)))
+        assertTrue(set.toSortedList().isEmpty())
+        assertFalse(set.remove(1))
+        assertFalse(set.removeAll(listOf(1, 2)))
+        assertEquals(0, set.hashCode())
+        assertEquals(IdentitySet<Int>(), set)
+
+        // Adding all of an empty set is a no-op that must not allocate/break anything.
+        set.addAllWithoutCheck(IdentitySet())
+        assertTrue(set.isEmpty())
+
+        // Clearing an empty (never-allocated) set is safe.
+        set.clear()
+        assertTrue(set.isEmpty())
+    }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/helpers/SmallMutableSetTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/helpers/SmallMutableSetTest.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.helpers
+
+import kotlin.test.*
+
+/**
+ * Exercises [SmallMutableSet] across its inline-storage (0/1/2 elements) and overflow (3+ elements)
+ * regimes, including the transitions between them and iterator-based removal at each stage.
+ */
+class SmallMutableSetTest {
+    @Test
+    fun testEmpty() {
+        val set = smallMutableSetOf<String>()
+        assertEquals(0, set.size)
+        assertTrue(set.isEmpty())
+        assertFalse(set.contains("a"))
+        assertTrue(set.containsAll(emptyList()))
+        assertFalse(set.iterator().hasNext())
+    }
+
+    @Test
+    fun testAddInlineAndDeduplicate() {
+        val set = smallMutableSetOf<String>()
+        assertTrue(set.add("a"))
+        assertTrue(set.add("b"))
+        assertFalse(set.add("a")) // duplicate in inline slot 0
+        assertFalse(set.add("b")) // duplicate in inline slot 1
+        assertEquals(2, set.size)
+        assertTrue(set.containsAll(listOf("a", "b")))
+        assertEquals(setOf("a", "b"), set.toSet())
+    }
+
+    @Test
+    fun testOverflow() {
+        val set = smallMutableSetOf<Int>()
+        set.addAll(listOf(1, 2, 3, 4, 5))
+        assertEquals(5, set.size)
+        for (i in 1..5) assertTrue(i in set)
+        assertFalse(set.add(3)) // duplicate in overflow
+        assertEquals(setOf(1, 2, 3, 4, 5), set.toSet())
+    }
+
+    @Test
+    fun testRemoveFromInlineAndOverflow() {
+        val set = smallMutableSetOf<Int>()
+        set.addAll(listOf(1, 2, 3, 4))
+
+        // Remove from an inline slot.
+        assertTrue(set.remove(1))
+        assertFalse(set.contains(1))
+        assertEquals(3, set.size)
+
+        // Remove from the overflow.
+        assertTrue(set.remove(4))
+        assertEquals(2, set.size)
+
+        // Removing something absent.
+        assertFalse(set.remove(42))
+
+        // Draining the overflow entirely still leaves the set consistent.
+        assertTrue(set.remove(3))
+        assertEquals(setOf(2), set.toSet())
+    }
+
+    @Test
+    fun testRemoveAllRetainAllClear() {
+        val set = smallMutableSetOf<Int>()
+        set.addAll(listOf(1, 2, 3, 4))
+
+        assertTrue(set.removeAll(listOf(2, 4, 99)))
+        assertEquals(setOf(1, 3), set.toSet())
+
+        set.addAll(listOf(5, 6))
+        assertTrue(set.retainAll(listOf(3, 5)))
+        assertEquals(setOf(3, 5), set.toSet())
+
+        set.clear()
+        assertTrue(set.isEmpty())
+        assertEquals(0, set.size)
+    }
+
+    @Test
+    fun testIteratorRemoveAtEveryStage() {
+        // Remove the first inline element via the iterator.
+        val a = smallMutableSetOf<Int>().apply { addAll(listOf(1, 2, 3)) }
+        var it = a.iterator()
+        it.next()
+        it.remove()
+        assertEquals(2, a.size)
+
+        // Remove all elements (spanning inline + overflow) via the iterator.
+        val b = smallMutableSetOf<Int>().apply { addAll(listOf(1, 2, 3, 4)) }
+        it = b.iterator()
+        while (it.hasNext()) {
+            it.next()
+            it.remove()
+        }
+        assertTrue(b.isEmpty())
+
+        // remove() before next() must fail.
+        assertFailsWith<IllegalStateException> { smallMutableSetOf<Int>().iterator().remove() }
+    }
+
+    @Test
+    fun testEqualsAndHashCode() {
+        val set = smallMutableSetOf<Int>().apply { addAll(listOf(1, 2, 3)) }
+        val reference = hashSetOf(1, 2, 3)
+        assertEquals(reference, set)
+        assertEquals(set, reference)
+        assertEquals(reference.hashCode(), set.hashCode())
+        assertNotEquals(smallMutableSetOf<Int>().apply { addAll(listOf(1, 2)) }, set)
+    }
+}

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/helpers/functional/PersistentLatticesTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/helpers/functional/PersistentLatticesTest.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.helpers.functional
+
+import kotlin.test.*
+import kotlinx.coroutines.runBlocking
+
+/** Tests [PersistentMapLattice] using a [PowersetLattice] of strings as the inner lattice. */
+class PersistentLatticesTest {
+
+    private val lattice =
+        PersistentMapLattice<String, PowersetLattice.Element<String>>(PowersetLattice())
+
+    private fun element(vararg entries: Pair<String, PowersetLattice.Element<String>>) =
+        PersistentMapLattice.Element(*entries)
+
+    @Test
+    fun testElementBasics() {
+        val a = element("k1" to PowersetLattice.Element("a"))
+        assertEquals(1, a.size)
+        assertEquals(setOf("k1"), a.keys)
+        assertNotNull(a["k1"])
+        assertNull(a["missing"])
+        assertEquals(1, a.entries.size)
+        assertEquals(1, a.iterator().asSequence().count())
+    }
+
+    @Test
+    fun testPutIsImmutable() {
+        val a = element("k1" to PowersetLattice.Element("a"))
+        val b = a.put("k2", PowersetLattice.Element("b"))
+
+        // The original is unchanged (structural sharing / copy-on-write).
+        assertEquals(1, a.size)
+        assertEquals(setOf("k1"), a.keys)
+
+        assertEquals(2, b.size)
+        assertEquals(setOf("k1", "k2"), b.keys)
+    }
+
+    @Test
+    fun testCompare() {
+        val empty = lattice.bottom
+        val one = element("k1" to PowersetLattice.Element("a"))
+        val oneCopy = element("k1" to PowersetLattice.Element("a"))
+
+        assertEquals(Order.EQUAL, lattice.compare(one, oneCopy))
+        assertEquals(Order.LESSER, lattice.compare(empty, one))
+        assertEquals(Order.GREATER, lattice.compare(one, empty))
+
+        // A greater key set (superset).
+        val two =
+            element("k1" to PowersetLattice.Element("a"), "k2" to PowersetLattice.Element("c"))
+        assertEquals(Order.GREATER, lattice.compare(two, one))
+        assertEquals(Order.LESSER, lattice.compare(one, two))
+
+        // Same key, disjoint values -> incomparable.
+        val other = element("k1" to PowersetLattice.Element("b"))
+        assertEquals(Order.UNEQUAL, lattice.compare(one, other))
+
+        assertEquals(one, oneCopy)
+    }
+
+    @Test
+    fun testLub() = runBlocking {
+        val one = element("k1" to PowersetLattice.Element("a"))
+        val two =
+            element("k1" to PowersetLattice.Element("b"), "k2" to PowersetLattice.Element("c"))
+
+        val merged = lattice.lub(one, two)
+        assertEquals(setOf("k1", "k2"), merged.keys)
+        // k1 = lub({a}, {b}) = {a, b}
+        assertEquals(2, merged["k1"]?.size)
+        assertEquals(1, merged["k2"]?.size)
+
+        // lub is >= both operands.
+        assertEquals(Order.GREATER, lattice.compare(merged, one))
+        assertEquals(Order.GREATER, lattice.compare(merged, two))
+
+        // The operands were not mutated.
+        assertEquals(1, one.size)
+        assertEquals(2, two.size)
+    }
+
+    @Test
+    fun testGlb() = runBlocking {
+        val one =
+            element("k1" to PowersetLattice.Element("a", "x"), "k2" to PowersetLattice.Element("c"))
+        val two =
+            element("k1" to PowersetLattice.Element("a"), "k3" to PowersetLattice.Element("d"))
+
+        val glb = lattice.glb(one, two)
+        // Only the shared key survives.
+        assertEquals(setOf("k1"), glb.keys)
+        // k1 = glb({a, x}, {a}) = {a}
+        assertEquals(1, glb["k1"]?.size)
+    }
+
+    @Test
+    fun testElementConstructorsAndHelpers() {
+        val fromMap = PersistentMapLattice.Element(mapOf("k1" to PowersetLattice.Element("a")))
+        val fromPairs = PersistentMapLattice.Element(listOf("k1" to PowersetLattice.Element("a")))
+        assertEquals(fromMap, fromPairs)
+        assertEquals(fromMap.hashCode(), fromMap.hashCode())
+
+        val two =
+            element("k1" to PowersetLattice.Element("a"), "k2" to PowersetLattice.Element("b"))
+        assertEquals(listOf("k1"), two.filter { (k, _) -> k == "k1" }.map { it.first })
+        assertEquals(2, two.entries.size)
+    }
+
+    @Test
+    fun testCompareIncomparableMixed() {
+        // On k1 `left` is smaller, on k2 `left` is larger -> the two are incomparable.
+        val left =
+            element("k1" to PowersetLattice.Element("a"), "k2" to PowersetLattice.Element("b", "c"))
+        val right =
+            element("k1" to PowersetLattice.Element("a", "x"), "k2" to PowersetLattice.Element("b"))
+        assertEquals(Order.UNEQUAL, lattice.compare(left, right))
+        assertEquals(Order.UNEQUAL, lattice.compare(right, left))
+    }
+
+    @Test
+    fun testDuplicateAndBottom() {
+        assertTrue(lattice.bottom.keys.isEmpty())
+
+        val one = element("k1" to PowersetLattice.Element("a"))
+        val dup = lattice.duplicate(one)
+        assertEquals(Order.EQUAL, lattice.compare(one, dup))
+        assertEquals(one, dup)
+    }
+}

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CXXLanguageFrontendTest.kt
@@ -397,7 +397,7 @@ internal class CXXLanguageFrontendTest : BaseTest() {
             assertTrue(initializer is Literal<*>)
             assertEquals(1, initializer.value)
 
-            val twoDeclarations = statements[2].declarations
+            val twoDeclarations = (statements[2] as DeclarationStatement).declarations
             assertEquals(2, twoDeclarations.size)
 
             val b = twoDeclarations[0] as Variable
@@ -430,7 +430,7 @@ internal class CXXLanguageFrontendTest : BaseTest() {
             assertLocalName("ptr2", pointerWithAssign)
             assertLiteralValue(null, pointerWithAssign.initializer)
 
-            val classWithVariable = statements[6].declarations
+            val classWithVariable = (statements[6] as DeclarationStatement).declarations
             assertEquals(2, classWithVariable.size)
 
             val classA = classWithVariable[0] as Record

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
@@ -28,10 +28,10 @@ package de.fraunhofer.aisec.cpg.passes
 import de.fraunhofer.aisec.cpg.frontends.cxx.CLanguage
 import de.fraunhofer.aisec.cpg.frontends.cxx.CPPLanguage
 import de.fraunhofer.aisec.cpg.graph.*
-import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.declarations.Field
 import de.fraunhofer.aisec.cpg.graph.declarations.Function
 import de.fraunhofer.aisec.cpg.graph.declarations.Parameter
+import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
 import de.fraunhofer.aisec.cpg.graph.declarations.Variable
 import de.fraunhofer.aisec.cpg.graph.edges.flows.*
 import de.fraunhofer.aisec.cpg.graph.expressions.*
@@ -346,8 +346,10 @@ class PointsToPassTest {
         assertNotNull(tu)
 
         // Declarations
-        val iDecl = tu.allChildren<Declaration> { it.location?.region?.startLine == 22 }.first()
-        val jDecl = tu.allChildren<Declaration> { it.location?.region?.startLine == 23 }.first()
+        val iDecl =
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 22 }.first()
+        val jDecl =
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 23 }.first()
 
         // PointerDerefs
         val aPointerDerefLine27 =
@@ -626,56 +628,56 @@ class PointsToPassTest {
 
         // Declarations
         val aDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 89 }.firstOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 89 }.firstOrNull()
         assertNotNull(aDecl)
         val bDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 90 }.firstOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 90 }.firstOrNull()
         assertNotNull(bDecl)
         val cDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 91 }.firstOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 91 }.firstOrNull()
         assertNotNull(cDecl)
         val caddrDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 92 }.firstOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 92 }.firstOrNull()
         assertNotNull(caddrDecl)
         val dDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 93 }.firstOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 93 }.firstOrNull()
         assertNotNull(dDecl)
         val eDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 94 }.firstOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 94 }.firstOrNull()
         assertNotNull(eDecl)
         val fDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 95 }.firstOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 95 }.firstOrNull()
         assertNotNull(fDecl)
         val gDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 96 }.firstOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 96 }.firstOrNull()
         assertNotNull(gDecl)
         val hDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 97 }.firstOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 97 }.firstOrNull()
         assertNotNull(hDecl)
 
         val paDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 99 }.firstOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 99 }.firstOrNull()
         assertNotNull(paDecl)
         val pbDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 100 }.firstOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 100 }.firstOrNull()
         assertNotNull(pbDecl)
         val pcDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 101 }.firstOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 101 }.firstOrNull()
         assertNotNull(pcDecl)
         val pdDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 102 }.firstOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 102 }.firstOrNull()
         assertNotNull(pdDecl)
         val peDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 103 }.firstOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 103 }.firstOrNull()
         assertNotNull(peDecl)
         val pfDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 104 }.firstOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 104 }.firstOrNull()
         assertNotNull(pfDecl)
         val pgDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 105 }.firstOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 105 }.firstOrNull()
         assertNotNull(pgDecl)
         val phDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 106 }.firstOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 106 }.firstOrNull()
         assertNotNull(phDecl)
 
         // References
@@ -1126,13 +1128,13 @@ class PointsToPassTest {
 
         // Declarations
         val aDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 134 }.firstOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 134 }.firstOrNull()
         assertNotNull(aDecl)
         val bDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 135 }.firstOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 135 }.firstOrNull()
         assertNotNull(bDecl)
         val cDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 136 }.firstOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 136 }.firstOrNull()
         assertNotNull(cDecl)
 
         // References
@@ -2418,19 +2420,24 @@ class PointsToPassTest {
 
         // Declarations
         val oldvalDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 256 }.singleOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 256 }
+                .singleOrNull()
         assertNotNull(oldvalDecl)
         val newvalDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 259 }.singleOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 259 }
+                .singleOrNull()
         assertNotNull(newvalDecl)
         val pOldvalDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 257 }.singleOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 257 }
+                .singleOrNull()
         assertNotNull(pOldvalDecl)
         val pNewvalDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 260 }.singleOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 260 }
+                .singleOrNull()
         assertNotNull(pNewvalDecl)
         val p2pDecl =
-            tu.allChildren<Declaration> { it.location?.region?.startLine == 258 }.singleOrNull()
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 258 }
+                .singleOrNull()
         assertNotNull(p2pDecl)
 
         // Literals
@@ -2547,7 +2554,8 @@ class PointsToPassTest {
         assertNotNull(tu)
 
         // Declarations
-        val keyDecl = tu.allChildren<Declaration> { it.location?.region?.startLine == 267 }.first()
+        val keyDecl =
+            tu.allChildren<ValueDeclaration> { it.location?.region?.startLine == 267 }.first()
         assertNotNull(keyDecl)
 
         // PointerReferences

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/StatementHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/StatementHandler.kt
@@ -1206,7 +1206,7 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
         val newArrayDecl = declarationOrNot(frontend.getOperandValueAtIndex(instr, 0), instr)
         compoundStatement.statements += newArrayDecl
 
-        val decl = newArrayDecl.declarations[0] as? Variable
+        val decl = (newArrayDecl as? DeclarationHolder)?.declarations?.get(0) as? Variable
         val arrayExpr = newSubscription(rawNode = instr)
         arrayExpr.arrayExpression =
             newReference(

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/StatementHandler.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/StatementHandler.kt
@@ -1206,7 +1206,7 @@ class StatementHandler(lang: LLVMIRLanguageFrontend) :
         val newArrayDecl = declarationOrNot(frontend.getOperandValueAtIndex(instr, 0), instr)
         compoundStatement.statements += newArrayDecl
 
-        val decl = (newArrayDecl as? DeclarationHolder)?.declarations?.get(0) as? Variable
+        val decl = (newArrayDecl as? DeclarationHolder)?.declarations?.firstOrNull() as? Variable
         val arrayExpr = newSubscription(rawNode = instr)
         arrayExpr.arrayExpression =
             newReference(

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/LLVMIRLanguageFrontendTest.kt
@@ -352,7 +352,7 @@ class LLVMIRLanguageFrontendTest {
 
         // Check that the first statement is "literal_i32_i1 val_success = literal_i32_i1(*ptr, *ptr
         // == 5)"
-        val declaration = cmpxchgStatement.statements[0].declarations[0]
+        val declaration = (cmpxchgStatement.statements[0] as DeclarationStatement).declarations[0]
         assertIs<Variable>(declaration)
         assertLocalName("val_success", declaration)
         assertLocalName("literal_i32_i1", declaration.type)

--- a/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/StatementHandlerTest.kt
+++ b/cpg-language-llvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/llvm/StatementHandlerTest.kt
@@ -846,7 +846,7 @@ class StatementHandlerTest {
         requiresUintCast: Boolean,
     ) {
         // Check that the value is assigned to
-        val declaration = atomicrmwStatement.statements[0].declarations[0]
+        val declaration = (atomicrmwStatement.statements[0] as DeclarationStatement).declarations[0]
         assertIs<Variable>(declaration)
         assertLocalName(variableName, declaration)
         assertLocalName("i32", declaration.type)
@@ -897,7 +897,7 @@ class StatementHandlerTest {
         variableName: String,
     ) {
         // Check that the value is assigned to
-        val declaration = atomicrmwStatement.statements[0].declarations[0]
+        val declaration = (atomicrmwStatement.statements[0] as DeclarationStatement).declarations[0]
         assertIs<Variable>(declaration)
         assertLocalName(variableName, declaration)
         assertLocalName("i32", declaration.type)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", versi
 kotlin-serialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-json" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.10.2"}
+kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version = "0.4.0"}
 
 reflections = { module = "org.reflections:reflections", version = "0.10.2"}
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                      

  Reduces the in-memory footprint and analysis runtime of the CPG without changing
  the graph model or any public pass/edge semantics. The work targets the three
  cost centers that dominate at scale: millions of `Node`s each carrying rarely-used
  properties, millions of `Edge`s each over-allocating, and fixed-point/graph passes
  doing redundant work.

  All changes are isolated, independently reviewable commits. Each was validated
  against the full test suite (excluding the `@Ignore`d `ExternalPerformanceTest`s).

  ## Memory

  - **Per-node edge containers allocated lazily.** CDG, PDG, overlay, memory-value/
    -address (on `Expression` *and* `Declaration`), `annotations`, `locals`, and
    `template*` containers are only populated by optional/specific passes yet were
    eagerly constructed on every node. They now allocate on first use. Measurements
    over the test corpus showed these empty on 95–100% of nodes.
  - **Per-edge overhead cut.** Edges are the most numerous objects: their `labels`
    set is now a shared per-subclass constant instead of a fresh `Set` per edge,
    `Edge.assumptions` is lazily allocated, and `ControlDependence.branches`
    defaults to the shared empty set.
  - **`EdgeList`/`EdgeSet` small-storage.** `EdgeList` no longer eagerly allocates a
    backing array; `EdgeSet` stores up to two elements inline before falling back to
    a `HashSet` (measurements: the vast majority of edge sets hold 0–2 elements).
  - **`Node.assumptions`/`additionalProblems`** use a lightweight `SmallMutableSet`;
    **`IdentitySet`** allocates its backing map lazily (helps every empty
    `typeObservers`, etc.).
  - **`ArtifactLocation` interned per URI** instead of reconstructed (with a
    recomputed `fileName`) per node.

  ## Runtime

  - **`Node.hashCode` cached** (invalidated by the `name`/`location` setters), since                                                                                                              
    passes hash nodes constantly. `Node.id` gets faster for free.
  - **`ScopeManager.lookupSymbolByName` cached**, invalidated on symbol-table
    mutation — cuts repeated scope-chain walks during resolution (frontend-side).
  - **`Worklist.push` O(n) → O(1)** by replacing a per-push linear scan with a
    `LinkedHashMap`.
  - **CDG fixed-point state uses a persistent map** (`kotlinx.collections.immutable`),
    making the per-branch `duplicate()` O(1) structural-sharing instead of a deep
    copy. Measured on `slow-cdg.c`: ~46.6s → ~38.7s median full analysis.
  - **`ProgramDependenceGraphPass` reachability memoized**, and repeated
    `allChildren`/`flattenAST` walks hoisted out of hot loops.

  ## Correctness / safety notes

  - The `hashCode` cache is *behaviorally identical* to the live computation: `Name`
    is immutable and no `PhysicalLocation` is mutated in place, so the `name`/
    `location` setters observe every change that can affect the hash.
  - Lazily-backed containers are never part of `equals`/`hashCode`; unwrapped views
    are `@DoNotPersist`, matching the previous `by unwrapping` delegates, so the
    Neo4j schema is unchanged.
  - The one new dependency is `kotlinx.collections.immutable` (JetBrains, for the
    persistent-map lattice).

  ## Explicitly not included (discussed, deferred as too risky/low-value)
  - Caching `Node.id` (unsound to invalidate — depends on the whole ancestor chain).
  - Pass-level parallelism, type/string interning, scope-collection laziness,
    `PointsToPass` persistent lattice.

  ## Testing
  Full unit-test suite green after each commit. Additional tests on real-world code bases
  to measure impact.