### PR TITLE
Optional codyze console

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ For parsing TypeScript, the necessary TypeScript-based code can be found in the 
 
 [Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro) functionality is provided via the optional `cpg-mcp` module. It can be enabled/disabled via the `gradle.properties` setting `enableMCPModule`.
 
+#### Codyze Console
+
+The [Codyze Console](codyze-console/README.md) web application is an optional module, enabled/disabled via the `gradle.properties` setting `enableCodyzeConsole`. Its AI chat feature additionally requires the `cpg-mcp` module (see above) to be enabled separately.
+
 ### Code Style
 
 We use [Google Java Style](https://github.com/google/google-java-format) as a formatting. Please install the appropriate plugin for your IDE, such as the [google-java-format IntelliJ plugin](https://plugins.jetbrains.com/plugin/8527-google-java-format) or [google-java-format Eclipse plugin](https://github.com/google/google-java-format/releases/download/google-java-format-1.6/google-java-format-eclipse-plugin_1.6.0.jar).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -139,9 +139,6 @@ project.logger.lifecycle(
 
 val enableMCPModule: Boolean by extra {
     val enableMCPModule: String? by project
-    // codyze-console cannot build without this module, so default to whatever codyze-console
-    // resolved to instead of requiring both to be enabled separately; an explicit setting here
-    // always takes precedence over that default.
-    enableMCPModule?.toBoolean() ?: enableCodyzeConsole
+    enableMCPModule.toBoolean()
 }
 project.logger.lifecycle("MCP module is ${if (enableMCPModule) "enabled" else "disabled"}")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -129,8 +129,19 @@ val enableINIFrontend: Boolean by extra {
 }
 project.logger.lifecycle("INI frontend is ${if (enableINIFrontend) "enabled" else "disabled"}")
 
+val enableCodyzeConsole: Boolean by extra {
+    val enableCodyzeConsole: String? by project
+    enableCodyzeConsole.toBoolean()
+}
+project.logger.lifecycle(
+    "codyze-console is ${if (enableCodyzeConsole) "enabled" else "disabled"}"
+)
+
 val enableMCPModule: Boolean by extra {
     val enableMCPModule: String? by project
-    enableMCPModule.toBoolean()
+    // codyze-console cannot build without this module, so default to whatever codyze-console
+    // resolved to instead of requiring both to be enabled separately; an explicit setting here
+    // always takes precedence over that default.
+    enableMCPModule?.toBoolean() ?: enableCodyzeConsole
 }
 project.logger.lifecycle("MCP module is ${if (enableMCPModule) "enabled" else "disabled"}")

--- a/codyze-compliance/build.gradle.kts
+++ b/codyze-compliance/build.gradle.kts
@@ -32,8 +32,12 @@ mavenPublishing {
     }
 }
 
+val codyzeConsoleEnabled = findProject(":codyze-console") != null
+
 dependencies {
-    implementation(projects.codyzeConsole)
+    if (codyzeConsoleEnabled) {
+        implementation(project(":codyze-console"))
+    }
     implementation(libs.kaml)
 
     // We depend on the Python frontend for the integration tests, but the frontend is only

--- a/codyze-compliance/src/main/kotlin/de/fraunhofer/aisec/codyze/compliance/Command.kt
+++ b/codyze-compliance/src/main/kotlin/de/fraunhofer/aisec/codyze/compliance/Command.kt
@@ -31,8 +31,6 @@ import com.github.ajalt.clikt.parameters.groups.provideDelegate
 import de.fraunhofer.aisec.codyze.AnalysisProject
 import de.fraunhofer.aisec.codyze.ProjectOptions
 import de.fraunhofer.aisec.codyze.TranslationOptions
-import de.fraunhofer.aisec.codyze.console.ConsoleService
-import de.fraunhofer.aisec.codyze.console.startConsole
 import java.io.File
 
 /** The main `compliance` command. */
@@ -65,7 +63,7 @@ open class ScanCommand : ProjectCommand() {
         }
 
         if (projectOptions.startConsole) {
-            ConsoleService.fromAnalysisResult(result).startConsole()
+            ConsoleServiceHelper.startConsole(result)
         }
     }
 }

