### PR TITLE
 cpg-ai: omit source code from bulk-listing tools

### DIFF
--- a/cpg-ai/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/tools/BulkListingCodeOmissionTest.kt
+++ b/cpg-ai/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/tools/BulkListingCodeOmissionTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.ai.mcp.tools
+
+import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.getNode
+import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.listCalls
+import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.listFunctions
+import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.runCpgAnalyze
+import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.utils.CallInfo
+import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.utils.CpgAnalyzePayload
+import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.utils.FunctionInfo
+import de.fraunhofer.aisec.cpg.ai.mcp.utils.withClient
+import de.fraunhofer.aisec.cpg.serialization.NodeJSON
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.BeforeEach
+
+/**
+ * Covers the bulk-listing code-omission change: `cpg_list_functions`/`cpg_list_calls` are for
+ * finding candidates by name/signature, not for reading every returned item's full body, so they
+ * should omit [FunctionInfo.code]/[CallInfo.code] - `cpg_get_node` remains the way to fetch full
+ * details (code included) for a specific node once picked.
+ */
+class BulkListingCodeOmissionTest {
+    @BeforeEach
+    fun setAnalysisResult() {
+        val payload =
+            CpgAnalyzePayload(
+                content =
+                    "void hello() { printf(\"Hello World\"); }\nint main() { hello(); return 0; }",
+                extension = "c",
+            )
+        runCpgAnalyze(payload, runPasses = true, cleanup = true)
+    }
+
+    @Test
+    fun listFunctionsOmitsCode() =
+        withClient(registerTools = { listFunctions() }) { client ->
+            val result = client.callTool(name = "cpg_list_functions", arguments = emptyMap())
+            assertTrue(result.content.isNotEmpty(), "Should have function declarations")
+            result.content.forEach {
+                assertIs<TextContent>(it)
+                val info = Json.decodeFromString<FunctionInfo>(it.text)
+                assertNull(info.code, "cpg_list_functions should omit code for ${info.name}")
+            }
+        }
+
+    @Test
+    fun listCallsOmitsCode() =
+        withClient(registerTools = { listCalls() }) { client ->
+            val result = client.callTool(name = "cpg_list_calls", arguments = emptyMap())
+            assertTrue(result.content.isNotEmpty(), "Should have call expressions")
+            result.content.forEach {
+                assertIs<TextContent>(it)
+                val info = Json.decodeFromString<CallInfo>(it.text)
+                assertNull(info.code, "cpg_list_calls should omit code for ${info.name}")
+            }
+        }
+
+    @Test
+    fun getNodeStillReturnsCode() =
+        withClient(
+            registerTools = {
+                listFunctions()
+                getNode()
+            }
+        ) { client ->
+            val listResult = client.callTool(name = "cpg_list_functions", arguments = emptyMap())
+            val functionInfo =
+                Json.decodeFromString<FunctionInfo>(
+                    (listResult.content.first() as TextContent).text
+                )
+
+            val result =
+                client.callTool(
+                    name = "cpg_get_node",
+                    arguments = mapOf("id" to functionInfo.nodeId),
+                )
+            val node =
+                Json.decodeFromString<NodeJSON>((result.content.single() as TextContent).text)
+            assertNotNull(node.code, "cpg_get_node should still return the full source")
+            assertTrue(node.code.isNotBlank())
+        }
+}

--- a/cpg-ai/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/tools/BulkListingCodeOmissionTest.kt
+++ b/cpg-ai/src/integrationTest/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/tools/BulkListingCodeOmissionTest.kt
@@ -27,6 +27,7 @@ package de.fraunhofer.aisec.cpg.ai.mcp.tools
 
 import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.getNode
 import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.listCalls
+import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.listCallsTo
 import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.listFunctions
 import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.runCpgAnalyze
 import de.fraunhofer.aisec.cpg.ai.mcp.mcpserver.tools.utils.CallInfo
@@ -82,6 +83,19 @@ class BulkListingCodeOmissionTest {
                 assertIs<TextContent>(it)
                 val info = Json.decodeFromString<CallInfo>(it.text)
                 assertNull(info.code, "cpg_list_calls should omit code for ${info.name}")
+            }
+        }
+
+    @Test
+    fun listCallsToOmitsCode() =
+        withClient(registerTools = { listCallsTo() }) { client ->
+            val result =
+                client.callTool(name = "cpg_list_calls_to", arguments = mapOf("name" to "hello"))
+            assertTrue(result.content.isNotEmpty(), "Should have call expressions")
+            result.content.forEach {
+                assertIs<TextContent>(it)
+                val info = Json.decodeFromString<CallInfo>(it.text)
+                assertNull(info.code, "cpg_list_calls_to should omit code for ${info.name}")
             }
         }
 

