### PR TITLE
Handle special case of single block functions in CDG

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlDependenceGraphPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/ControlDependenceGraphPass.kt
@@ -169,6 +169,14 @@ open class ControlDependenceGraphPass(ctx: TranslationContext) : EOGStarterPass(
         }
 
         log.trace("Done iterating EOG for {}. Generating the edges now.", startNode.name)
+        if (finalState.isEmpty()) {
+            // There's no useful EOG, which also means that firstBasicBlock is not visited. We have
+            // to draw the CDG edge from the startNode to the firstBasicBlock manually in this case.
+            firstBasicBlock.nodes.forEach { node ->
+                if (node != startNode) node.prevCDG += startNode
+            }
+            return
+        }
 
         // branchingNodeConditionals is a map organized as follows:
         //   BranchingNode -> Set of BasicBlocks where, if we visited all of these, the

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ControlDependenceGraphPassTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/ControlDependenceGraphPassTest.kt
@@ -43,6 +43,23 @@ import kotlin.test.assertTrue
 import org.junit.jupiter.api.assertInstanceOf
 
 class ControlDependenceGraphPassTest {
+
+    @Test
+    fun testFlatFunction() {
+        val result = getFlatTest()
+        assertNotNull(result)
+        val main = result.functions["main"]
+        assertNotNull(main)
+        val allNodes = main.body.allChildren<AstNode>().filter { it != main.body }
+        allNodes.forEach { node ->
+            assertEquals(
+                main,
+                node.prevCDG.singleOrNull(),
+                "Expected node ${node} to have a CDG edge to main, but found ${node.prevCDG}",
+            )
+        }
+    }
+
     @Test
     fun testIfStatements() {
         val result = getIfTest()
@@ -183,6 +200,30 @@ class ControlDependenceGraphPassTest {
                                     call("foo") logicAnd call("bar")
                                     call("baz") logicOr call("quux")
                                     returnStmt { literal(1, t("int")) }
+                                }
+                            }
+                        }
+                    }
+                }
+
+        fun getFlatTest() =
+            testFrontend(
+                    TranslationConfiguration.builder()
+                        .registerLanguage<TestLanguageWithColon>()
+                        .defaultPasses()
+                        .registerPass<ControlDependenceGraphPass>()
+                        .build()
+                )
+                .build {
+                    translationResult {
+                        translationUnit("if.cpp") {
+                            // The main method
+                            function("main", t("int")) {
+                                body {
+                                    declare { variable("i", t("int")) { literal(0, t("int")) } }
+                                    call("printf") { literal("1\n", t("string")) }
+                                    call("printf") { literal("2\n", t("string")) }
+                                    returnStmt { ref("i") }
                                 }
                             }
                         }


### PR DESCRIPTION
Currently, the CDG does nothing if a function contains a single basic block. This PR adds a test case for this and also implements the fix.