### PR TITLE
Replace map/filter/flatMap chains with single-pass collection helpers

### DIFF
--- a/codyze-console/src/main/kotlin/de/fraunhofer/aisec/codyze/console/ConsoleService.kt
+++ b/codyze-console/src/main/kotlin/de/fraunhofer/aisec/codyze/console/ConsoleService.kt
@@ -36,6 +36,7 @@ import de.fraunhofer.aisec.cpg.graph.concepts.Concept
 import de.fraunhofer.aisec.cpg.graph.concepts.conceptBuildHelper
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnit
 import de.fraunhofer.aisec.cpg.graph.nodes
+import de.fraunhofer.aisec.cpg.helpers.mapFlatMapped
 import de.fraunhofer.aisec.cpg.passes.concepts.LoadPersistedConcepts
 import de.fraunhofer.aisec.cpg.passes.concepts.LoadPersistedConcepts.PersistedConceptEntry
 import de.fraunhofer.aisec.cpg.passes.concepts.LoadPersistedConcepts.PersistedConcepts
@@ -358,7 +359,7 @@ class ConsoleService {
      */
     private fun extractNodes(tu: TranslationUnit, overlayNodes: Boolean): List<NodeJSON> {
         return if (overlayNodes) {
-            tu.nodes.flatMap { it.overlays }.map { it.toJSON() }
+            tu.nodes.mapFlatMapped({ it.overlays }) { it.toJSON() }
         } else {
             tu.declarations.map { it.toJSON() } + tu.statements.map { it.toJSON() }
         }

--- a/codyze-console/src/main/kotlin/de/fraunhofer/aisec/codyze/console/Nodes.kt
+++ b/codyze-console/src/main/kotlin/de/fraunhofer/aisec/codyze/console/Nodes.kt
@@ -491,7 +491,7 @@ fun <T> QueryTree<T>.toJSON(): QueryTreeJSON {
                     lineNumber = it.lineNumber,
                 )
             },
-        assumptions = this.relevantAssumptions().map { it.toJSON() }.toSet(),
+        assumptions = this.relevantAssumptions().mapTo(mutableSetOf()) { it.toJSON() },
     )
 }
 

--- a/codyze-core/src/main/kotlin/de/fraunhofer/aisec/codyze/Sarif.kt
+++ b/codyze-core/src/main/kotlin/de/fraunhofer/aisec/codyze/Sarif.kt
@@ -35,6 +35,7 @@ import de.fraunhofer.aisec.cpg.graph.declarations.Parameter
 import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnit
 import de.fraunhofer.aisec.cpg.graph.declarations.Variable
 import de.fraunhofer.aisec.cpg.graph.types.Type
+import de.fraunhofer.aisec.cpg.helpers.mapFlatMapped
 import de.fraunhofer.aisec.cpg.query.AcceptedResult
 import de.fraunhofer.aisec.cpg.query.NotYetEvaluated
 import de.fraunhofer.aisec.cpg.query.QueryTree
@@ -113,19 +114,17 @@ fun QueryTree<Boolean>.toSarif(ruleID: String): List<Result> {
                     null
                 },
             codeFlows =
-                child.children
-                    .flatMap { it.getCodeflow() }
-                    .map {
-                        CodeFlow(
-                            threadFlows =
-                                listOf(
-                                    ThreadFlow(
-                                        message = Message(text = "Thread flow"),
-                                        locations = it.toSarifThreadFlowLocation(),
-                                    )
+                child.children.mapFlatMapped({ it.getCodeflow() }) {
+                    CodeFlow(
+                        threadFlows =
+                            listOf(
+                                ThreadFlow(
+                                    message = Message(text = "Thread flow"),
+                                    locations = it.toSarifThreadFlowLocation(),
                                 )
-                        )
-                    },
+                            )
+                    )
+                },
         )
     }
 }

--- a/codyze-core/src/main/kotlin/de/fraunhofer/aisec/codyze/dsl/Dsl.kt
+++ b/codyze-core/src/main/kotlin/de/fraunhofer/aisec/codyze/dsl/Dsl.kt
@@ -219,10 +219,11 @@ class ProjectBuilder(val projectDir: Path = Path(".")) {
      */
     val allRequirements: Map<String, RequirementBuilder>
         get() {
-            return requirementsBuilder.categoryBuilders
-                .map { it.value }
-                .flatMap { it.requirements.entries }
-                .associate { it.key to it.value }
+            return buildMap {
+                for (category in requirementsBuilder.categoryBuilders.values) {
+                    putAll(category.requirements)
+                }
+            }
         }
 
     /** Builds an [AnalysisProject] out of the current state of the builder. */
@@ -274,11 +275,13 @@ class ProjectBuilder(val projectDir: Path = Path(".")) {
             }
 
         // Collect all requirements functions from all categories
-        val requirementFunctions =
-            requirementsBuilder.categoryBuilders
-                .map { it.value }
-                .flatMap { it.requirements.map { rq -> Pair(rq.key, rq.value.fulfilledBy) } }
-                .associate { it }
+        val requirementFunctions = buildMap {
+            for (category in requirementsBuilder.categoryBuilders.values) {
+                for ((key, value) in category.requirements) {
+                    put(key, value.fulfilledBy)
+                }
+            }
+        }
 
         return AnalysisProject(
             builder = this,

--- a/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/clients/LlmProviderConfig.kt
+++ b/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/clients/LlmProviderConfig.kt
@@ -26,6 +26,7 @@
 package de.fraunhofer.aisec.cpg.ai.clients
 
 import com.typesafe.config.Config
+import de.fraunhofer.aisec.cpg.helpers.filterMapped
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.plugins.*
@@ -125,8 +126,7 @@ class LlmProviderConfig(private val httpClient: HttpClient, val clients: List<Cl
             .body<GeminiModelsResponse>()
             .models
             // Gemini returns names as "models/gemini-2.5-flash"
-            .map { it.name.removePrefix("models/") }
-            .filter { allowed.matches(it) }
+            .filterMapped({ it.name.removePrefix("models/") }) { allowed.matches(it) }
             .sorted()
     }
 }

--- a/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/mcpserver/tools/CpgDfgBackwardTool.kt
+++ b/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/mcpserver/tools/CpgDfgBackwardTool.kt
@@ -31,6 +31,7 @@ import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.utils.NodeInfo
 import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.utils.addTool
 import de.fraunhofer.aisec.cpg.graph.collectAllPrevDFGPaths
 import de.fraunhofer.aisec.cpg.graph.nodes
+import de.fraunhofer.aisec.cpg.helpers.mapFlatMapped
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
@@ -61,7 +62,7 @@ fun Server.addDfgBackwardTool() {
                 )
 
         val paths = startNode.collectAllPrevDFGPaths()
-        val nodes = paths.flatMap { it.nodes }.map { NodeInfo(it) }
+        val nodes = paths.mapFlatMapped({ it.nodes }) { NodeInfo(it) }
 
         CallToolResult(content = listOf(TextContent(Json.encodeToString(nodes))))
     }

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFAOrderEvaluator.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/DFAOrderEvaluator.kt
@@ -33,6 +33,8 @@ import de.fraunhofer.aisec.cpg.graph.expressions.Construction
 import de.fraunhofer.aisec.cpg.graph.expressions.MemberCall
 import de.fraunhofer.aisec.cpg.graph.expressions.Reference
 import de.fraunhofer.aisec.cpg.graph.expressions.Return