--- a/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/mcpserver/tools/ListCommands.kt
+++ b/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/mcpserver/tools/ListCommands.kt
@@ -132,6 +132,8 @@ fun Server.listCallsTo() {
     val toolDescription =
         """
         This tool lists all function and method calls to the method/function with the specified name, which are held in the graph.
+        Results omit source code to keep this listing compact - use cpg_get_node with a id to retrieve
+        the full node details (including its code) for a specific call once picked.
 
         Example prompts:
         - "Show me all calls to the function 'encrypt'"
@@ -142,7 +144,12 @@ fun Server.listCallsTo() {
     this.addTool<CpgNamePayload>(name = "cpg_list_calls_to", description = toolDescription) {
         result: TranslationResult,
         payload: CpgNamePayload ->
-        CallToolResult(content = result.calls(payload.name).map { TextContent(it.toJson()) })
+        CallToolResult(
+            content =
+                result.calls(payload.name).map {
+                    TextContent(Json.encodeToString(it.toInfo(includeCode = false)))
+                }
+        )
     }
 }
 

--- a/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/mcpserver/tools/ListCommands.kt
+++ b/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/mcpserver/tools/ListCommands.kt
@@ -46,7 +46,9 @@ fun Server.listFunctions() {
     val toolDescription =
         """
         This tool lists all functions, more precisely function declarations, which are held in the graph.
-        
+        Results omit source code to keep this listing compact - use cpg_get_node with a id to retrieve
+        the full node details (including its code) for a specific function once picked.
+
         Example prompts:
         - "Show me all functions in the analyzed code"
         - "What functions are defined in this codebase?"
@@ -56,7 +58,10 @@ fun Server.listFunctions() {
     this.addTool(name = "cpg_list_functions", description = toolDescription) { request ->
         request.runOnCpg { result: TranslationResult, _ ->
             CallToolResult(
-                content = result.functions.map { TextContent(Json.encodeToString(it.toInfo())) }
+                content =
+                    result.functions.map {
+                        TextContent(Json.encodeToString(it.toInfo(includeCode = false)))
+                    }
             )
         }
     }
@@ -114,7 +119,10 @@ fun Server.listCalls() {
     this.addTool(name = "cpg_list_calls", description = toolDescription) { request ->
         request.runOnCpg { result: TranslationResult, _ ->
             CallToolResult(
-                content = result.calls.map { TextContent(Json.encodeToString(it.toInfo())) }
+                content =
+                    result.calls.map {
+                        TextContent(Json.encodeToString(it.toInfo(includeCode = false)))
+                    }
             )
         }
     }

--- a/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/mcpserver/tools/utils/Serializable.kt
+++ b/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/mcpserver/tools/utils/Serializable.kt
@@ -141,14 +141,15 @@ data class FunctionInfo(
     val translationUnitId: String?,
 ) {
     constructor(
-        functionDeclaration: Function
+        functionDeclaration: Function,
+        includeCode: Boolean = true,
     ) : this(
         nodeId = functionDeclaration.id.toString(),
         name = functionDeclaration.name.toString(),
         parameters = functionDeclaration.parameters.map { ParameterInfo(it) },
         signature = functionDeclaration.signature,
         callees = functionDeclaration.callees.map { it.name.localName },
-        code = functionDeclaration.code,
+        code = if (includeCode) functionDeclaration.code else null,
         fileName = functionDeclaration.location?.artifactLocation?.fileName,
         startLine = functionDeclaration.location?.region?.startLine,
         endLine = functionDeclaration.location?.region?.endLine,
@@ -196,13 +197,14 @@ data class CallInfo(
     val translationUnitId: String?,
 ) {
     constructor(
-        callExpression: Call
+        callExpression: Call,
+        includeCode: Boolean = true,
     ) : this(
         nodeId = callExpression.id.toString(),
         name = callExpression.name.toString(),
         argumentNames = callExpression.arguments.map { it.name.localName },
         resolvedTo = callExpression.invokes.map { it.name.toString() },
-        code = callExpression.code,
+        code = if (includeCode) callExpression.code else null,
         fileName = callExpression.location?.artifactLocation?.fileName,
         startLine = callExpression.location?.region?.startLine,
         endLine = callExpression.location?.region?.endLine,

--- a/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/mcpserver/tools/utils/Util.kt
+++ b/cpg-ai/src/main/kotlin/de/fraunhofer/aisec/cpg/ai/mcp/mcpserver/tools/utils/Util.kt
@@ -211,11 +211,20 @@ fun Node.toJson() = Json.encodeToString(this.toJSON())
 
 fun OverlayNode.toJson() = Json.encodeToString(OverlayInfo(this))
 
-fun Function.toInfo() = FunctionInfo(this)
+/**
+ * Converts to a [FunctionInfo], omitting the (often large - can be an entire function body)
+ * [FunctionInfo.code] field when [includeCode] is false. Bulk-listing tools (e.g.
+ * `cpg_list_functions`) should pass `false`: they're for finding candidates by name/signature, and
+ * embedding every returned function's full body multiplies context size for code the model will
+ * mostly never read - `cpg_get_node` fetches the full details (code included) for a specific one
+ * once picked.
+ */
+fun Function.toInfo(includeCode: Boolean = true) = FunctionInfo(this, includeCode)
 
 fun Record.toInfo() = RecordInfo(this)
 
-fun Call.toInfo() = CallInfo(this)
+/** See [Function.toInfo] - the same reasoning applies to [Call]/[CallInfo.code]. */
+fun Call.toInfo(includeCode: Boolean = true) = CallInfo(this, includeCode)
 
 /** Returns all available concrete (non-abstract) concept classes. */
 fun getAvailableConcepts(): List<Class<out Concept>> {


### PR DESCRIPTION
`cpg_list_functions`, `cpg_list_calls`, and `cpg_list_calls_to` embed every matching function/call's full source (`FunctionInfo.code`/`CallInfo.code`) — measured at 35–45% of a typical result's bytes. These tools are for finding candidates by  name/signature; agents only need the body of a handful of what's returned, so embedding all of it is mostly wasted context.

Adds an `includeCode` parameter (default `true`) to `FunctionInfo`/`CallInfo` and has these three tools pass `false`. `cpg_get_node` already covers fetching full details for a specific node once picked.

In a real agent session analyzing several C libraries, per-call result sizes dropped ~33–46% depending on the library, with zero sampled calls leaking code post-fix — confirming the estimate holds in practice.

Covered by `BulkListingCodeOmissionTest`.