### PR TITLE
Persist and reload LLM-tagged concepts and operations across CPG rebuilds

### DIFF
--- a/cpg-ai/build.gradle.kts
+++ b/cpg-ai/build.gradle.kts
@@ -106,6 +106,7 @@ dependencies {
     integrationTestImplementation(libs.mcp.testing)
     integrationTestImplementation(libs.ktor.serialization.kotlinx.json)
     integrationTestImplementation(project(":cpg-serialization"))
+    integrationTestImplementation(project(":cpg-concepts"))
     // We depend on the Python frontend for the integration tests, but the frontend is only
     // available if enabled.
     // If it's not available, the integration tests fail (which is ok). But if we would directly

--- a/cpg-ai/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/tools/CpgGenericConceptsPersistenceTest.kt
+++ b/cpg-ai/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/tools/CpgGenericConceptsPersistenceTest.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.ai.mcp.tools
+
+import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.addLLMConceptAndOperations
+import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.globalAnalysisResult
+import de.fraunhofer.aisec.cpg.ai.mcp.utils.withClient
+import de.fraunhofer.aisec.cpg.frontends.python.PythonLanguage
+import de.fraunhofer.aisec.cpg.graph.concepts.GenericLLMConcept
+import de.fraunhofer.aisec.cpg.graph.concepts.GenericLLMOperation
+import de.fraunhofer.aisec.cpg.graph.literals
+import de.fraunhofer.aisec.cpg.graph.nodes
+import de.fraunhofer.aisec.cpg.passes.concepts.LoadPersistedConcepts
+import de.fraunhofer.aisec.cpg.test.analyze
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import java.io.File
+import kotlin.test.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+
+class CpgGenericConceptsPersistenceTest {
+
+    private val conceptsFile = File("concepts.yaml")
+    private val llmConceptsFile = File("llm-tagged-concepts.yaml")
+
+    @BeforeEach
+    fun setUp() {
+        cleanFiles()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        cleanFiles()
+    }
+
+    private fun cleanFiles() {
+        listOf(
+                File("concepts.yaml").absoluteFile,
+                File("llm-tagged-concepts.yaml").absoluteFile,
+                File("cpg-ai/concepts.yaml").absoluteFile,
+                File("cpg-ai/llm-tagged-concepts.yaml").absoluteFile,
+                File("../llm-tagged-concepts.yaml").absoluteFile,
+                File("../cpg-ai/llm-tagged-concepts.yaml").absoluteFile,
+            )
+            .forEach { file ->
+                if (file.exists()) {
+                    file.delete()
+                }
+                file.deleteOnExit()
+            }
+    }
+
+    @Test
+    fun testPersistAndReloadLLMConceptsAndOperations() =
+        withClient(registerTools = { addLLMConceptAndOperations() }) { client ->
+            try {
+                val pyContent =
+                    "class Foo:\n    secretKey = '0000'\ndef hello():\n    print('Hello World')"
+                val tempPyFile = File.createTempFile("persistence_test_", ".py")
+                tempPyFile.writeText(pyContent)
+                tempPyFile.deleteOnExit()
+
+                val initialResult =
+                    analyze(
+                        files = listOf(tempPyFile),
+                        topLevel = tempPyFile.parentFile.toPath(),
+                        usePasses = true,
+                    ) {
+                        it.registerLanguage<PythonLanguage>()
+                        it.symbols(mapOf("PYTHON_PLATFORM" to "linux"))
+                    }
+                globalAnalysisResult = initialResult
+                assertNotNull(globalAnalysisResult, "Result should be set after analyze")
+
+                val secretLiteral =
+                    globalAnalysisResult?.literals?.singleOrNull { it.value == "0000" }
+                assertNotNull(secretLiteral, "Expected '0000' literal")
+                val nodeId = secretLiteral.id.toString()
+
+                val applyResult =
+                    client.callTool(
+                        name = "cpg_add_llm_concept_and_operations",
+                        arguments =
+                            mapOf(
+                                "concepts" to
+                                    listOf(
+                                        mapOf(
+                                            "name" to "SecretKey",
+                                            "description" to "A hardcoded API secret key",
+                                            "nodeId" to nodeId,
+                                            "properties" to
+                                                listOf(
+                                                    mapOf(
+                                                        "name" to "severity",
+                                                        "type" to "String",
+                                                        "value" to "CRITICAL",
+                                                    )
+                                                ),
+                                            "operations" to
+                                                listOf(
+                                                    mapOf(
+                                                        "name" to "AccessSecret",
+                                                        "description" to
+                                                            "Accesses the secret value",
+                                                        "nodeId" to nodeId,
+                                                        "properties" to
+                                                            listOf(
+                                                                mapOf(
+                                                                    "name" to "accessType",
+                                                                    "type" to "String",
+                                                                    "value" to "READ",
+                                                                )
+                                                            ),
+                                                    )
+                                                ),
+                                        )
+                                    )
+                            ),
+                    )
+
+                assertNotNull(applyResult)
+                val textContent = applyResult.content.filterIsInstance<TextContent>().firstOrNull()
+                assertNotNull(textContent, "Expected TextContent in tool response")
+                assertTrue(
+                    textContent.text.contains("SecretKey"),
+                    "Response should mention SecretKey",
+                )
+                assertTrue(
+                    textContent.text.contains("AccessSecret"),
+                    "Response should mention AccessSecret",
+                )
+
+                assertTrue(llmConceptsFile.exists(), "llm-tagged-concepts.yaml should be created")
+
+                val reloadedResult =
+                    analyze(
+                        files = listOf(tempPyFile),
+                        topLevel = tempPyFile.parentFile.toPath(),
+                        usePasses = true,
+                    ) {
+                        it.registerLanguage<PythonLanguage>()
+                        it.registerPass<LoadPersistedConcepts>()
+                        it.symbols(mapOf("PYTHON_PLATFORM" to "linux"))
+                        it.configurePass<LoadPersistedConcepts>(
+                            LoadPersistedConcepts.Configuration(
+                                conceptFiles = listOf(llmConceptsFile)
+                            )
+                        )
+                    }
+                assertNotNull(reloadedResult)
+
+                val reloadedConcept =
+                    reloadedResult.nodes
+                        .flatMap { it.overlays }
+                        .filterIsInstance<GenericLLMConcept>()
+                        .singleOrNull()
+                assertIs<GenericLLMConcept>(reloadedConcept)
+                assertEquals("SecretKey", reloadedConcept.conceptName)
+                assertEquals("A hardcoded API secret key", reloadedConcept.description)
+                assertEquals("CRITICAL", reloadedConcept.properties.properties["severity"])
+
+                val reloadedOp = reloadedConcept.ops.singleOrNull()
+                assertIs<GenericLLMOperation>(reloadedOp)
+                assertEquals("AccessSecret", reloadedOp.operationName)
+                assertEquals("Accesses the secret value", reloadedOp.description)
+                assertEquals("READ", reloadedOp.properties.properties["accessType"])
+                assertSame(reloadedConcept, reloadedOp.genericLLMConcept)
+            } finally {
+                cleanFiles()
+            }
+        }
+}

--- a/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/mcpserver/tools/CpgGenericConceptsTool.kt
+++ b/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/mcpserver/tools/CpgGenericConceptsTool.kt
@@ -38,6 +38,7 @@ import de.fraunhofer.aisec.cpg.graph.concepts.GenericLLMConcept
 import de.fraunhofer.aisec.cpg.graph.concepts.GenericLLMOperation
 import de.fraunhofer.aisec.cpg.graph.concepts.GenericProperties
 import de.fraunhofer.aisec.cpg.graph.nodes
+import de.fraunhofer.aisec.cpg.passes.concepts.persistLLMConcepts
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
@@ -228,6 +229,7 @@ fun Server.addLLMConceptAndOperations() {
                                 )
                             NodeBuilder.log(this)
                         }
