### PR TITLE
PtP: No LastWrite for literals

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
@@ -2825,7 +2825,7 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                 NodeWithPropertiesKey(it, equalLinkedHashSetOf<Any>(false))
             }
 
-        /* For literals, we store the address and the lastWrite as "theirs" in the DeclarationState so that we know from where we have to draw DFGEdges in the future */
+        /* For literals, we store the address as "theirs" in the DeclarationState */
         // TODO: would this make sense for everything in the lhs?
         val l = currentNode.rhs.singleOrNull() as? Literal<*>
         l?.let {
@@ -2836,7 +2836,7 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                     DeclarationStateEntryElement(
                         PowersetLattice.Element(destinationsAddresses),
                         PowersetLattice.Element(),
-                        PowersetLattice.Element(lastWrites),
+                        PowersetLattice.Element(),
                     ),
                 )
         }

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
@@ -4162,10 +4162,6 @@ class PointsToPassTest {
             strlSrcParam.memoryValues.singleOrNull { it.name.localName == "derefvalue" }
         assertNotNull(strlSrcDerefPMV)
 
-        val memsetDstParam = memsetFunc.parameters[0]
-        val memsetDstDerefPMV =
-            memsetDstParam.memoryValues.singleOrNull { it.name.localName == "derefvalue" }
-
         val realCodeParam = testFunc.parameters.single()
         val realCodeDerefPMV =
             realCodeParam.memoryValues.singleOrNull { it.name.localName == "derefvalue" }

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
@@ -5138,4 +5138,27 @@ class PointsToPassTest {
         // For this one, we rely on the DynamicInvokesResolver
         assertInvokes(funcPtrCall2, incpFunc)
     }
+
+    @Test
+    fun testPMVDeref() {
+        val file = File("src/test/resources/pointsToPass/pmv_deref.c")
+        val tu =
+            analyzeAndGetFirstTU(listOf(file), file.parentFile.toPath(), true) {
+                it.registerLanguage<CLanguage>()
+                it.registerPass<PointsToPass>()
+                it.registerFunctionSummaries(File("src/test/resources/hardcodedDFGedges.yml"))
+            }
+        assertNotNull(tu)
+
+        // Functions
+        val fFunc = tu.functions("f").single()
+
+        // Params and PMVs
+        val dataParam = fFunc.parameters.single()
+        val dataDerefPMV = dataParam.memoryValues.single { it.name.localName == "derefvalue" }
+
+        // Actual test
+        // The PMV should have no prevDFG
+        assertTrue(dataDerefPMV.prevDFG.isEmpty())
+    }
 }

--- a/cpg-language-cxx/src/test/resources/pointsToPass/pmv_deref.c
+++ b/cpg-language-cxx/src/test/resources/pointsToPass/pmv_deref.c
@@ -1,0 +1,14 @@
+#include<stdio.h>
+
+void f(char * data)
+{
+    printf("%d", data[0]);
+}
+
+void main()
+{
+    char * data;
+    data = NULL;
+    f(data);
+}
+


### PR DESCRIPTION
Previously, we set the lastwrites of literals. This can cause wrong DFG-Edges, so this PR removes this step. 