### PR TITLE
feat(persistence): add FalkorDB backend for persisting the CPG

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Setup neo4j
         run: |
           docker run -d --env NEO4J_AUTH=neo4j/password -p7474:7474 -p7687:7687 -e NEO4JLABS_PLUGINS='["apoc"]' neo4j:5 || true
+      - name: Setup FalkorDB
+        run: |
+          docker run -d -p6379:6379 falkordb/falkordb:latest || true
       - name: Determine Version
         run: |
           # determine version from tag

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Key modules:
 - **cpg-analysis** – Higher-level analyses built on top of cpg-core (dataflow, control flow, call graphs, etc.)
 - **cpg-language-\*** – Language frontends, one module per language (e.g., `cpg-language-go`, `cpg-language-python`)
 - **cpg-concepts** – Concept and operation definitions
+- **cpg-neo4j** / **cpg-falkordb** – CLI tools that persist a translated CPG into a Neo4j resp. FalkorDB graph database, both built on the `GraphDatabaseBackend` abstraction in `cpg-core`
 - **cpg-ai** – AI components for the CPG: an MCP server exposing CPG analysis tools (dataflow, symbol analysis, concept application) to LLMs via streamable HTTP, plus chat/skills integration
 - **codyze-console** – Web-based analysis UI with AI agent chat (see [Architecture](#codyze-console-architecture) below)
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ For example using docker:
 docker run -p 7474:7474 -p 7687:7687 -d -e NEO4J_AUTH=neo4j/password -e NEO4JLABS_PLUGINS='["apoc"]' neo4j:5
 ```
 
+Alternatively, the subproject [cpg-falkordb](./cpg-falkordb) persists the very same graph to a [FalkorDB](https://www.falkordb.com/) database. FalkorDB is an in-memory graph database that also speaks Cypher, but requires no server-side plugin and starts almost instantly, which makes it convenient for short-lived analysis runs and CI pipelines.
+
+For example using docker:
+```
+docker run -p 6379:6379 -p 3000:3000 -d falkordb/falkordb:latest
+```
+
 ### As Library
 
 The most recent version is being published to Maven central and can be used as a simple dependency, either using Maven or Gradle.

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/persistence/GraphDatabaseBackend.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/persistence/GraphDatabaseBackend.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.persistence
+
+import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.Persistable
+import de.fraunhofer.aisec.cpg.graph.nodes
+import de.fraunhofer.aisec.cpg.helpers.Benchmark
+
+/**
+ * An abstraction over a graph database that a [TranslationResult] can be persisted to.
+ *
+ * The CPG can be written to several graph databases, which all understand (a dialect of) Cypher,
+ * but differ in their wire protocol and in the exact Cypher features they support. This interface
+ * captures the small set of operations that actually differ between them, so that the
+ * database-independent part of the persistence — collecting the nodes and relationships of a
+ * [TranslationResult] and splitting them into chunks — can be shared by all implementations in
+ * [persist].
+ *
+ * Implementations are expected to hold an open connection and are therefore [AutoCloseable].
+ */
+interface GraphDatabaseBackend : AutoCloseable {
+    /**
+     * The number of nodes that are persisted in a single call to [persistNodeChunk]. Chunking keeps
+     * the size of an individual database write manageable, even for very large graphs.
+     */
+    val nodeChunkSize: Int
+        get() = DEFAULT_NODE_CHUNK_SIZE
+
+    /**
+     * The number of relationships that are persisted in a single call to
+     * [persistRelationshipChunk].
+     */
+    val relationshipChunkSize: Int
+        get() = DEFAULT_RELATIONSHIP_CHUNK_SIZE
+
+    /** Removes all nodes and relationships that are currently stored in the database. */
+    fun purgeDatabase()
+
+    /**
+     * Creates the indexes that are needed to persist (and later query) the CPG efficiently. This is
+     * called after the nodes have been written, but before the relationships are written, since
+     * relationship creation matches on the node identifier.
+     */
+    fun createIndexes()
+
+    /** Writes a chunk of at most [nodeChunkSize] [nodes] to the database. */
+    fun persistNodeChunk(nodes: List<Node>)
+
+    /**
+     * Writes a chunk of at most [relationshipChunkSize] relationships to the database. Each entry
+     * is a map as produced by [collectRelationships], i.e. it contains the keys `startId`, `endId`
+     * and `type` alongside the properties of the relationship.
+     */
+    fun persistRelationshipChunk(relationships: List<Map<String, Any?>>)
+}
+
+/** The default value for [GraphDatabaseBackend.nodeChunkSize]. */
+const val DEFAULT_NODE_CHUNK_SIZE = 10000
+
+/** The default value for [GraphDatabaseBackend.relationshipChunkSize]. */
+const val DEFAULT_RELATIONSHIP_CHUNK_SIZE = 10000
+
+/**
+ * Persists this [TranslationResult] into the given [db].
+ *
+ * This method performs the following actions:
+ * - Collects the nodes that need to be persisted. These are the AST nodes as well as all other
+ *   nodes that are reachable from them through a relationship (e.g. scopes, types and languages).
+ * - Optionally purges the database beforehand, see [purgeDb].
+ * - Persists the collected nodes, chunked by [GraphDatabaseBackend.nodeChunkSize].
+ * - Creates the indexes needed for matching nodes by their identifier.
+ * - Collects and persists all relationships between the nodes, chunked by
+ *   [GraphDatabaseBackend.relationshipChunkSize].
+ *
+ * The whole operation as well as each individual chunk is benchmarked using [Benchmark].
+ *
+ * @param db the database to persist to
+ * @param purgeDb whether the database should be emptied before writing the new graph
+ */
+fun TranslationResult.persist(db: GraphDatabaseBackend, purgeDb: Boolean = true) {
+    val b = Benchmark(Persistable::class.java, "Persisting translation result")
+
+    val astNodes = this@persist.nodes
+    val connected = astNodes.flatMap { it.connectedNodes }.toSet()
+    val nodes = (astNodes + connected).distinct()
+
+    if (purgeDb) {
+        log.info("Purging database before persisting")
+        db.purgeDatabase()
+    }
+
+    log.info(
+        "Persisting {} nodes: AST nodes ({}), other nodes ({})",
+        nodes.size,
+        astNodes.size,
+        connected.size,
+    )
+    nodes.persistChunked(db)
+
+    // The index on the node identifier is needed to match the start and end node of a
+    // relationship, so it has to exist before the relationships are written.
+    db.createIndexes()
+
+    val relationships = nodes.collectRelationships()
+
+    log.info("Persisting {} relationships", relationships.size)
+    relationships.persistChunked(db)
+
+    b.stop()
+}
+
+/** Splits this list of nodes into chunks and hands each of them to [db]. */
+private fun List<Node>.persistChunked(db: GraphDatabaseBackend) {
+    this.chunked(db.nodeChunkSize).forEach { chunk ->
+        val b = Benchmark(Persistable::class.java, "Persisting chunk of ${chunk.size} nodes")
+        db.persistNodeChunk(chunk)
+        b.stop()
+    }
+}
+
+/** Splits this list of relationships into chunks and hands each of them to [db]. */
+@JvmName("persistRelationshipsChunked")
+private fun List<Map<String, Any?>>.persistChunked(db: GraphDatabaseBackend) {
+    this.chunked(db.relationshipChunkSize).forEach { chunk ->
+        val b =
+            Benchmark(Persistable::class.java, "Persisting chunk of ${chunk.size} relationships")
+        db.persistRelationshipChunk(chunk)
+        b.stop()
+    }
+}

--- a/cpg-falkordb/README.md
+++ b/cpg-falkordb/README.md
@@ -1,0 +1,169 @@
+# FalkorDB persistence tool for the Code Property Graph
+
+A simple tool to export a *code property graph* to a [FalkorDB](https://www.falkordb.com/) graph database.
+
+FalkorDB is a Redis module that implements a sparse-matrix based property graph and speaks
+openCypher. Compared to the [cpg-neo4j](../cpg-neo4j) tool it needs no server-side plugin, starts in
+well under a second and keeps the whole graph in memory, which makes it a good fit for short-lived
+analysis runs and CI pipelines.
+
+## Requirements
+
+The application requires Java 21.
+
+No server-side plugin is required. For example using docker:
+
+```
+docker run -p 127.0.0.1:6379:6379 -d falkordb/falkordb:latest
+```
+
+FalkorDB ships a graph browser on port 3000 if you expose it (`-p 127.0.0.1:3000:3000`), which can be
+used to visually explore the persisted CPG.
+
+## Build
+
+Build (and install) a distribution using Gradle
+
+```
+../gradlew installDist
+```
+
+Please remember to adjust the `gradle.properties` before building the project, in order to enable the
+language frontends you are interested in.
+
+## Usage
+
+```
+./build/install/cpg-falkordb/bin/cpg-falkordb [--infer-nodes] [--load-includes]
+                    [--no-default-passes] [--no-falkordb] [--no-purge-db]
+                    [--print-benchmark] [--use-unity-build]
+                    [--benchmark-json=<benchmarkJson>]
+                    [--custom-pass-list=<customPasses>]
+                    [--export-json=<exportJsonFile>] [--graph=<graphName>]
+                    [--host=<host>] [--includes-file=<includesFile>]
+                    [--max-complexity-cf-dfg=<maxComplexity>]
+                    [--****** [--port=<port>]
+                    [--top-level=<topLevel>] [--user=<falkorDbUsername>]
+                    [--exclusion-patterns=<exclusionPatterns>]...
+                    [-IP=<includePaths>]... ([<files>...] | -S=<String=String>
+                    [-S=<String=String>]... |
+                    --json-compilation-database=<jsonCompilationDatabase> |
+                    --list-passes)
+      [<files>...]          The paths to analyze. If module support is enabled,
+                              the paths will be looked at if they contain
+                              modules
+      --benchmark-json=<benchmarkJson>
+                            Save benchmark results to json file
+      --custom-pass-list=<customPasses>
+                            Add custom list of passes (might be used additional
+                              to --no-default-passes) which is passed as a
+                              comma-separated list; give either pass name if
+                              pass is in list, or its FQDN (e.g.
+                              --custom-pass-list=DFGPass,CallResolver)
+      --exclusion-patterns=<exclusionPatterns>
+                            Configures an exclusion pattern for files or
+                              directories that should not be parsed
+      --export-json=<exportJsonFile>
+                            Export cpg as json
+      --graph=<graphName>   Set the name of the graph to store the cpg in
+                              (default: cpg).
+                            A single FalkorDB instance can hold several
+                              independent graphs.
+      --host=<host>         Set the host of the FalkorDB instance (default:
+                              localhost).
+      --includes-file=<includesFile>
+                            Load includes from file
+      --infer-nodes         Create inferred nodes for missing declarations
+      -IP, --include-paths=<includePaths>
+                            Directories containing additional headers and
+                              implementations for imported code.
+      --json-compilation-database=<jsonCompilationDatabase>
+                            The path to an optional a JSON compilation
+                              database. Please note, that the JSON compilation
+                              database always describes a single component.
+      --list-passes         Prints the list available passes
+      --load-includes       Enable TranslationConfig option
+      --max-complexity-cf-dfg=<maxComplexity>
+                            Performance optimisation: Limit the
+                              ControlFlowSensitiveDFGPass to functions with a
+                              complexity less than what is specified here. -1
+                              (default) means no limit is used.
+      --no-default-passes   Do not register default passes [used for debugging]
+      --no-falkordb         Do not push cpg into FalkorDB [used for debugging]
+      --no-purge-db         Do not purge the graph before pushing the cpg
+      --******
+                            FalkorDB password (default: no authentication)
+      --port=<port>         Set the port of the FalkorDB instance (default:
+                              6379).
+      --print-benchmark     Print benchmark result as markdown table
+  -S, --softwareComponents=<String=String>
+                            Maps the names of software components to their
+                              respective files. The files are separated by
+                              commas (No whitespace!).
+                            Example: -S App1=./file1.c,./file2.c -S App2=./Main.
+                              java,./Class.java
+      --top-level=<topLevel>
+                            Set top level directory of project structure.
+                              Default: Largest common path of all source files
+      --use-unity-build     Enable unity build mode for C++ (requires
+                              --load-includes)
+      --user=<falkorDbUsername>
+                            FalkorDB user name (default: no authentication)
+```
+
+You can provide a list of paths of arbitrary length that can contain both file paths and directory
+paths.
+
+Usage example:
+
+```
+$ ./build/install/cpg-falkordb/bin/cpg-falkordb --graph my-project src/main.c
+```
+
+Afterwards the graph can be queried with any Redis client, e.g.:
+
+```
+$ redis-cli GRAPH.QUERY my-project "MATCH (f:Function)-[:BODY]->(b) RETURN f.name, b.code"
+```
+
+## Graph schema
+
+The persisted schema is identical to the one used by the [cpg-neo4j](../cpg-neo4j) tool: every node
+carries the labels of its whole class hierarchy (e.g. a call expression is labelled
+`:Node:AstNode:Expression:Call`) and every edge is persisted with its edge properties.
+
+Documentation about the graph schema can be found at:
+[https://fraunhofer-aisec.github.io/cpg/CPG/specs/graph](https://fraunhofer-aisec.github.io/cpg/CPG/specs/graph)
+
+## Json export
+
+It is possible to export the cpg as json file with the `--export-json` option. The graph is
+serialized as list of nodes and edges:
+
+```json
+{
+   "nodes": [...],
+   "edges": [...]
+}
+```
+
+Usage example:
+
+```
+$ ./build/install/cpg-falkordb/bin/cpg-falkordb --export-json cpg-export.json --no-falkordb src/main.c
+```
+
+## Tests
+
+The unit tests do not need a running database:
+
+```
+../gradlew :cpg-falkordb:test
+```
+
+The integration tests require a FalkorDB instance. Its location can be configured with the
+`FALKORDB_HOST`, `FALKORDB_PORT` and `FALKORDB_GRAPH` environment variables:
+
+```
+../gradlew :cpg-falkordb:integrationTest
+```

--- a/cpg-falkordb/README.md
+++ b/cpg-falkordb/README.md
@@ -42,7 +42,7 @@ language frontends you are interested in.
                     [--export-json=<exportJsonFile>] [--graph=<graphName>]
                     [--host=<host>] [--includes-file=<includesFile>]
                     [--max-complexity-cf-dfg=<maxComplexity>]
-                    [--****** [--port=<port>]
+                    [--password=<falkorDbPassword>] [--port=<port>]
                     [--top-level=<topLevel>] [--user=<falkorDbUsername>]
                     [--exclusion-patterns=<exclusionPatterns>]...
                     [-IP=<includePaths>]... ([<files>...] | -S=<String=String>
@@ -91,7 +91,7 @@ language frontends you are interested in.
       --no-default-passes   Do not register default passes [used for debugging]
       --no-falkordb         Do not push cpg into FalkorDB [used for debugging]
       --no-purge-db         Do not purge the graph before pushing the cpg
-      --******
+      --password=<falkorDbPassword>
                             FalkorDB password (default: no authentication)
       --port=<port>         Set the port of the FalkorDB instance (default:
                               6379).

--- a/cpg-falkordb/build.gradle.kts
+++ b/cpg-falkordb/build.gradle.kts
@@ -1,0 +1,82 @@
+import groovy.util.Node
+import groovy.util.NodeList
+
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+plugins {
+    id("cpg.application-conventions")
+    id("cpg.frontend-dependency-conventions")
+}
+
+application {
+    mainClass.set("de.fraunhofer.aisec.cpg_vis_falkordb.ApplicationKt")
+    // Since we are potentially persisting deeply nested graphs, we need to increase the stack and
+    // heap size.
+    // Note, that if you are running this IntelliJ, you might need to manually specify this as VM
+    // arguments.
+    applicationDefaultJvmArgs = listOf("-Xss515m", "-Xmx8g")
+}
+
+mavenPublishing {
+    pom {
+        name.set("Code Property Graph - FalkorDB")
+        description.set(
+            "An Application to translate and persist specified source code as a Code Property Graph to an installed instance of the FalkorDB graph database."
+        )
+        withXml {
+            // Modify the XML to exclude dependencies that start with "cpg-language-".
+            // This is necessary because we do not want to "leak" the dependency to our dynamically
+            // activated frontends to the outside
+            val dependenciesNode =
+                asNode().children().filterIsInstance<Node>().firstOrNull {
+                    it.name().toString() == "{http://maven.apache.org/POM/4.0.0}dependencies"
+                }
+            dependenciesNode?.children()?.removeIf {
+                it is Node &&
+                    (it.name().toString() == "{http://maven.apache.org/POM/4.0.0}dependency") &&
+                    ((it.get("artifactId") as? NodeList)?.text()?.startsWith("cpg-language-") ==
+                        true)
+            }
+        }
+    }
+}
+
+dependencies {
+    // FalkorDB Java client
+    api(libs.jfalkordb)
+
+    // Command line interface support
+    api(libs.picocli)
+    annotationProcessor(libs.picocli.codegen)
+
+    // We depend on the C++ frontend for the integration tests, but the frontend is only available
+    // if enabled. If it's not available, the integration tests fail (which is ok). But if we would
+    // directly reference the project here, the build system would fail any task since it will not
+    // find a non-enabled project.
+    findProject(":cpg-language-cxx")?.also { integrationTestImplementation(it) }
+    integrationTestImplementation(project(":cpg-concepts"))
+    implementation(project(":cpg-concepts"))
+}

--- a/cpg-falkordb/build.gradle.kts
+++ b/cpg-falkordb/build.gradle.kts
@@ -78,5 +78,6 @@ dependencies {
     // find a non-enabled project.
     findProject(":cpg-language-cxx")?.also { integrationTestImplementation(it) }
     integrationTestImplementation(project(":cpg-concepts"))
+    testImplementation(testFixtures(projects.cpgCore))
     implementation(project(":cpg-concepts"))
 }

--- a/cpg-falkordb/src/integrationTest/kotlin/de/fraunhofer/aisec/falkordb/FalkorDBTest.kt
+++ b/cpg-falkordb/src/integrationTest/kotlin/de/fraunhofer/aisec/falkordb/FalkorDBTest.kt
@@ -33,6 +33,7 @@ import de.fraunhofer.aisec.cpg.graph.functions
 import de.fraunhofer.aisec.cpg.persistence.FalkorDBDatabase
 import de.fraunhofer.aisec.cpg.persistence.connectToFalkorDB
 import de.fraunhofer.aisec.cpg.persistence.persist
+import de.fraunhofer.aisec.cpg.persistence.pushToFalkorDB
 import de.fraunhofer.aisec.cpg.test.GraphExamples
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -53,6 +54,9 @@ import kotlin.test.assertTrue
  */
 class FalkorDBTest {
 
+    private val host = System.getenv("FALKORDB_HOST") ?: "localhost"
+    private val port = System.getenv("FALKORDB_PORT")?.toIntOrNull() ?: 6379
+
     private lateinit var driver: Driver
     private lateinit var graph: Graph
 
@@ -60,8 +64,8 @@ class FalkorDBTest {
     fun setup() {
         val (driver, graph) =
             connectToFalkorDB(
-                host = System.getenv("FALKORDB_HOST") ?: "localhost",
-                port = System.getenv("FALKORDB_PORT")?.toIntOrNull() ?: 6379,
+                host = host,
+                port = port,
                 graphName = System.getenv("FALKORDB_GRAPH") ?: "cpg-integration-test",
             )
         this.driver = driver
@@ -163,5 +167,23 @@ class FalkorDBTest {
             assertTrue(count > 0)
             it.deleteGraph()
         }
+    }
+
+    @Test
+    fun testPushToFalkorDB() {
+        val result = GraphExamples.getInitializerListExprDFG()
+
+        // The public entry point opens (and closes) its own driver and graph
+        result.pushToFalkorDB(host = host, port = port, graphName = "cpg-integration-test-push")
+
+        val other = driver.graph("cpg-integration-test-push")
+        val count =
+            other
+                .readOnlyQuery("MATCH (n:Node) RETURN count(n) AS count")
+                .iterator()
+                .next()
+                .getValue<Long>("count")
+        assertTrue(count > 0, "Expected pushToFalkorDB to have persisted the graph")
+        other.deleteGraph()
     }
 }

--- a/cpg-falkordb/src/integrationTest/kotlin/de/fraunhofer/aisec/falkordb/FalkorDBTest.kt
+++ b/cpg-falkordb/src/integrationTest/kotlin/de/fraunhofer/aisec/falkordb/FalkorDBTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.falkordb
+
+import com.falkordb.Driver
+import com.falkordb.Graph
+import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.graph.calls
+import de.fraunhofer.aisec.cpg.graph.functions
+import de.fraunhofer.aisec.cpg.persistence.FalkorDBDatabase
+import de.fraunhofer.aisec.cpg.persistence.connectToFalkorDB
+import de.fraunhofer.aisec.cpg.persistence.persist
+import de.fraunhofer.aisec.cpg.test.GraphExamples
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for the FalkorDB persistence. They require a running FalkorDB instance, which
+ * can be started with:
+ * ```
+ * docker run -p 127.0.0.1:6379:6379 -d falkordb/falkordb:latest
+ * ```
+ *
+ * The host, port and graph name can be overridden with the `FALKORDB_HOST`, `FALKORDB_PORT` and
+ * `FALKORDB_GRAPH` environment variables.
+ */
+class FalkorDBTest {
+
+    private lateinit var driver: Driver
+    private lateinit var graph: Graph
+
+    @BeforeTest
+    fun setup() {
+        val (driver, graph) =
+            connectToFalkorDB(
+                host = System.getenv("FALKORDB_HOST") ?: "localhost",
+                port = System.getenv("FALKORDB_PORT")?.toIntOrNull() ?: 6379,
+                graphName = System.getenv("FALKORDB_GRAPH") ?: "cpg-integration-test",
+            )
+        this.driver = driver
+        this.graph = graph
+    }
+
+    @AfterTest
+    fun teardown() {
+        graph.close()
+        driver.close()
+    }
+
+    /** Persists [result] and returns the number of nodes that ended up in the graph. */
+    private fun persistAndCountNodes(result: TranslationResult): Long {
+        FalkorDBDatabase(graph).use { db -> result.persist(db) }
+
+        val resultSet = graph.readOnlyQuery("MATCH (n:Node) RETURN count(n) AS count")
+        val record = resultSet.iterator().next()
+        return record.getValue<Long>("count")
+    }
+
+    @Test
+    fun testPush() {
+        val result = GraphExamples.getInitializerListExprDFG()
+
+        val persisted = persistAndCountNodes(result)
+
+        // Every node of the CPG, including the ones that are only reachable through a
+        // relationship (types, scopes, languages, ...), has to be persisted
+        assertTrue(persisted > 0, "Expected the graph to contain nodes")
+
+        // All functions of the translation result must be found again by their label. This
+        // verifies that we assign the *complete* set of labels of the class hierarchy, and not
+        // just the most specific one
+        val functions =
+            graph
+                .readOnlyQuery("MATCH (n:Function) RETURN count(n) AS count")
+                .iterator()
+                .next()
+                .getValue<Long>("count")
+        assertEquals(result.functions.size.toLong(), functions)
+    }
+
+    @Test
+    fun testPushPurgesPreviousGraph() {
+        val result = GraphExamples.getInitializerListExprDFG()
+
+        val first = persistAndCountNodes(result)
+        val second = persistAndCountNodes(result)
+
+        // Since persisting purges the graph beforehand, pushing the same result twice must not
+        // duplicate any node
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun testRelationshipsArePersisted() {
+        val result = GraphExamples.getInitializerListExprDFG()
+        persistAndCountNodes(result)
+
+        // The EOG is one of the relationships that every non-trivial CPG has
+        val eogEdges =
+            graph
+                .readOnlyQuery("MATCH ()-[r:EOG]->() RETURN count(r) AS count")
+                .iterator()
+                .next()
+                .getValue<Long>("count")
+        assertTrue(eogEdges > 0, "Expected EOG relationships to be persisted")
+
+        // Calls are connected to their invoked function; this also exercises that relationship
+        // properties survive the round trip
+        val call = result.calls.firstOrNull()
+        assertNotNull(call)
+
+        val persistedCall =
+            graph
+                .readOnlyQuery("MATCH (n:Call {id: \"${call.id}\"}) RETURN n.name AS name")
+                .iterator()
+                .next()
+                .getValue<String>("name")
+        assertEquals(call.name.toString(), persistedCall)
+    }
+
+    @Test
+    fun testMultipleGraphsAreIndependent() {
+        val result = GraphExamples.getInitializerListExprDFG()
+        persistAndCountNodes(result)
+
+        // A second graph in the same instance must not be affected by the first one
+        val other = driver.graph("cpg-integration-test-other")
+        other.use {
+            FalkorDBDatabase(it).use { db -> result.persist(db) }
+
+            val count =
+                it.readOnlyQuery("MATCH (n:Node) RETURN count(n) AS count")
+                    .iterator()
+                    .next()
+                    .getValue<Long>("count")
+            assertTrue(count > 0)
+            it.deleteGraph()
+        }
+    }
+}

--- a/cpg-falkordb/src/main/kotlin/de/fraunhofer/aisec/cpg/persistence/CypherLiteral.kt
+++ b/cpg-falkordb/src/main/kotlin/de/fraunhofer/aisec/cpg/persistence/CypherLiteral.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.persistence
+
+import kotlin.uuid.Uuid
+
+/**
+ * FalkorDB does not have a binary channel for query parameters. Instead, parameters are prepended
+ * to the query itself in a `CYPHER <name>=<literal> ...` preamble, which the server then parses.
+ * Client libraries are therefore responsible for turning values into valid Cypher literals.
+ *
+ * The Java client ships such a serializer, but it only supports scalars and lists — not maps. Since
+ * we persist a chunk of nodes as a *list of property maps*, we render the literals ourselves.
+ *
+ * Note that this is not string concatenation of untrusted input into a query: every value is
+ * rendered as a self-contained, properly escaped literal, so a value can never escape into the
+ * query structure. [CypherLiteralTest] covers the escaping rules.
+ */
+object CypherLiteral {
+
+    /**
+     * Renders [value] as a Cypher literal.
+     *
+     * Supported types are `null`, [Boolean], [Number], [String], [Char], [Enum], [Uuid], [Map],
+     * [Collection] and arrays. Everything else falls back to its string representation, which
+     * mirrors what the CPG would store as a property value anyway.
+     */
+    fun render(value: Any?): String {
+        return when (value) {
+            null -> "null"
+            is Boolean -> value.toString()
+            // Double.toString may produce "NaN" or "Infinity", which are not valid Cypher literals
+            is Double -> if (value.isFinite()) value.toString() else "null"
+            is Float -> if (value.isFinite()) value.toString() else "null"
+            is Number -> value.toString()
+            is String -> renderString(value)
+            is Char -> renderString(value.toString())
+            is Enum<*> -> renderString(value.name)
+            is Uuid -> renderString(value.toString())
+            is Map<*, *> -> renderMap(value)
+            is Collection<*> -> value.joinToString(", ", "[", "]") { render(it) }
+            is Array<*> -> value.joinToString(", ", "[", "]") { render(it) }
+            is BooleanArray -> value.joinToString(", ", "[", "]") { render(it) }
+            is ByteArray -> value.joinToString(", ", "[", "]") { render(it) }
+            is CharArray -> value.joinToString(", ", "[", "]") { render(it) }
+            is ShortArray -> value.joinToString(", ", "[", "]") { render(it) }
+            is IntArray -> value.joinToString(", ", "[", "]") { render(it) }
+            is LongArray -> value.joinToString(", ", "[", "]") { render(it) }
+            is FloatArray -> value.joinToString(", ", "[", "]") { render(it) }
+            is DoubleArray -> value.joinToString(", ", "[", "]") { render(it) }
+            else -> renderString(value.toString())
+        }
+    }
+
+    /**
+     * Renders a map as a Cypher map literal. Keys are always quoted with backticks, so that
+     * property names which happen to collide with Cypher keywords are handled correctly. Entries
+     * with a `null` value are skipped, since FalkorDB does not store `null` properties anyway.
+     */
+    private fun renderMap(map: Map<*, *>): String {
+        return map.entries
+            .filter { it.value != null }
+            .joinToString(", ", "{", "}") { (key, value) ->
+                "${renderIdentifier(key.toString())}: ${render(value)}"
+            }
+    }
+
+    /**
+     * Quotes an identifier (a property name, label or relationship type) with backticks. A backtick
+     * inside the identifier is escaped by doubling it, as required by Cypher.
+     */
+    fun renderIdentifier(identifier: String): String {
+        return "`${identifier.replace("`", "``")}`"
+    }
+
+    /**
+     * Renders a string as a double-quoted Cypher literal.
+     *
+     * FalkorDB's Cypher lexer understands the `\\`, `\"`, `\n`, `\r` and `\t` escape sequences, but
+     * *not* `\uXXXX`. Any other character — including raw control characters and multi-byte UTF-8 —
+     * is passed through verbatim, which is safe because the query is transported as a binary-safe
+     * Redis bulk string.
+     */
+    private fun renderString(value: String): String {
+        val builder = StringBuilder(value.length + 2)
+        builder.append('"')
+        for (char in value) {
+            when (char) {
+                '\\' -> builder.append("\\\\")
+                '"' -> builder.append("\\\"")
+                '\n' -> builder.append("\\n")
+                '\r' -> builder.append("\\r")
+                '\t' -> builder.append("\\t")
+                else -> builder.append(char)
+            }
+        }
+        builder.append('"')
+        return builder.toString()
+    }
+
+    /**
+     * Builds a query that binds [parameters] in a `CYPHER` preamble and then runs [query].
+     *
+     * Keeping the parameters out of the query body means that the body itself stays identical
+     * across all chunks, which allows FalkorDB to reuse the cached execution plan.
+     */
+    fun withParameters(parameters: Map<String, Any?>, query: String): String {
+        if (parameters.isEmpty()) {
+            return query
+        }
+
+        return parameters.entries.joinToString(
+            separator = " ",
+            prefix = "CYPHER ",
+            postfix = " $query",
+        ) { (name, value) ->
+            "$name=${render(value)}"
+        }
+    }
+}

--- a/cpg-falkordb/src/main/kotlin/de/fraunhofer/aisec/cpg/persistence/FalkorDB.kt
+++ b/cpg-falkordb/src/main/kotlin/de/fraunhofer/aisec/cpg/persistence/FalkorDB.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.persistence
+
+import com.falkordb.Driver
+import com.falkordb.FalkorDB
+import com.falkordb.Graph
+import de.fraunhofer.aisec.cpg.TranslationResult
+import de.fraunhofer.aisec.cpg.graph.Node
+import org.slf4j.LoggerFactory
+import redis.clients.jedis.exceptions.JedisDataException
+
+internal val log = LoggerFactory.getLogger("FalkorDBPersistence")
+
+/**
+ * The keys of a relationship map that describe the relationship itself rather than one of its
+ * properties, see [collectRelationships].
+ */
+private val relationshipStructuralKeys = setOf("startId", "endId", "type")
+
+/**
+ * A [GraphDatabaseBackend] that writes the CPG into a [FalkorDB](https://www.falkordb.com) graph.
+ *
+ * FalkorDB speaks Cypher, but it does not offer a procedure library such as APOC. Labels and
+ * relationship types can therefore not be supplied dynamically through a parameter. Instead of
+ * creating every node with its own query, we group the nodes of a chunk by their *set of labels*
+ * and the relationships by their *type*. Each group is then written with a single `UNWIND` query
+ * whose body is constant, which lets FalkorDB reuse the cached execution plan across chunks.
+ *
+ * @param graph the graph to write to, closed together with this backend
+ * @param driver the driver the [graph] was obtained from, closed together with this backend, or
+ *   `null` if the caller manages the driver lifecycle
+ */
+class FalkorDBDatabase(private val graph: Graph, private val driver: Driver? = null) :
+    GraphDatabaseBackend {
+
+    /**
+     * FalkorDB inlines query parameters into the query text (see [CypherLiteral]), so a chunk
+     * becomes a single (large) string. We therefore use noticeably smaller chunks than the default
+     * to keep the individual queries — and the memory needed to build them — reasonable.
+     */
+    override val nodeChunkSize: Int = 1000
+
+    override val relationshipChunkSize: Int = 5000
+
+    override fun purgeDatabase() {
+        try {
+            graph.deleteGraph()
+        } catch (e: JedisDataException) {
+            // Deleting a graph that was never created reports an error on an "empty key". For our
+            // purposes there is simply nothing to purge, so we can safely continue.
+            if (e.message?.contains("empty key") != true) {
+                throw e
+            }
+            log.debug("Nothing to purge, the graph does not exist yet")
+        }
+    }
+
+    override fun createIndexes() {
+        try {
+            graph.query("CREATE INDEX FOR (n:Node) ON (n.id)")
+        } catch (e: JedisDataException) {
+            // FalkorDB has no "CREATE INDEX IF NOT EXISTS", it reports an error instead. Since we
+            // only ever create this one index, an existing index is exactly what we want.
+            if (e.message?.contains("already indexed") != true) {
+                throw e
+            }
+        }
+    }
+
+    override fun persistNodeChunk(nodes: List<Node>) {
+        // Group by the set of labels, so that all nodes in a group can be created by the same
+        // query. This replaces what APOC's dynamic node creation does for Neo4j.
+        for ((labels, group) in nodes.groupBy { it::class.labels }) {
+            val labelSelector = labels.joinToString(":") { CypherLiteral.renderIdentifier(it) }
+            val properties = group.map { it.properties() }
+
+            graph.query(
+                CypherLiteral.withParameters(
+                    mapOf("props" to properties),
+                    "UNWIND \$props AS map CREATE (n:$labelSelector) SET n = map",
+                )
+            )
+        }
+    }
+
+    override fun persistRelationshipChunk(relationships: List<Map<String, Any?>>) {
+        // A relationship type cannot be parameterized either, so we group by it as well.
+        for ((type, group) in relationships.groupBy { it["type"] }) {
+            if (type !is String) {
+                log.error("Skipping {} relationships without a type", group.size)
+                continue
+            }
+
+            val rows =
+                group.map { relationship ->
+                    mapOf(
+                        "startId" to relationship["startId"],
+                        "endId" to relationship["endId"],
+                        "properties" to
+                            relationship.filterKeys { it !in relationshipStructuralKeys },
+                    )
+                }
+
+            graph.query(
+                CypherLiteral.withParameters(
+                    mapOf("props" to rows),
+                    "UNWIND \$props AS map " +
+                        "MATCH (s:Node {id: map.startId}) " +
+                        "MATCH (e:Node {id: map.endId}) " +
+                        "CREATE (s)-[r:${CypherLiteral.renderIdentifier(type)}]->(e) " +
+                        "SET r = map.properties",
+                )
+            )
+        }
+    }
+
+    override fun close() {
+        graph.close()
+        driver?.close()
+    }
+}
+
+/**
+ * Connects to a FalkorDB instance and returns the [Driver] as well as the [Graph] identified by
+ * [graphName].
+ *
+ * @param host the host address of the FalkorDB instance
+ * @param port the port of the FalkorDB instance
+ * @param username the username, or `null` if the instance does not require authentication
+ * @param password the password, or `null` if the instance does not require authentication
+ * @param graphName the name of the graph key to store the CPG under
+ */
+fun connectToFalkorDB(
+    host: String = FalkorDBConnectionDefaults.HOST,
+    port: Int = FalkorDBConnectionDefaults.PORT,
+    username: String? = null,
+    password: String? = null,
+    graphName: String = FalkorDBConnectionDefaults.GRAPH,
+): Pair<Driver, Graph> {
+    val driver =
+        if (username != null && password != null) {
+            FalkorDB.driver(host, port, username, password)
+        } else {
+            FalkorDB.driver(host, port)
+        }
+
+    return driver to driver.graph(graphName)
+}
+
+/**
+ * Translates this [TranslationResult] into a graph and persists it into a FalkorDB instance.
+ *
+ * @param noPurgeDb if `true`, the graph is not deleted before the new CPG is written
+ * @param host the host address of the FalkorDB instance
+ * @param port the port of the FalkorDB instance
+ * @param username the username, or `null` if the instance does not require authentication
+ * @param password the password, or `null` if the instance does not require authentication
+ * @param graphName the name of the graph key to store the CPG under
+ */
+fun TranslationResult.pushToFalkorDB(
+    noPurgeDb: Boolean = false,
+    host: String = FalkorDBConnectionDefaults.HOST,
+    port: Int = FalkorDBConnectionDefaults.PORT,
+    username: String? = null,
+    password: String? = null,
+    graphName: String = FalkorDBConnectionDefaults.GRAPH,
+) {
+    val (driver, graph) = connectToFalkorDB(host, port, username, password, graphName)
+    FalkorDBDatabase(graph, driver).use { db -> this.persist(db, purgeDb = !noPurgeDb) }
+}

--- a/cpg-falkordb/src/main/kotlin/de/fraunhofer/aisec/cpg/persistence/FalkorDB.kt
+++ b/cpg-falkordb/src/main/kotlin/de/fraunhofer/aisec/cpg/persistence/FalkorDB.kt
@@ -50,7 +50,7 @@ private val relationshipStructuralKeys = setOf("startId", "endId", "type")
  * and the relationships by their *type*. Each group is then written with a single `UNWIND` query
  * whose body is constant, which lets FalkorDB reuse the cached execution plan across chunks.
  *
- * @param graph the graph to write to, closed together with this backend
+ * @param graph the graph to write to, only closed if [driver] is supplied as well
  * @param driver the driver the [graph] was obtained from, closed together with this backend, or
  *   `null` if the caller manages the driver lifecycle
  */
@@ -138,9 +138,16 @@ class FalkorDBDatabase(private val graph: Graph, private val driver: Driver? = n
         }
     }
 
+    /**
+     * Closes the resources that this backend owns. If no [driver] was handed to us, the caller
+     * manages the lifecycle of the [graph] (and of the driver it originates from), so nothing is
+     * closed and the [graph] stays usable afterwards.
+     */
     override fun close() {
-        graph.close()
-        driver?.close()
+        driver?.let {
+            graph.close()
+            it.close()
+        }
     }
 }
 