+                conceptNode.ops += opNode
                 appliedOps.add(
                     AppliedOperation(operation = operation, overlayNodeId = opNode.id.toString())
                 )
@@ -246,6 +248,10 @@ fun Server.addLLMConceptAndOperations() {
 
         if (schemasToPersist.isNotEmpty()) {
             persistConceptSchemas(schemasToPersist)
+        }
+
+        if (applied.isNotEmpty()) {
+            result.persistLLMConcepts()
         }
 
         val response = AddConceptsResult(applied = applied, failed = failed)

--- a/cpg-concepts/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/concepts/LoadPersistedConceptsTest.kt
+++ b/cpg-concepts/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/concepts/LoadPersistedConceptsTest.kt
@@ -26,13 +26,22 @@
 package de.fraunhofer.aisec.cpg.concepts
 
 import de.fraunhofer.aisec.cpg.frontends.python.PythonLanguage
+import de.fraunhofer.aisec.cpg.graph.Name
+import de.fraunhofer.aisec.cpg.graph.NodeBuilder
 import de.fraunhofer.aisec.cpg.graph.calls
+import de.fraunhofer.aisec.cpg.graph.codeAndLocationFrom
 import de.fraunhofer.aisec.cpg.graph.conceptNodes
+import de.fraunhofer.aisec.cpg.graph.concepts.GenericLLMConcept
+import de.fraunhofer.aisec.cpg.graph.concepts.GenericLLMOperation
+import de.fraunhofer.aisec.cpg.graph.concepts.GenericProperties
 import de.fraunhofer.aisec.cpg.graph.concepts.file.File
 import de.fraunhofer.aisec.cpg.graph.invoke
 import de.fraunhofer.aisec.cpg.passes.concepts.LoadPersistedConcepts
+import de.fraunhofer.aisec.cpg.passes.concepts.loadLLMConceptsFromFile
+import de.fraunhofer.aisec.cpg.passes.concepts.persistLLMConcepts
 import de.fraunhofer.aisec.cpg.test.BaseTest
 import de.fraunhofer.aisec.cpg.test.analyze
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.*
 
@@ -115,5 +124,277 @@ class LoadPersistedConceptsTest : BaseTest() {
         )
 
         assertEquals("foo", fileConcept.fileName, "Expected name of the file concept to be `foo`.")
+    }
+
+    @Test
+    fun testReadGenericLLMConceptWithNestedOperationAndProperties() {
+        val topLevel = Path.of("src", "integrationTest", "resources", "python", "file")
+
+        val result =
+            analyze(
+                files = listOf(topLevel.resolve("file_read.py").toFile()),
+                topLevel = topLevel,
+                usePasses = true,
+            ) {
+                it.registerLanguage<PythonLanguage>()
+                it.registerPass<LoadPersistedConcepts>()
+                it.symbols(mapOf("PYTHON_PLATFORM" to "linux"))
+                it.configurePass<LoadPersistedConcepts>(
+                    LoadPersistedConcepts.Configuration(
+                        conceptFiles = listOf(topLevel.resolve("generic-llm-concept.yaml").toFile())
+                    )
+                )
+            }
+        assertNotNull(result)
+
+        val concept = result.conceptNodes.singleOrNull { it is GenericLLMConcept }
+        assertIs<GenericLLMConcept>(concept)
+        assertEquals("Authentication", concept.conceptName)
+        assertEquals("Handles user authentication", concept.description)
+        assertEquals("high", concept.properties.properties["tier"])
+
+        val op = concept.ops.singleOrNull()
+        assertIs<GenericLLMOperation>(op)
+        assertEquals("Login", op.operationName)
+        assertEquals("Performs user login", op.description)
+        assertEquals("POST", op.properties.properties["method"])
+        assertSame(concept, op.genericLLMConcept)
+    }
+
+    @Test
+    fun testPersistAndLoadLLMConceptsRoundTripViaDirectApi() {
+        val topLevel = Path.of("src", "integrationTest", "resources", "python", "file")
+        val outFile =
+            Files.createTempFile("llm-concepts-", ".yaml").toFile().apply { deleteOnExit() }
+
+        val result =
+            analyze(
+                files = listOf(topLevel.resolve("file_read.py").toFile()),
+                topLevel = topLevel,
+                usePasses = true,
+            ) {
+                it.registerLanguage<PythonLanguage>()
+                it.symbols(mapOf("PYTHON_PLATFORM" to "linux"))
+            }
+
+        val target = result.calls("open").single()
+        val concept =
+            GenericLLMConcept(
+                    underlyingNode = target,
+                    conceptName = "Authentication",
+                    description = "Handles user authentication",
+                    properties = GenericProperties(mapOf("tier" to "high")),
+                )
+                .apply {
+                    this.codeAndLocationFrom(target)
+                    this.name =
+                        Name("${GenericLLMConcept::class.simpleName}[$conceptName]", target.name)
+                    NodeBuilder.log(this)
+                }
+        val op =
+            GenericLLMOperation(
+                    underlyingNode = target,
+                    operationName = "Login",
+                    description = "Performs user login",
+                    genericLLMConcept = concept,
+                    properties = GenericProperties(mapOf("method" to "POST")),
+                )
+                .apply {
+                    this.codeAndLocationFrom(target)
+                    this.name =
+                        Name(
+                            "${GenericLLMOperation::class.simpleName}[$operationName]",
+                            target.name,
+                        )
+                    NodeBuilder.log(this)
+                }
+        concept.ops += op
+
+        result.persistLLMConcepts(outFile)
+        assertTrue(outFile.exists() && outFile.length() > 0)
+
+        val reloaded =
+            analyze(
+                files = listOf(topLevel.resolve("file_read.py").toFile()),
+                topLevel = topLevel,
+                usePasses = true,
+            ) {
+                it.registerLanguage<PythonLanguage>()
+                it.symbols(mapOf("PYTHON_PLATFORM" to "linux"))
+            }
+        reloaded.loadLLMConceptsFromFile(outFile)
+
+        val reloadedConcept = reloaded.conceptNodes.singleOrNull { it is GenericLLMConcept }
+        assertIs<GenericLLMConcept>(reloadedConcept)
+        assertEquals("Authentication", reloadedConcept.conceptName)
+        assertEquals("Handles user authentication", reloadedConcept.description)
+        assertEquals("high", reloadedConcept.properties.properties["tier"])
+
+        val reloadedOp = reloadedConcept.ops.singleOrNull()
+        assertIs<GenericLLMOperation>(reloadedOp)
+        assertEquals("Login", reloadedOp.operationName)
+        assertEquals("POST", reloadedOp.properties.properties["method"])
+        assertSame(reloadedConcept, reloadedOp.genericLLMConcept)
+        assertNull(reloadedConcept.notes)
+        assertNull(reloadedOp.notes)
+    }
+
+    @Test
+    fun testPersistAndLoadLLMConceptsRoundTripPreservesNotes() {
+        val topLevel = Path.of("src", "integrationTest", "resources", "python", "file")
+        val outFile =
+            Files.createTempFile("llm-concepts-notes-", ".yaml").toFile().apply { deleteOnExit() }
+
+        val result =
+            analyze(
+                files = listOf(topLevel.resolve("file_read.py").toFile()),
+                topLevel = topLevel,
+                usePasses = true,
+            ) {
+                it.registerLanguage<PythonLanguage>()
+                it.symbols(mapOf("PYTHON_PLATFORM" to "linux"))
+            }
+
+        val target = result.calls("open").single()
+        val concept =
+            GenericLLMConcept(
+                    underlyingNode = target,
+                    conceptName = "Authentication",
+                    description = "Handles user authentication",
+                    properties = GenericProperties(mapOf("tier" to "high")),
+                    notes = "Must run after the session init call.",
+                )
+                .apply {
+                    this.codeAndLocationFrom(target)
+                    this.name =
+                        Name("${GenericLLMConcept::class.simpleName}[$conceptName]", target.name)
+                    NodeBuilder.log(this)
+                }
+        val op =
+            GenericLLMOperation(
+                    underlyingNode = target,
+                    operationName = "Login",
+                    description = "Performs user login",
+                    genericLLMConcept = concept,
+                    properties = GenericProperties(mapOf("method" to "POST")),
+                    notes = "Requires a valid session cookie.",
+                )
+                .apply {
+                    this.codeAndLocationFrom(target)
+                    this.name =
+                        Name(
+                            "${GenericLLMOperation::class.simpleName}[$operationName]",
+                            target.name,
+                        )
+                    NodeBuilder.log(this)
+                }
+        concept.ops += op
+
+        result.persistLLMConcepts(outFile)
+
+        val reloaded =
+            analyze(
+                files = listOf(topLevel.resolve("file_read.py").toFile()),
+                topLevel = topLevel,
+                usePasses = true,
+            ) {
+                it.registerLanguage<PythonLanguage>()
+                it.symbols(mapOf("PYTHON_PLATFORM" to "linux"))
+            }
+        reloaded.loadLLMConceptsFromFile(outFile)
+
+        val reloadedConcept = reloaded.conceptNodes.singleOrNull { it is GenericLLMConcept }
+        assertIs<GenericLLMConcept>(reloadedConcept)
+        assertEquals("Must run after the session init call.", reloadedConcept.notes)
+
+        val reloadedOp = reloadedConcept.ops.singleOrNull()
+        assertIs<GenericLLMOperation>(reloadedOp)
+        assertEquals("Requires a valid session cookie.", reloadedOp.notes)
+    }
+
+    @Test
+    fun testLoadLLMConceptsFromFileSkipsUnmatchedLocation() {
+        val topLevel = Path.of("src", "integrationTest", "resources", "python", "file")
+        val result =
+            analyze(
+                files = listOf(topLevel.resolve("file_read.py").toFile()),
+                topLevel = topLevel,
+                usePasses = true,
+            ) {
+                it.registerLanguage<PythonLanguage>()
+                it.symbols(mapOf("PYTHON_PLATFORM" to "linux"))
+            }
+
+        val badFile =
+            Files.createTempFile("llm-concepts-missing-", ".yaml").toFile().apply { deleteOnExit() }
+        badFile.writeText(
+            """
+            concepts:
+              - concept:
+                  name: "de.fraunhofer.aisec.cpg.graph.concepts.GenericLLMConcept"
+                  constructorArguments:
+                    - name: "conceptName"
+                      value: "Ghost"
+                    - name: "description"
+                      value: "Should never match"
+                  properties:
+                    tier: "n/a"
+                location:
+                  file: "src/integrationTest/resources/python/file/file_read.py"
+                  region: "999:1-999:5"
+                  type: "de.fraunhofer.aisec.cpg.graph.expressions.Call"
+            """
+                .trimIndent()
+        )
+
+        // Must not throw - a non-matching location should be logged as a warning and skipped, not
+        // abort the load.
+        result.loadLLMConceptsFromFile(badFile)
+
+        assertTrue(
+            result.conceptNodes.none { it is GenericLLMConcept },
+            "No GenericLLMConcept should have been attached for a non-matching location.",
+        )
+    }
+
+    @Test
+    fun testPersistLLMConceptsUsesDefaultFileName() {
+        val topLevel = Path.of("src", "integrationTest", "resources", "python", "file")
+        val defaultFile = java.io.File("llm-tagged-concepts.yaml")
+        if (defaultFile.exists()) defaultFile.delete()
+
+        val result =
+            analyze(
+                files = listOf(topLevel.resolve("file_read.py").toFile()),
+                topLevel = topLevel,
+                usePasses = true,
+            ) {
+                it.registerLanguage<PythonLanguage>()
+                it.symbols(mapOf("PYTHON_PLATFORM" to "linux"))
+            }
+
+        val target = result.calls("open").single()
+        GenericLLMConcept(
+                underlyingNode = target,
+                conceptName = "DefaultFileCheck",
+                description = "Regression guard for default persistLLMConcepts filename",
+                properties = GenericProperties(emptyMap()),
+            )
+            .apply {
+                this.codeAndLocationFrom(target)
+                this.name =
+                    Name("${GenericLLMConcept::class.simpleName}[$conceptName]", target.name)
+                NodeBuilder.log(this)
+            }
+
+        try {
+            result.persistLLMConcepts()
+            assertTrue(
+                defaultFile.exists(),
+                "persistLLMConcepts() with no argument should write llm-tagged-concepts.yaml",
+            )
+        } finally {
+            if (defaultFile.exists()) defaultFile.delete()
+        }
     }
 }

