### PR TITLE
Thread-safe ValueEvaluator

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluator.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluator.kt
@@ -70,8 +70,17 @@ open class ValueEvaluator(
     open val log: Logger
         get() = LoggerFactory.getLogger(ValueEvaluator::class.java)
 
-    /** This property contains the path of the latest execution of [evaluateInternal]. */
-    val path: MutableList<Node> = mutableListOf()
+    /**
+     * This property contains the path of the latest execution of [evaluateInternal]. Since a single
+     * [ValueEvaluator] instance (e.g. the one held by [de.fraunhofer.aisec.cpg.frontends.Language])
+     * can be shared and invoked concurrently from multiple threads (e.g. via parallel query
+     * evaluation), the underlying list is kept thread-local to avoid a
+     * [java.util.ConcurrentModificationException] when one thread mutates it while another is
+     * iterating over it.
+     */
+    private val threadLocalPath = ThreadLocal.withInitial { mutableListOf<Node>() }
+    val path: MutableList<Node>
+        get() = threadLocalPath.get()
 
     /** Cache calculated values so that we don't have to calculate them each time */
     companion object {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/Language.kt
@@ -132,8 +132,14 @@ abstract class Language<T : LanguageFrontend<*, *>>() : Node() {
     /** All operators which perform a simple assignment from the rhs to the lhs. */
     open val simpleAssignmentOperators: Set<String> = setOf("=")
 
-    /** The standard evaluator to be used with this language. */
-    @DoNotPersist open val evaluator: ValueEvaluator = ValueEvaluator()
+    /**
+     * The standard evaluator to be used with this language. A fresh instance is returned on every
+     * access, so that concurrent evaluations (e.g. from parallel query evaluation) never share
+     * mutable evaluator state such as [ValueEvaluator.path].
+     */
+    @DoNotPersist
+    open val evaluator: ValueEvaluator
+        get() = ValueEvaluator()
 
     /**
      * Determines whether [value] (the result of evaluating a condition with [evaluator]) is


### PR DESCRIPTION
Fixes `ConcurrentModificationException` which can occur if the `ValueEvaluator` is not instantiated as fresh instance when calling `Node.evaluate()`.