### PR TITLE
Rust frontend: fix crash on float literals with `_` digit separators

### DIFF
--- a/cpg-language-rust/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/rust/ExpressionHandler.kt
+++ b/cpg-language-rust/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/rust/ExpressionHandler.kt
@@ -188,7 +188,8 @@ class ExpressionHandler(frontend: RustLanguageFrontend) :
                     (if (stringValue.endsWith("f32")) language.builtInTypes["f32"]
                     else language.builtInTypes["f64"]) ?: unknownType()
 
-                val valueString = stringValue.removeSuffix("f32").removeSuffix("f64")
+                val valueString =
+                    stringValue.removeSuffix("f32").removeSuffix("f64").replace("_", "")
 
                 newLiteral(
                     if (type == language.builtInTypes["f32"]) valueString.toFloat()

--- a/cpg-language-rust/src/test/kotlin/de/fraunhoder/aisec/cpg/frontends/rust/ExpressionsTest.kt
+++ b/cpg-language-rust/src/test/kotlin/de/fraunhoder/aisec/cpg/frontends/rust/ExpressionsTest.kt
@@ -325,6 +325,11 @@ class ExpressionsTest {
         val floatLiterals = literals.filter { it.value is Float || it.value is Double }
         assertTrue(floatLiterals.isNotEmpty(), "Should have floating point literals")
 
+        // Test floating point literal with `_` digit separators
+        val underscoredFloatLit =
+            floatLiterals.firstOrNull { (it.value as? Double) == 1_000_000_000.0 }
+        assertNotNull(underscoredFloatLit, "Should parse '1_000_000_000.0' as 1e9")
+
         // Test boolean literal
         val boolLiterals = literals.filter { it.value is Boolean }
         assertTrue(boolLiterals.isNotEmpty(), "Should have boolean literals")

--- a/cpg-language-rust/src/test/resources/literals.rs
+++ b/cpg-language-rust/src/test/resources/literals.rs
@@ -22,6 +22,7 @@ fn main() {
     let f2 = 1.0;
     let f3 = 2.5e10;
     let f4 = 2e-10;
+    let f5 = 1_000_000_000.0;
 
     // Boolean literals
     let b1 = true;


### PR DESCRIPTION
`Double`/`Float.parseXxx` don't understand Rust's `_` digit-separator syntax (e.g. `1_000_000_000.0`), so any such literal crashed the frontend with a NumberFormatException. `buildIntType` already stripped separators for integer literals; do the same for FLOAT_NUMBER_L before parsing.

Adds a regression case to literals.rs / ExpressionsTest.testLiterals.