--- a/cpg-concepts/src/integrationTest/resources/python/file/generic-llm-concept.yaml
+++ b/cpg-concepts/src/integrationTest/resources/python/file/generic-llm-concept.yaml
@@ -1,0 +1,23 @@
+concepts:
+  - concept:
+      name: "de.fraunhofer.aisec.cpg.graph.concepts.GenericLLMConcept"
+      constructorArguments:
+        - name: "conceptName"
+          value: "Authentication"
+        - name: "description"
+          value: "Handles user authentication"
+      properties:
+        tier: "high"
+      operations:
+        - name: "de.fraunhofer.aisec.cpg.graph.concepts.GenericLLMOperation"
+          constructorArguments:
+            - name: "operationName"
+              value: "Login"
+            - name: "description"
+              value: "Performs user login"
+          properties:
+            method: "POST"
+    location:
+      file: "src/integrationTest/resources/python/file/file_read.py"
+      region: "1:6-1:30"
+      type: "de.fraunhofer.aisec.cpg.graph.expressions.Call"

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericLLMConcept.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericLLMConcept.kt
@@ -36,12 +36,15 @@ import java.util.*
  * @param conceptName The name of the concept. This should be unique across all concepts.
  * @param description A description of the concept.
  * @param properties The properties of the concept.