--- a/codyze-compliance/src/main/kotlin/de/fraunhofer/aisec/codyze/compliance/ConsoleServiceHelper.kt
+++ b/codyze-compliance/src/main/kotlin/de/fraunhofer/aisec/codyze/compliance/ConsoleServiceHelper.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.codyze.compliance
+
+import de.fraunhofer.aisec.codyze.AnalysisResult
+import org.slf4j.LoggerFactory
+
+/**
+ * Helper object to make the web console from the (optional) `codyze-console` module conditionally
+ * available. When the module is available in the build, this starts the actual console via
+ * reflection.
+ */
+object ConsoleServiceHelper {
+    private val log = LoggerFactory.getLogger(ConsoleServiceHelper::class.java)
+
+    /** Check if the codyze-console module is enabled. */
+    val isEnabled: Boolean by lazy {
+        try {
+            Class.forName("de.fraunhofer.aisec.codyze.console.ConsoleService")
+            true
+        } catch (_: ClassNotFoundException) {
+            false
+        }
+    }
+
+    /** Starts the web console for the given [result], if codyze-console is enabled. */
+    fun startConsole(result: AnalysisResult) {
+        if (!isEnabled) {
+            log.warn(
+                "The --console option was set, but the codyze-console module is not enabled in " +
+                    "this build (set enableCodyzeConsole=true in gradle.properties)."
+            )
+            return
+        }
+
+        try {
+            val consoleServiceClass =
+                Class.forName("de.fraunhofer.aisec.codyze.console.ConsoleService")
+            val companion = consoleServiceClass.getField("Companion").get(null)
+            val service =
+                companion.javaClass
+                    .getMethod("fromAnalysisResult", AnalysisResult::class.java)
+                    .invoke(companion, result)
+
+            val mainKt = Class.forName("de.fraunhofer.aisec.codyze.console.MainKt")
+            val startConsole =
+                mainKt.methods.first { it.name == "startConsole" && it.parameterCount == 3 }
+            startConsole.invoke(null, service, "localhost", 8080)
+        } catch (e: Exception) {
+            log.error("Failed to start web console: {}", e.message, e)
+        }
+    }
+}

--- a/codyze-console/README.md
+++ b/codyze-console/README.md
@@ -5,6 +5,8 @@ The agent uses the tools of the CPG MCP server to analyze code and answer questi
 
 ## Getting Started
 
+Codyze Console is an optional module. Enable it by setting `enableCodyzeConsole=true` in `gradle.properties` (or via `./configure_frontends.sh`), then rerun/resync Gradle.
+
 The easiest way to get started is by using the predefined IntelliJ run configurations in the `.run/` directory:
 - *Codyze Console* (standalone)
 - *Codyze Compliance Scan (with Console and Example)* (with an example project).

--- a/codyze/build.gradle.kts
+++ b/codyze/build.gradle.kts
@@ -55,8 +55,12 @@ mavenPublishing {
     }
 }
 
+val codyzeConsoleEnabled = findProject(":codyze-console") != null
+
 dependencies {
     implementation(projects.codyzeCompliance)
-    implementation(projects.codyzeConsole)
+    if (codyzeConsoleEnabled) {
+        implementation(project(":codyze-console"))
+    }
     implementation(libs.clikt)
 }

