### PR TITLE
ci: only exclude shadowJar/shadowDistZip/shadowDistTar when codyze-console is enabled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,8 +76,15 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
       - name: Build ${{ env.version }}
         run: |
-          # The distZip/distTar and shadowJar/shadowDistZip/shadowDistTar slow down the build and are not needed in CI
-          ./gradlew --parallel spotlessCheck -x spotlessApply build -x distZip -x distTar -x shadowJar -x shadowDistZip -x shadowDistTar koverXmlReport koverHtmlReport performanceTest integrationTest
+          # The distZip/distTar and shadowJar/shadowDistZip/shadowDistTar slow down the build and are not needed in CI.
+          # shadowJar/shadowDistZip/shadowDistTar only exist on codyze-console (the only module using the Shadow
+          # plugin) - excluding a task that doesn't exist anywhere in the build fails the whole build ("Task
+          # 'shadowJar' not found"), so only exclude them when that module is actually enabled.
+          EXCLUDES="-x distZip -x distTar"
+          if grep -q '^enableCodyzeConsole=true' gradle.properties; then
+            EXCLUDES="$EXCLUDES -x shadowJar -x shadowDistZip -x shadowDistTar"
+          fi
+          ./gradlew --parallel spotlessCheck -x spotlessApply build $EXCLUDES koverXmlReport koverHtmlReport performanceTest integrationTest
         id: build
         env:
           ORG_GRADLE_PROJECT_version: ${{ env.version }}


### PR DESCRIPTION
Those tasks only exist on codyze-console (the only module using the Shadow
plugin). Excluding a task via `-x` that doesn't exist anywhere in the build
fails the whole build with "Task 'shadowJar' not found" - which happens
whenever a CI run disables codyze-console (e.g. to shorten build time).