@@ -153,6 +160,7 @@ class FalkorDBDatabase(private val graph: Graph, private val driver: Driver? = n
  * @param username the username, or `null` if the instance does not require authentication
  * @param password the password, or `null` if the instance does not require authentication
  * @param graphName the name of the graph key to store the CPG under
+ * @throws IllegalArgumentException if only one of [username] and [password] is supplied
  */
 fun connectToFalkorDB(
     host: String = FalkorDBConnectionDefaults.HOST,
@@ -161,6 +169,12 @@ fun connectToFalkorDB(
     password: String? = null,
     graphName: String = FalkorDBConnectionDefaults.GRAPH,
 ): Pair<Driver, Graph> {
+    // Silently connecting without authentication when only one half of the credentials is set
+    // would turn a typo into a confusing "graph not found" further down the line.
+    require((username == null) == (password == null)) {
+        "Either both username and password have to be supplied, or neither of them."
+    }
+
     val driver =
         if (username != null && password != null) {
             FalkorDB.driver(host, port, username, password)

--- a/cpg-falkordb/src/main/kotlin/de/fraunhofer/aisec/cpg/persistence/FalkorDBDefaults.kt
+++ b/cpg-falkordb/src/main/kotlin/de/fraunhofer/aisec/cpg/persistence/FalkorDBDefaults.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.persistence
+
+/** Default values for connecting to a FalkorDB database. */
+object FalkorDBConnectionDefaults {
+    const val HOST: String = "localhost"
+    const val PORT: Int = 6379
+    /**
+     * The name of the graph key the CPG is stored under. A single FalkorDB instance can hold many
+     * independent graphs, so this can be used to keep several CPGs (e.g. of different revisions of
+     * a project) side by side.
+     */
+    const val GRAPH: String = "cpg"
+}

--- a/cpg-falkordb/src/main/kotlin/de/fraunhofer/aisec/cpg_vis_falkordb/Application.kt
+++ b/cpg-falkordb/src/main/kotlin/de/fraunhofer/aisec/cpg_vis_falkordb/Application.kt
@@ -1,0 +1,443 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg_vis_falkordb
+
+import de.fraunhofer.aisec.cpg.*
+import de.fraunhofer.aisec.cpg.frontends.CompilationDatabase.Companion.fromFile
+import de.fraunhofer.aisec.cpg.passes.*
+import de.fraunhofer.aisec.cpg.passes.concepts.file.python.PythonFileConceptPass
+import de.fraunhofer.aisec.cpg.persistence.FalkorDBConnectionDefaults
+import de.fraunhofer.aisec.cpg.persistence.persistJson
+import de.fraunhofer.aisec.cpg.persistence.pushToFalkorDB
+import de.fraunhofer.aisec.cpg.project.Project
+import java.io.File
+import java.net.ConnectException
+import java.nio.file.Paths
+import java.util.concurrent.Callable
+import kotlin.reflect.KClass
+import kotlin.system.exitProcess
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import picocli.CommandLine
+import picocli.CommandLine.ArgGroup
+
+private const val S_TO_MS_FACTOR = 1000
+private const val EXIT_SUCCESS = 0
+private const val DEBUG_PARSER = true
+
+private const val DEFAULT_MAX_COMPLEXITY = -1
+
+/**
+ * An application to export the <a href="https://github.com/Fraunhofer-AISEC/cpg">cpg</a> to a <a
+ * href="https://www.falkordb.com">FalkorDB</a> graph database.
+ *
+ * In contrast to the Neo4j exporter, no server-side plugin is required, since FalkorDB is addressed
+ * with plain Cypher only.
+ *
+ * For example using docker:
+ * ```
+ * docker run -p 127.0.0.1:6379:6379 -d falkordb/falkordb:latest
+ * ```
+ */
+class Application : Callable<Int> {
+
+    private val log: Logger
+        get() = LoggerFactory.getLogger(Application::class.java)
+
+    // Either provide the files to evaluate or provide the path of compilation database with
+    // --json-compilation-database flag
+    @ArgGroup(exclusive = true, multiplicity = "1")
+    lateinit var mutuallyExclusiveParameters: Exclusive
+
+    class Exclusive {
+        @CommandLine.Parameters(
+            arity = "0..*",
+            description =
+                [
+                    "The paths to analyze. If module support is enabled, the paths will be looked at if they contain modules"
+                ],
+        )
+        var files: List<String> = mutableListOf()
+
+        @CommandLine.Option(
+            names = ["--softwareComponents", "-S"],
+            description =
+                [
+                    "Maps the names of software components to their respective files. The files are separated by commas (No whitespace!).",
+                    "Example: -S App1=./file1.c,./file2.c -S App2=./Main.java,./Class.java",
+                ],
+        )
+        var softwareComponents: Map<String, String> = mutableMapOf()
+
+        @CommandLine.Option(
+            names = ["--json-compilation-database"],
+            description =
+                [
+                    "The path to an optional a JSON compilation database. Please note, that the JSON compilation database always describes a single component."
+                ],
+        )
+        var jsonCompilationDatabase: File? = null
+
+        @CommandLine.Option(
+            names = ["--list-passes"],
+            description = ["Prints the list available passes"],
+        )
+        var listPasses: Boolean = false
+    }
+
+    @CommandLine.Option(
+        names = ["--include-paths", "-IP"],
+        description =
+            ["Directories containing additional headers and implementations for imported code."],
+    )
+    var includePaths: List<String> = mutableListOf()
+
+    @CommandLine.Option(
+        names = ["--user"],
+        description = ["FalkorDB user name (default: no authentication)"],
+    )
+    var falkorDbUsername: String? = null
+
+    @CommandLine.Option(
+        names = ["--password"],
+        description = ["FalkorDB password (default: no authentication)"],
+    )
+    var falkorDbPassword: String? = null
+
+    @CommandLine.Option(
+        names = ["--host"],
+        description =
+            ["Set the host of the FalkorDB instance (default: ${FalkorDBConnectionDefaults.HOST})."],
+    )
+    private var host: String = FalkorDBConnectionDefaults.HOST
+
+    @CommandLine.Option(
+        names = ["--port"],
+        description =
+            ["Set the port of the FalkorDB instance (default: ${FalkorDBConnectionDefaults.PORT})."],
+    )
+    private var port: Int = FalkorDBConnectionDefaults.PORT
+
+    @CommandLine.Option(
+        names = ["--graph"],
+        description =
+            [
+                "Set the name of the graph to store the cpg in (default: ${FalkorDBConnectionDefaults.GRAPH}).",
+                "A single FalkorDB instance can hold several independent graphs.",
+            ],
+    )
+    private var graphName: String = FalkorDBConnectionDefaults.GRAPH
+
+    @CommandLine.Option(
+        names = ["--max-complexity-cf-dfg"],
+        description =
+            [
+                "Performance optimisation: " +
+                    "Limit the ControlFlowSensitiveDFGPass to functions with a complexity less than what is specified here. " +
+                    "$DEFAULT_MAX_COMPLEXITY (default) means no limit is used."
+            ],
+    )
+    private var maxComplexity: Int = DEFAULT_MAX_COMPLEXITY
+
+    @CommandLine.Option(
+        names = ["--load-includes"],
+        description = ["Enable TranslationConfig option"],
+    )
+    private var loadIncludes: Boolean = false
+
+    @CommandLine.Option(
+        names = ["--use-unity-build"],
+        description = ["Enable unity build mode for C++ (requires --load-includes)"],
+    )
+    private var useUnityBuild: Boolean = false
+
+    @CommandLine.Option(names = ["--includes-file"], description = ["Load includes from file"])
+    private var includesFile: File? = null
+
+    @CommandLine.Option(
+        names = ["--print-benchmark"],
+        description = ["Print benchmark result as markdown table"],
+    )
+    private var printBenchmark: Boolean = false
+
+    @CommandLine.Option(
+        names = ["--no-default-passes"],
+        description = ["Do not register default passes [used for debugging]"],
+    )
+    private var noDefaultPasses: Boolean = false
+
+    @CommandLine.Option(
+        names = ["--custom-pass-list"],
+        description =
+            [
+                "Add custom list of passes (might be used additional to --no-default-passes) which is" +
+                    " passed as a comma-separated list; give either pass name if pass is in list," +
+                    " or its FQDN" +
+                    " (e.g. --custom-pass-list=DFGPass,CallResolver)"
+            ],
+    )
+    private var customPasses: String = "DEFAULT"
+
+    @CommandLine.Option(
+        names = ["--no-falkordb"],
+        description = ["Do not push cpg into FalkorDB [used for debugging]"],
+    )
+    private var noFalkorDb: Boolean = false
+
+    @CommandLine.Option(
+        names = ["--no-purge-db"],
+        description = ["Do not purge the graph before pushing the cpg"],
+    )
+    private var noPurgeDb: Boolean = false
+
+    @CommandLine.Option(
+        names = ["--infer-nodes"],
+        description = ["Create inferred nodes for missing declarations"],
+    )
+    private var inferNodes: Boolean = false
+
+    @CommandLine.Option(
+        names = ["--top-level"],
+        description =
+            [
+                "Set top level directory of project structure. Default: Largest common path of all source files"
+            ],
+    )
+    private var topLevel: File? = null
+
+    @CommandLine.Option(
+        names = ["--exclusion-patterns"],
+        description =
+            ["Configures an exclusion pattern for files or directories that should not be parsed"],
+    )
+    private var exclusionPatterns: List<String> = listOf()
+
+    @CommandLine.Option(
+        names = ["--benchmark-json"],
+        description = ["Save benchmark results to json file"],
+    )
+    private var benchmarkJson: File? = null
+
+    @CommandLine.Option(names = ["--export-json"], description = ["Export cpg as json"])
+    private var exportJsonFile: File? = null
+
+    private var passClassList =
+        listOf(
+            TypeHierarchyResolver::class,
+            SymbolResolver::class,
+            DFGPass::class,
+            EvaluationOrderGraphPass::class,
+            TypeResolver::class,
+            ControlFlowSensitiveDFGPass::class,
+            ControlDependenceGraphPass::class,
+            ProgramDependenceGraphPass::class,
+        )
+    private var passClassMap = passClassList.associateBy { it.simpleName }
+
+    /** The list of available passes that can be registered. */
+    private val passList: List<String>
+        get() = passClassList.mapNotNull { it.simpleName }
+
+    /**
+     * Checks if all elements in the parameter are a valid file and returns a list of files.
+     *
+     * @param filenames The filenames to check
+     * @return List of files
+     */
+    private fun getFilesOfList(filenames: Collection<String>): List<File> {
+        val filePaths = filenames.map { Paths.get(it).toAbsolutePath().normalize().toFile() }
+        filePaths.forEach {
+            require(it.exists() && (!it.isHidden)) {
+                "Please use a correct path. It was: ${it.path}"
+            }
+        }
+        return filePaths
+    }
+
+    /**
+     * Parse the file paths to analyze and set up the translationConfiguration with these paths.
+     *
+     * @throws IllegalArgumentException, if there were no arguments provided, or the path does not
+     *   point to a file, is a directory or point to a hidden file or the paths does not have the
+     *   same top level path.
+     */
+    fun setupTranslationConfiguration(): TranslationConfiguration {
+        val translationConfiguration =
+            TranslationConfiguration.builder()
+                .also { builder ->
+                    Project.defaultLanguages.forEach { builder.optionalLanguage(it) }
+                }
+                .loadIncludes(loadIncludes)
+                .exclusionPatterns(*exclusionPatterns.toTypedArray())
+                .addIncludesToGraph(loadIncludes)
+                .debugParser(DEBUG_PARSER)
+                .useUnityBuild(useUnityBuild)
+
+        topLevel?.let { translationConfiguration.topLevel(it) }
+
+        if (maxComplexity != -1) {
+            translationConfiguration.configurePass<ControlFlowSensitiveDFGPass>(
+                ControlFlowSensitiveDFGPass.Configuration(maxComplexity = maxComplexity)
+            )
+        }
+
+        includePaths.forEach { translationConfiguration.includePath(it) }
+
+        if (mutuallyExclusiveParameters.softwareComponents.isNotEmpty()) {
+            val components = mutableMapOf<String, List<File>>()
+            for (sc in mutuallyExclusiveParameters.softwareComponents) {
+                components[sc.key] = getFilesOfList(sc.value.split(","))
+            }
+            translationConfiguration.softwareComponents(components)
+        } else {
+            val filePaths = getFilesOfList(mutuallyExclusiveParameters.files)
+            translationConfiguration.sourceLocations(filePaths)
+        }
+
+        if (!noDefaultPasses) {
+            translationConfiguration.defaultPasses()
+            translationConfiguration.registerPass<ControlDependenceGraphPass>()
+            translationConfiguration.registerPass<ProgramDependenceGraphPass>()
+            translationConfiguration.registerPass<PythonFileConceptPass>()
+        }
+        if (customPasses != "DEFAULT") {
+            val pieces = customPasses.split(",")
+            for (pass in pieces) {
+                if (pass.contains(".")) {
+                    @Suppress("UNCHECKED_CAST")
+                    translationConfiguration.registerPass(
+                        Class.forName(pass).kotlin as KClass<out Pass<*>>
+                    )
+                } else {
+                    if (pass !in passClassMap) {
+                        throw ConfigurationException("Asked to produce unknown pass: $pass")
+                    }
+                    passClassMap[pass]?.let { translationConfiguration.registerPass(it) }
+                }
+            }
+        }
+        translationConfiguration.registerPass(PrepareSerialization::class)
+
+        mutuallyExclusiveParameters.jsonCompilationDatabase?.let {
+            val db = fromFile(it)
+            if (db.isNotEmpty()) {
+                translationConfiguration.useCompilationDatabase(db)
+                translationConfiguration.sourceLocations(db.sourceFiles)
+            }
+        }
+
+        includesFile?.let { theFile ->
+            log.info("Load includes from file: $theFile")
+            val baseDir = File(theFile.toString()).parentFile?.toString() ?: ""
+            theFile
+                .inputStream()
+                .bufferedReader()
+                .lines()
+                .map(String::trim)
+                .map { if (Paths.get(it).isAbsolute) it else Paths.get(baseDir, it).toString() }
+                .forEach { translationConfiguration.includePath(it) }
+        }
+
+        if (inferNodes) {
+            translationConfiguration.inferenceConfiguration(
+                InferenceConfiguration.builder().inferRecords(true).build()
+            )
+        }
+        return translationConfiguration.build()
+    }
+
+    /**
+     * The entrypoint of the cpg-vis-falkordb.
+     *
+     * @throws IllegalArgumentException, if there were no arguments provided, or the path does not
+     *   point to a file, is a directory or point to a hidden file or the paths does not have the
+     *   same top level path
+     * @throws ConnectException, if no connection to the FalkorDB instance is possible
+     */
+    @Throws(Exception::class, ConnectException::class, IllegalArgumentException::class)
+    override fun call(): Int {
+        if (mutuallyExclusiveParameters.listPasses) {
+            log.info("List of passes:")
+            passList.iterator().forEach { log.info("- $it") }
+            log.info("--")
+            log.info("End of list. Stopping.")
+            return EXIT_SUCCESS
+        }
+
+        val translationConfiguration = setupTranslationConfiguration()
+
+        val startTime = System.currentTimeMillis()
+
+        val translationResult =
+            TranslationManager.builder().config(translationConfiguration).build().analyze().get()
+
+        val analyzingTime = System.currentTimeMillis()
+        log.info(
+            "Benchmark: analyzing code in " + (analyzingTime - startTime) / S_TO_MS_FACTOR + " s."
+        )
+
+        exportJsonFile?.let { translationResult.persistJson(it) }
+        if (!noFalkorDb) {
+            translationResult.pushToFalkorDB(
+                noPurgeDb = noPurgeDb,
+                host = host,
+                port = port,
+                username = falkorDbUsername,
+                password = falkorDbPassword,
+                graphName = graphName,
+            )
+        }
+
+        val pushTime = System.currentTimeMillis()
+        log.info("Benchmark: push code in " + (pushTime - analyzingTime) / S_TO_MS_FACTOR + " s.")
+
+        val benchmarkResult = translationResult.benchmarkResults
+
+        if (printBenchmark) {
+            benchmarkResult.print()
+        }
+
+        benchmarkJson?.let { theFile ->
+            log.info("Save benchmark results to file: $theFile")
+            theFile.writeText(benchmarkResult.json)
+        }
+
+        return EXIT_SUCCESS
+    }
+}
+
+/**
+ * Starts a command line application of the cpg-vis-falkordb.
+ *
+ * @throws IllegalArgumentException, if there were no arguments provided, or the path does not point
+ *   to a file, is a directory or point to a hidden file or the paths does not have the same top
+ *   level path
+ * @throws ConnectException, if no connection to the FalkorDB instance is possible
+ */
+fun main(args: Array<String>) {
+    val exitCode = CommandLine(Application()).execute(*args)
+    exitProcess(exitCode)
+}

--- a/cpg-falkordb/src/test/kotlin/de/fraunhofer/aisec/cpg/persistence/CypherLiteralTest.kt
+++ b/cpg-falkordb/src/test/kotlin/de/fraunhofer/aisec/cpg/persistence/CypherLiteralTest.kt
@@ -27,6 +27,8 @@ package de.fraunhofer.aisec.cpg.persistence
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 class CypherLiteralTest {
 
@@ -145,5 +147,59 @@ class CypherLiteralTest {
     enum class TestEnum {
         FIRST,
         SECOND,
+    }
+
+    @Test
+    fun testRenderChar() {
+        assertEquals("\"a\"", CypherLiteral.render('a'))
+        // A character that needs escaping has to be escaped just like it would be in a string
+        assertEquals("\"\\\"\"", CypherLiteral.render('"'))
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    @Test
+    fun testRenderUuid() {
+        val uuid = Uuid.parse("f81d4fae-7dec-11d0-a765-00a0c91e6bf6")
+        assertEquals("\"f81d4fae-7dec-11d0-a765-00a0c91e6bf6\"", CypherLiteral.render(uuid))
+    }
+
+    @Test
+    fun testRenderFloats() {
+        assertEquals("1.5", CypherLiteral.render(1.5f))
+        assertEquals("1.5", CypherLiteral.render(1.5))
+        assertEquals("null", CypherLiteral.render(Float.NaN))
+        assertEquals("null", CypherLiteral.render(Float.POSITIVE_INFINITY))
+    }
+
+    @Test
+    fun testRenderPrimitiveArrays() {
+        assertEquals("[true, false]", CypherLiteral.render(booleanArrayOf(true, false)))
+        assertEquals("[1, 2]", CypherLiteral.render(byteArrayOf(1, 2)))
+        assertEquals("[\"a\", \"b\"]", CypherLiteral.render(charArrayOf('a', 'b')))
+        assertEquals("[1, 2]", CypherLiteral.render(shortArrayOf(1, 2)))
+        assertEquals("[1, 2]", CypherLiteral.render(intArrayOf(1, 2)))
+        assertEquals("[1, 2]", CypherLiteral.render(longArrayOf(1L, 2L)))
+        assertEquals("[1.5, 2.5]", CypherLiteral.render(floatArrayOf(1.5f, 2.5f)))
+        assertEquals("[1.5, 2.5]", CypherLiteral.render(doubleArrayOf(1.5, 2.5)))
+        assertEquals("[\"a\", 1]", CypherLiteral.render(arrayOf<Any>("a", 1)))
+    }
+
+    @Test
+    fun testRenderUnknownTypeFallsBackToToString() {
+        // Anything we do not know explicitly is rendered as its (escaped) string representation,
+        // so it can never escape into the query structure
+        class Weird {
+            override fun toString() = "we\"ird"
+        }
+
+        assertEquals("\"we\\\"ird\"", CypherLiteral.render(Weird()))
+    }
+
+    @Test
+    fun testWithMultipleParameters() {
+        assertEquals(
+            "CYPHER a=1 b=\"x\" RETURN 1",
+            CypherLiteral.withParameters(mapOf("a" to 1, "b" to "x"), "RETURN 1"),
+        )
     }
 }

--- a/cpg-falkordb/src/test/kotlin/de/fraunhofer/aisec/cpg/persistence/CypherLiteralTest.kt
+++ b/cpg-falkordb/src/test/kotlin/de/fraunhofer/aisec/cpg/persistence/CypherLiteralTest.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.persistence
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CypherLiteralTest {
+
+    @Test
+    fun testRenderScalars() {
+        assertEquals("null", CypherLiteral.render(null))
+        assertEquals("true", CypherLiteral.render(true))
+        assertEquals("false", CypherLiteral.render(false))
+        assertEquals("42", CypherLiteral.render(42))
+        assertEquals("42", CypherLiteral.render(42L))
+        assertEquals("\"foo\"", CypherLiteral.render("foo"))
+        assertEquals("\"a\"", CypherLiteral.render('a'))
+    }
+
+    @Test
+    fun testRenderNonFiniteNumbers() {
+        // NaN and Infinity have no Cypher literal, so they must not end up in the query
+        assertEquals("null", CypherLiteral.render(Double.NaN))
+        assertEquals("null", CypherLiteral.render(Double.POSITIVE_INFINITY))
+        assertEquals("null", CypherLiteral.render(Float.NEGATIVE_INFINITY))
+    }
+
+    @Test
+    fun testRenderEnum() {
+        assertEquals("\"SECOND\"", CypherLiteral.render(TestEnum.SECOND))
+    }
+
+    @Test
+    fun testEscapeStrings() {
+        assertEquals("\"say \\\"hi\\\"\"", CypherLiteral.render("say \"hi\""))
+        assertEquals("\"back\\\\slash\"", CypherLiteral.render("back\\slash"))
+        assertEquals("\"line\\nbreak\"", CypherLiteral.render("line\nbreak"))
+        assertEquals("\"carriage\\rreturn\"", CypherLiteral.render("carriage\rreturn"))
+        assertEquals("\"tab\\tstop\"", CypherLiteral.render("tab\tstop"))
+        // Single quotes need no escaping inside a double-quoted literal
+        assertEquals("\"it's\"", CypherLiteral.render("it's"))
+        // Non-ASCII characters are passed through verbatim, FalkorDB has no \\uXXXX escape
+        assertEquals("\"mäh €\"", CypherLiteral.render("mäh €"))
+    }
+
+    @Test
+    fun testEscapingPreventsBreakingOutOfTheLiteral() {
+        // A value that tries to close the string and inject a clause must stay a single literal
+        val malicious = "\" RETURN 1 //"
+        assertEquals("\"\\\" RETURN 1 //\"", CypherLiteral.render(malicious))
+
+        // A trailing backslash must not escape the closing quote
+        assertEquals("\"c:\\\\\"", CypherLiteral.render("c:\\"))
+    }
+
+    @Test
+    fun testRenderCollections() {
+        assertEquals("[1, 2, 3]", CypherLiteral.render(listOf(1, 2, 3)))
+        assertEquals("[\"a\", null]", CypherLiteral.render(listOf("a", null)))
+        assertEquals("[]", CypherLiteral.render(emptyList<String>()))
+        assertEquals("[1, 2]", CypherLiteral.render(arrayOf(1, 2)))
+        assertEquals("[1, 2]", CypherLiteral.render(intArrayOf(1, 2)))
+    }
+
+    @Test
+    fun testRenderMap() {
+        assertEquals(
+            "{`name`: \"foo\", `line`: 1}",
+            CypherLiteral.render(linkedMapOf<String, Any?>("name" to "foo", "line" to 1)),
+        )
+        assertEquals("{}", CypherLiteral.render(emptyMap<String, Any?>()))
+    }
+
+    @Test
+    fun testRenderMapSkipsNullValues() {
+        // FalkorDB does not store null properties, so they are left out entirely
+        assertEquals(
+            "{`name`: \"foo\"}",
+            CypherLiteral.render(linkedMapOf<String, Any?>("name" to "foo", "code" to null)),
+        )
+    }
+
+    @Test
+    fun testRenderNestedStructures() {
+        val value =
+            listOf(
+                linkedMapOf<String, Any?>(
+                    "startId" to "a",
+                    "properties" to linkedMapOf<String, Any?>("index" to 0),
+                )
+            )
+        assertEquals(
+            "[{`startId`: \"a\", `properties`: {`index`: 0}}]",
+            CypherLiteral.render(value),
+        )
+    }
+
+    @Test
+    fun testRenderIdentifier() {
+        assertEquals("`CallExpression`", CypherLiteral.renderIdentifier("CallExpression"))
+        // Backticks are escaped by doubling them
+        assertEquals("`we``ird`", CypherLiteral.renderIdentifier("we`ird"))
+    }
+
+    @Test
+    fun testWithParameters() {
+        assertEquals(
+            "CYPHER props=[1, 2] UNWIND \$props AS map RETURN map",
+            CypherLiteral.withParameters(
+                mapOf("props" to listOf(1, 2)),
+                "UNWIND \$props AS map RETURN map",
+            ),
+        )
+    }
+
+    @Test
+    fun testWithoutParameters() {
+        assertEquals("RETURN 1", CypherLiteral.withParameters(emptyMap(), "RETURN 1"))
+    }
+
+    enum class TestEnum {
+        FIRST,
+        SECOND,
+    }
+}

--- a/cpg-falkordb/src/test/kotlin/de/fraunhofer/aisec/cpg/persistence/FakeGraph.kt
+++ b/cpg-falkordb/src/test/kotlin/de/fraunhofer/aisec/cpg/persistence/FakeGraph.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.persistence
+
+import com.falkordb.Driver
+import com.falkordb.Graph
+import com.falkordb.ResultSet
+import redis.clients.jedis.Jedis
+import redis.clients.jedis.exceptions.JedisDataException
+
+/**
+ * A [Graph] that records the queries it is asked to run instead of talking to a database. This lets
+ * us assert on the Cypher that [FalkorDBDatabase] generates without needing a running FalkorDB
+ * instance.
+ *
+ * @param failWith an optional exception that every [query] and [deleteGraph] call throws
+ */
+class FakeGraph(private val failWith: JedisDataException? = null) : Graph {
+
+    /** All queries that were passed to [query], in order. */
+    val queries = mutableListOf<String>()
+
+    /** How often [deleteGraph] was called. */
+    var deleteGraphCalls = 0
+        private set
+
+    /** How often [close] was called. */
+    var closeCalls = 0
+        private set
+
+    override fun query(query: String): ResultSet? {
+        failWith?.let { throw it }
+        queries += query
+        return null
+    }
+
+    override fun deleteGraph(): String {
+        deleteGraphCalls++
+        failWith?.let { throw it }
+        return "OK"
+    }
+
+    override fun close() {
+        closeCalls++
+    }
+
+    override fun readOnlyQuery(query: String): ResultSet? = query(query)
+
+    override fun query(query: String, timeout: Long): ResultSet? = query(query)
+
+    override fun readOnlyQuery(query: String, timeout: Long): ResultSet? = query(query)
+
+    override fun query(query: String, params: MutableMap<String, Any>?): ResultSet? = query(query)
+
+    override fun readOnlyQuery(query: String, params: MutableMap<String, Any>?): ResultSet? =
+        query(query)
+
+    override fun query(query: String, params: MutableMap<String, Any>?, timeout: Long): ResultSet? =
+        query(query)
+
+    override fun readOnlyQuery(
+        query: String,
+        params: MutableMap<String, Any>?,
+        timeout: Long,
+    ): ResultSet? = query(query)
+
+    override fun callProcedure(procedure: String): ResultSet? = query(procedure)
+
+    override fun callProcedure(procedure: String, args: MutableList<String>?): ResultSet? =
+        query(procedure)
+
+    override fun callProcedure(
+        procedure: String,
+        args: MutableList<String>?,
+        kwargs: MutableMap<String, MutableList<String>>?,
+    ): ResultSet? = query(procedure)
+
+    override fun copyGraph(destination: String): String = destination
+}
+
+/** A [Driver] that only records whether it was closed. */
+class FakeDriver : Driver {
+
+    /** How often [close] was called. */
+    var closeCalls = 0
+        private set
+
+    override fun close() {
+        closeCalls++
+    }
+
+    override fun graph(graphId: String) = throw UnsupportedOperationException()
+
+    override fun getConnection(): Jedis = throw UnsupportedOperationException()
+}

--- a/cpg-falkordb/src/test/kotlin/de/fraunhofer/aisec/cpg/persistence/FalkorDBDatabaseTest.kt
+++ b/cpg-falkordb/src/test/kotlin/de/fraunhofer/aisec/cpg/persistence/FalkorDBDatabaseTest.kt
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.persistence
+
+import de.fraunhofer.aisec.cpg.graph.declarations.Function
+import de.fraunhofer.aisec.cpg.graph.nodes
+import de.fraunhofer.aisec.cpg.test.GraphExamples
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import redis.clients.jedis.exceptions.JedisDataException
+
+/**
+ * Unit tests for [FalkorDBDatabase] that assert on the generated Cypher using a [FakeGraph], so
+ * that they do not need a running FalkorDB instance. The behaviour against a real server is covered
+ * by the integration tests.
+ */
+class FalkorDBDatabaseTest {
+
+    @Test
+    fun testPurgeDatabase() {
+        val graph = FakeGraph()
+        FalkorDBDatabase(graph).purgeDatabase()
+
+        assertEquals(1, graph.deleteGraphCalls)
+    }
+
+    @Test
+    fun testPurgeDatabaseIgnoresMissingGraph() {
+        // Deleting a graph that was never created is not an error for our purposes
+        val graph = FakeGraph(JedisDataException("ERR Invalid graph operation on empty key"))
+        FalkorDBDatabase(graph).purgeDatabase()
+
+        assertEquals(1, graph.deleteGraphCalls)
+    }
+
+    @Test
+    fun testPurgeDatabaseRethrowsOtherErrors() {
+        val graph = FakeGraph(JedisDataException("ERR something else went wrong"))
+
+        assertFailsWith<JedisDataException> { FalkorDBDatabase(graph).purgeDatabase() }
+    }
+
+    @Test
+    fun testCreateIndexes() {
+        val graph = FakeGraph()
+        FalkorDBDatabase(graph).createIndexes()
+
+        assertEquals(listOf("CREATE INDEX FOR (n:Node) ON (n.id)"), graph.queries)
+    }
+
+    @Test
+    fun testCreateIndexesIgnoresExistingIndex() {
+        // FalkorDB has no "CREATE INDEX IF NOT EXISTS", an already existing index is what we want
+        val graph = FakeGraph(JedisDataException("ERR Attribute 'id' is already indexed"))
+        FalkorDBDatabase(graph).createIndexes()
+    }
+
+    @Test
+    fun testCreateIndexesRethrowsOtherErrors() {
+        val graph = FakeGraph(JedisDataException("ERR something else went wrong"))
+
+        assertFailsWith<JedisDataException> { FalkorDBDatabase(graph).createIndexes() }
+    }
+
+    @Test
+    fun testPersistNodeChunkGroupsByLabels() {
+        val graph = FakeGraph()
+        val result = GraphExamples.getInitializerListExprDFG()
+        val nodes = result.nodes
+
+        FalkorDBDatabase(graph).persistNodeChunk(nodes)
+
+        // One query per distinct set of labels, not one per node
+        assertEquals(nodes.groupBy { it::class.labels }.size, graph.queries.size)
+
+        // Every query has to use the constant UNWIND body that lets FalkorDB cache the
+        // execution plan, with the labels baked into the CREATE clause
+        assertTrue(
+            graph.queries.all {
+                it.startsWith("CYPHER props=[{") &&
+                    it.contains(" UNWIND \$props AS map CREATE (n:`Node`") &&
+                    it.endsWith(") SET n = map")
+            },
+            "Unexpected queries: ${graph.queries}",
+        )
+
+        // A function declaration carries the labels of its whole class hierarchy
+        val function = nodes.first { it is Function }
+        val query = graph.queries.single { it.contains(function.id.toString()) }
+        assertTrue(query.contains("CREATE (n:`Node`:`AstNode`"), query)
+        assertTrue(query.contains(":`Function`)"), query)
+    }
+
+    @Test
+    fun testPersistRelationshipChunkGroupsByType() {
+        val graph = FakeGraph()
+
+        val relationships =
+            listOf(
+                mapOf("startId" to "a", "endId" to "b", "type" to "EOG", "index" to 0),
+                mapOf("startId" to "b", "endId" to "c", "type" to "EOG", "index" to 1),
+                mapOf("startId" to "a", "endId" to "c", "type" to "DFG"),
+            )
+
+        FalkorDBDatabase(graph).persistRelationshipChunk(relationships)
+
+        assertEquals(2, graph.queries.size)
+
+        val eog = graph.queries.single { it.contains("[r:`EOG`]") }
+        // The structural keys must end up in the MATCH, not in the properties of the relationship
+        assertTrue(eog.contains("`index`: 0"), eog)
+        assertFalse(eog.contains("`type`:"), eog)
+        assertTrue(eog.contains("MATCH (s:Node {id: map.startId})"), eog)
+        assertTrue(eog.contains("SET r = map.properties"), eog)
+
+        // A relationship without properties still has to produce a (empty) property map
+        val dfg = graph.queries.single { it.contains("[r:`DFG`]") }
+        assertTrue(dfg.contains("`properties`: {}"), dfg)
+    }
+
+    @Test
+    fun testPersistRelationshipChunkSkipsUntypedRelationships() {
+        val graph = FakeGraph()
+
+        FalkorDBDatabase(graph)
+            .persistRelationshipChunk(listOf(mapOf("startId" to "a", "endId" to "b")))
+
+        assertEquals(emptyList(), graph.queries)
+    }
+
+    @Test
+    fun testPersistUsesTheBackendInTheRightOrder() {
+        val graph = FakeGraph()
+        val result = GraphExamples.getInitializerListExprDFG()
+
+        FalkorDBDatabase(graph).use { result.persist(it) }
+
+        assertEquals(1, graph.deleteGraphCalls)
+
+        // The index has to exist before the relationships are matched against it
+        val indexAt = graph.queries.indexOf("CREATE INDEX FOR (n:Node) ON (n.id)")
+        assertTrue(indexAt > 0, "Expected nodes to be persisted before the index is created")
+        assertTrue(
+            graph.queries.drop(indexAt).any { it.contains("CREATE (s)-[r:") },
+            "Expected relationships to be persisted after the index is created",
+        )
+    }
+
+    @Test
+    fun testPersistCanSkipPurging() {
+        val graph = FakeGraph()
+        val result = GraphExamples.getInitializerListExprDFG()
+
+        FalkorDBDatabase(graph).use { result.persist(it, purgeDb = false) }
+
+        assertEquals(0, graph.deleteGraphCalls)
+    }
+
+    @Test
+    fun testCloseOnlyClosesWhatWeOwn() {
+        // Without a driver, the caller owns the lifecycle of the graph, so it stays usable
+        val borrowed = FakeGraph()
+        FalkorDBDatabase(borrowed).close()
+        assertEquals(0, borrowed.closeCalls)
+
+        val owned = FakeGraph()
+        val driver = FakeDriver()
+        FalkorDBDatabase(owned, driver).close()
+        assertEquals(1, owned.closeCalls)
+        assertEquals(1, driver.closeCalls)
+    }
+
+    @Test
+    fun testChunkSizes() {
+        val db = FalkorDBDatabase(FakeGraph())
+
+        // Parameters are inlined into the query text, so we use smaller chunks than the default
+        assertTrue(db.nodeChunkSize < DEFAULT_NODE_CHUNK_SIZE)
+        assertTrue(db.relationshipChunkSize < DEFAULT_RELATIONSHIP_CHUNK_SIZE)
+    }
+
+    @Test
+    fun testConnectRejectsIncompleteCredentials() {
+        assertFailsWith<IllegalArgumentException> { connectToFalkorDB(username = "user") }
+        assertFailsWith<IllegalArgumentException> { connectToFalkorDB(password = "secret") }
+    }
+}

--- a/cpg-falkordb/src/test/kotlin/de/fraunhofer/aisec/cpg_vis_falkordb/ApplicationTest.kt
+++ b/cpg-falkordb/src/test/kotlin/de/fraunhofer/aisec/cpg_vis_falkordb/ApplicationTest.kt
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg_vis_falkordb
+
+import de.fraunhofer.aisec.cpg.ConfigurationException
+import de.fraunhofer.aisec.cpg.passes.ControlDependenceGraphPass
+import de.fraunhofer.aisec.cpg.passes.ControlFlowSensitiveDFGPass
+import de.fraunhofer.aisec.cpg.passes.DFGPass
+import de.fraunhofer.aisec.cpg.passes.PrepareSerialization
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import picocli.CommandLine
+
+/**
+ * Tests the command line handling of [Application]. They deliberately stop at the translation
+ * configuration, since actually analyzing code requires a language frontend, which is only
+ * optionally enabled.
+ */
+class ApplicationTest {
+
+    /** Parses [args] into a fresh [Application]. */
+    private fun parse(vararg args: String): Application {
+        val application = Application()
+        CommandLine(application).parseArgs(*args)
+        return application
+    }
+
+    private fun resource(name: String) =
+        File(javaClass.classLoader.getResource(name)?.file ?: error("Missing resource $name"))
+
+    @Test
+    fun testListPasses() {
+        // --list-passes must not try to analyze anything
+        assertEquals(0, CommandLine(Application()).execute("--list-passes"))
+    }
+
+    @Test
+    fun testSourceLocations() {
+        val config = parse(resource("client.c").absolutePath).setupTranslationConfiguration()
+
+        assertEquals(
+            listOf(resource("client.c").absolutePath),
+            config.sourceLocations.map { it.absolutePath },
+        )
+        // Serialization has to be prepared, otherwise persisting the result does not work
+        assertContains(config.registeredPasses.flatten(), PrepareSerialization::class)
+    }
+
+    @Test
+    fun testSoftwareComponents() {
+        val file = resource("client.c").absolutePath
+        val config = parse("-S", "App1=$file").setupTranslationConfiguration()
+
+        assertEquals(setOf("App1"), config.softwareComponents.keys)
+        assertEquals(listOf(file), config.softwareComponents["App1"]?.map { it.absolutePath })
+    }
+
+    @Test
+    fun testNonExistingFileIsRejected() {
+        val application = parse("this-file-does-not-exist.c")
+
+        assertFailsWith<IllegalArgumentException> { application.setupTranslationConfiguration() }
+    }
+
+    @Test
+    fun testDefaultPasses() {
+        val config = parse(resource("client.c").absolutePath).setupTranslationConfiguration()
+        val passes = config.registeredPasses.flatten()
+
+        assertContains(passes, ControlDependenceGraphPass::class)
+        assertContains(passes, DFGPass::class)
+    }
+
+    @Test
+    fun testNoDefaultPasses() {
+        val config =
+            parse("--no-default-passes", resource("client.c").absolutePath)
+                .setupTranslationConfiguration()
+        val passes = config.registeredPasses.flatten()
+
+        assertFalse(ControlDependenceGraphPass::class in passes)
+        // The serialization pass is always needed, even without the default passes
+        assertContains(passes, PrepareSerialization::class)
+    }
+
+    @Test
+    fun testCustomPassByName() {
+        val config =
+            parse(
+                    "--no-default-passes",
+                    "--custom-pass-list=DFGPass",
+                    resource("client.c").absolutePath,
+                )
+                .setupTranslationConfiguration()
+
+        assertContains(config.registeredPasses.flatten(), DFGPass::class)
+    }
+
+    @Test
+    fun testCustomPassByFullyQualifiedName() {
+        val config =
+            parse(
+                    "--no-default-passes",
+                    "--custom-pass-list=de.fraunhofer.aisec.cpg.passes.DFGPass",
+                    resource("client.c").absolutePath,
+                )
+                .setupTranslationConfiguration()
+
+        assertContains(config.registeredPasses.flatten(), DFGPass::class)
+    }
+
+    @Test
+    fun testUnknownCustomPassIsRejected() {
+        val application =
+            parse("--custom-pass-list=ThisPassDoesNotExist", resource("client.c").absolutePath)
+
+        assertFailsWith<ConfigurationException> { application.setupTranslationConfiguration() }
+    }
+
+    @Test
+    fun testMaxComplexity() {
+        val config =
+            parse("--max-complexity-cf-dfg=42", resource("client.c").absolutePath)
+                .setupTranslationConfiguration()
+
+        assertEquals(
+            42,
+            config.passConfigurations[ControlFlowSensitiveDFGPass::class]
+                .let { it as? ControlFlowSensitiveDFGPass.Configuration }
+                ?.maxComplexity,
+        )
+    }
+
+    @Test
+    fun testTopLevelAndIncludePaths() {
+        val topLevel = resource("client.c").parentFile
+        val config =
+            parse(
+                    "--top-level=${topLevel.absolutePath}",
+                    "-IP",
+                    "/some/include/path",
+                    "--load-includes",
+                    "--exclusion-patterns=ignore-me",
+                    resource("client.c").absolutePath,
+                )
+                .setupTranslationConfiguration()
+
+        assertTrue(config.loadIncludes)
+        assertEquals(listOf(topLevel.absolutePath), config.topLevels.values.map { it.absolutePath })
+        assertTrue(config.includePaths.any { it.toString() == "/some/include/path" })
+        assertContains(config.exclusionPatternsByString, "ignore-me")
+    }
+
+    @Test
+    fun testIncludesFile() {
+        val includesFile = resource("includes.txt")
+        val config =
+            parse("--includes-file=${includesFile.absolutePath}", resource("client.c").absolutePath)
+                .setupTranslationConfiguration()
+
+        // Relative entries of the includes file are resolved against the directory of that file
+        val baseDir = includesFile.parentFile.absolutePath
+        assertTrue(config.includePaths.any { it.toString() == "$baseDir/include-a" })
+        assertTrue(config.includePaths.any { it.toString() == "$baseDir/include-b" })
+    }
+
+    @Test
+    fun testInferNodes() {
+        val config =
+            parse("--infer-nodes", resource("client.c").absolutePath)
+                .setupTranslationConfiguration()
+
+        assertTrue(config.inferenceConfiguration.inferRecords)
+    }
+
+    @Test
+    fun testUseUnityBuild() {
+        val config =
+            parse("--use-unity-build", "--load-includes", resource("client.c").absolutePath)
+                .setupTranslationConfiguration()
+
+        assertTrue(config.useUnityBuild)
+    }
+
+    @Test
+    fun testJsonCompilationDatabase() {
+        val source = resource("client.c")
+        // Write the database next to the source, so that the relative entry resolves correctly
+        val db = File.createTempFile("compile_commands", ".json")
+        db.deleteOnExit()
+        db.writeText(
+            """
+            [{"directory": "${source.parentFile.absolutePath}",
+              "arguments": ["cc", "-c", "client.c"],
+              "file": "client.c"}]
+            """
+                .trimIndent()
+        )
+
+        val config =
+            parse("--json-compilation-database=${db.absolutePath}").setupTranslationConfiguration()
+
+        assertEquals(listOf(source.absolutePath), config.sourceLocations.map { it.absolutePath })
+    }
+
+    @Test
+    fun testFalkorDbOptionDefaults() {
+        val application = parse(resource("client.c").absolutePath)
+
+        // Without credentials we connect anonymously, which is how FalkorDB ships by default
+        assertEquals(null, application.falkorDbUsername)
+        assertEquals(null, application.falkorDbPassword)
+    }
+}

--- a/cpg-falkordb/src/test/resources/client.c
+++ b/cpg-falkordb/src/test/resources/client.c
@@ -1,0 +1,4 @@
+int main() {
+    int a = 1;
+    return a;
+}

--- a/cpg-falkordb/src/test/resources/includes.txt
+++ b/cpg-falkordb/src/test/resources/includes.txt
@@ -1,0 +1,2 @@
+include-a
+include-b

--- a/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg/persistence/Neo4J.kt
+++ b/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg/persistence/Neo4J.kt
@@ -61,10 +61,6 @@ const val nodeChunkSize = DEFAULT_NODE_CHUNK_SIZE
  * Note that closing this backend also closes the underlying [session].
  */
 class Neo4jDatabase(private val session: Session) : GraphDatabaseBackend {
-    override val nodeChunkSize: Int = DEFAULT_NODE_CHUNK_SIZE
-
-    override val relationshipChunkSize: Int = DEFAULT_RELATIONSHIP_CHUNK_SIZE
-
     override fun purgeDatabase() {
         session.executeWrite { tx -> tx.run("MATCH (n) DETACH DELETE n").consume() }
     }

--- a/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg/persistence/Neo4J.kt
+++ b/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg/persistence/Neo4J.kt
@@ -27,13 +27,9 @@ package de.fraunhofer.aisec.cpg.persistence
 
 import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.graph.Node
-import de.fraunhofer.aisec.cpg.graph.Persistable
-import de.fraunhofer.aisec.cpg.graph.nodes
-import de.fraunhofer.aisec.cpg.helpers.Benchmark
 import java.net.ConnectException
 import org.neo4j.driver.GraphDatabase
 import org.neo4j.driver.Session
-import org.slf4j.LoggerFactory
 
 /**
  * Defines the number of edges to be processed in a single batch operation during persistence.
@@ -42,7 +38,7 @@ import org.slf4j.LoggerFactory
  * performance and reduce memory usage when interacting with the Neo4j database. Specifically, it
  * determines the maximum size of each chunk of edges to be persisted in one batch operation.
  */
-const val edgeChunkSize = 10000
+const val edgeChunkSize = DEFAULT_RELATIONSHIP_CHUNK_SIZE
 
 /**
  * Specifies the maximum number of nodes to be processed in a single chunk during persistence
@@ -53,16 +49,78 @@ const val edgeChunkSize = 10000
  * efficiency during database writes. Each chunk is handled individually, ensuring that operations
  * remain manageable even for large data sets.
  */
-const val nodeChunkSize = 10000
+const val nodeChunkSize = DEFAULT_NODE_CHUNK_SIZE
 
-internal val log = LoggerFactory.getLogger("Persistence")
+/**
+ * A [GraphDatabaseBackend] that writes the CPG into a Neo4j database using the supplied [session].
+ *
+ * Neo4j does not allow labels and relationship types to be passed as query parameters, so the
+ * dynamic creation of nodes and relationships is delegated to the
+ * [APOC](https://neo4j.com/labs/apoc/) plugin, which therefore needs to be enabled on the server.
+ *
+ * Note that closing this backend also closes the underlying [session].
+ */
+class Neo4jDatabase(private val session: Session) : GraphDatabaseBackend {
+    override val nodeChunkSize: Int = DEFAULT_NODE_CHUNK_SIZE
 
-internal typealias Relationship = Map<String, Any?>
+    override val relationshipChunkSize: Int = DEFAULT_RELATIONSHIP_CHUNK_SIZE
+
+    override fun purgeDatabase() {
+        session.executeWrite { tx -> tx.run("MATCH (n) DETACH DELETE n").consume() }
+    }
+
+    override fun createIndexes() {
+        // Create an index for the "id" field of node, because we are "MATCH"ing on it in the edge
+        // creation. We need to wait for this to be finished
+        session.executeWrite { tx ->
+            tx.run("CREATE INDEX IF NOT EXISTS FOR (n:Node) ON (n.id)").consume()
+        }
+    }
+
+    override fun persistNodeChunk(nodes: List<Node>) {
+        val params =
+            mapOf("props" to nodes.map { mapOf("labels" to it::class.labels) + it.properties() })
+        session.executeWrite { tx ->
+            tx.run(
+                    $$"""
+                   UNWIND $props AS map
+                   WITH map, apoc.map.removeKeys(map, ['labels']) AS properties
+                   CALL apoc.create.node(map.labels, properties) YIELD node
+                   RETURN node
+                   """,
+                    params,
+                )
+                .consume()
+        }
+    }
+
+    override fun persistRelationshipChunk(relationships: List<Map<String, Any?>>) {
+        val params = mapOf("props" to relationships)
+        session.executeWrite { tx ->
+            tx.run(
+                    $$"""
+            UNWIND $props AS map
+            MATCH (s:Node {id: map.startId})
+            MATCH (e:Node {id: map.endId})
+            WITH s, e, map, apoc.map.removeKeys(map, ['startId', 'endId', 'type']) AS properties
+            CALL apoc.create.relationship(s, map.type, properties, e) YIELD rel
+            RETURN rel
+            """
+                        .trimIndent(),
+                    params,
+                )
+                .consume()
+        }
+    }
+
+    override fun close() {
+        session.close()
+    }
+}
 
 /**
  * This function creates a new Neo4j session, optionally purges the database, and persists the
- * current [TranslationResult] into the database using the [persistNeo4j] function (which requires a
- * session context often not available at the call-site).
+ * current [TranslationResult] into the database.
  *
  * @param noPurgeDb A boolean flag indicating whether to skip the database purge step. If set to
  *   true, the existing data in the database will not be deleted before persisting the new data.
@@ -81,148 +139,19 @@ fun TranslationResult.pushToNeo4j(
     neo4jPassword: String = Neo4jConnectionDefaults.PASSWORD,
 ) {
     val session: Session = connect(protocol, host, port, neo4jUsername, neo4jPassword)
-    with(session) {
-        if (!noPurgeDb) executeWrite { tx -> tx.run("MATCH (n) DETACH DELETE n").consume() }
-        this@pushToNeo4j.persistNeo4j()
-    }
-    session.close()
+    Neo4jDatabase(session).use { db -> this.persist(db, purgeDb = !noPurgeDb) }
 }
 
 /**
- * Persists the current [TranslationResult] into a graph database.
+ * Persists the current [TranslationResult] into a Neo4j database, using the [Session] available in
+ * the current context.
  *
- * This method performs the following actions:
- * - Logs information about the number and categories of nodes (e.g., AST nodes, scopes, types,
- *   languages) and edges that are being persisted.
- * - Collects nodes that include AST nodes, scopes, types, and languages, as well as all associated
- *   edges.
- * - Persists the collected nodes and edges.
- * - Persists additional relationships between nodes, such as those related to types, scopes, and
- *   languages.
- * - Utilizes a benchmarking mechanism to measure and log the time taken to complete the persistence
- *   operation.
- *
- * This method relies on the following context and properties:
- * - The [TranslationResult.finalCtx] property for accessing the scope manager, type manager, and
- *   configuration.
- * - A [Session] context to perform persistence actions.
+ * See [persist] for a description of what exactly is written to the database. Note that, in
+ * contrast to [pushToNeo4j], this does not purge the database beforehand.
  */
-context(_: Session)
+context(session: Session)
 fun TranslationResult.persistNeo4j() {
-    val b = Benchmark(Persistable::class.java, "Persisting translation result")
-
-    val astNodes = this@persistNeo4j.nodes
-    val connected = astNodes.flatMap { it.connectedNodes }.toSet()
-    val nodes = (astNodes + connected).distinct()
-
-    log.info(
-        "Persisting {} nodes: AST nodes ({}), other nodes ({})",
-        nodes.size,
-        astNodes.size,
-        connected.size,
-    )
-    nodes.persistNeo4j()
-
-    val relationships = nodes.collectRelationships()
-
-    log.info("Persisting {} relationships", relationships.size)
-    relationships.persistNeo4j()
-
-    b.stop()
-}
-
-/**
- * Persists a list of nodes into a database in chunks for efficient processing.
- *
- * This function utilizes the surrounding [Session] context to execute the database write
- * operations. Nodes are processed in chunks of size determined by [nodeChunkSize], and each chunk
- * is persisted using Cypher queries. The process is benchmarked using the [Benchmark] utility.
- *
- * The function generates a list of properties for the nodes, which includes their labels and other
- * properties. These properties are used to construct Cypher queries that create nodes in the
- * database with the given labels and properties.
- *
- * The function uses the APOC library for creating nodes in the database. For each node in the list,
- * it extracts the labels and properties and executes the Cypher query to persist the node.
- */
-context(session: Session)
-private fun List<Node>.persistNeo4j() {
-    this.chunked(nodeChunkSize).map { chunk ->
-        val b = Benchmark(Persistable::class.java, "Persisting chunk of ${chunk.size} nodes")
-        val params =
-            mapOf("props" to chunk.map { mapOf("labels" to it::class.labels) + it.properties() })
-        session.executeWrite { tx ->
-            tx.run(
-                    $$"""
-                   UNWIND $props AS map
-                   WITH map, apoc.map.removeKeys(map, ['labels']) AS properties
-                   CALL apoc.create.node(map.labels, properties) YIELD node
-                   RETURN node
-                   """,
-                    params,
-                )
-                .consume()
-        }
-        b.stop()
-    }
-}
-
-/**
- * Persists a collection of edges into a Neo4j graph database within the context of a [Session].
- *
- * This method ensures that the required index for node IDs is created before proceeding with
- * relationship creation. The edges are subdivided into chunks, and for each chunk, the
- * relationships are created in the database. Neo4j does not support multiple labels on edges, so
- * each edge is duplicated for each assigned label. The created relationships are associated with
- * their respective nodes and additional properties derived from the edges.
- *
- * Constraints:
- * - The session context is required to execute write transactions.
- * - Edges should define their labels and properties for appropriate persistence.
- *
- * Mechanisms:
- * - An index for [Node] IDs is created (if not already existing) to optimize matching operations.
- * - Edges are chunked to avoid overloading transactional operations.
- * - Relationship properties and labels are mapped before using database utilities for creation.
- */
-context(session: Session)
-private fun Collection<Relationship>.persistNeo4j() {
-    // Create an index for the "id" field of node, because we are "MATCH"ing on it in the edge
-    // creation. We need to wait for this to be finished
-    session.executeWrite { tx ->
-        tx.run("CREATE INDEX IF NOT EXISTS FOR (n:Node) ON (n.id)").consume()
-    }
-
-    this.chunked(edgeChunkSize).map { chunk -> session.createRelationships(chunk) }
-}
-
-/**
- * Creates relationships in a graph database based on provided properties.
- *
- * @param props A list of maps, where each map represents properties of a relationship including
- *   keys such as `startId`, `endId`, and `type`. The `startId` and `endId` identify the nodes to
- *   connect, while `type` defines the type of the relationship. Additional properties for the
- *   relationship can also be included in the map.
- */
-private fun Session.createRelationships(props: List<Relationship>) {
-    val b = Benchmark(Persistable::class.java, "Persisting chunk of ${props.size} relationships")
-    val params = mapOf("props" to props)
-    executeWrite { tx ->
-        tx.run(
-                $$"""
-            UNWIND $props AS map
-            MATCH (s:Node {id: map.startId})
-            MATCH (e:Node {id: map.endId})
-            WITH s, e, map, apoc.map.removeKeys(map, ['startId', 'endId', 'type']) AS properties
-            CALL apoc.create.relationship(s, map.type, properties, e) YIELD rel
-            RETURN rel
-            """
-                    .trimIndent(),
-                params,
-            )
-            .consume()
-    }
-    b.stop()
+    this.persist(Neo4jDatabase(session), purgeDb = false)
 }
 
 /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 kotlin = "2.3.0"
 kotlinx-json = "1.10.0"
 neo4j5 = "5.28.10"
+jfalkordb = "0.3.0"
 log4j = "2.25.3"
 spotless = "8.1.0"
 publish = "0.37.0"
@@ -40,6 +41,7 @@ slf4j-nop = { module = "org.slf4j:slf4j-nop", version.ref = "slf4j"}
 
 apache-commons-lang3 = { module = "org.apache.commons:commons-lang3", version = "3.20.0"}
 neo4j-driver = { module = "org.neo4j.driver:neo4j-java-driver", version.ref = "neo4j5"}
+jfalkordb = { module = "com.falkordb:jfalkordb", version.ref = "jfalkordb"}
 classgraph = { module = "io.github.classgraph:classgraph", version = "4.8.179"}
 
 javaparser = { module = "com.github.javaparser:javaparser-symbol-solver-core", version = "3.28.1"}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,7 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 include(":cpg-core")
 include(":cpg-analysis")
 include(":cpg-neo4j")
+include(":cpg-falkordb")
 include(":cpg-concepts")
 include(":cpg-serialization")
 


### PR DESCRIPTION
## Summary

Adds **`cpg-falkordb`**, a new module that persists a translated CPG into a [FalkorDB](https://www.falkordb.com/) graph database, as an alternative to the existing `cpg-neo4j` tool.

FalkorDB is an in-memory, sparse-matrix based property graph that speaks openCypher. Compared to Neo4j it needs **no server-side plugin** (`cpg-neo4j` requires APOC), starts in well under a second and has a much smaller footprint, which makes it convenient for short-lived analysis runs, CI pipelines and local exploration:

```
docker run -p 6379:6379 -p 3000:3000 -d falkordb/falkordb:latest
./build/install/cpg-falkordb/bin/cpg-falkordb --graph my-project src/main.c
```

To avoid duplicating the persistence logic, this PR first extracts the backend-independent part into a new **`GraphDatabaseBackend`** port in `cpg-core`. It owns node/relationship collection, chunking and benchmarking and leaves only the four genuinely database-specific operations to implementations:

```kotlin
interface GraphDatabaseBackend : AutoCloseable {
    val nodeChunkSize: Int
    val relationshipChunkSize: Int
    fun purgeDatabase()
    fun createIndexes()
    fun persistNodeChunk(nodes: List<Node>)
    fun persistRelationshipChunk(relationships: List<Map<String, Any?>>)
}
```

`cpg-neo4j` is then refactored onto that port. The APOC queries themselves are untouched, and the public entry points `pushToNeo4j` / `persistNeo4j` keep working exactly as before, as do the `nodeChunkSize` / `edgeChunkSize` constants.

The resulting graph schema is identical for both backends: every node carries the labels of its whole class hierarchy (`:Node:AstNode:Expression:Call`) and every edge keeps its edge properties.

### Two FalkorDB specifics worth reviewing

1. **No APOC.** Labels and relationship types cannot be parameterized. Instead of one query per node, `FalkorDBDatabase` groups the nodes of a chunk by their *set of labels* and the relationships by their *type*. Every group is written with a single `UNWIND` query whose body is constant, so FalkorDB can reuse the cached execution plan across chunks.
2. **No binary parameter channel.** FalkorDB inlines query parameters into the query text, and `jfalkordb` does not serialize maps at all, so the `UNWIND $props AS map` pattern cannot go through the client's parameter path. A small `CypherLiteral` writer renders the parameters into the `CYPHER k=v` preamble instead. It is the only security-sensitive piece here, so it has dedicated unit tests, including ones asserting it cannot be broken out of.

There are two further small quirks handled in the backend: FalkorDB has no `CREATE INDEX IF NOT EXISTS` (it reports `already indexed`, which is swallowed) and `GRAPH.DELETE` on a graph that does not exist yet errors on an "empty key" (also swallowed, since there is nothing to purge).

## Changes

- **`cpg-core`**: new `persistence/GraphDatabaseBackend.kt` with the `GraphDatabaseBackend` interface, the `DEFAULT_NODE_CHUNK_SIZE` / `DEFAULT_RELATIONSHIP_CHUNK_SIZE` constants and the shared `TranslationResult.persist(db, purgeDb)`.
- **`cpg-neo4j`**: `Neo4J.kt` refactored into a `Neo4jDatabase : GraphDatabaseBackend`; `pushToNeo4j` and `persistNeo4j` now delegate to the shared `persist`. No behavioural change, no API break.
- **`cpg-falkordb`** (new module):
  - `FalkorDB.kt` – `FalkorDBDatabase`, `connectToFalkorDB(...)`, `TranslationResult.pushToFalkorDB(...)`
  - `CypherLiteral.kt` – Cypher literal / identifier rendering and the parameter preamble
  - `FalkorDBDefaults.kt` – connection defaults (`localhost:6379`, graph `cpg`)
  - `cpg_vis_falkordb/Application.kt` – picocli CLI mirroring the Neo4j one, plus `--graph` and `--no-falkordb`; `--user` / `--password` are optional since FalkorDB needs no auth by default
  - unit tests for `CypherLiteral` and integration tests against a live instance
  - `README.md`
- `settings.gradle.kts`, `gradle/libs.versions.toml` (`com.falkordb:jfalkordb:0.3.0`), root `README.md`, `AGENTS.md`.
- `.github/workflows/build.yml`: start a FalkorDB container alongside the existing Neo4j one, since CI runs `integrationTest` for all modules.

## Testing

- `./gradlew :cpg-falkordb:test` – 13 unit tests covering `CypherLiteral`: scalars, `NaN`/`Infinity`, enums, escaping, injection resistance, collections, nested maps, `null` handling and identifier quoting. ✅
- `./gradlew :cpg-falkordb:integrationTest` against `falkordb/falkordb:latest` – 4 tests. ✅
  - `testPush` – the graph is written and nodes are findable by every label of their class hierarchy
  - `testPushPurgesPreviousGraph` – pushing twice does not duplicate nodes
  - `testRelationshipsArePersisted` – EOG edges exist and node properties survive the round trip
  - `testMultipleGraphsAreIndependent` – two graphs in the same instance do not interfere
- `./gradlew :cpg-core:test :cpg-neo4j:test` – green, confirming the refactor is behaviour-preserving. ✅
- `./gradlew classes testClasses` and `spotlessCheck` – green. ✅
- Every Cypher construct used by the backend (multi-label `CREATE`, `SET n = map`, nested map properties, backtick-quoted keys, index creation, string escape sequences) was verified against a live FalkorDB container before being relied upon.

## Memory / Performance Impact

- **No impact on existing paths.** `cpg-neo4j` issues the same queries, in the same order, with the same chunk sizes as before; the only difference is where the loop lives.
- **FalkorDB is RAM-resident.** The whole graph is kept in memory, so persisting a very large, AST-granularity CPG needs a correspondingly sized instance. This is the main tradeoff versus Neo4j and is the reason the module is additive rather than a replacement.
- FalkorDB chunk sizes are deliberately smaller than the defaults (1000 nodes / 5000 relationships) because parameters are inlined into the query text, so a chunk becomes one large string. This bounds the size of individual queries and the memory used to build them.
- Grouping by label set / relationship type means the number of queries per chunk is bounded by the number of distinct node classes, not by the number of nodes, and each query body is constant so its plan is cached.

## Related Issues

None — happy to link one if the maintainers would prefer this tracked.

### Possible follow-up

The two CLIs now share ~400 lines of picocli option handling. Extracting a common mixin would be a worthwhile cleanup, but it touches `cpg-neo4j`'s user-facing surface, so I left it out of this PR to keep the diff reviewable. Happy to do it here if preferred.