+ * @param notes Free-text notes about this concept's application, e.g. relationships to other tagged
+ *   nodes (such as a function that must be called before this one).
  */
 class GenericLLMConcept(
     underlyingNode: Node? = null,
     val conceptName: String,
     val description: String,
     val properties: GenericProperties,
+    val notes: String? = null,
 ) : Concept(underlyingNode = underlyingNode) {
 
     override fun equals(other: Any?): Boolean {
@@ -49,8 +52,10 @@ class GenericLLMConcept(
             super.equals(other) &&
             other.conceptName == this.conceptName &&
             other.description == this.description &&
-            other.properties == this.properties
+            other.properties == this.properties &&
+            other.notes == this.notes
     }
 
-    override fun hashCode() = Objects.hash(super.hashCode(), conceptName, description, properties)
+    override fun hashCode() =
+        Objects.hash(super.hashCode(), conceptName, description, properties, notes)
 }

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericLLMOperation.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/concepts/GenericLLMOperation.kt
@@ -37,6 +37,8 @@ import java.util.*
  * @param description A human-readable description of the operation.
  * @param genericLLMConcept The concept this operation belongs to.
  * @param properties The properties of the operation.
+ * @param notes Free-text notes about this operation's application, e.g. other functions that must
+ *   be called before this one (such as an init/setKey call before encrypt).
  */
 class GenericLLMOperation(
     underlyingNode: Node? = null,
@@ -44,6 +46,7 @@ class GenericLLMOperation(
     val description: String,
     val genericLLMConcept: GenericLLMConcept,
     val properties: GenericProperties,
+    val notes: String? = null,
 ) : Operation(concept = genericLLMConcept, underlyingNode = underlyingNode) {
 
     override fun equals(other: Any?): Boolean {
@@ -52,9 +55,17 @@ class GenericLLMOperation(
             other.operationName == this.operationName &&
             other.description == this.description &&
             other.genericLLMConcept == this.genericLLMConcept &&
-            other.properties == this.properties
+            other.properties == this.properties &&
+            other.notes == this.notes
     }
 
     override fun hashCode() =
-        Objects.hash(super.hashCode(), operationName, description, genericLLMConcept, properties)
+        Objects.hash(
+            super.hashCode(),
+            operationName,
+            description,
+            genericLLMConcept,
+            properties,
+            notes,
+        )
 }

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/LoadPersistedConcepts.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/LoadPersistedConcepts.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.passes.concepts
 
 import com.fasterxml.jackson.core.JsonFactory
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
@@ -36,8 +37,13 @@ import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.byFQN
 import de.fraunhofer.aisec.cpg.graph.calls
 import de.fraunhofer.aisec.cpg.graph.concepts.Concept
+import de.fraunhofer.aisec.cpg.graph.concepts.GenericLLMConcept
+import de.fraunhofer.aisec.cpg.graph.concepts.GenericLLMOperation
+import de.fraunhofer.aisec.cpg.graph.concepts.GenericProperties
 import de.fraunhofer.aisec.cpg.graph.concepts.conceptBuildHelper
+import de.fraunhofer.aisec.cpg.graph.concepts.operationBuildHelper
 import de.fraunhofer.aisec.cpg.graph.expressions.Call
+import de.fraunhofer.aisec.cpg.graph.nodes
 import de.fraunhofer.aisec.cpg.helpers.getNodesByRegion
 import de.fraunhofer.aisec.cpg.passes.*
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
@@ -45,6 +51,8 @@ import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteBefore
 import de.fraunhofer.aisec.cpg.sarif.PhysicalLocation
 import de.fraunhofer.aisec.cpg.sarif.Region
 import java.io.File
+import java.net.URI
+import kotlin.reflect.KParameter
 
 /**
  * This pass reads a yaml or JSON file and creates a [Concept] for each entry in the file. The pass
@@ -83,7 +91,7 @@ class LoadPersistedConcepts(ctx: TranslationContext) : TranslationResultPass(ctx
      * @param file The file containing the persisted concepts.
      * @param translationResult The [TranslationResult] to which the [Concept]s will be added.
      */
-    private fun addEntriesFromFile(file: File, translationResult: TranslationResult) {
+    internal fun addEntriesFromFile(file: File, translationResult: TranslationResult) {
         val entries =
             try {
                 val mapper =
@@ -107,11 +115,11 @@ class LoadPersistedConcepts(ctx: TranslationContext) : TranslationResultPass(ctx
                 return@forEach
             } else if (concept.signature != null) {
                 translationResult.getNodesBySignature(concept.signature).forEach { underlyingNode ->
-                    addConcept(underlyingNode, concept.concept)
+                    addConcept(underlyingNode, concept.concept, translationResult)
                 }
             } else if (concept.location != null) {
                 translationResult.getNodesByLocation(concept.location).forEach { underlyingNode ->
-                    addConcept(underlyingNode, concept.concept)
+                    addConcept(underlyingNode, concept.concept, translationResult)
                 }
             } else {
                 log.error(
@@ -150,7 +158,7 @@ class LoadPersistedConcepts(ctx: TranslationContext) : TranslationResultPass(ctx
                 val region =
                     regex.matchEntire(location.region)
                         ?: throw IllegalArgumentException(
-                            "Invalid region format: \${location.region}"
+                            "Invalid region format: ${location.region}"
                         )
                 val startLine =
                     region.groups["startLine"]?.value?.toIntOrNull()
@@ -167,8 +175,16 @@ class LoadPersistedConcepts(ctx: TranslationContext) : TranslationResultPass(ctx
                     region.groups["endColumn"]?.value?.toIntOrNull()
                         ?: throw IllegalArgumentException("Invalid or missing endColumn in region.")
 
+                val fileUri =
+                    try {
+                        val u = URI(location.file)
+                        if (u.isAbsolute) u else File(location.file).toURI()
+                    } catch (e: Exception) {
+                        File(location.file).toURI()
+                    }
+
                 PhysicalLocation(
-                    uri = File(location.file).toURI(),
+                    uri = fileUri,
                     region = Region(startLine, startColumn, endLine, endColumn),
                 )
             } catch (ex: Exception) {
@@ -184,23 +200,100 @@ class LoadPersistedConcepts(ctx: TranslationContext) : TranslationResultPass(ctx
         }
     }
 
+    private fun constructorParameters(className: String): List<KParameter>? {
+        return try {
+            Class.forName(className).kotlin.constructors.singleOrNull()?.parameters
+        } catch (e: Exception) {
+            null
+        }
+    }
+
     /**
-     * This is a helper function to add a [Concept] node to the [underlyingNode] as described in the
-     * provided [ConceptEntry].
+     * Helper function to add a [Concept] node to the [underlyingNode] from [ConceptEntry].
      *
      * @param underlyingNode The node to which the concept will be added.
-     * @param concept The [ConceptEntry] containing the concept information.
+     * @param concept The [ConceptEntry] containing concept data.
+     * @param translationResult The [TranslationResult] used for resolving operation targets.
      */
-    private fun addConcept(underlyingNode: Node, concept: ConceptEntry) {
+    private fun addConcept(
+        underlyingNode: Node,
+        concept: ConceptEntry,
+        translationResult: TranslationResult,
+    ) {
         log.debug("Adding concept {} to node {}.", concept, underlyingNode)
-        underlyingNode.conceptBuildHelper(
-            name = concept.name,
-            underlyingNode = underlyingNode,
-            constructorArguments =
-                concept.constructorArguments.associate { arg -> arg.name to arg.value },
-            connectDFGUnderlyingNodeToConcept = concept.dfg.fromThisNodeToConcept,
-            connectDFGConceptToUnderlyingNode = concept.dfg.fromConceptToThisNode,
-        )
+        try {
+            val ctorParams = constructorParameters(concept.name)
+            val args: MutableMap<String, Any?> =
+                concept.constructorArguments
+                    .associate { arg -> arg.name to (arg.value as Any?) }
+                    .toMutableMap()
+            if (concept.properties != null && ctorParams?.any { it.name == "properties" } == true) {
+                args["properties"] = GenericProperties(concept.properties)
+            }
+
+            val builtConcept =
+                underlyingNode.conceptBuildHelper(
+                    name = concept.name,
+                    underlyingNode = underlyingNode,
+                    constructorArguments = args,
+                    connectDFGUnderlyingNodeToConcept = concept.dfg.fromThisNodeToConcept,
+                    connectDFGConceptToUnderlyingNode = concept.dfg.fromConceptToThisNode,
+                )
+
+            concept.operations.forEach { op ->
+                addOperation(underlyingNode, builtConcept, op, translationResult)
+            }
+        } catch (ex: Exception) {
+            log.error("Failed to add concept ${concept.name}: ${ex.message}", ex)
+        }
+    }
+
+    private fun addOperation(
+        defaultNode: Node,
+        concept: Concept,
+        op: OperationEntry,
+        translationResult: TranslationResult,
+    ) {
+        val targetNodes =
+            if (op.signature != null && op.location != null) {
+                log.error(
+                    "Both signature and location are set on operation entry. The operation entry will be ignored!"
+                )
+                return
+            } else if (op.signature != null) {
+                translationResult.getNodesBySignature(op.signature)
+            } else if (op.location != null) {
+                translationResult.getNodesByLocation(op.location)
+            } else {
+                listOf(defaultNode)
+            }
+
+        targetNodes.forEach { node ->
+            try {
+                val args: MutableMap<String, Any?> =
+                    op.constructorArguments
+                        .associate { arg -> arg.name to (arg.value as Any?) }
+                        .toMutableMap()
+                val ctorParams = constructorParameters(op.name)
+                if (ctorParams?.any { it.name == "genericLLMConcept" } == true) {
+                    args["genericLLMConcept"] = concept
+                }
+                if (op.properties != null && ctorParams?.any { it.name == "properties" } == true) {
+                    args["properties"] = GenericProperties(op.properties)
+                }
+
+                node.operationBuildHelper(
+                    name = op.name,
+                    underlyingNode = node,
+                    concept = concept,
+                    constructorArguments = args,
+                    connectDFGUnderlyingNodeToConcept = op.dfg.fromThisNodeToConcept,
+                    connectDFGConceptToUnderlyingNode = op.dfg.fromConceptToThisNode,
+                )
+            } catch (ex: Exception) {
+                log.error("Failed to add operation ${op.name}: ${ex.message}", ex)
+            }
+        }
     }
 
     /** The root node of our YAML/JSON structure. It contains a list of [PersistedConceptEntry]s. */
@@ -224,16 +317,41 @@ class LoadPersistedConcepts(ctx: TranslationContext) : TranslationResultPass(ctx
 
     /**
      * This class represents a single concept entry in the YAML/JSON file. It contains the name of
-     * the concept, optional constructor arguments, and optional DFG connections.
+     * the concept, optional constructor arguments, optional properties, optional operations, and
+     * optional DFG connections.
      *
      * @param name The FQN of the concept to be added.
      * @param constructorArguments The constructor arguments to be passed to the concepts'
      *   constructor.
+     * @param properties The properties of the concept.
+     * @param operations The operations belonging to this concept.
      * @param dfg The DFG connections to be created between the concept and the underlying node.
      */
     data class ConceptEntry(
         val name: String,
         val constructorArguments: List<ConstructorArgumentEntry> = listOf(),
+        val properties: Map<String, String>? = null,
+        val operations: List<OperationEntry> = listOf(),
+        val dfg: DFGEntry = DFGEntry(fromThisNodeToConcept = false, fromConceptToThisNode = false),
+    )
+
+    /**
+     * This class represents a single operation entry in the YAML/JSON file.
+     *
+     * @param name The FQN of the operation to be added.
+     * @param constructorArguments The constructor arguments to be passed to the operations'
+     *   constructor.
+     * @param properties The properties of the operation.
+     * @param location The location of the node to which the operation applies.
+     * @param signature The signature of the node to which the operation applies.
+     * @param dfg The DFG connections to be created between the operation and the underlying node.
+     */
+    data class OperationEntry(
+        val name: String,
+        val constructorArguments: List<ConstructorArgumentEntry> = listOf(),
+        val properties: Map<String, String>? = null,
+        val location: LocationEntry? = null,
+        val signature: SignatureEntry? = null,
         val dfg: DFGEntry = DFGEntry(fromThisNodeToConcept = false, fromConceptToThisNode = false),
     )
 
@@ -275,4 +393,111 @@ class LoadPersistedConcepts(ctx: TranslationContext) : TranslationResultPass(ctx
      * @param fqn The fully qualified name of the [Call] to match against. E.g. `foo.bar.baz`.
      */
     data class SignatureEntry(val fqn: String)
+}
+
+/**
+ * Persists all [GenericLLMConcept] and [GenericLLMOperation] overlay nodes in this
+ * [TranslationResult] to [file] in YAML format.
+ *
+ * @param file The destination file. Defaults to `llm-tagged-concepts.yaml`.
+ */
+fun TranslationResult.persistLLMConcepts(file: File = File("llm-tagged-concepts.yaml")) {
+    val concepts = this.nodes.flatMap { it.overlays }.filterIsInstance<GenericLLMConcept>()
+    val entries =
+        concepts.map { concept ->
+            LoadPersistedConcepts.PersistedConceptEntry(
+                concept =
+                    LoadPersistedConcepts.ConceptEntry(
+                        name = concept::class.java.name,
+                        constructorArguments =
+                            listOfNotNull(
+                                LoadPersistedConcepts.ConstructorArgumentEntry(
+                                    "conceptName",
+                                    concept.conceptName,
+                                ),
+                                LoadPersistedConcepts.ConstructorArgumentEntry(
+                                    "description",
+                                    concept.description,
+                                ),
+                                concept.notes?.let {
+                                    LoadPersistedConcepts.ConstructorArgumentEntry("notes", it)
+                                },
+                            ),
+                        properties = concept.properties.properties,
+                        operations =
+                            concept.ops.filterIsInstance<GenericLLMOperation>().map { op ->
+                                LoadPersistedConcepts.OperationEntry(
+                                    name = op::class.java.name,
+                                    constructorArguments =
+                                        listOfNotNull(
+                                            LoadPersistedConcepts.ConstructorArgumentEntry(
+                                                "operationName",
+                                                op.operationName,
+                                            ),
+                                            LoadPersistedConcepts.ConstructorArgumentEntry(
+                                                "description",
+                                                op.description,
+                                            ),
+                                            op.notes?.let {
+                                                LoadPersistedConcepts.ConstructorArgumentEntry(
+                                                    "notes",
+                                                    it,
+                                                )
+                                            },
+                                        ),
+                                    properties = op.properties.properties,
+                                    location =
+                                        op.underlyingNode
+                                            ?.takeIf { it != concept.underlyingNode }
+                                            ?.let { node ->
+                                                LoadPersistedConcepts.LocationEntry(
+                                                    file =
+                                                        node.location?.artifactLocation?.uri?.let {
+                                                            uri ->
+                                                            try {
+                                                                File(uri).path
+                                                            } catch (e: Exception) {
+                                                                uri.toString()
+                                                            }
+                                                        } ?: "",
+                                                    region = node.location?.region.toString(),
+                                                    type = node::class.java.name,
+                                                )
+                                            },
+                                )
+                            },
+                    ),
+                location =
+                    concept.underlyingNode?.let { node ->
+                        LoadPersistedConcepts.LocationEntry(
+                            file =
+                                node.location?.artifactLocation?.uri?.let { uri ->
+                                    try {
+                                        File(uri).path
+                                    } catch (e: Exception) {
+                                        uri.toString()
+                                    }
+                                } ?: "",
+                            region = node.location?.region.toString(),
+                            type = node::class.java.name,
+                        )
+                    },
+                signature = null,
+            )
+        }
+    ObjectMapper(YAMLFactory())
+        .registerKotlinModule()
+        .enable(SerializationFeature.INDENT_OUTPUT)
+        .disable(SerializationFeature.WRITE_NULL_MAP_VALUES)
+        .writeValue(file, LoadPersistedConcepts.PersistedConcepts(concepts = entries))
+}
+
+/**
+ * Loads persisted concepts and operations from [file] and attaches them to this
+ * [TranslationResult].
+ *
+ * @param file The YAML or JSON file containing persisted concept entries.
+ */
+fun TranslationResult.loadLLMConceptsFromFile(file: File) {
+    LoadPersistedConcepts(this.ctx).addEntriesFromFile(file, this)
 }


### PR DESCRIPTION
## Summary

Adds `TranslationResult.persistLLMConcepts()` and `TranslationResult.loadLLMConceptsFromFile()`
so `GenericLLMConcept`/`GenericLLMOperation` overlay nodes created by the LLM-tagging MCP tool
(`cpg_add_llm_concept_and_operations`) survive a CPG rebuild without rerunning the LLM. Built-in
concepts (File, Database, Log) are unaffected; this covers LLM-tagged nodes only.

- `persistLLMConcepts(file)` walks the current `TranslationResult`'s `GenericLLMConcept`/
  `GenericLLMOperation` overlays and writes them to YAML (default `llm-tagged-concepts.yaml`).
- `loadLLMConceptsFromFile(file)` reloads them into an already-built `TranslationResult`,
  matching each entry's underlying node by location or signature. A non-matching entry is logged
  as a warning and skipped, the rest of the file still loads.
- The existing `cpg_add_llm_concept_and_operations` MCP tool now calls `persistLLMConcepts()`
  automatically on every successful tag application, replacing its previous ad hoc write.
- Extends the existing `LoadPersistedConcepts` YAML/JSON schema with `properties` and nested
  `operations` on `ConceptEntry`, plus `notes` on both `GenericLLMConcept`/`GenericLLMOperation`.

## Test plan

- [x] `LoadPersistedConceptsTest`: direct-API persist/reload round trip, missing-node
      warn-and-skip, default filename, `notes` round trip (7 tests)
- [x] `CpgGenericConceptsPersistenceTest`: full MCP-tool-to-reload round trip (1 test)
- [x] `./gradlew :cpg-concepts:integrationTest :cpg-ai:integrationTest` (forced rerun, not cached)
- [x] `./gradlew :cpg-concepts:spotlessCheck :cpg-ai:spotlessCheck` (forced rerun)