### PR TITLE
Stop publishing the 2.6 GB codyze-console fat jar

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,19 @@ JavaDoc generation via Dokka is currently disabled.
 
 Note that distribution archives (distZip, distTar) and shadow JARs are not built in CI, since they are currently not needed. 
 
+## Native binaries (JavaCPP)
+
+The LLVM frontend depends on `org.bytedeco:llvm-platform`, which ships native binaries for nine platforms (~2.2 GB in total). We apply the 
+[JavaCPP platform plugin](https://github.com/bytedeco/gradle-javacpp) so that a build only resolves the natives for the platform it runs on. 
+To build for other platforms - e.g. when assembling a distribution archive that has to run elsewhere - pass the platforms explicitly:
+
+```
+./gradlew -PjavacppPlatform=linux-x86_64,linux-arm64,macosx-arm64,windows-x86_64 installDist
+```
+
+This filtering only affects how *we* resolve the dependency. The published POMs still declare plain `llvm-platform`, so consumers keep 
+getting the natives for every platform unless they apply the same plugin themselves.
+
 ## Publishing
 
 To publish a release, push a tag that contains the version number beginning with `v`, i.e. `v2.0.0`. The GitHub Actions workflow will 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,5 +13,6 @@ dependencies {
     implementation(libs.kover.gradle)
     implementation(libs.spotless.gradle)
     implementation(libs.publish.central)
+    implementation(libs.javacpp.gradle)
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))  // this is only there to be able to import 'LibrariesForLibs' in the convention plugins to access the version catalog in buildSrc
 }

--- a/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts
@@ -11,6 +11,14 @@ plugins {
     signing
     kotlin("jvm")
     kotlin("plugin.serialization")
+
+    // Restricts the native binaries pulled in by JavaCPP "-platform" artifacts (we use
+    // org.bytedeco:llvm-platform in cpg-language-llvm) to the platforms in `javacppPlatform`,
+    // which defaults to the host platform. Without it, every build resolves the natives for all
+    // nine LLVM target platforms, ~2.2 GB. This only filters how *we* resolve the dependency; the
+    // published POM still declares plain `llvm-platform`, so consumers keep getting every
+    // platform unless they opt into the same filtering.
+    id("org.bytedeco.gradle-javacpp-platform")
 }
 
 java {

--- a/codyze-console/build.gradle.kts
+++ b/codyze-console/build.gradle.kts
@@ -81,3 +81,18 @@ var jarTasks = tasks.withType<Jar>()
 jarTasks.forEach { it.dependsOn(pnpmBuild) }
 
 tasks.shadowJar { setProperty("zip64", true) }
+
+// The Shadow plugin - applied transitively by the Ktor plugin, since that also applies the
+// `application` plugin - registers `shadowRuntimeElements` as a variant of the `java` component, so
+// our publishing conventions upload the fat jar under the `all` classifier. That jar is >2 GB, most
+// of it the per-platform native binaries of `org.bytedeco:llvm-platform`, and building plus
+// uploading it took roughly 7 of the 9 minutes of the CI publish step. Nothing consumes it from
+// Maven Central (the docs run the console via `installDist`), so keep it out of the publication.
+// The Shadow plugin wires up the variant in an `afterEvaluate`, so we have to do the same.
+afterEvaluate {
+    (components["java"] as AdhocComponentWithVariants).withVariantsFromConfiguration(
+        configurations["shadowRuntimeElements"]
+    ) {
+        skip()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -88,6 +88,7 @@ dokka-gradle = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "
 dokka-versioning = { module = "org.jetbrains.dokka:versioning-plugin", version = "2.2.0"}
 kover-gradle = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version = "0.9.3" }
 spotless-gradle = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
+javacpp-gradle = { module = "org.bytedeco:gradle-javacpp", version = "1.5.10" }
 
 # Served by JitPack, so the group is com.github.KuechA.SootUp (the fork's
 # com.github.<owner>.<repo>); the artifactIds are unchanged (sootup.*).


### PR DESCRIPTION
## Why

Pushes to `main` took 9-15 minutes and were sometimes cancelled by the job's `timeout-minutes: 15` (e.g. run [31113736612](https://github.com/Fraunhofer-AISEC/cpg/actions/runs/31113736612), killed at 15.5 min).

The build itself is fast (~150s). The `Publish to Maven Central (snapshot)` step was 525-600s of it, and ~7 of those 9 minutes went to a single module:

| Window | Task | Duration |
|---|---|---|
| 16:23:35-16:25:22 | publish all 17 other modules | 1m47s |
| 16:25:21-16:28:47 | `:codyze-console:shadowJar` | **3m26s** |
| 16:29:01-16:32:20 | `:codyze-console:publish…ToMavenCentral` | **3m19s** |

Because `codyze-console` published its fat jar under the `all` classifier — and that artifact is **2.67 GB**:

```
codyze-console-main-...-all.jar   2,675,342,925 bytes
```

168s of that publish task was one single PUT.

## What changed

**1. Don't publish the fat jar.** The Ktor plugin applies the `application` plugin, which makes it apply Shadow, which registers `shadowRuntimeElements` as a variant of the `java` component — so our publishing conventions picked it up. Nothing consumes it from Maven Central (the docs run the console via `installDist`), so the variant is skipped. Shadow wires it up in an `afterEvaluate`, so the `skip()` has to be deferred too. The `shadowJar` task itself stays available for local fat-jar builds.

**2. Filter JavaCPP native binaries.** Most of those 2.67 GB are `org.bytedeco:llvm-platform`, which ships natives for nine platforms (~2.2 GB). The JavaCPP platform plugin makes a build resolve only its host platform. It lives in `cpg.common-conventions` rather than just `cpg-language-llvm`, because filtering happens per-project at resolution time and `codyze-console` resolves LLVM transitively.

## Publishing is unaffected

The plugin filters inside `llvm-platform`'s own metadata, never our declaration. Verified with a control experiment — generated `cpg-language-llvm`'s POM with the change stashed, then applied:

```
=== POM DIFF (without vs with javacpp plugin) ===
>>> POMs are BYTE-IDENTICAL <<<
```

Consumers still get every platform. Only our builds get the host-only slice.

## Verification

| Check | Result |
|---|---|
| Published POM | byte-identical (control experiment) |
| `codyze-console` runtime classpath | **2551 MB → 456 MB** (−82%) |
| LLVM natives resolved | 9 → 1 (host) |
| `shadowJar` in publish task graph | gone |
| LLVM frontend tests | 33 run, 0 failed |
| Full `assemble` | BUILD SUCCESSFUL |
| `linux-arm64` native on Central | HTTP 200 (CI runner platform) |
| `-PjavacppPlatform=linux-arm64,macosx-arm64` | resolves both |

`llvm-platform` is the only `-platform` artifact in the build, so the blast radius is one dependency.

Expected: publish step ~9-10 min → ~2 min; total run ~12-13 min → ~5 min. This PR carries the `publish-to-github-packages` label so its own CI run actually exercises the publish path and confirms that.

## Notes

- `build.yml` is untouched — `assemble` still pulls in shadowJar/shadowDistZip/shadowDistTar, so the `-x` exclusions from #2865 remain load-bearing. Only the *publish* path stopped needing them.
- Distributions now contain natives only for the building machine. Nothing in CI builds dists, but portable `installDist`/`distZip` needs `-PjavacppPlatform=…`; documented in `CONTRIBUTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