--- a/codyze/src/main/kotlin/de/fraunhofer/aisec/codyze/Application.kt
+++ b/codyze/src/main/kotlin/de/fraunhofer/aisec/codyze/Application.kt
@@ -36,8 +36,10 @@ class Codyze : CliktCommand() {
 fun main(args: Array<String>) {
     Codyze()
         .subcommands(
-            de.fraunhofer.aisec.codyze.console.Command,
-            de.fraunhofer.aisec.codyze.compliance.Command,
+            listOfNotNull(
+                ConsoleCommandHelper.consoleCommand(),
+                de.fraunhofer.aisec.codyze.compliance.Command,
+            )
         )
         .main(args)
 }

--- a/codyze/src/main/kotlin/de/fraunhofer/aisec/codyze/ConsoleCommandHelper.kt
+++ b/codyze/src/main/kotlin/de/fraunhofer/aisec/codyze/ConsoleCommandHelper.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.codyze
+
+import com.github.ajalt.clikt.core.CliktCommand
+import org.slf4j.LoggerFactory
+
+/**
+ * Helper object to make the `console` subcommand from the (optional) `codyze-console` module
+ * conditionally available. When the module is available in the build, this loads the actual command
+ * via reflection.
+ */
+object ConsoleCommandHelper {
+    private val log = LoggerFactory.getLogger(ConsoleCommandHelper::class.java)
+
+    /** Check if the codyze-console module is enabled. */
+    val isEnabled: Boolean by lazy {
+        try {
+            Class.forName("de.fraunhofer.aisec.codyze.console.CommandKt")
+            true
+        } catch (_: ClassNotFoundException) {
+            false
+        }
+    }
+
+    /** Returns the `console` subcommand, or `null` if codyze-console is not enabled. */
+    fun consoleCommand(): CliktCommand? {
+        if (!isEnabled) {
+            return null
+        }
+
+        return try {
+            val commandKt = Class.forName("de.fraunhofer.aisec.codyze.console.CommandKt")
+            commandKt.getMethod("getCommand").invoke(null) as? CliktCommand
+        } catch (e: Exception) {
+            log.error("Failed to load codyze-console command: {}", e.message, e)
+            null
+        }
+    }
+}

--- a/configure_frontends.sh
+++ b/configure_frontends.sh
@@ -62,5 +62,7 @@ answerJVM=$(ask "Do you want to enable the JVM frontend? (currently $(getPropert
 setProperty "enableJVMFrontend" $answerJVM
 answerINI=$(ask "Do you want to enable the INI frontend? (currently $(getProperty "enableINIFrontend"))")
 setProperty "enableINIFrontend" $answerINI
+answerCodyzeConsole=$(ask "Do you want to enable codyze-console? (currently $(getProperty "enableCodyzeConsole"))")
+setProperty "enableCodyzeConsole" $answerCodyzeConsole
 answerMCP=$(ask "Do you want to enable the MCP module? (currently $(getProperty "enableMCPModule"))")
 setProperty "enableMCPModule" $answerMCP

--- a/gradle.properties.example
+++ b/gradle.properties.example
@@ -10,7 +10,7 @@ enableTypeScriptFrontend=true
 enableRubyFrontend=true
 enableJVMFrontend=true
 enableINIFrontend=true
-enableMCPModule=true
+enableCodyzeConsole=true
 
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 ## Suppress warnings about using the experimental Dokka plugin

--- a/gradle.properties.example
+++ b/gradle.properties.example
@@ -11,7 +11,7 @@ enableRubyFrontend=true
 enableJVMFrontend=true
 enableINIFrontend=true
 enableMCPModule=true
-enableCodyzeConsole=false
+enableCodyzeConsole=true
 
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 ## Suppress warnings about using the experimental Dokka plugin

--- a/gradle.properties.example
+++ b/gradle.properties.example
@@ -10,7 +10,8 @@ enableTypeScriptFrontend=true
 enableRubyFrontend=true
 enableJVMFrontend=true
 enableINIFrontend=true
-enableCodyzeConsole=true
+enableMCPModule=true
+enableCodyzeConsole=false
 
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 ## Suppress warnings about using the experimental Dokka plugin

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,6 @@ include(":cpg-serialization")
 include(":codyze")
 include(":codyze-core")
 include(":codyze-compliance")
-include(":codyze-console")
 
 // this code block also exists in the root build.gradle.kts
 val enableJavaFrontend: Boolean by extra {
@@ -54,9 +53,16 @@ val enableINIFrontend: Boolean by extra {
     val enableINIFrontend: String? by settings
     enableINIFrontend.toBoolean()
 }
+val enableCodyzeConsole: Boolean by extra {
+    val enableCodyzeConsole: String? by settings
+    enableCodyzeConsole.toBoolean()
+}
 val enableMCPModule: Boolean by extra {
     val enableMCPModule: String? by settings
-    enableMCPModule.toBoolean()
+    // codyze-console cannot build without this module, so default to whatever codyze-console
+    // resolved to instead of requiring both to be enabled separately; an explicit setting here
+    // always takes precedence over that default.
+    enableMCPModule?.toBoolean() ?: enableCodyzeConsole
 }
 
 if (enableJavaFrontend) include(":cpg-language-java")
@@ -69,6 +75,7 @@ if (enableRubyFrontend) include(":cpg-language-ruby")
 if (enableJVMFrontend) include(":cpg-language-jvm")
 if (enableINIFrontend) include(":cpg-language-ini")
 if (enableMCPModule) include(":cpg-mcp")
+if (enableCodyzeConsole) include(":codyze-console")
 
 
 kover {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -59,10 +59,7 @@ val enableCodyzeConsole: Boolean by extra {
 }
 val enableMCPModule: Boolean by extra {
     val enableMCPModule: String? by settings
-    // codyze-console cannot build without this module, so default to whatever codyze-console
-    // resolved to instead of requiring both to be enabled separately; an explicit setting here
-    // always takes precedence over that default.
-    enableMCPModule?.toBoolean() ?: enableCodyzeConsole
+    enableMCPModule.toBoolean()
 }
 
 if (enableJavaFrontend) include(":cpg-language-java")


### PR DESCRIPTION
Adds an `enableCodyzeConsole` gradle.properties toggle (default `true`) so `codyze-console` can be excluded from the build, independent of `enableMCPModule`.

`codyze` and `codyze-compliance` no longer have a hard dependency on `codyze-console` — both the Gradle dependency and the source-level references (the `console` subcommand, the `--console flag`) are conditional now. When the module isn't enabled, the `console` subcommand is simply omitted and `--console` logs a warning instead of failing to compile.

Reflection

The conditional class loading uses `Class.forName`/reflective invocation (`ConsoleCommandHelper`, `ConsoleServiceHelper`), not a type-safe reference. Not my favorite pattern — it trades compile-time safety for a runtime lookup — but it matches how this codebase already handles this exact kind of problem: `codyze-console` uses the identical approach (`McpServerHelper.kt`) for its own optional dependency on `cpg-mcp`. Keeping one consistent mechanism for "optional module dependency" across the project outweighs the type-safety loss here.

Alternatives considered: a shared interface/API module with a service-provider pattern would be more type-safe, but requires a new module just to support the optional case, and would leave two different mechanisms solving the same problem in the same codebase.