### PR TITLE
feat: allow location-based node addressing for concept-tagging tools

### DIFF
--- a/cpg-ai/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/tools/CpgGenericConceptsToolTest.kt
+++ b/cpg-ai/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/tools/CpgGenericConceptsToolTest.kt
@@ -30,6 +30,7 @@ import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.addOrUpdateConcept
 import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.globalAnalysisResult
 import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.listLLMConceptsOperations
 import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.runCpgAnalyze
+import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.suggestLLMConceptsAndOperations
 import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.utils.CpgAnalyzePayload
 import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.utils.LLMConceptDescription
 import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.utils.LLMOperation
@@ -279,5 +280,118 @@ class CpgGenericConceptsToolTest {
             val text = (applyResult.content.single() as TextContent).text
             assertTrue("not found" in text)
             assertTrue(!conceptsFile.exists() || conceptsFile.readText().isBlank())
+        }
+
+    @Test
+    fun suggestLLMConceptsAndOperationsWithLocationTest() =
+        withClient(registerTools = { suggestLLMConceptsAndOperations() }) { client ->
+            val secretInitializer =
+                globalAnalysisResult?.literals?.singleOrNull { it.value == "0000" }
+            assertNotNull(secretInitializer, "Expected the '0000' literal in the analyzed code")
+            val loc = secretInitializer.location
+            assertNotNull(loc)
+            val fileName = loc.artifactLocation.uri?.path?.substringAfterLast('/')!!
+            val line = loc.region.startLine
+            val column = loc.region.startColumn
+
+            val suggestResult =
+                client.callTool(
+                    name = "cpg_suggest_llm_concepts_and_operations",
+                    arguments =
+                        mapOf(
+                            "name" to "Secret",
+                            "description" to "A hardcoded secret",
+                            "location" to
+                                mapOf("file" to fileName, "line" to line, "column" to column),
+                            "properties" to emptyList<LLMProperty>(),
+                            "operations" to emptyList<LLMOperation>(),
+                        ),
+                )
+            assertNotNull(suggestResult)
+            val text = (suggestResult.content.single() as TextContent).text
+            assertTrue("Secret" in text)
+            assertTrue(secretInitializer.id.toString() in text)
+        }
+
+    @Test
+    fun suggestLLMConceptsAndOperationsWithAmbiguousLocationTest() =
+        withClient(registerTools = { suggestLLMConceptsAndOperations() }) { client ->
+            val secretInitializer =
+                globalAnalysisResult?.literals?.singleOrNull { it.value == "0000" }
+            assertNotNull(secretInitializer, "Expected the '0000' literal in the analyzed code")
+            val loc = secretInitializer.location
+            assertNotNull(loc)
+            val fileName = loc.artifactLocation.uri?.path?.substringAfterLast('/')!!
+            val line = loc.region.startLine
+
+            val suggestResult =
+                client.callTool(
+                    name = "cpg_suggest_llm_concepts_and_operations",
+                    arguments =
+                        mapOf(
+                            "name" to "Secret",
+                            "description" to "A hardcoded secret",
+                            "location" to mapOf("file" to fileName, "line" to line),
+                            "properties" to emptyList<LLMProperty>(),
+                            "operations" to emptyList<LLMOperation>(),
+                        ),
+                )
+            assertNotNull(suggestResult)
+            val text = (suggestResult.content.single() as TextContent).text
+            assertTrue("Concept error" in text)
+            assertTrue("Ambiguous" in text || "Multiple nodes found" in text)
+        }
+
+    @Test
+    fun addLLMConceptAndOperationsWithLocationTest() =
+        withClient(
+            registerTools = {
+                addLLMConceptAndOperations()
+                listLLMConceptsOperations()
+            }
+        ) { client ->
+            val secretInitializer =
+                globalAnalysisResult?.literals?.singleOrNull { it.value == "0000" }
+            assertNotNull(secretInitializer, "Expected the '0000' literal in the analyzed code")
+            val loc = secretInitializer.location
+            assertNotNull(loc)
+            val fileName = loc.artifactLocation.uri?.path?.substringAfterLast('/')!!
+            val line = loc.region.startLine
+            val column = loc.region.startColumn
+
+            val applyResult =
+                client.callTool(
+                    name = "cpg_add_llm_concept_and_operations",
+                    arguments =
+                        mapOf(
+                            "concepts" to
+                                listOf(
+                                    mapOf(
+                                        "name" to "Secret",
+                                        "description" to "A hardcoded secret",
+                                        "location" to
+                                            mapOf(
+                                                "file" to fileName,
+                                                "line" to line,
+                                                "column" to column,
+                                            ),
+                                        "properties" to emptyList<LLMProperty>(),
+                                        "operations" to emptyList<LLMOperation>(),
+                                    )
+                                )
+                        ),
+                )
+            assertNotNull(applyResult)
+            val text = (applyResult.content.single() as TextContent).text
+            assertTrue("\"applied\"" in text, "Response should contain applied section")
+            assertTrue(secretInitializer.id.toString() in text, "Should contain resolved nodeId")
+
+            val listResult =
+                client.callTool(name = "cpg_list_llm_concepts_operations", arguments = emptyMap())
+            assertEquals(
+                1,
+                listResult.content.size,
+                "The applied concept's schema should be persisted",
+            )
         }
 }