+import de.fraunhofer.aisec.cpg.helpers.filterMappedTo
+import de.fraunhofer.aisec.cpg.helpers.mapFiltered
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -275,10 +277,12 @@ open class DFAOrderEvaluator(
      */
     private fun callUsesInterestingBase(node: Call, eogPath: String): List<String> {
         val allUsedBases =
-            node.arguments
-                .map { arg -> (arg as? Reference)?.refersTo }
-                .filter { arg -> arg != null && consideredBases.contains(arg) }
-                .toMutableList()
+            node.arguments.filterMappedTo(
+                mutableListOf(),
+                { arg -> (arg as? Reference)?.refersTo },
+            ) { arg ->
+                arg != null && consideredBases.contains(arg)
+            }
         if (
             node is MemberCall &&
                 node.base is Reference &&
@@ -421,7 +425,7 @@ open class DFAOrderEvaluator(
         val outNodes = mutableListOf<Node>()
         outNodes +=
             if (eliminateUnreachableCode) {
-                node.nextEOGEdges.filter { e -> !e.unreachable }.map { it.end }
+                node.nextEOGEdges.mapFiltered({ e -> !e.unreachable }) { it.end }
             } else {
                 node.nextEOG
             }
@@ -515,7 +519,7 @@ open class DFAOrderEvaluator(
             baseToFSM.entries
                 .groupBy { e -> e.key.split("|")[1] }
                 .map { x ->
-                    "${x.key}(${x.value.mapNotNull { y -> y.value.currentState }.toSet().joinToString(",")})"
+                    "${x.key}(${x.value.mapNotNullTo(mutableSetOf()) { y -> y.value.currentState }.joinToString(",")})"
                 }
                 .sorted()
                 .joinToString(",")

--- a/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/NFA.kt
+++ b/cpg-analysis/src/main/kotlin/de/fraunhofer/aisec/cpg/analysis/fsm/NFA.kt
@@ -48,7 +48,9 @@ class NFA(states: Set<State> = setOf()) : FSM(states) {
         fun getEpsilonClosure(states: MutableSet<State>): Set<State> {
             for (epsilonEdges in
                 states.map { state -> state.outgoingEdges.filter { edge -> edge.op == EPSILON } }) {
-                states.addAll(getEpsilonClosure(epsilonEdges.map { it.nextState }.toMutableSet()))
+                states.addAll(
+                    getEpsilonClosure(epsilonEdges.mapTo(mutableSetOf()) { it.nextState })
+                )
             }
             return states
         }
@@ -103,7 +105,8 @@ class NFA(states: Set<State> = setOf()) : FSM(states) {
                 // because multiple states in the current epsilonClosure might have edges with the
                 // same 'name' but to different states
                 // we again have to get the epsilonClosure of the target states
-                val transitionClosure = getEpsilonClosure(edges.map { it.nextState }.toMutableSet())
+                val transitionClosure =
+                    getEpsilonClosure(edges.mapTo(mutableSetOf()) { it.nextState })
                 if (transitionClosure in epsilonClosures) {
                     // if the transitionClosure is already in the DFA, get the DFA state it
                     // corresponds to

--- a/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/file/python/PythonFileConceptPass.kt
+++ b/cpg-concepts/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/concepts/file/python/PythonFileConceptPass.kt
@@ -477,7 +477,7 @@ class PythonFileConceptPass(ctx: TranslationContext) : EOGConceptPass(ctx) {
             result += lastNode.filterIsInstance<File>()
         } else {
             // There is a [FileHandle] but no [File] overlay, so we create a new [File] node
-            lastNode.filterIsInstance<FileHandle>().map { fileHandle ->
+            lastNode.filterIsInstance<FileHandle>().forEach { fileHandle ->
                 result +=
                     newFile(
                             underlyingNode = fileHandle.underlyingNode!! /* TODO */,

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TypeManager.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/TypeManager.kt
@@ -35,6 +35,7 @@ import de.fraunhofer.aisec.cpg.graph.expressions.Reference
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.graph.scopes.TemplateScope
 import de.fraunhofer.aisec.cpg.graph.types.*
+import de.fraunhofer.aisec.cpg.helpers.flatMapFiltered
 import de.fraunhofer.aisec.cpg.helpers.identitySetOf
 import de.fraunhofer.aisec.cpg.passes.Pass
 import de.fraunhofer.aisec.cpg.passes.Pass.Companion.log
@@ -237,19 +238,19 @@ internal fun Type.getAncestors(depth: Int): Set<Type.Ancestor> {
 
     // Recursively call ourselves on our super types.
     types +=
-        superTypes
-            .filter {
-                if (it == this) {
-                    log.warn(
-                        "Removing type {} from the list of its own supertypes. This would create a type cycle that is not allowed.",
-                        this,
-                    )
-                    false
-                } else {
-                    true
-                }
+        superTypes.flatMapFiltered({
+            if (it == this) {
+                log.warn(
+                    "Removing type {} from the list of its own supertypes. This would create a type cycle that is not allowed.",
+                    this,
+                )
+                false
+            } else {
+                true
             }
-            .flatMap { it.getAncestors(depth + 1) }
+        }) {
+            it.getAncestors(depth + 1)
+        }
 
     // Since the chain starts with our type, we add ourselves to it
     types += Type.Ancestor(this, depth)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/MultiValueEvaluator.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/MultiValueEvaluator.kt
@@ -64,7 +64,7 @@ class MultiValueEvaluator : ValueEvaluator() {
                 valuesCache.getOrPut(node.hashCode()) { evaluateInternal(node as? Node, 0) }
             else evaluateInternal(node as? Node, 0)
         return if (result is Collection<*> && result.all { r -> r is Number }) {
-            ConcreteNumberSet(result.map { r -> (r as Number).toLong() }.toMutableSet())
+            ConcreteNumberSet(result.mapTo(mutableSetOf()) { r -> (r as Number).toLong() })
         } else {
             result
         }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Annotation.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Annotation.kt
@@ -33,9 +33,8 @@ class Annotation : AstNode() {
 
     fun getValueForName(name: String): Expression? {
         return members
-            .filter { member: AnnotationMember -> member.name.lastPartsMatch(name) }
-            .map { obj: AnnotationMember -> obj.value }
-            .firstOrNull()
+            .firstOrNull { member: AnnotationMember -> member.name.lastPartsMatch(name) }
+            ?.value
     }
 
     override fun equals(other: Any?): Boolean {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/Extensions.kt
@@ -40,6 +40,7 @@ import de.fraunhofer.aisec.cpg.graph.edges.flows.Usage
 import de.fraunhofer.aisec.cpg.graph.expressions.*
 import de.fraunhofer.aisec.cpg.graph.scopes.Scope
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
+import de.fraunhofer.aisec.cpg.helpers.filterIsInstanceAndFilterTo
 import de.fraunhofer.aisec.cpg.helpers.functional.CPU_CORES
 import de.fraunhofer.aisec.cpg.helpers.functional.MIN_CHUNK_SIZE
 import de.fraunhofer.aisec.cpg.helpers.identitySetOf
@@ -114,7 +115,9 @@ inline fun <reified T> Node?.allChildrenWithOverlays(
             nodesWithOverlays
                 .splitInto()
                 .map { chunk ->
-                    async(Dispatchers.Default) { chunk.filterIsInstance<T>().filter(predicate) }
+                    async(Dispatchers.Default) {
+                        chunk.filterIsInstanceAndFilterTo<T, _>(mutableListOf(), predicate)
+                    }
                 }
                 .awaitAll()
                 .flatten()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/EdgeWalker.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/edges/EdgeWalker.kt
@@ -31,6 +31,7 @@ import de.fraunhofer.aisec.cpg.graph.edges.ast.AstEdge
 import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeCollection
 import de.fraunhofer.aisec.cpg.graph.edges.flows.Dataflow
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
+import de.fraunhofer.aisec.cpg.helpers.filterMapped
 import de.fraunhofer.aisec.cpg.helpers.identitySetOf
 
 /**
@@ -85,11 +86,11 @@ inline fun <reified EdgeType : Edge<out Node>> Node.allEdges(
         val node = worklist.removeFirst()
         val toAdd = node.edges(predicate)
 
-        val newStart = toAdd.map { it.start }.filter { it !in alreadySeen }
+        val newStart = toAdd.filterMapped({ it.start }) { it !in alreadySeen }
         worklist += newStart
         alreadySeen += newStart
 
-        val newEnd = toAdd.map { it.end }.filter { it !in alreadySeen }
+        val newEnd = toAdd.filterMapped({ it.end }) { it !in alreadySeen }
         worklist += newEnd
         alreadySeen += newEnd
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/overlays/BasicBlock.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/graph/overlays/BasicBlock.kt
@@ -30,6 +30,7 @@ import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.OverlayNode
 import de.fraunhofer.aisec.cpg.graph.edges.overlay.BasicBlockEdgeList
 import de.fraunhofer.aisec.cpg.graph.edges.unwrapping
+import de.fraunhofer.aisec.cpg.helpers.mapNotNullFiltered
 import de.fraunhofer.aisec.cpg.passes.BasicBlockCollectorPass
 import de.fraunhofer.aisec.cpg.persistence.Convert
 import de.fraunhofer.aisec.cpg.persistence.Relationship
@@ -85,14 +86,16 @@ class BasicBlock() : OverlayNode() {
             val startLine = nodes.mapNotNull { it.location?.region?.startLine }.minOrNull() ?: -1
             val startColumn =
                 nodes
-                    .filter { it.location?.region?.startLine == startLine }
-                    .mapNotNull { it.location?.region?.startColumn }
+                    .mapNotNullFiltered({ it.location?.region?.startLine == startLine }) {
+                        it.location?.region?.startColumn
+                    }
                     .minOrNull() ?: -1
             val endLine = nodes.mapNotNull { it.location?.region?.endLine }.maxOrNull() ?: -1
             val endColumn =
                 nodes
-                    .filter { it.location?.region?.endLine == endLine }
-                    .mapNotNull { it.location?.region?.endColumn }
+                    .mapNotNullFiltered({ it.location?.region?.endLine == endLine }) {
+                        it.location?.region?.endColumn
+                    }
                     .maxOrNull() ?: -1
             return PhysicalLocation(
                 uri = startNode?.location?.artifactLocation?.uri ?: URI(""),

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/CollectionUtils.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/CollectionUtils.kt
@@ -56,6 +56,7 @@ fun <T, R, C : MutableCollection<in R>> Iterable<T>.filterMappedTo(
     return target
 }
 
+/** Single-pass equivalent of `this.map(transform).filter(predicate)`. */
 fun <T, R> Iterable<T>.filterMapped(transform: (T) -> R, predicate: (R) -> Boolean): List<R> =
     filterMappedTo(mutableListOf(), transform, predicate)
 
@@ -73,6 +74,7 @@ fun <T, R, C : MutableCollection<in R>> Iterable<T>.flatMapFilteredTo(
     return target
 }
 
+/** Single-pass equivalent of `this.filter(predicate).flatMap(transform)`. */
 fun <T, R> Iterable<T>.flatMapFiltered(
     predicate: (T) -> Boolean,
     transform: (T) -> Iterable<R>,
@@ -94,6 +96,7 @@ fun <T, R, C : MutableCollection<in R>> Iterable<T>.filterFlatMappedTo(
     return target
 }
 
+/** Single-pass equivalent of `this.flatMap(transform).filter(predicate)`. */
 fun <T, R> Iterable<T>.filterFlatMapped(
     transform: (T) -> Iterable<R>,
     predicate: (R) -> Boolean,
@@ -113,6 +116,7 @@ fun <T, R, U, C : MutableCollection<in U>> Iterable<T>.mapFlatMappedTo(
     return target
 }
 
+/** Single-pass equivalent of `this.flatMap(transform).map(mapper)`. */
 fun <T, R, U> Iterable<T>.mapFlatMapped(transform: (T) -> Iterable<R>, mapper: (R) -> U): List<U> =
     mapFlatMappedTo(mutableListOf(), transform, mapper)
 
@@ -130,6 +134,7 @@ fun <T, R, C : MutableCollection<in R>> Iterable<T>.mapNotNullFilteredTo(
     return target
 }
 
+/** Single-pass equivalent of `this.filter(predicate).mapNotNull(transform)`. */
 fun <T, R> Iterable<T>.mapNotNullFiltered(
     predicate: (T) -> Boolean,
     transform: (T) -> R?,
@@ -150,6 +155,7 @@ fun <T, R, C : MutableCollection<in R>> Iterable<T>.filterMapNotNulledTo(
     return target
 }
 
+/** Single-pass equivalent of `this.mapNotNull(transform).filter(predicate)`. */
 fun <T, R> Iterable<T>.filterMapNotNulled(
     transform: (T) -> R?,
     predicate: (R) -> Boolean,
@@ -167,6 +173,7 @@ fun <T, R, U, C : MutableCollection<in U>> Iterable<T>.mapMapNotNulledTo(
     return target
 }
 
+/** Single-pass equivalent of `this.mapNotNull(transform).map(mapper)`. */
 fun <T, R, U> Iterable<T>.mapMapNotNulled(transform: (T) -> R?, mapper: (R) -> U): List<U> =
     mapMapNotNulledTo(mutableListOf(), transform, mapper)
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/CollectionUtils.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/CollectionUtils.kt
@@ -41,6 +41,161 @@ fun <R, T, C : MutableCollection<in R>> Iterable<T>.mapFilteredTo(
 fun <R, T> Iterable<T>.mapFiltered(predicate: (T) -> Boolean, transform: (T) -> R): List<R> =
     mapFilteredTo(mutableListOf(), predicate, transform)
 
+/** Single-pass equivalent of `this.map(transform).filter(predicate)`. */
+fun <T, R, C : MutableCollection<in R>> Iterable<T>.filterMappedTo(
+    target: C,
+    transform: (T) -> R,
+    predicate: (R) -> Boolean,
+): C {
+    for (element in this) {
+        val mapped = transform(element)
+        if (predicate(mapped)) {
+            target.add(mapped)
+        }
+    }
+    return target
+}
+
+fun <T, R> Iterable<T>.filterMapped(transform: (T) -> R, predicate: (R) -> Boolean): List<R> =
+    filterMappedTo(mutableListOf(), transform, predicate)
+
+/** Single-pass equivalent of `this.filter(predicate).flatMap(transform)`. */
+fun <T, R, C : MutableCollection<in R>> Iterable<T>.flatMapFilteredTo(
+    target: C,
+    predicate: (T) -> Boolean,
+    transform: (T) -> Iterable<R>,
+): C {
+    for (element in this) {
+        if (predicate(element)) {
+            target.addAll(transform(element))
+        }
+    }
+    return target
+}
+
+fun <T, R> Iterable<T>.flatMapFiltered(
+    predicate: (T) -> Boolean,
+    transform: (T) -> Iterable<R>,
+): List<R> = flatMapFilteredTo(mutableListOf(), predicate, transform)
+
+/** Single-pass equivalent of `this.flatMap(transform).filter(predicate)`. */
+fun <T, R, C : MutableCollection<in R>> Iterable<T>.filterFlatMappedTo(
+    target: C,
+    transform: (T) -> Iterable<R>,
+    predicate: (R) -> Boolean,
+): C {
+    for (element in this) {
+        for (mapped in transform(element)) {
+            if (predicate(mapped)) {
+                target.add(mapped)
+            }
+        }
+    }
+    return target
+}
+
+fun <T, R> Iterable<T>.filterFlatMapped(
+    transform: (T) -> Iterable<R>,
+    predicate: (R) -> Boolean,
+): List<R> = filterFlatMappedTo(mutableListOf(), transform, predicate)
+
+/** Single-pass equivalent of `this.flatMap(transform).map(mapper)`. */
+fun <T, R, U, C : MutableCollection<in U>> Iterable<T>.mapFlatMappedTo(
+    target: C,
+    transform: (T) -> Iterable<R>,
+    mapper: (R) -> U,
+): C {
+    for (element in this) {
+        for (mapped in transform(element)) {
+            target.add(mapper(mapped))
+        }
+    }
+    return target
+}
+
+fun <T, R, U> Iterable<T>.mapFlatMapped(transform: (T) -> Iterable<R>, mapper: (R) -> U): List<U> =
+    mapFlatMappedTo(mutableListOf(), transform, mapper)
+
+/** Single-pass equivalent of `this.filter(predicate).mapNotNull(transform)`. */
+fun <T, R, C : MutableCollection<in R>> Iterable<T>.mapNotNullFilteredTo(
+    target: C,
+    predicate: (T) -> Boolean,
+    transform: (T) -> R?,
+): C {
+    for (element in this) {
+        if (predicate(element)) {
+            transform(element)?.let { target.add(it) }
+        }
+    }
+    return target
+}
+
+fun <T, R> Iterable<T>.mapNotNullFiltered(
+    predicate: (T) -> Boolean,
+    transform: (T) -> R?,
+): List<R> = mapNotNullFilteredTo(mutableListOf(), predicate, transform)
+
+/** Single-pass equivalent of `this.mapNotNull(transform).filter(predicate)`. */
+fun <T, R, C : MutableCollection<in R>> Iterable<T>.filterMapNotNulledTo(
+    target: C,
+    transform: (T) -> R?,
+    predicate: (R) -> Boolean,
+): C {
+    for (element in this) {
+        val mapped = transform(element)
+        if (mapped != null && predicate(mapped)) {
+            target.add(mapped)
+        }
+    }
+    return target
+}
+
+fun <T, R> Iterable<T>.filterMapNotNulled(
+    transform: (T) -> R?,
+    predicate: (R) -> Boolean,
+): List<R> = filterMapNotNulledTo(mutableListOf(), transform, predicate)
+
+/** Single-pass equivalent of `this.mapNotNull(transform).map(mapper)`. */
+fun <T, R, U, C : MutableCollection<in U>> Iterable<T>.mapMapNotNulledTo(
+    target: C,
+    transform: (T) -> R?,
+    mapper: (R) -> U,
+): C {
+    for (element in this) {
+        transform(element)?.let { target.add(mapper(it)) }
+    }
+    return target
+}
+
+fun <T, R, U> Iterable<T>.mapMapNotNulled(transform: (T) -> R?, mapper: (R) -> U): List<U> =
+    mapMapNotNulledTo(mutableListOf(), transform, mapper)
+
+/** Single-pass equivalent of `this.filterIsInstance<T>().filter(predicate)`. */
+inline fun <reified T, C : MutableCollection<in T>> Iterable<*>.filterIsInstanceAndFilterTo(
+    target: C,
+    predicate: (T) -> Boolean,
+): C {
+    for (element in this) {
+        if (element is T && predicate(element)) {
+            target.add(element)
+        }
+    }
+    return target
+}
+
+/** Single-pass equivalent of `this.filterIsInstance<T>().map(transform)`. */
+inline fun <reified T, R, C : MutableCollection<in R>> Iterable<*>.filterIsInstanceAndMapTo(
+    target: C,
+    transform: (T) -> R,
+): C {
+    for (element in this) {
+        if (element is T) {
+            target.add(transform(element))
+        }
+    }
+    return target
+}
+
 fun <T, R> Iterable<T>.flatMapNotNull(transform: (T) -> Collection<R>?): List<R> {
     val result = ArrayList<R>()
     for (element in this) {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/Util.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/helpers/Util.kt
@@ -102,7 +102,7 @@ object Util {
                     val pe = border.entries.flatMap { it.prevEOGEdges }
                     if (Quantifier.ALL == quantifier && pe.any { predicate?.invoke(it) == false })
                         return false
-                    pe.filter { predicate?.invoke(it) != false }.map { it.start }
+                    pe.mapFiltered({ predicate?.invoke(it) != false }) { it.start }
                 } else border.exits
             } else {
                 nodeSide.flatMap {
@@ -113,7 +113,7 @@ object Util {
                                 pe.any { predicate?.invoke(it) == false }
                         )
                             return false
-                        pe.filter { predicate?.invoke(it) != false }.map { it.start }
+                        pe.mapFiltered({ predicate?.invoke(it) != false }) { it.start }
                     } else listOf(it)
                 }
             })
@@ -130,7 +130,7 @@ object Util {
                                 pe.any { predicate?.invoke(it) == false }
                         )
                             return false
-                        pe.filter { predicate?.invoke(it) != false }.map { it.start }
+                        pe.mapFiltered({ predicate?.invoke(it) != false }) { it.start }
                     } else border.exits
                 }
             } else {
@@ -142,7 +142,7 @@ object Util {
                                 pe.any { predicate?.invoke(it) == false }
                         )
                             return false
-                        pe.filter { predicate?.invoke(it) != false }.map { it.start }
+                        pe.mapFiltered({ predicate?.invoke(it) != false }) { it.start }
                     } else listOf(node)
                 }
             })

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/EvaluationOrderGraphPass.kt
@@ -1016,7 +1016,7 @@ open class EvaluationOrderGraphPass(ctx: TranslationContext) : TranslationUnitPa
             // nodes following the loop
             currentPredecessors.addAll(cfNode.filterIsInstance<Break>())
             // [Continue]s are attached to the start of loops
-            val continues = cfNode.filterIsInstance<Continue>().toMutableList()
+            val continues = cfNode.filterIsInstanceTo<Continue, _>(mutableListOf())
             if (continues.isNotEmpty()) {
                 val conditions =
                     loop.conditions.map { SubgraphWalker.getEOGPathEdges(it).entries }.flatten()

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
@@ -51,6 +51,7 @@ import de.fraunhofer.aisec.cpg.helpers.functional.TupleLattice.Element
 import de.fraunhofer.aisec.cpg.helpers.identitySetOf
 import de.fraunhofer.aisec.cpg.helpers.mapFiltered
 import de.fraunhofer.aisec.cpg.helpers.mapFilteredTo
+import de.fraunhofer.aisec.cpg.helpers.mapFlatMappedTo
 import de.fraunhofer.aisec.cpg.helpers.toIdentitySet
 import de.fraunhofer.aisec.cpg.passes.PointsToPass.NodeWithPropertiesKey
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
@@ -1454,19 +1455,19 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                     return@forEach
                 }
                 val derefPMVs =
-                    p.memoryValueEdges
-                        .filter {
-                            (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget ==
-                                "derefvalue"
-                        }
-                        .map { it.start }
+                    p.memoryValueEdges.mapFiltered({
+                        (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget ==
+                            "derefvalue"
+                    }) {
+                        it.start
+                    }
                 val derefderefPMVs =
-                    p.memoryValueEdges
-                        .filter {
-                            (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget ==
-                                "derefderefvalue"
-                        }
-                        .map { it.start }
+                    p.memoryValueEdges.mapFiltered({
+                        (it.granularity as? PartialDataflowGranularity<*>)?.partialTarget ==
+                            "derefderefvalue"
+                    }) {
+                        it.start
+                    }
                 argVals.forEachMaybeParallel(minChunkSize = MIN_CHUNK_SIZE / 10) { (argVal, _) ->
                     doubleState =
                         innerCalculateIncomingCallingContexts(
@@ -2987,11 +2988,11 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                                 node = value,
                                 excludeShortFSValues = true,
                             )
-                            .map { it.value }
-                            .filter { derefValue ->
-                                doubleState.hasDeclarationStateValueEntry(derefValue)
-                            }
-                            .forEach { derefValue ->
+                            .forEach { entry ->
+                                val derefValue = entry.value
+                                if (!doubleState.hasDeclarationStateValueEntry(derefValue)) {
+                                    return@forEach
+                                }
                                 doubleState
                                     .getLastWrites(derefValue)
                                     .filter { it.properties.none { it == true } }
@@ -3913,10 +3914,12 @@ fun PointsToState.Element.getValues(
             if (node.memoryAddresses.isEmpty()) {
                 node.memoryAddresses += MemoryAddress(node.name, isGlobal(node))
             }
-            node.memoryAddresses
-                .flatMap { fetchValueFromDeclarationState(it) }
-                .map { it.value }
-                .mapTo(PowersetLattice.Element()) { Pair(it, false) }
+            node.memoryAddresses.mapFlatMappedTo(
+                PowersetLattice.Element(),
+                { fetchValueFromDeclarationState(it) },
+            ) {
+                Pair(it.value, false)
+            }
         }
         is MemoryAddress,
         is Call -> {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolver.kt
@@ -786,7 +786,7 @@ open class SymbolResolver(ctx: TranslationContext) : EOGStarterPass(ctx) {
                 workingPossibleTypes.flatMap {
                     getInvocationCandidatesFromParents(
                         name,
-                        it.superTypeDeclarations.filter { it !in possibleTypes }.toSet(),
+                        it.superTypeDeclarations.filterTo(mutableSetOf()) { it !in possibleTypes },
                     )
                 }
             }
@@ -1001,20 +1001,19 @@ internal fun Pass<*>.resolveWithArguments(
     // Filter functions that match the signature of our call, either directly or with casts;
     // those functions are "viable". Take default arguments into account if the language has
     // them.
-    result.signatureResults =
-        result.candidateFunctions
-            .map {
-                Pair(
-                    it,
-                    it.matchesSignature(
-                        arguments.map(Expression::type),
-                        arguments,
-                        source.language is HasDefaultArguments,
-                    ),
+    result.signatureResults = buildMap {
+        for (candidate in result.candidateFunctions) {
+            val signatureResult =
+                candidate.matchesSignature(
+                    arguments.map(Expression::type),
+                    arguments,
+                    source.language is HasDefaultArguments,
                 )
+            if (signatureResult is SignatureMatches) {
+                put(candidate, signatureResult)
             }
-            .filter { it.second is SignatureMatches }
-            .associate { it }
+        }
+    }
     result.viableFunctions = result.signatureResults.keys
 
     // If we have a "problematic" result, we can stop here. In this case we cannot really

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolverEOGIteration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolverEOGIteration.kt
@@ -54,6 +54,7 @@ import de.fraunhofer.aisec.cpg.helpers.functional.Lattice
 import de.fraunhofer.aisec.cpg.helpers.functional.PowersetLattice
 import de.fraunhofer.aisec.cpg.helpers.functional.TripleLattice
 import de.fraunhofer.aisec.cpg.helpers.identitySetOf
+import de.fraunhofer.aisec.cpg.helpers.mapMapNotNulled
 import de.fraunhofer.aisec.cpg.passes.Pass.Companion.log
 import kotlin.collections.toSet
 import kotlinx.coroutines.runBlocking
@@ -119,8 +120,10 @@ fun DeclarationStateElement.pushDeclarationToScope(
                 NodeToDeclarationElement(),
                 NodeToTypeElement(
                     *elements
-                        .mapNotNull { it as? HasType }
-                        .map { it as Node to PowersetLatticeTypeElement(it.type) }
+                        .asIterable()
+                        .mapMapNotNulled({ it as? HasType }) {
+                            it as Node to PowersetLatticeTypeElement(it.type)
+                        }
                         .toTypedArray()
                 ),
             ),

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolverEOGIteration.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SymbolResolverEOGIteration.kt
@@ -54,7 +54,6 @@ import de.fraunhofer.aisec.cpg.helpers.functional.Lattice
 import de.fraunhofer.aisec.cpg.helpers.functional.PowersetLattice
 import de.fraunhofer.aisec.cpg.helpers.functional.TripleLattice
 import de.fraunhofer.aisec.cpg.helpers.identitySetOf
-import de.fraunhofer.aisec.cpg.helpers.mapMapNotNulled
 import de.fraunhofer.aisec.cpg.passes.Pass.Companion.log
 import kotlin.collections.toSet
 import kotlinx.coroutines.runBlocking
@@ -120,9 +119,10 @@ fun DeclarationStateElement.pushDeclarationToScope(
                 NodeToDeclarationElement(),
                 NodeToTypeElement(
                     *elements
-                        .asIterable()
-                        .mapMapNotNulled({ it as? HasType }) {
-                            it as Node to PowersetLatticeTypeElement(it.type)
+                        .mapNotNull {
+                            (it as? HasType)?.let { hasType ->
+                                hasType as Node to PowersetLatticeTypeElement(hasType.type)
+                            }
                         }
                         .toTypedArray()
                 ),

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/DFGFunctionSummaries.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/inference/DFGFunctionSummaries.kt
@@ -55,6 +55,7 @@ import de.fraunhofer.aisec.cpg.graph.unknownType
 import de.fraunhofer.aisec.cpg.helpers.functional.PowersetLattice
 import de.fraunhofer.aisec.cpg.helpers.functional.equalLinkedHashSetOf
 import de.fraunhofer.aisec.cpg.helpers.identitySetOf
+import de.fraunhofer.aisec.cpg.helpers.mapFiltered
 import de.fraunhofer.aisec.cpg.matchesSignature
 import de.fraunhofer.aisec.cpg.passes.DFGPass
 import de.fraunhofer.aisec.cpg.passes.PointsToPass
@@ -219,16 +220,14 @@ class DFGFunctionSummaries {
              * If nothing helped to get a unique entry, we pick the first remaining entry and hope it's the most precise one.
              */
             val typeEntryList =
-                matchingEntries
-                    .filter { it.signature != null }
-                    .map {
-                        Pair(
-                            language.parseName(it.methodName).parent?.let { it1 ->
-                                typeManager.lookupResolvedType(it1, language = language)
-                            } ?: language.unknownType(),
-                            it,
-                        )
-                    }
+                matchingEntries.mapFiltered({ it.signature != null }) {
+                    Pair(
+                        language.parseName(it.methodName).parent?.let { it1 ->
+                            typeManager.lookupResolvedType(it1, language = language)
+                        } ?: language.unknownType(),
+                        it,
+                    )
+                }
             val uniqueTypes = typeEntryList.map { it.first }.distinct()
             val targetType =
                 language.parseName(functionDecl.name).parent?.let { it1 ->
@@ -242,29 +241,28 @@ class DFGFunctionSummaries {
                     ?.first
 
             val mostPreciseClassEntries =
-                typeEntryList.filter { it.first == mostPreciseType }.map { it.second }
+                typeEntryList.mapFiltered({ it.first == mostPreciseType }) { it.second }
 
-            val signatureResults =
-                mostPreciseClassEntries
-                    .map {
-                        Pair(
-                            it,
-                            functionDecl.matchesSignature(
-                                it.signature?.map {
-                                    typeManager.lookupResolvedType(it, language = language)
-                                        ?: language.unknownType()
-                                } ?: listOf()
-                            ),
+            val signatureResults = buildMap {
+                for (entry in mostPreciseClassEntries) {
+                    val result =
+                        functionDecl.matchesSignature(
+                            entry.signature?.map {
+                                typeManager.lookupResolvedType(it, language = language)
+                                    ?: language.unknownType()
+                            } ?: listOf()
                         )
+                    if (result is SignatureMatches) {
+                        put(entry, result)
                     }
-                    .filter { it.second is SignatureMatches }
-                    .associate { it }
+                }
+            }
 
             val rankings = signatureResults.entries.map { Pair(it.value.ranking, it.key) }
 
             // Find the best (lowest) rank and find functions with the specific rank
             val bestRanking = rankings.minBy { it.first }.first
-            val list = rankings.filter { it.first == bestRanking }.map { it.second }
+            val list = rankings.mapFiltered({ it.first == bestRanking }) { it.second }
 
             functionToDFGEntryMap[list.first()]
         } else {

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/persistence/Common.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/persistence/Common.kt
@@ -31,6 +31,7 @@ import de.fraunhofer.aisec.cpg.graph.Persistable
 import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeCollection
 import de.fraunhofer.aisec.cpg.graph.edges.collections.EdgeList
 import de.fraunhofer.aisec.cpg.helpers.IdentitySet
+import de.fraunhofer.aisec.cpg.helpers.filterIsInstanceAndMapTo
 import de.fraunhofer.aisec.cpg.helpers.identitySetOf
 import de.fraunhofer.aisec.cpg.persistence.converters.NameConverter
 import kotlin.collections.plusAssign
@@ -466,16 +467,15 @@ fun List<Node>.collectRelationships(): List<RelationshipMap> {
                         }
                 }
                 is List<*> -> {
-                    relationships +=
-                        value.filterIsInstance<Node>().map { end ->
-                            mapOf(
-                                "startId" to node.id.toString(),
-                                "startLegacyId" to node.legacyId,
-                                "endId" to end.id.toString(),
-                                "endLegacyId" to end.legacyId,
-                                "type" to entry.key,
-                            )
-                        }
+                    value.filterIsInstanceAndMapTo<Node, _, _>(relationships) { end ->
+                        mapOf(
+                            "startId" to node.id.toString(),
+                            "startLegacyId" to node.legacyId,
+                            "endId" to end.id.toString(),
+                            "endLegacyId" to end.legacyId,
+                            "type" to entry.key,
+                        )
+                    }
                 }
                 is Node -> {
                     relationships +=

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/processing/strategy/Strategy.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/processing/strategy/Strategy.kt
@@ -34,6 +34,7 @@ import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnit
 import de.fraunhofer.aisec.cpg.graph.edges.ast.*
 import de.fraunhofer.aisec.cpg.graph.edges.astEdges
 import de.fraunhofer.aisec.cpg.graph.edges.flows.*
+import de.fraunhofer.aisec.cpg.helpers.mapFiltered
 import java.util.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -65,7 +66,7 @@ object Strategy {
 
     /** A strategy to traverse the EOG in forward direction, but only if the edge is reachable. */
     fun REACHABLE_EOG_FORWARD(x: Node): Iterator<Node> {
-        return x.nextEOGEdges.filter { !it.unreachable }.map { it.end }.iterator()
+        return x.nextEOGEdges.mapFiltered({ !it.unreachable }) { it.end }.iterator()
     }
 
     fun COMPONENTS_LEAST_IMPORTS(x: TranslationResult): Iterator<Component> {

--- a/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CPPLanguage.kt
+++ b/cpg-language-cxx/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/cxx/CPPLanguage.kt
@@ -238,11 +238,14 @@ open class CPPLanguage :
                 (expr.operatorCode == "++" || expr.operatorCode == "--") &&
                 expr.isPostfix
         ) {
-            result.signatureResults =
-                result.candidateFunctions
-                    .map { Pair(it, it.matchesSignature(listOf(primitiveType("int")))) }
-                    .filter { it.second is SignatureMatches }
-                    .associate { it }
+            result.signatureResults = buildMap {
+                for (candidate in result.candidateFunctions) {
+                    val signatureResult = candidate.matchesSignature(listOf(primitiveType("int")))
+                    if (signatureResult is SignatureMatches) {
+                        put(candidate, signatureResult)
+                    }
+                }
+            }
         }
 
         return super.bestViableResolution(result)

--- a/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontend.kt
+++ b/cpg-language-go/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/golang/GoLanguageFrontend.kt
@@ -43,6 +43,7 @@ import de.fraunhofer.aisec.cpg.graph.newNamespace
 import de.fraunhofer.aisec.cpg.graph.types.*
 import de.fraunhofer.aisec.cpg.graph.unknownType
 import de.fraunhofer.aisec.cpg.helpers.Util
+import de.fraunhofer.aisec.cpg.helpers.mapNotNullFiltered
 import de.fraunhofer.aisec.cpg.passes.EvaluationOrderGraphPass
 import de.fraunhofer.aisec.cpg.passes.GoEvaluationOrderGraphPass
 import de.fraunhofer.aisec.cpg.passes.GoExtraPass
@@ -557,7 +558,7 @@ fun funcTypeName(paramTypes: List<Type>, returnTypes: List<Type>): String {
 
 val Record.embeddedStructs: List<Record>
     get() {
-        return this.fields
-            .filter { "embedded" in it.modifiers }
-            .mapNotNull { it.type.root.recordDeclaration }
+        return this.fields.mapNotNullFiltered({ "embedded" in it.modifiers }) {
+            it.type.root.recordDeclaration
+        }
     }

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/DeclarationHandler.kt
@@ -90,7 +90,9 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
                 rawNode = constructorDeclaration,
             )
         declaration.modifiers =
-            constructorDeclaration.modifiers.map { modifier -> modifier.keyword.asString() }.toSet()
+            constructorDeclaration.modifiers.mapTo(mutableSetOf()) { modifier ->
+                modifier.keyword.asString()
+            }
         language.applyModifiers(declaration, frontend.scopeManager.currentScope)
         frontend.scopeManager.enterScope(declaration)
         createMethodReceiver(currentRecordDecl, declaration)
@@ -160,7 +162,9 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
                 rawNode = constructorDeclaration,
             )
         declaration.modifiers =
-            constructorDeclaration.modifiers.map { modifier -> modifier.keyword.asString() }.toSet()
+            constructorDeclaration.modifiers.mapTo(mutableSetOf()) { modifier ->
+                modifier.keyword.asString()
+            }
         language.applyModifiers(declaration, frontend.scopeManager.currentScope)
         frontend.scopeManager.enterScope(declaration)
         createMethodReceiver(currentRecordDecl, declaration)
@@ -209,7 +213,7 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
                 rawNode = methodDecl,
             )
         functionDeclaration.modifiers =
-            methodDecl.modifiers.map { modifier -> modifier.keyword.asString() }.toSet()
+            methodDecl.modifiers.mapTo(mutableSetOf()) { modifier -> modifier.keyword.asString() }
         language.applyModifiers(functionDeclaration, frontend.scopeManager.currentScope)
 
         frontend.scopeManager.enterScope(functionDeclaration)
@@ -287,7 +291,9 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
             ?.let { recordDeclaration.implementedInterfaces = it }
 
         recordDeclaration.modifiers =
-            classInterDecl.modifiers.map { modifier -> modifier.keyword.asString() }.toSet()
+            classInterDecl.modifiers.mapTo(mutableSetOf()) { modifier ->
+                modifier.keyword.asString()
+            }
         language.applyModifiers(recordDeclaration, frontend.scopeManager.currentScope)
 
         frontend.typeManager.addTypeParameter(
@@ -381,7 +387,9 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
                 this.newField(
                     variable.name.asString(),
                     type,
-                    fieldDecl.modifiers.map { modifier -> modifier.keyword.asString() }.toSet(),
+                    fieldDecl.modifiers.mapTo(mutableSetOf()) { modifier ->
+                        modifier.keyword.asString()
+                    },
                     isStatic = fieldDecl.isStatic,
                     initializer = initializer,
                     rawNode = fieldDecl,
@@ -397,7 +405,7 @@ open class DeclarationHandler(lang: JavaLanguageFrontend) :
         val name = enumDecl.nameAsString
         val enumDeclaration = this.newEnumeration(name, rawNode = enumDecl)
         enumDeclaration.modifiers =
-            enumDecl.modifiers.map { modifier -> modifier.keyword.asString() }.toSet()
+            enumDecl.modifiers.mapTo(mutableSetOf()) { modifier -> modifier.keyword.asString() }
         language.applyModifiers(enumDeclaration, frontend.scopeManager.currentScope)
 
         val superTypes = enumDecl.implementedTypes.map { frontend.getTypeAsGoodAsPossible(it) }

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguage.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/JavaLanguage.kt
@@ -180,9 +180,9 @@ open class JavaLanguage :
         // therefore do some additional filtering of the candidates here, before handling it.
         if (ref.candidates.size > 1) {
             if (ref.resolutionHelper is Call) {
-                ref.candidates = ref.candidates.filter { it is Function }.toSet()
+                ref.candidates = ref.candidates.filterTo(mutableSetOf()) { it is Function }
             } else {
-                ref.candidates = ref.candidates.filter { it is Variable }.toSet()
+                ref.candidates = ref.candidates.filterTo(mutableSetOf()) { it is Variable }
             }
         }
 

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/java/StatementHandler.kt
@@ -452,10 +452,9 @@ class StatementHandler(lang: JavaLanguageFrontend?) :
         }
 
         val arguments =
-            explicitConstructorInvocationStmt.arguments
-                .map(frontend.expressionHandler::handle)
-                .filterIsInstance<Expression>()
-                .toMutableList()
+            explicitConstructorInvocationStmt.arguments.mapNotNullTo(mutableListOf()) {
+                frontend.expressionHandler.handle(it) as? Expression
+            }
         node.arguments = arguments
 
         return node

--- a/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaImportResolver.kt
+++ b/cpg-language-java/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/JavaImportResolver.kt
@@ -32,6 +32,7 @@ import de.fraunhofer.aisec.cpg.graph.declarations.*
 import de.fraunhofer.aisec.cpg.graph.declarations.Enumeration
 import de.fraunhofer.aisec.cpg.graph.declarations.Method
 import de.fraunhofer.aisec.cpg.graph.types.UnknownType
+import de.fraunhofer.aisec.cpg.helpers.filterFlatMappedTo
 import de.fraunhofer.aisec.cpg.passes.configuration.DependsOn
 import de.fraunhofer.aisec.cpg.passes.configuration.RequiresLanguage
 import de.fraunhofer.aisec.cpg.processing.IVisitor
@@ -116,16 +117,14 @@ open class JavaImportResolver(ctx: TranslationContext) : ComponentPass(ctx) {
             base.methods.filterTo(mutableSetOf()) { it.name.localName.endsWith(name) }
 
         // add methods from superclasses
-        memberMethods.addAll(
-            base.superTypeDeclarations
-                .flatMap { it.methods }
-                .filter { it.name.localName.endsWith(name) }
-        )
-        val memberFields = base.fields.filter { it.name.localName == name }.toMutableSet()
+        base.superTypeDeclarations.filterFlatMappedTo(memberMethods, { it.methods }) {
+            it.name.localName.endsWith(name)
+        }
+        val memberFields = base.fields.filterTo(mutableSetOf()) { it.name.localName == name }
         // add fields from superclasses
-        memberFields.addAll(
-            base.superTypeDeclarations.flatMap { it.fields }.filter { it.name.localName == name }
-        )
+        base.superTypeDeclarations.filterFlatMappedTo(memberFields, { it.fields }) {
+            it.name.localName == name
+        }
 
         val memberEntries = mutableSetOf<EnumConstant>()
         if (base is Enumeration) {

--- a/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMLanguage.kt
+++ b/cpg-language-jvm/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/jvm/JVMLanguage.kt
@@ -87,7 +87,7 @@ open class JVMLanguage : Language<JVMLanguageFrontend>(), HasClasses, HasFunctio
                 if (filteredFunctions.isNotEmpty()) ref.candidates = filteredFunctions
                 else ref.candidates = functionDecls.toSet()
             } else {
-                ref.candidates = ref.candidates.filterIsInstance<Variable>().toSet()
+                ref.candidates = ref.candidates.filterIsInstanceTo<Variable, _>(mutableSetOf())
             }
         }
 

--- a/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CompressLLVMPass.kt
+++ b/cpg-language-llvm/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/CompressLLVMPass.kt
@@ -32,6 +32,7 @@ import de.fraunhofer.aisec.cpg.graph.declarations.TranslationUnit
 import de.fraunhofer.aisec.cpg.graph.expressions.*
 import de.fraunhofer.aisec.cpg.graph.types.UnknownType
 import de.fraunhofer.aisec.cpg.helpers.SubgraphWalker
+import de.fraunhofer.aisec.cpg.helpers.filterIsInstanceAndFilterTo
 import de.fraunhofer.aisec.cpg.passes.configuration.ExecuteFirst
 import de.fraunhofer.aisec.cpg.passes.configuration.RequiresLanguage
 import java.util.*
@@ -48,7 +49,7 @@ class CompressLLVMPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {
         val allGotos = flatAST.filterIsInstance<Goto>()
         // Get all Labels which are only referenced from a single Goto
         val singleEntryLabels =
-            flatAST.filterIsInstance<Label>().filter { l ->
+            flatAST.filterIsInstanceAndFilterTo<Label, _>(mutableListOf()) { l ->
                 allGotos.filter { g -> g.targetLabel == l }.size == 1
             }
 
@@ -176,7 +177,9 @@ class CompressLLVMPass(ctx: TranslationContext) : TranslationUnitPass(ctx) {
      */
     private fun fixThrowsForCatch(catch: CatchClause) {
         val reachableThrowNodes =
-            getAllChildrenRecursively(catch).filterIsInstance<Throw>().filter { n ->
+            getAllChildrenRecursively(catch).filterIsInstanceAndFilterTo<Throw, _>(
+                mutableListOf()
+            ) { n ->
                 n.exception is ProblemExpression
             }
         if (reachableThrowNodes.isNotEmpty()) {

--- a/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
+++ b/cpg-language-python/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/python/PythonLanguage.kt
@@ -394,17 +394,15 @@ open class PythonLanguage :
      */
     fun nameToLanguageFiles(name: Name): Set<File> {
         val filesForNamespace =
-            fileExtensions
-                .flatMap { extension ->
-                    setOf(name, Name(IDENTIFIER_INIT, name)).map {
-                        File(
-                            it.toString().replace(language.namespaceDelimiter, File.separator) +
-                                "." +
-                                extension
-                        )
-                    }
+            fileExtensions.flatMapTo(mutableSetOf()) { extension ->
+                setOf(name, Name(IDENTIFIER_INIT, name)).map {
+                    File(
+                        it.toString().replace(language.namespaceDelimiter, File.separator) +
+                            "." +
+                            extension
+                    )
                 }
-                .toMutableSet()
+            }
         return filesForNamespace
     }
 

--- a/cpg-language-ruby/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/ruby/DeclarationHandler.kt
+++ b/cpg-language-ruby/src/main/kotlin/de/fraunhofer/aisec/cpg/frontends/ruby/DeclarationHandler.kt
@@ -151,8 +151,9 @@ class DeclarationHandler(lang: RubyLanguageFrontend) :
     private fun applyVisibilityToExisting(record: Record, name: String, visibilityKeyword: String) {
         val method = record.methods.firstOrNull { it.name.localName == name } ?: return
         method.modifiers =
-            method.modifiers.filterNot { it in RubyLanguage.visibilityModifiers }.toSet() +
-                visibilityKeyword
+            method.modifiers
+                .filterNotTo(mutableSetOf()) { it in RubyLanguage.visibilityModifiers }
+                .apply { add(visibilityKeyword) }
         language.applyModifiers(method, frontend.scopeManager.currentScope)
     }
 

--- a/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg/persistence/Neo4J.kt
+++ b/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg/persistence/Neo4J.kt
@@ -112,7 +112,7 @@ fun TranslationResult.persistNeo4j() {
     val b = Benchmark(Persistable::class.java, "Persisting translation result")
 
     val astNodes = this@persistNeo4j.nodes
-    val connected = astNodes.flatMap { it.connectedNodes }.toSet()
+    val connected = astNodes.flatMapTo(mutableSetOf()) { it.connectedNodes }
     val nodes = (astNodes + connected).distinct()
 
     log.info(

--- a/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Schema.kt
+++ b/cpg-neo4j/src/main/kotlin/de/fraunhofer/aisec/cpg_vis_neo4j/Schema.kt
@@ -28,6 +28,7 @@ package de.fraunhofer.aisec.cpg_vis_neo4j
 import com.fasterxml.jackson.databind.ObjectMapper
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.Persistable
+import de.fraunhofer.aisec.cpg.helpers.filterMapped
 import de.fraunhofer.aisec.cpg.persistence.*
 import io.github.classgraph.ClassGraph
 import java.io.File
@@ -164,18 +165,16 @@ class Schema {
         // Include both abstract and concrete classes for hierarchy building
         val allEntities =
             allSubclasses
-                .map { it.kotlin }
-                .filter { !it.java.isInterface }
-                .filterIsInstance<KClass<out Node>>()
-                .toMutableList()
+                .filterMapped({ it.kotlin }) { !it.java.isInterface }
+                .filterIsInstanceTo<KClass<out Node>, _>(mutableListOf())
 
         // Also keep track of just the concrete entities for schema output
         val entities =
             allSubclasses
-                .map { it.kotlin }
-                .filter { !it.java.isInterface && !Modifier.isAbstract(it.java.modifiers) }
-                .filterIsInstance<KClass<out Node>>()
-                .toMutableList()
+                .filterMapped({ it.kotlin }) {
+                    !it.java.isInterface && !Modifier.isAbstract(it.java.modifiers)
+                }
+                .filterIsInstanceTo<KClass<out Node>, _>(mutableListOf())
 
         // Add the Node class itself
         allEntities.add(0, nodeClass)
@@ -204,11 +203,9 @@ class Schema {
             val relationships = entity.schemaRelationships
 
             allRels[name] =
-                relationships
-                    .map { (propertyName, property) ->
-                        Pair(propertyName, property.relationshipName)
-                    }
-                    .toSet()
+                relationships.mapTo(mutableSetOf()) { (propertyName, property) ->
+                    Pair(propertyName, property.relationshipName)
+                }
         }
 
         // Complements the hierarchy and relationship information for abstract classes
@@ -221,16 +218,16 @@ class Schema {
             val relationships = entity.schemaRelationships
 
             // Get relationships declared directly in this class
-            val declaredProps = entity.memberProperties.map { it.name }.toSet()
+            val declaredProps = entity.memberProperties.mapTo(mutableSetOf()) { it.name }
             relationships.forEach { (propName, property) ->
                 relationshipFields[Pair(entity, propName)] = property
             }
 
             allRels[name]?.let { relationPair ->
                 inherentRels[name] =
-                    relationPair
-                        .filter { rel -> relationships.keys.any { it == rel.first } }
-                        .toSet()
+                    relationPair.filterTo(mutableSetOf()) { rel ->
+                        relationships.keys.any { it == rel.first }
+                    }
             }
 
             // Extracting the key-value pairs that are persisted as node properties
@@ -298,13 +295,10 @@ class Schema {
             .forEach { kClass ->
                 val name = kClass.qualifiedName ?: kClass.simpleName ?: ""
                 relCanHave[name] =
-                    hierarchy[kClass]
-                        ?.second
-                        ?.flatMap { childClass ->
-                            relCanHave[childClass.qualifiedName ?: childClass.simpleName ?: ""]
-                                ?: setOf()
-                        }
-                        ?.toSet() ?: setOf()
+                    hierarchy[kClass]?.second?.flatMapTo(mutableSetOf()) { childClass ->
+                        relCanHave[childClass.qualifiedName ?: childClass.simpleName ?: ""]
+                            ?: setOf()
+                    } ?: setOf()
             }
     }
 
@@ -536,8 +530,7 @@ class Schema {
         return list
             .map { it.second }
             .distinct()
-            .map { label -> list.first { it.second == label } }
-            .toSet()
+            .mapTo(mutableSetOf()) { label -> list.first { it.second == label } }
     }
 
     private fun toLabel(kClass: KClass<out Node>?): String {


### PR DESCRIPTION
## Summary
- Benchmarking in #2567 showed `map().toSet()`-style chains allocate an avoidable intermediate collection and are measurably slower/more memory-hungry than a single-pass `mapTo(HashSet())`. This PR applies that fix consistently, and extends it to the same anti-pattern in `filter().map()`, `flatMap().filter()`, `filterIsInstance().map()`, and similar multi-operator chains.
- Adds single-pass helpers to `cpg-core`'s `CollectionUtils.kt`: `mapFilteredTo`/`mapFiltered` (already present), `filterMappedTo`/`filterMapped`, `flatMapFilteredTo`/`flatMapFiltered`, `filterFlatMappedTo`/`filterFlatMapped`, `mapFlatMappedTo`/`mapFlatMapped`, `mapNotNullFilteredTo`/`mapNotNullFiltered`, `filterMapNotNulledTo`/`filterMapNotNulled`, `mapMapNotNulledTo`/`mapMapNotNulled`, and inline reified `filterIsInstanceAndFilterTo`/`filterIsInstanceAndMapTo`.
- Rewires ~35 call sites across `cpg-core`, `cpg-analysis`, `cpg-concepts`, `cpg-ai`, `cpg-neo4j`, `cpg-language-{java,go,jvm,llvm,cxx,python,ruby}`, `codyze-core`, and `codyze-console` to use these helpers (or a plain `filterTo`/`mapTo`/`buildMap`/`forEach` where a new helper wasn't warranted), including hot paths that run per-node/per-edge during graph construction (`SymbolResolver.kt`, `PointsToPass.kt`, `EdgeWalker.kt`, `Util.kt`, `TypeManager.kt`, `Strategy.kt`).
- Two sites were intentionally left unfused: `PassOrderingHelper.kt` (the mapped function mutates the list being iterated, so fusing would risk a `ConcurrentModificationException`) and `Detector.kt` (I/O-bound directory listing where `sortedBy` already forces full materialization, so there's nothing to gain).
- No `IdentitySet`/`ConcurrentIdentitySet` target was swapped for a plain `HashSet` — verified each touched call site's target collection type before rewriting.

Closes #2567

## Test plan
- [x] `./gradlew spotlessApply` — clean, only touches files in this diff
- [x] `./gradlew :cpg-core:compileKotlin :cpg-analysis:compileKotlin :cpg-concepts:compileKotlin :cpg-neo4j:compileKotlin -PenableAIModule=true :cpg-ai:compileKotlin -PenableCodyzeConsole=true :codyze-console:compileKotlin :codyze-core:compileKotlin :cpg-language-{java,go,jvm,llvm,cxx,python,ruby}:compileKotlin` — all succeed
- [x] Full test suites for all touched modules (`cpg-core`, `cpg-analysis`, `cpg-language-java`, `cpg-language-go`, `cpg-language-jvm`, `cpg-language-llvm`, `cpg-neo4j`, `cpg-language-python`, `cpg-language-ruby`, `cpg-language-cxx`, `cpg-concepts`, `codyze-core`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)