### PR TITLE
Improved positions for JVM bytecode

### DIFF
--- a/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/DeclarationHandler.kt
+++ b/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/DeclarationHandler.kt
@@ -95,9 +95,11 @@ class DeclarationHandler(frontend: JVMLanguageFrontend) :
             }
         }
 
-        // Loop through all methods
+        // Loop through all methods. A method whose body cannot be rebuilt from the reprinted Jimple
+        // text is translated from the original, compiled class instead -- see
+        // JVMLanguageFrontend.withMethodPositions.
         for (sootMethod in sootClass.methods) {
-            val method = handle(sootMethod) as? Method
+            val method = frontend.withMethodPositions(sootMethod) { handle(it) as? Method }
             if (method != null) {
                 frontend.scopeManager.addDeclaration(method)
                 record.addDeclaration(method)
@@ -144,8 +146,22 @@ class DeclarationHandler(frontend: JVMLanguageFrontend) :
 
         // Parse body if doNotParseBody returns false
         if (!frontend.frontendConfiguration.doNotParseBody(method) && sootMethod.isConcrete) {
-            // Handle method body
-            method.body = frontend.statementHandler.handle(sootMethod.body)
+            // Handle method body. Building the body can still fail -- a Jimple body is resolved
+            // lazily, so this is where a body that cannot be reconstructed surfaces. Keep the
+            // method declaration (with its parameters and signature) in that case instead of
+            // dropping the whole method: a body-less method is a much smaller loss, and the graph
+            // stays consistent for everyone referring to this method.
+            runCatching { frontend.statementHandler.handle(sootMethod.body) }
+                .onFailure {
+                    log.error(
+                        "Could not translate the body of {}; keeping the method declaration " +
+                            "without a body",
+                        sootMethod.signature,
+                        it,
+                    )
+                }
+                .getOrNull()
+                ?.let { method.body = it }
         }
 
         // Leave method scope

--- a/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMFrontendConfiguration.kt
+++ b/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMFrontendConfiguration.kt
@@ -30,8 +30,24 @@ import de.fraunhofer.aisec.cpg.graph.FrontendProvider
 import de.fraunhofer.aisec.cpg.graph.declarations.Function
 import de.fraunhofer.aisec.cpg.graph.declarations.Method
 
-class JVMFrontendConfiguration(val packagesToIgnore: List<String> = listOf()) :
-    FrontendConfiguration<JVMLanguageFrontend>() {
+/**
+ * @param packagesToIgnore Fully-qualified package prefixes whose method bodies should not be
+ *   parsed.
+ * @param useJimpleTextPositions When true, every class is round-tripped through its textual Jimple
+ *   representation (see `sootup.jimple.frontend.JimpleTextPositions`) before translation, so that
+ *   statements and values receive per-line, column-precise positions into the reprinted Jimple text
+ *   instead of the coarse, frequently collapsed line numbers a compiled artifact (`.class`/dex)
+ *   carries. The reprinted text is written to a `.jimple` file (under a temporary directory) and
+ *   used as the location's file name so that "the node on line N" resolves to a real, readable
+ *   line.
+ *
+ *   This trades the original source file name (e.g. `MainActivity.kt`, only recoverable from dex
+ *   debug info) for coherent per-node positions, which is why it is opt-in and defaults to false.
+ */
+class JVMFrontendConfiguration(
+    val packagesToIgnore: List<String> = listOf(),
+    val useJimpleTextPositions: Boolean = false,
+) : FrontendConfiguration<JVMLanguageFrontend>() {
     /**
      * Determines whether the body of a function should NOT be parsed.
      *

--- a/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMFrontendConfiguration.kt
+++ b/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMFrontendConfiguration.kt
@@ -46,7 +46,7 @@ import de.fraunhofer.aisec.cpg.graph.declarations.Method
  */
 class JVMFrontendConfiguration(
     val packagesToIgnore: List<String> = listOf(),
-    val useJimpleTextPositions: Boolean = false,
+    val useJimpleTextPositions: Boolean = true,
 ) : FrontendConfiguration<JVMLanguageFrontend>() {
     /**
      * Determines whether the body of a function should NOT be parsed.

--- a/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMLanguageFrontend.kt
+++ b/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMLanguageFrontend.kt
@@ -51,6 +51,7 @@ import sootup.core.jimple.common.stmt.Stmt
 import sootup.core.model.Body
 import sootup.core.model.HasPosition
 import sootup.core.model.Position
+import sootup.core.model.SootClass
 import sootup.core.model.SootMethod
 import sootup.core.model.SourceType
 import sootup.core.types.ArrayType
@@ -85,6 +86,29 @@ class JVMLanguageFrontend(
      * whereas value positions are 0-based. See [locationOf] for how this is handled.
      */
     var currentClassUsesTextPositions: Boolean = false
+
+    /**
+     * The successful Jimple-text round-trip of the class currently being translated, or `null` when
+     * positions come from the compiled artifact. Method bodies of a reparsed class are built
+     * lazily, so a body that does not survive the round-trip only surfaces while translating that
+     * method -- long after [JimpleTextPositions.reparse] returned. See [withMethodPositions], which
+     * degrades such a method individually instead of losing it (or the whole class) with it.
+     */
+    private var currentReparse: JimpleTextPositions.Result? = null
+
+    /**
+     * The original, compiled class behind [currentReparse]. It provides the fallback method whose
+     * body [withMethodPositions] translates for a method that has no text positions.
+     */
+    private var currentOriginalClass: SootClass? = null
+
+    /**
+     * The [classFileName] that refers to the compiled artifact of the class currently being
+     * translated (as opposed to the reprinted `.jimple` file). This is what [classFileName] is set
+     * to outside text-position mode, and what [withMethodPositions] restores for a single degraded
+     * method.
+     */
+    private var artifactFileName: String? = null
 
     /**
      * Lazily-created temporary directory into which the reprinted Jimple text of each class is
@@ -216,6 +240,8 @@ class JVMLanguageFrontend(
                 }
             val sootClass = reparse?.sootClass ?: originalClass
             currentClassUsesTextPositions = reparse != null
+            currentReparse = reparse
+            currentOriginalClass = originalClass
 
             // Create an appropriate namespace, if it does not already exist
             var pkg =
@@ -236,14 +262,7 @@ class JVMLanguageFrontend(
                     innerPkg
                 }
 
-            // Try to obtain a meaningful file name/path for this class:
-            // - For APK/dex input, the original source file name (e.g. "MainActivity.java") is
-            //   available from the dex debug information via DexClassSource.getSourceFile().
-            // - Otherwise we fall back to the path from which the class was loaded (the .class
-            //   file, the entry inside a jar, or the .jimple file). Note that for plain .class/.jar
-            //   bytecode SootUp does not read the `SourceFile` attribute, so the *original* .java
-            //   name is not available there -- only the load path is.
-            // - As a last resort we use the fully-qualified class name (the previous behavior).
+            artifactFileName = artifactFileNameOf(originalClass)
             classFileName =
                 if (reparse != null) {
                     // Positions now index into the reprinted Jimple text, so the file name must
@@ -252,14 +271,7 @@ class JVMLanguageFrontend(
                     runCatching { writeJimpleText(sootClass.name, reparse.jimpleText).toString() }
                         .getOrNull() ?: sootClass.name.replace(language.namespaceDelimiter, "/")
                 } else {
-                    val classSource = sootClass.classSource
-                    // A dex `SourceFile` entry can be present but blank (e.g. an obfuscator that
-                    // empties the attribute); reject blank so the fallback chain still applies.
-                    (classSource as? DexClassSource)?.sourceFile?.getOrNull()?.takeIf {
-                        it.isNotBlank()
-                    }
-                        ?: runCatching { classSource.sourcePath?.toString() }.getOrNull()
-                        ?: sootClass.name.replace(language.namespaceDelimiter, "/")
+                    artifactFileName
                 }
 
             val decl = declarationHandler.handle(sootClass)
@@ -276,12 +288,98 @@ class JVMLanguageFrontend(
             // frontend for all files
             clearProcessed()
             currentClassUsesTextPositions = false
+            currentReparse = null
+            currentOriginalClass = null
+            artifactFileName = null
         }
 
         return tu
     }
 
     override fun setComment(node: Node, astNode: Any) {}
+
+    /**
+     * A meaningful file name/path for the compiled artifact [sootClass] was loaded from:
+     * - For APK/dex input, the original source file name (e.g. "MainActivity.java") is available
+     *   from the dex debug information via `DexClassSource.getSourceFile()`.
+     * - Otherwise we fall back to the path from which the class was loaded (the .class file, the
+     *   entry inside a jar, or the .jimple file). Note that for plain .class/.jar bytecode SootUp
+     *   does not read the `SourceFile` attribute, so the *original* .java name is not available
+     *   there -- only the load path is.
+     * - As a last resort we use the fully-qualified class name (the original behavior).
+     */
+    private fun artifactFileNameOf(sootClass: SootClass): String {
+        val classSource = sootClass.classSource
+        // A dex `SourceFile` entry can be present but blank (e.g. an obfuscator that empties the
+        // attribute); reject blank so the fallback chain still applies.
+        return (classSource as? DexClassSource)?.sourceFile?.getOrNull()?.takeIf { it.isNotBlank() }
+            ?: runCatching { classSource.sourcePath?.toString() }.getOrNull()
+            ?: sootClass.name.replace(language.namespaceDelimiter, "/")
+    }
+
+    /**
+     * Invokes [block] with the [SootMethod] that should actually be translated for [sootMethod],
+     * and with [locationOf] configured to match where that method's positions come from.
+     *
+     * Normally this is just [sootMethod] itself. But in text-position mode a method body is only
+     * rebuilt from the reprinted Jimple text when it is first requested, so a construct that does
+     * not survive the round-trip fails here -- long after [JimpleTextPositions.reparse] succeeded
+     * for the class, and thus outside the class-level fallback in [parse]. Instead of letting one
+     * such method cost us the whole class, we degrade *per method*: its counterpart from the
+     * original, compiled class is translated instead, with the compiled artifact's positions and
+     * file name ([artifactFileName]). Every other method of the class keeps its text positions.
+     *
+     * The decision is taken before the method declaration is created so that a degraded method is
+     * coherent -- its declaration and its statements then all point into the same file. Since it
+     * asks for the body, this forces every concrete method's body of a reparsed class to be built
+     * (rather than only those that are translated); in text-position mode all bodies are built
+     * anyway, because reprinting the class to Jimple already requires them.
+     */
+    internal fun <T> withMethodPositions(sootMethod: SootMethod, block: (SootMethod) -> T): T {
+        val reparse = currentReparse
+        if (reparse == null || !sootMethod.isConcrete) {
+            // Nothing to degrade: not in text-position mode, or the method has no body to lose (an
+            // abstract/native declaration is positioned by the reprinted text just fine).
+            return block(sootMethod)
+        }
+        // `hasTextPositions` handles a failing body itself; the guard is only for a body that fails
+        // with something it does not catch (e.g. a StackOverflowError from a huge method).
+        if (runCatching { reparse.hasTextPositions(sootMethod) }.getOrDefault(false)) {
+            return block(sootMethod)
+        }
+
+        val fallback =
+            currentOriginalClass?.getMethod(sootMethod.signature.subSignature)?.getOrNull()
+        if (fallback == null) {
+            // Should not happen: the reparsed class is printed from the original one. Keep the
+            // declaration (its header does have a text position); DeclarationHandler will leave it
+            // without a body.
+            log.warn(
+                "Body of {} could not be rebuilt from the reprinted Jimple text and the method has " +
+                    "no counterpart in the original class; keeping it without a body",
+                sootMethod.signature,
+            )
+            return block(sootMethod)
+        }
+
+        log.warn(
+            "Body of {} could not be rebuilt from the reprinted Jimple text; translating this " +
+                "method from {} with compiled-artifact positions instead",
+            sootMethod.signature,
+            artifactFileName,
+        )
+
+        val previousUsesTextPositions = currentClassUsesTextPositions
+        val previousFileName = classFileName
+        currentClassUsesTextPositions = false
+        classFileName = artifactFileName
+        try {
+            return block(fallback)
+        } finally {
+            currentClassUsesTextPositions = previousUsesTextPositions
+            classFileName = previousFileName
+        }
+    }
 
     /**
      * Writes the reprinted Jimple [text] of the class with the given fully-qualified [className] to

--- a/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMLanguageFrontend.kt
+++ b/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMLanguageFrontend.kt
@@ -38,6 +38,8 @@ import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 import de.fraunhofer.aisec.cpg.sarif.Region
 import java.io.File
 import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
 import kotlin.jvm.optionals.getOrNull
 import sootup.apk.frontend.ApkAnalysisInputLocation
 import sootup.apk.frontend.DexBodyInterceptors
@@ -58,6 +60,7 @@ import sootup.interceptors.*
 import sootup.java.bytecode.frontend.inputlocation.JavaClassPathAnalysisInputLocation
 import sootup.java.core.views.JavaView
 import sootup.jimple.frontend.JimpleAnalysisInputLocation
+import sootup.jimple.frontend.JimpleTextPositions
 
 typealias SootType = sootup.core.types.Type
 
@@ -73,6 +76,32 @@ class JVMLanguageFrontend(
     lateinit var view: JavaView
 
     var classFileName: String? = null
+
+    /**
+     * True while translating a class whose positions come from the reprinted Jimple text (see
+     * [JVMFrontendConfiguration.useJimpleTextPositions] and [JimpleTextPositions]). In that mode
+     * [classFileName] points at the written `.jimple` file and [locationOf] must reconcile the two
+     * line bases the Jimple parser produces: statement positions are 1-based (matching the file),
+     * whereas value positions are 0-based. See [locationOf] for how this is handled.
+     */
+    var currentClassUsesTextPositions: Boolean = false
+
+    /**
+     * Lazily-created temporary directory into which the reprinted Jimple text of each class is
+     * written (only when [JVMFrontendConfiguration.useJimpleTextPositions] is enabled), so that the
+     * `.jimple` line numbers reported in positions resolve to a real, readable file.
+     */
+    val jimpleOutputDir: Path by lazy { Files.createTempDirectory("cpg-jimple-positions-") }
+
+    /** The `.jimple` file already written for a given fully-qualified class name (idempotent). */
+    private val jimpleFiles = mutableMapOf<String, Path>()
+
+    /**
+     * Lower-cased relative paths already claimed under [jimpleOutputDir], used to keep file names
+     * unique on case-insensitive filesystems (macOS/Windows) where two class names differing only
+     * in case would otherwise map to the same file and overwrite each other.
+     */
+    private val usedJimplePaths = mutableSetOf<String>()
 
     override val frontendConfiguration: JVMFrontendConfiguration by lazy {
         (this.ctx.config.frontendConfigurations[this::class] as? JVMFrontendConfiguration)
@@ -162,7 +191,32 @@ class JVMLanguageFrontend(
 
         val packages = mutableMapOf<String, Namespace>()
 
-        for (sootClass in view.classes) {
+        for (originalClass in view.classes) {
+            // Optionally round-trip the class through its textual Jimple representation so that
+            // statements and values get per-line, column-precise positions into the reprinted text
+            // instead of the coarse, often collapsed line numbers of the compiled artifact. When
+            // this succeeds we translate the *reparsed* class and point locations at the written
+            // `.jimple` file; if it fails (a construct that does not round-trip) we fall back to
+            // the
+            // original class and its compiled-artifact positions. See JimpleTextPositions.
+            val reparse =
+                if (frontendConfiguration.useJimpleTextPositions) {
+                    runCatching { JimpleTextPositions.reparse(originalClass) }
+                        .onFailure {
+                            log.warn(
+                                "Could not reparse class {} through Jimple text; " +
+                                    "falling back to compiled-artifact positions",
+                                originalClass.type,
+                                it,
+                            )
+                        }
+                        .getOrNull()
+                } else {
+                    null
+                }
+            val sootClass = reparse?.sootClass ?: originalClass
+            currentClassUsesTextPositions = reparse != null
+
             // Create an appropriate namespace, if it does not already exist
             var pkg =
                 sootClass.type.packageName?.name?.split(language.namespaceDelimiter)?.fold(null) {
@@ -190,16 +244,23 @@ class JVMLanguageFrontend(
             //   bytecode SootUp does not read the `SourceFile` attribute, so the *original* .java
             //   name is not available there -- only the load path is.
             // - As a last resort we use the fully-qualified class name (the previous behavior).
-            val classSource = sootClass.classSource
             classFileName =
-                // A dex `SourceFile` entry can be present but blank (e.g. an obfuscator that
-                // empties
-                // the attribute); reject blank so the fallback chain still applies.
-                (classSource as? DexClassSource)?.sourceFile?.getOrNull()?.takeIf {
-                    it.isNotBlank()
+                if (reparse != null) {
+                    // Positions now index into the reprinted Jimple text, so the file name must
+                    // refer to that text (not the original source): write it out and use its path,
+                    // so "line N" resolves to a real, readable line of the produced `.jimple` file.
+                    runCatching { writeJimpleText(sootClass.name, reparse.jimpleText).toString() }
+                        .getOrNull() ?: sootClass.name.replace(language.namespaceDelimiter, "/")
+                } else {
+                    val classSource = sootClass.classSource
+                    // A dex `SourceFile` entry can be present but blank (e.g. an obfuscator that
+                    // empties the attribute); reject blank so the fallback chain still applies.
+                    (classSource as? DexClassSource)?.sourceFile?.getOrNull()?.takeIf {
+                        it.isNotBlank()
+                    }
+                        ?: runCatching { classSource.sourcePath?.toString() }.getOrNull()
+                        ?: sootClass.name.replace(language.namespaceDelimiter, "/")
                 }
-                    ?: runCatching { classSource.sourcePath?.toString() }.getOrNull()
-                    ?: sootClass.name.replace(language.namespaceDelimiter, "/")
 
             val decl = declarationHandler.handle(sootClass)
             scopeManager.addDeclaration(decl)
@@ -214,12 +275,43 @@ class JVMLanguageFrontend(
             // We need to clear the processed because they need to be per-file and we only have one
             // frontend for all files
             clearProcessed()
+            currentClassUsesTextPositions = false
         }
 
         return tu
     }
 
     override fun setComment(node: Node, astNode: Any) {}
+
+    /**
+     * Writes the reprinted Jimple [text] of the class with the given fully-qualified [className] to
+     * a `.jimple` file under [jimpleOutputDir] and returns its path. The file's line N corresponds
+     * to the 1-based line N that statement positions report, so a downstream consumer can open it
+     * to inspect "the node on line N".
+     *
+     * Writing is idempotent per class, and file names are kept unique even on case-insensitive
+     * filesystems (see [usedJimplePaths]) so that a location captured for one class never resolves
+     * to another class's text.
+     */
+    private fun writeJimpleText(className: String, text: String): Path {
+        jimpleFiles[className]?.let {
+            return it
+        }
+
+        val base = className.replace(language.namespaceDelimiter, "/")
+        var relative = "$base.jimple"
+        var suffix = 1
+        while (!usedJimplePaths.add(relative.lowercase())) {
+            relative = "${base}_${suffix}.jimple"
+            suffix++
+        }
+
+        val target = jimpleOutputDir.resolve(relative)
+        target.parent?.let { Files.createDirectories(it) }
+        Files.write(target, text.toByteArray())
+        jimpleFiles[className] = target
+        return target
+    }
 
     override fun locationOf(astNode: Any): PhysicalLocation? {
         // A position is only useful if it actually points at a source line (>= 1). We prefer the
@@ -231,10 +323,20 @@ class JVMLanguageFrontend(
         // -1:-1:-1:-1 (which is what NoPositionInformation represents).
         fun usable(position: Position?) = position?.takeIf { it.firstLine >= 1 }
 
-        val position =
-            usable((astNode as? HasPosition)?.position)
-                ?: usable(currentStmt?.position)
-                ?: return null
+        // Prefer the node's own per-occurrence position; otherwise fall back to the enclosing
+        // statement's (see above). We remember which one we used because the two disagree on their
+        // line base when positions come from the reprinted Jimple text (see below).
+        val ownPosition = usable((astNode as? HasPosition)?.position)
+        val position = ownPosition ?: usable(currentStmt?.position) ?: return null
+
+        // Reconcile line bases against the written `.jimple` file. The Jimple parser reports
+        // statement positions 1-based (so a statement on the first text line is line 1, exactly
+        // matching the file) but value positions 0-based. When we translate the reprinted text we
+        // therefore lift a *value's* own line by one so that every node -- statement or value --
+        // reports the same 1-based line the file uses. Statement positions (and the whole
+        // non-reparse path) are already 1-based and left untouched.
+        val lineOffset =
+            if (currentClassUsesTextPositions && ownPosition != null && astNode !is Stmt) 1 else 0
 
         // Build a URI from the (best-effort) file name. The three-argument URI constructor properly
         // encodes spaces/special characters and yields a hierarchical (path-bearing) URI for the
@@ -262,8 +364,8 @@ class JVMLanguageFrontend(
             uri = uri,
             region =
                 Region(
-                    startLine = position.firstLine,
-                    endLine = position.lastLine,
+                    startLine = position.firstLine + lineOffset,
+                    endLine = position.lastLine + lineOffset,
                     startColumn = position.firstCol,
                     endColumn = position.lastCol,
                 ),

--- a/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMLanguageFrontend.kt
+++ b/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMLanguageFrontend.kt
@@ -314,29 +314,34 @@ class JVMLanguageFrontend(
     }
 
     override fun locationOf(astNode: Any): PhysicalLocation? {
-        // A position is only useful if it actually points at a source line (>= 1). We prefer the
-        // node's own per-occurrence position; if it does not have a usable one -- which is the case
-        // for locals as well as `this`/parameter references (SootUp interns and shares those across
-        // all their use sites) and occasionally for synthetic expressions -- we fall back to the
-        // position of the statement currently being translated. That way e.g. a reference to a
-        // local reports the line of the statement that uses it instead of the dummy location
-        // -1:-1:-1:-1 (which is what NoPositionInformation represents).
-        fun usable(position: Position?) = position?.takeIf { it.firstLine >= 1 }
+        // Reconcile line bases against the written `.jimple` file. The Jimple parser reports
+        // statement positions 1-based (so a statement on the first text line is line 1, exactly
+        // matching the file) but every other position -- values, but also the class and its fields
+        // -- 0-based. When we translate the reprinted text we therefore lift such a node's own line
+        // by one so that every node reports the same 1-based line the file uses. Statement
+        // positions (and the whole non-reparse path) are already 1-based and left untouched.
+        val ownIsZeroBased = currentClassUsesTextPositions && astNode !is Stmt
+
+        // A position is only useful if it actually points at a source line, i.e. at line >= 1 once
+        // its line base is accounted for -- a 0-based position of 0 is the first line and thus
+        // perfectly usable (this is where the class declaration itself sits), whereas the dummy
+        // -1:-1:-1:-1 of NoPositionInformation never is. We prefer the node's own per-occurrence
+        // position; if it does not have a usable one -- which is the case for locals as well as
+        // `this`/parameter references (SootUp interns and shares those across all their use sites)
+        // and occasionally for synthetic expressions -- we fall back to the position of the
+        // statement currently being translated, which is 1-based either way. That way e.g. a
+        // reference to a local reports the line of the statement that uses it instead of the dummy
+        // location.
+        fun usable(position: Position?, zeroBased: Boolean = false) =
+            position?.takeIf { it.firstLine >= if (zeroBased) 0 else 1 }
 
         // Prefer the node's own per-occurrence position; otherwise fall back to the enclosing
         // statement's (see above). We remember which one we used because the two disagree on their
-        // line base when positions come from the reprinted Jimple text (see below).
-        val ownPosition = usable((astNode as? HasPosition)?.position)
+        // line base when positions come from the reprinted Jimple text (see above).
+        val ownPosition = usable((astNode as? HasPosition)?.position, ownIsZeroBased)
         val position = ownPosition ?: usable(currentStmt?.position) ?: return null
 
-        // Reconcile line bases against the written `.jimple` file. The Jimple parser reports
-        // statement positions 1-based (so a statement on the first text line is line 1, exactly
-        // matching the file) but value positions 0-based. When we translate the reprinted text we
-        // therefore lift a *value's* own line by one so that every node -- statement or value --
-        // reports the same 1-based line the file uses. Statement positions (and the whole
-        // non-reparse path) are already 1-based and left untouched.
-        val lineOffset =
-            if (currentClassUsesTextPositions && ownPosition != null && astNode !is Stmt) 1 else 0
+        val lineOffset = if (ownIsZeroBased && ownPosition != null) 1 else 0
 
         // Build a URI from the (best-effort) file name. The three-argument URI constructor properly
         // encodes spaces/special characters and yields a hierarchical (path-bearing) URI for the

--- a/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMLanguageFrontend.kt
+++ b/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMLanguageFrontend.kt
@@ -227,12 +227,18 @@ class JVMLanguageFrontend(
                 if (frontendConfiguration.useJimpleTextPositions) {
                     runCatching { JimpleTextPositions.reparse(originalClass) }
                         .onFailure {
+                            // Log a one-line summary, not the full exception: a failing round-trip
+                            // is an expected degradation path (some construct the Jimple grammar
+                            // does not accept), not a bug, and its stack trace is dominated by
+                            // internal ANTLR/parser frames that are noise for a user watching the
+                            // log. The full trace is still available at DEBUG for diagnosis.
                             log.warn(
-                                "Could not reparse class {} through Jimple text; " +
+                                "Could not reparse class {} through Jimple text ({}); " +
                                     "falling back to compiled-artifact positions",
                                 originalClass.type,
-                                it,
+                                it.message,
                             )
+                            log.debug("Reparse failure for class {}", originalClass.type, it)
                         }
                         .getOrNull()
                 } else {

--- a/cpg-language-jvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMLanguageFrontendTest.kt
+++ b/cpg-language-jvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMLanguageFrontendTest.kt
@@ -1312,4 +1312,85 @@ class JVMLanguageFrontendTest {
             "a value should carry a real, non-degenerate column span, was $binopRegion",
         )
     }
+
+    /**
+     * In text-position mode a method body is only rebuilt from the reprinted Jimple text when it is
+     * first requested, i.e. *after* the class-level round-trip succeeded. A single body that does
+     * not survive the round-trip is therefore degraded per method (it is translated from the
+     * original compiled class instead, see `JVMLanguageFrontend.withMethodPositions`), which this
+     * test pins down through the invariants that fallback has to keep:
+     * 1. no method and no body is lost, and
+     * 2. a method is never a mix of both position sources -- its declaration and its statements
+     *    always point into the same file.
+     */
+    @Test
+    fun testJimpleTextPositionsPerMethod() {
+        val topLevel = Path.of("src", "test", "resources", "class", "operators")
+        val result =
+            analyze(listOf(topLevel.resolve("Operators.class").toFile()), topLevel, true) {
+                it.registerLanguage<JVMLanguage>()
+                it.configureFrontend<JVMLanguageFrontend>(
+                    JVMFrontendConfiguration(useJimpleTextPositions = true)
+                )
+            }
+        assertNotNull(result)
+
+        val record = result.records["Operators"]
+        assertNotNull(record)
+
+        // (1) Every method the class declares is still there, with a translated body. A method
+        //     whose body cannot be built is kept (body-less) rather than dropped, and a method
+        //     without text positions is translated from the compiled artifact -- either way it must
+        //     not disappear from the record.
+        val expected =
+            setOf(
+                "<init>",
+                "testArithmetic",
+                "testComparison",
+                "testBitwise",
+                "testUnary",
+                "testArrayLength",
+                "testCast",
+                "testInstanceOf",
+            )
+        // (constructors are modelled separately from the other methods)
+        val methods = record.methods + record.constructors
+        assertEquals(
+            expected,
+            methods.map { it.name.localName }.toSet(),
+            "no method may be lost in text-position mode",
+        )
+        methods.forEach {
+            assertNotNull(it.body, "method '${it.name}' lost its body in text-position mode")
+        }
+
+        // (2) Each method is coherent: whichever of the two position sources it ended up using, its
+        //     declaration and all of its located statements refer to the same, existing file. (For
+        //     this fixture everything round-trips, so that file is the reprinted `.jimple`; a
+        //     degraded method would consistently point at the compiled artifact instead.)
+        methods.forEach { method ->
+            val methodFile = method.location?.artifactLocation?.uri?.path
+            assertNotNull(methodFile, "method '${method.name}' must carry a file URI")
+            assertTrue(
+                File(methodFile).isFile,
+                "the location of method '${method.name}' must resolve to a real file, was " +
+                    methodFile,
+            )
+            val statementFiles =
+                method
+                    .allChildren<Expression>()
+                    .filter { (it.location?.region?.startLine ?: -1) >= 1 }
+                    .mapNotNull { it.location?.artifactLocation?.uri?.path }
+                    .toSet()
+            assertTrue(
+                statementFiles.isNotEmpty(),
+                "method '${method.name}' has no located statement at all",
+            )
+            assertTrue(
+                statementFiles.all { it == methodFile },
+                "method '${method.name}' mixes position sources: its declaration is in " +
+                    "$methodFile but statements are in ${statementFiles - methodFile}",
+            )
+        }
+    }
 }

--- a/cpg-language-jvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMLanguageFrontendTest.kt
+++ b/cpg-language-jvm/src/test/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMLanguageFrontendTest.kt
@@ -49,6 +49,7 @@ import de.fraunhofer.aisec.cpg.test.assertInvokes
 import de.fraunhofer.aisec.cpg.test.assertLiteralValue
 import de.fraunhofer.aisec.cpg.test.assertLocalName
 import de.fraunhofer.aisec.cpg.test.assertRefersTo
+import java.io.File
 import java.nio.file.Path
 import kotlin.test.*
 import org.junit.jupiter.api.Disabled
@@ -1231,6 +1232,84 @@ class JVMLanguageFrontendTest {
             locatedFields.isNotEmpty(),
             "Expected at least one user field declaration with a source location from the APK, " +
                 "but none of ${userFields.size} user fields had one",
+        )
+    }
+
+    /**
+     * Verifies the opt-in [JVMFrontendConfiguration.useJimpleTextPositions] mode. Instead of the
+     * coarse, frequently collapsed line numbers a compiled artifact carries (many statements
+     * sharing one line, no columns), every class is round-tripped through its textual Jimple
+     * representation so that each statement lands on its own, distinct line of a written `.jimple`
+     * file. This is the "pick the node on line N" guarantee: the reported line resolves to a real,
+     * readable line of a real file.
+     */
+    @Test
+    fun testJimpleTextPositions() {
+        val topLevel = Path.of("src", "test", "resources", "class", "operators")
+        val result =
+            analyze(listOf(topLevel.resolve("Operators.class").toFile()), topLevel, true) {
+                it.registerLanguage<JVMLanguage>()
+                it.configureFrontend<JVMLanguageFrontend>(
+                    JVMFrontendConfiguration(useJimpleTextPositions = true)
+                )
+            }
+        assertNotNull(result)
+
+        val testArithmetic = result.methods["testArithmetic"]
+        assertNotNull(testArithmetic)
+
+        // (1) Every located statement points into a real `.jimple` file, and the line it reports is
+        //     a real, non-blank line of that file -- i.e. "line N" actually resolves to content.
+        val assigns = testArithmetic.allChildren<Assign>()
+        val located = assigns.filter { (it.location?.region?.startLine ?: -1) >= 1 }
+        assertTrue(located.isNotEmpty(), "Expected located assignments in text-position mode")
+
+        located.forEach { assign ->
+            val region = assign.location?.region
+            assertNotNull(region)
+            val fileName = assign.location?.artifactLocation?.uri?.path
+            assertNotNull(fileName, "text-position nodes must carry a file URI")
+            assertTrue(
+                fileName.endsWith(".jimple"),
+                "in text-position mode the location file must be the reprinted .jimple, was $fileName",
+            )
+            val lines = File(fileName).readLines()
+            assertTrue(
+                region.startLine <= lines.size,
+                "reported line ${region.startLine} is outside the ${lines.size}-line file",
+            )
+            assertTrue(
+                lines[region.startLine - 1].isNotBlank(),
+                "statement reported on blank line ${region.startLine} of $fileName",
+            )
+        }
+
+        // (2) Statements land on DISTINCT lines -- the whole point of the round-trip (the compiled
+        //     artifact collapses many onto one). No two of our assignments share a start line.
+        val startLines = located.mapNotNull { it.location?.region?.startLine }
+        assertEquals(
+            startLines.size,
+            startLines.toSet().size,
+            "statements must occupy distinct lines in text-position mode, but some collapsed: " +
+                startLines.sorted(),
+        )
+
+        // (3) Line bases are reconciled: a value-level node (binary operator) reports the SAME line
+        //     as its enclosing statement (no 0-/1-based off-by-one), while still carrying real
+        //     columns -- so the line matches the file and the columns pinpoint the sub-expression.
+        val assignWithBinop = located.firstOrNull { it.allChildren<BinaryOperator>().isNotEmpty() }
+        assertNotNull(assignWithBinop, "expected an assignment containing a binary operator")
+        val binop = assignWithBinop.allChildren<BinaryOperator>().first()
+        assertEquals(
+            assignWithBinop.location?.region?.startLine,
+            binop.location?.region?.startLine,
+            "a value's line must match its enclosing statement's line (no off-by-one)",
+        )
+        val binopRegion = binop.location?.region
+        assertNotNull(binopRegion)
+        assertTrue(
+            binopRegion.startColumn >= 0 && binopRegion.endColumn > binopRegion.startColumn,
+            "a value should carry a real, non-degenerate column span, was $binopRegion",
         )
     }
 }


### PR DESCRIPTION
SootUp uses the jimple IR to emit the code of JVM bytecode. However, when reporting the code location, it refers to some dummy lines in the dex or jar file or so. This PR aligns the two things by doing the following: It creates intermediate jimple-files containing the IR and identifies the locations there. This is beneficial to align the code representation with the reported lines which, in turn, can help debugging, identifying nodes based on locations, and also helps to create more unique IDs compared to the other approach. I'm well aware that this PR is not really pretty but I'm not sure what would be better alternatives. 