--- a/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/mcpserver/tools/CpgGenericConceptsTool.kt
+++ b/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/mcpserver/tools/CpgGenericConceptsTool.kt
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.utils.*
 import de.fraunhofer.aisec.cpg.graph.Name
+import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.NodeBuilder
 import de.fraunhofer.aisec.cpg.graph.codeAndLocationFrom
 import de.fraunhofer.aisec.cpg.graph.concepts.GenericLLMConcept
@@ -43,6 +44,68 @@ import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import java.io.File
 import kotlinx.serialization.json.Json
+
+internal sealed class ResolveResult {
+    data class Success(val node: Node) : ResolveResult()
+
+    data class NotFound(val message: String) : ResolveResult()
+
+    data class Ambiguous(val candidates: List<Node>, val message: String) : ResolveResult()
+}
+
+internal fun resolveNode(
+    translationResult: TranslationResult,
+    nodeId: String? = null,
+    location: LLMLocation? = null,
+): ResolveResult {
+    if (nodeId == null && location == null) {
+        return ResolveResult.NotFound("Neither NodeId nor Location was provided")
+    }
+    if (nodeId != null) {
+        val node = translationResult.nodes.find { it.id.toString() == nodeId }
+        return if (node != null) {
+            ResolveResult.Success(node)
+        } else {
+            ResolveResult.NotFound("Node with ID $nodeId not found")
+        }
+    }
+    val loc = location!!
+    val llmGivenFile = loc.file.replace('\\', '/').trimStart('/')
+    val candidates =
+        translationResult.nodes.filter { node ->
+            val nodeLocation = node.location ?: return@filter false
+            val uri = nodeLocation.artifactLocation.uri ?: return@filter false
+            val path = uri.path ?: return@filter false
+            val nodePath = path.replace('\\', '/').trimStart('/')
+
+            val matchesFile =
+                nodePath.equals(llmGivenFile, ignoreCase = true) ||
+                    nodePath.endsWith("/$llmGivenFile", ignoreCase = true)
+
+            val matchesLine = loc.line == nodeLocation.region.startLine
+
+            val matchesColumn = loc.column == null || loc.column == nodeLocation.region.startColumn
+            matchesFile && matchesLine && matchesColumn
+        }
+
+    return when {
+        candidates.isEmpty() ->
+            ResolveResult.NotFound(
+                "Node not found at location ${loc.file}:${loc.line}${loc.column?.let { ":$it" } ?: ""}."
+            )
+        candidates.size == 1 -> ResolveResult.Success(candidates.single())
+        else -> {
+            val formatted =
+                candidates.joinToString {
+                    "${it::class.simpleName}(id=${it.id}, name=\"${it.name}\", code=\"${it.code?.trim()?.take(50)}\")"
+                }
+            ResolveResult.Ambiguous(
+                candidates,
+                "Multiple nodes found at location ${loc.file}:${loc.line}${loc.column?.let { ":$it" } ?: ""}: $formatted",
+            )
+        }
+    }
+}
 
 private const val fileName = "concepts.yaml"
 
