### PR TITLE
cpg-ai: add free-text notes and parameter-correspondence to LLMConcept/LLMOperation

### DIFF
--- a/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/mcpserver/tools/CpgGenericConceptsTool.kt
+++ b/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/mcpserver/tools/CpgGenericConceptsTool.kt
@@ -37,6 +37,7 @@ import de.fraunhofer.aisec.cpg.graph.codeAndLocationFrom
 import de.fraunhofer.aisec.cpg.graph.concepts.GenericLLMConcept
 import de.fraunhofer.aisec.cpg.graph.concepts.GenericLLMOperation
 import de.fraunhofer.aisec.cpg.graph.concepts.GenericProperties
+import de.fraunhofer.aisec.cpg.graph.concepts.GenericPropertyValue
 import de.fraunhofer.aisec.cpg.graph.nodes
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
@@ -182,7 +183,16 @@ fun Server.addLLMConceptAndOperations() {
                         conceptName = concept.name,
                         description = concept.description,
                         properties =
-                            GenericProperties(concept.properties.associate { it.name to it.value }),
+                            GenericProperties(
+                                concept.properties.associate {
+                                    it.name to
+                                        GenericPropertyValue(
+                                            value = it.value,
+                                            description = it.description,
+                                        )
+                                }
+                            ),
+                        notes = concept.notes,
                     )
                     .apply {
                         this.codeAndLocationFrom(cpgConceptNode)
@@ -216,8 +226,15 @@ fun Server.addLLMConceptAndOperations() {
                             genericLLMConcept = conceptNode,
                             properties =
                                 GenericProperties(
-                                    operation.properties.associate { it.name to it.value }
+                                    operation.properties.associate {
+                                        it.name to
+                                            GenericPropertyValue(
+                                                value = it.value,
+                                                description = it.description,
+                                            )
+                                    }
                                 ),
+                            notes = operation.notes,
                         )
                         .apply {
                             this.codeAndLocationFrom(cpgOperationNode)

--- a/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/mcpserver/tools/utils/PayloadsLLMConceptsOperations.kt
+++ b/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/mcpserver/tools/utils/PayloadsLLMConceptsOperations.kt
@@ -94,7 +94,12 @@ data class LLMProperty(
         "The type of the property. It should be a simple Kotlin data type (e.g. string, integer, boolean)."
     )
     val type: String,
-    @Description("A short description of the property.") val description: String? = null,
+    @Description(
+        "A short description of the property. If this property corresponds to one of the " +
+            "tagged function's actual parameters, mention which one here (name and/or position " +
+            "in the signature)."
+    )
+    val description: String? = null,
     @Description(
         "The value to set for the property (as string representation). The type of the value should match the `type` field."
     )
@@ -117,6 +122,12 @@ data class LLMOperation(
         "The properties to set for the operation. Each property should have a name and a value. The name should match the name of a parameter defined in the operation description, and the value should be the corresponding value for this specific application of the operation."
     )
     val properties: List<LLMProperty>,
+    @Description(
+        "Free-text notes about this operation's application - e.g. other functions that must be " +
+            "called before this one (such as an init/setKey call before encrypt), caveats, or " +
+            "anything else worth recording that doesn't fit the structured fields above."
+    )
+    val notes: String? = null,
 )
 
 @Serializable
@@ -135,6 +146,11 @@ data class LLMConcept(
     val properties: List<LLMProperty>,
     @Description("A list of operations to apply to this concept.")
     val operations: List<LLMOperation>,
+    @Description(
+        "Free-text notes about this concept's application - anything worth recording that " +
+            "doesn't fit the structured fields above."
+    )
+    val notes: String? = null,
 )
 
 @Serializable

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericField.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericField.kt
@@ -28,10 +28,21 @@ package de.fraunhofer.aisec.cpg.graph.concepts
 import de.fraunhofer.aisec.cpg.persistence.DoNotPersist
 
 /**
+ * A single property's value, as attached to a [GenericLLMConcept]/[GenericLLMOperation].
+ *
+ * @param value The property's value (as a string representation).
+ * @param description A description of the property, e.g. what it represents, or - for a property
+ *   corresponding to one of the tagged function's actual parameters - which parameter that is
+ *   (name/position).
+ *
+ * TODO: also capture the property's declared `type` here once we decide how to represent/query it.
+ */
+@DoNotPersist data class GenericPropertyValue(val value: String, val description: String? = null)
+
+/**
  * Represents a generic set of properties for a concept or operation. This can be used to store
- * arbitrary "fields". The key represents the name of the property, and the value can be any type of
- * data.
+ * arbitrary "fields". The key represents the name of the property.
  *
  * TODO: neo4j persistence
  */
-@DoNotPersist data class GenericProperties(val properties: Map<String, String /* TODO */>)
+@DoNotPersist data class GenericProperties(val properties: Map<String, GenericPropertyValue>)

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericLLMConcept.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericLLMConcept.kt
@@ -36,12 +36,15 @@ import java.util.*
  * @param conceptName The name of the concept. This should be unique across all concepts.
  * @param description A description of the concept.
  * @param properties The properties of the concept.
+ * @param notes Free-text notes about this concept's application, e.g. relationships to other tagged
+ *   nodes (such as a function that must be called before this one).
  */
 class GenericLLMConcept(
     underlyingNode: Node? = null,
     val conceptName: String,
     val description: String,
     val properties: GenericProperties,
+    val notes: String? = null,
 ) : Concept(underlyingNode = underlyingNode) {
 
     override fun equals(other: Any?): Boolean {
@@ -49,8 +52,10 @@ class GenericLLMConcept(
             super.equals(other) &&
             other.conceptName == this.conceptName &&
             other.description == this.description &&
-            other.properties == this.properties
+            other.properties == this.properties &&
+            other.notes == this.notes
     }
 
-    override fun hashCode() = Objects.hash(super.hashCode(), conceptName, description, properties)
+    override fun hashCode() =
+        Objects.hash(super.hashCode(), conceptName, description, properties, notes)
 }

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericLLMOperation.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericLLMOperation.kt
@@ -37,6 +37,8 @@ import java.util.*
  * @param description A human-readable description of the operation.
  * @param genericLLMConcept The concept this operation belongs to.
  * @param properties The properties of the operation.
+ * @param notes Free-text notes about this operation's application, e.g. other functions that must
+ *   be called before this one (such as an init/setKey call before encrypt).
  */
 class GenericLLMOperation(
     underlyingNode: Node? = null,
@@ -44,6 +46,7 @@ class GenericLLMOperation(
     val description: String,
     val genericLLMConcept: GenericLLMConcept,
     val properties: GenericProperties,
+    val notes: String? = null,
 ) : Operation(concept = genericLLMConcept, underlyingNode = underlyingNode) {
 
     override fun equals(other: Any?): Boolean {
@@ -52,9 +55,17 @@ class GenericLLMOperation(
             other.operationName == this.operationName &&
             other.description == this.description &&
             other.genericLLMConcept == this.genericLLMConcept &&
-            other.properties == this.properties
+            other.properties == this.properties &&
+            other.notes == this.notes
     }
 
     override fun hashCode() =
-        Objects.hash(super.hashCode(), operationName, description, genericLLMConcept, properties)
+        Objects.hash(
+            super.hashCode(),
+            operationName,
+            description,
+            genericLLMConcept,
+            properties,
+            notes,
+        )
 }


### PR DESCRIPTION
Adds a `notes` field to `LLMConcept`/`LLMOperation` (and their `GenericLLMConcept`/`GenericLLMOperation` graph overlays) for free-text context such as required setup/prerequisite calls (e.g. `init` → `setKey` before `encrypt`).

Also fixes a pre-existing bug where a property's `description` was silently dropped when applying a concept/operation to the graph (`GenericProperties` only stored the bare value). `description` is now preserved, and its docs mention
using it to record which of the tagged function's actual parameters a property corresponds to.

- `LLMProperty`/`LLMOperation`/`LLMConcept`: `description`/`notes` wording updated
- `GenericProperties`/`GenericPropertyValue`: new value type carrying `description` alongside `value` (property `type` propagation left as a follow-up TODO)
- `GenericLLMConcept`/`GenericLLMOperation`: new `notes` field
- `CpgGenericConceptsTool`: threads `description`/`notes` through when applying concepts/operations