@@ -108,8 +171,8 @@ fun Server.suggestLLMConceptsAndOperations() {
     val toolDescription =
         """
         Suggests concept and operations for a node in the CPG.
-        The `nodeId` on the concept refers to the node the concept describes. Each operation's `nodeId` refers to the node where the operation is realized.
-        All node IDs must come from prior tool results, so do not pass placeholder or invented IDs.
+        The `nodeId` or `location` on the concept refers to the node the concept describes. Each operation's `nodeId` or `location` refers to the node where the operation is realized.
+        Either `nodeId` or `location` must be provided. All node IDs/locations must come from prior tool results or valid source files, so do not pass placeholder or invented IDs.
         """
             .trimIndent()
 
@@ -117,31 +180,50 @@ fun Server.suggestLLMConceptsAndOperations() {
         name = "cpg_suggest_llm_concepts_and_operations",
         description = toolDescription,
     ) { result: TranslationResult, payload: LLMConcept ->
-        val conceptNode = result.nodes.find { it.id.toString() == payload.nodeId }
-        if (conceptNode == null) {
-            return@addTool CallToolResult(
-                content =
-                    listOf(
-                        TextContent("Node ${payload.nodeId} not found for concept ${payload.name}.")
+        val conceptNode =
+            when (val res = resolveNode(result, payload.nodeId, payload.location)) {
+                is ResolveResult.Success -> res.node
+                is ResolveResult.NotFound ->
+                    return@addTool CallToolResult(
+                        content = listOf(TextContent("Concept error: ${res.message}"))
                     )
-            )
-        }
-
-        payload.operations.forEach { operation ->
-            val opNode = result.nodes.find { it.id.toString() == operation.nodeId }
-            if (opNode == null) {
-                return@addTool CallToolResult(
-                    content =
-                        listOf(
-                            TextContent(
-                                "Node ${operation.nodeId} not found for operation ${operation.name}."
-                            )
-                        )
-                )
+                is ResolveResult.Ambiguous ->
+                    return@addTool CallToolResult(
+                        content = listOf(TextContent("Concept error: ${res.message}"))
+                    )
             }
+
+        val resolvedOperations = mutableListOf<LLMOperation>()
+        payload.operations.forEach { operation ->
+            val opNode =
+                when (val res = resolveNode(result, operation.nodeId, operation.location)) {
+                    is ResolveResult.Success -> res.node
+                    is ResolveResult.NotFound ->
+                        return@addTool CallToolResult(
+                            content =
+                                listOf(
+                                    TextContent(
+                                        "Operation error for '${operation.name}': ${res.message}"
+                                    )
+                                )
+                        )
+                    is ResolveResult.Ambiguous ->
+                        return@addTool CallToolResult(
+                            content =
+                                listOf(
+                                    TextContent(
+                                        "Operation error for '${operation.name}': ${res.message}"
+                                    )
+                                )
+                        )
+                }
+            resolvedOperations.add(operation.copy(nodeId = opNode.id.toString()))
         }
 
-        CallToolResult(content = listOf(TextContent(Json.encodeToString(payload))))
+        val resolvedPayload =
+            payload.copy(nodeId = conceptNode.id.toString(), operations = resolvedOperations)
+
+        CallToolResult(content = listOf(TextContent(Json.encodeToString(resolvedPayload))))
     }
 }
 
@@ -152,7 +234,7 @@ fun Server.addLLMConceptAndOperations() {
     val toolDescription =
         """
         This tool applies a concept and all its operations to the graph.
-        It creates and attaches a concept node and all operation nodes using their nodeId to specific nodes in the graph.
+        It creates and attaches a concept node and all operation nodes using their nodeId or location to specific nodes in the graph.
         """
             .trimIndent()
     this.addTool<LLMConceptList>(
@@ -164,17 +246,17 @@ fun Server.addLLMConceptAndOperations() {
         val schemasToPersist = mutableListOf<LLMConceptDescription>()
 
         payload.concepts.forEach { concept ->
-            val cpgConceptNode = result.nodes.find { it.id.toString() == concept.nodeId }
-            if (cpgConceptNode == null) {
-                failed.add(
-                    FailedConcept(
-                        concept = concept,
-                        reason =
-                            "Underlying CPG node ${concept.nodeId} not found for concept \"${concept.name}\".",
-                    )
-                )
+            val conceptNodeResult = resolveNode(result, concept.nodeId, concept.location)
+            if (conceptNodeResult !is ResolveResult.Success) {
+                val reason =
+                    when (conceptNodeResult) {
+                        is ResolveResult.NotFound -> conceptNodeResult.message
+                        is ResolveResult.Ambiguous -> conceptNodeResult.message
+                    }
+                failed.add(FailedConcept(concept = concept, reason = reason))
                 return@forEach
             }
+            val cpgConceptNode = conceptNodeResult.node
 
             val conceptNode =
                 GenericLLMConcept(
@@ -196,18 +278,20 @@ fun Server.addLLMConceptAndOperations() {
 
             val appliedOps = mutableListOf<AppliedOperation>()
             val failedOps = mutableListOf<FailedOperation>()
+            val resolvedOps = mutableListOf<LLMOperation>()
             concept.operations.forEach { operation ->
-                val cpgOperationNode = result.nodes.find { it.id.toString() == operation.nodeId }
-                if (cpgOperationNode == null) {
-                    failedOps.add(
-                        FailedOperation(
-                            operation = operation,
-                            reason =
-                                "Underlying CPG node ${operation.nodeId} not found for operation \"${operation.name}\".",
-                        )
-                    )
+                val opNodeResult = resolveNode(result, operation.nodeId, operation.location)
+                if (opNodeResult !is ResolveResult.Success) {
+                    val reason =
+                        when (opNodeResult) {
+                            is ResolveResult.NotFound -> opNodeResult.message
+                            is ResolveResult.Ambiguous -> opNodeResult.message
+                        }
+                    failedOps.add(FailedOperation(operation = operation, reason = reason))
+                    resolvedOps.add(operation)
                     return@forEach
                 }
+                val cpgOperationNode = opNodeResult.node
                 val opNode =
                     GenericLLMOperation(
                             underlyingNode = cpgOperationNode,
@@ -228,20 +312,28 @@ fun Server.addLLMConceptAndOperations() {
                                 )
                             NodeBuilder.log(this)
                         }
+                val resolvedOperation = operation.copy(nodeId = cpgOperationNode.id.toString())
                 appliedOps.add(
-                    AppliedOperation(operation = operation, overlayNodeId = opNode.id.toString())
+                    AppliedOperation(
+                        operation = resolvedOperation,
+                        overlayNodeId = opNode.id.toString(),
+                    )
                 )
+                resolvedOps.add(resolvedOperation)
             }
+
+            val resolvedConcept =
+                concept.copy(nodeId = cpgConceptNode.id.toString(), operations = resolvedOps)
 
             applied.add(
                 AppliedConcept(
-                    concept = concept,
+                    concept = resolvedConcept,
                     overlayNodeId = conceptNode.id.toString(),
                     appliedOperations = appliedOps,
                     failedOperations = failedOps,
                 )
             )
-            schemasToPersist.add(LLMConceptDescription(concept))
+            schemasToPersist.add(LLMConceptDescription(resolvedConcept))
         }
 
         if (schemasToPersist.isNotEmpty()) {

--- a/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/mcpserver/tools/utils/PayloadsLLMConceptsOperations.kt
+++ b/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/mcpserver/tools/utils/PayloadsLLMConceptsOperations.kt
@@ -111,12 +111,26 @@ data class LLMOperation(
         "The description of the operation. It should explain what the operation does and provide guidance on when to apply it."
     )
     val description: String,
-    @Description("The CPG id of the node to which the operation should be applied.")
-    val nodeId: String,
+    @Description(
+        "The CPG id of the node to which the concept should be applied. Either this or the location must be specified"
+    )
+    val nodeId: String? = null,
+    @Description(
+        "The location of the node to which the operation should be applied. Either this or nodeId must be specified."
+    )
+    val location: LLMLocation? = null,
     @Description(
         "The properties to set for the operation. Each property should have a name and a value. The name should match the name of a parameter defined in the operation description, and the value should be the corresponding value for this specific application of the operation."
     )
     val properties: List<LLMProperty>,
+)
+
+@Serializable
+data class LLMLocation(
+    @Description("The name of the file or path (e.g., 'Foo.java' or 'src/Foo.java').")
+    val file: String,
+    @Description("The start line of the node") val line: Int,
+    @Description("Optional. The start column of the node") val column: Int? = null,
 )
 
 @Serializable
@@ -127,8 +141,14 @@ data class LLMConcept(
         "The description of the concept. It should explain the concept in more detail and provide guidance on when to apply it."
     )
     val description: String,
-    @Description("The CPG id of the node to which the concept should be applied.")
-    val nodeId: String,
+    @Description(
+        "The CPG id of the node to which the concept should be applied. Either this or the location must be specified"
+    )
+    val nodeId: String? = null,
+    @Description(
+        "The location of the node to which the operation should be applied. Either this or nodeId must be specified."
+    )
+    val location: LLMLocation? = null,
     @Description(
         "The properties to set for the concept. Each property should have a name and a value. The name should match the name of a parameter defined in the concept description, and the value should be the corresponding value for this specific application of the concept."
     )


### PR DESCRIPTION
Lets `cpg_suggest_llm_concepts_and_operations` and `cpg_add_llm_concept_and_operations` accept a file, line, and optional column instead of a raw node ID. If a location matches more than one node, the tool returns all candidates instead of picking one.

## Test plan
- [x] `spotlessCheck` passes
- [x] `CpgGenericConceptsToolTest` passes (9/9), including two new tests for location-based lookup