### PR TITLE
Fix ValueEvaluator for globals/statics with other writes

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluator.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluator.kt
@@ -179,18 +179,9 @@ open class ValueEvaluator(
      * their value. If not, we can try to use [handlePrevDFG].
      */
     protected fun handleHasInitializer(node: HasInitializer, depth: Int): Any? {
-        // A global or static variable can have writes somewhere else too, not just its
-        // initializer. If the DFG shows more than one, use handlePrevDFG to decide instead.
-        if (
-            node is Variable &&
-                (node.isGlobal || node.modifiers.contains("static")) &&
-                node.prevFullDFG.size > 1
-        ) {
-            return handlePrevDFG(node as Node, depth)
-        }
-
-        // If we have an initializer, we can use it. Otherwise, we can fall back to the prevDFG
-        return if (node.initializer != null) {
+        // If we have an initializer and nothing else writes to it, we can use the initializer.
+        // Otherwise, we let handlePrevDFG decide.
+        return if (node is Node && node.initializer != null && node.prevFullDFG.size <= 1) {
             evaluateInternal(node.initializer, depth + 1)
         } else {
             handlePrevDFG(node as Node, depth)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluator.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluator.kt
@@ -179,6 +179,16 @@ open class ValueEvaluator(
      * their value. If not, we can try to use [handlePrevDFG].
      */
     protected fun handleHasInitializer(node: HasInitializer, depth: Int): Any? {
+        // A global or static variable can have writes somewhere else too, not just its
+        // initializer. If the DFG shows more than one, use handlePrevDFG to decide instead.
+        if (
+            node is Variable &&
+                (node.isGlobal || node.modifiers.contains("static")) &&
+                node.prevFullDFG.size > 1
+        ) {
+            return handlePrevDFG(node as Node, depth)
+        }
+
         // If we have an initializer, we can use it. Otherwise, we can fall back to the prevDFG
         return if (node.initializer != null) {
             evaluateInternal(node.initializer, depth + 1)

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluationTests.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluationTests.kt
@@ -333,5 +333,40 @@ class ValueEvaluationTests {
                     }
                 }
             }
+
+        fun getInitializerWithWriteExample(
+            config: TranslationConfiguration =
+                TranslationConfiguration.builder()
+                    .defaultPasses()
+                    .registerLanguage<TestLanguage>()
+                    .build()
+        ) =
+            testFrontend(config).build {
+                translationResult {
+                    translationUnit("writeexample.cpp") {
+                        // a is written to elsewhere, b only has its initializer, c has no
+                        // initializer and is only assigned in `write`.
+                        declare { variable("a", t("int")) { literal(0, t("int")) } }
+                        declare { variable("b", t("int")) { literal(0, t("int")) } }
+                        declare { variable("c", t("int")) }
+
+                        function("write", t("void")) {
+                            body {
+                                ref("a") assign literal(5, t("int"))
+                                ref("c") assign literal(7, t("int"))
+                            }
+                        }
+
+                        function("main", t("int")) {
+                            body {
+                                call("println") { ref("a") }
+                                call("println") { ref("b") }
+                                call("println") { ref("c") }
+                                returnStmt { literal(0, t("int")) }
+                            }
+                        }
+                    }
+                }
+            }
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluatorTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluatorTest.kt
@@ -798,11 +798,10 @@ class ValueEvaluatorTest {
     }
 
     @Test
-    fun testHandleHasInitializerWithGlobalWrites() {
+    fun testHandleHasInitializerWithWrite() {
         with(TestLanguageFrontend()) {
-            // static int counter = 0;
+            // int counter = 0;
             val counter = newVariable("counter")
-            counter.modifiers = setOf("static")
             counter.initializer = newLiteral(0)
 
             // counter = 5; somewhere else, i.e. second prevDFG edge to counter.
@@ -823,7 +822,6 @@ class ValueEvaluatorTest {
         with(TestLanguageFrontend()) {
             // No writes to counter, only the initializer value.
             val counter = newVariable("counter")
-            counter.modifiers = setOf("static")
             counter.initializer = newLiteral(0)
             counter.prevDFG = mutableSetOf(counter.initializer as Node)
 
@@ -832,6 +830,14 @@ class ValueEvaluatorTest {
             read.prevDFG = mutableSetOf(counter)
 
             assertEquals(0, ValueEvaluator().evaluate(read))
+        }
+
+        with(TestLanguageFrontend()) {
+            // A non-Variable HasInitializer, e.g. `int a[] = {1, 2, 3};`
+            val array = newArrayConstruction()
+            array.initializer = newLiteral(1)
+
+            assertEquals(1, ValueEvaluator().evaluate(array))
         }
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluatorTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluatorTest.kt
@@ -799,57 +799,39 @@ class ValueEvaluatorTest {
 
     @Test
     fun testHandleHasInitializerWithWrite() {
-        with(TestLanguageFrontend()) {
-            // int counter = 0;
-            val counter = newVariable("counter")
-            counter.initializer = newLiteral(0)
+        val tu =
+            ValueEvaluationTests.getInitializerWithWriteExample()
+                .components
+                .first()
+                .translationUnits
+                .first()
+        val main = tu.functions["main"]
+        assertNotNull(main)
 
-            // counter = 5; somewhere else, i.e. second prevDFG edge to counter.
-            val write = newReference("counter")
-            write.refersTo = counter
-            write.prevDFG = mutableSetOf(newLiteral(5))
-            counter.prevDFG = mutableSetOf(counter.initializer as Node, write)
+        val a = main.calls("println").getOrNull(0)?.arguments?.firstOrNull()
+        val b = main.calls("println").getOrNull(1)?.arguments?.firstOrNull()
+        val c = main.calls("println").getOrNull(2)?.arguments?.firstOrNull()
+        assertNotNull(a)
+        assertNotNull(b)
+        assertNotNull(c)
 
-            // A read of counter, e.g. the condition of `if(counter)`.
-            val read = newReference("counter")
-            read.refersTo = counter
-            read.prevDFG = mutableSetOf(counter)
+        // `a` has another write, so we cannot evaluate a single value
+        assertEquals("{a}", ValueEvaluator().evaluate(a))
 
-            // There is a write to counter, so we cannot evaluate the value of counter.
-            assertEquals("{counter}", ValueEvaluator().evaluate(read))
-        }
+        // MultiValueEvaluator instead returns all values that `a` could have
+        assertEquals(ConcreteNumberSet(mutableSetOf(0, 5)), MultiValueEvaluator().evaluate(a))
 
-        with(TestLanguageFrontend()) {
-            // No writes to counter, only the initializer value.
-            val counter = newVariable("counter")
-            counter.initializer = newLiteral(0)
-            counter.prevDFG = mutableSetOf(counter.initializer as Node)
+        // `b` only has its initializer, no other writes
+        assertEquals(0, ValueEvaluator().evaluate(b))
 
-            val read = newReference("counter")
-            read.refersTo = counter
-            read.prevDFG = mutableSetOf(counter)
-
-            assertEquals(0, ValueEvaluator().evaluate(read))
-        }
+        // `c` has no initializer
+        assertEquals(7, ValueEvaluator().evaluate(c))
 
         with(TestLanguageFrontend()) {
-            // A non-Variable HasInitializer, e.g. `int a[] = {1, 2, 3};`
+            // A non-Variable HasInitializer, e.g. `new int[]{1}`.
             val array = newArrayConstruction()
             array.initializer = newLiteral(1)
-
             assertEquals(1, ValueEvaluator().evaluate(array))
-        }
-
-        with(TestLanguageFrontend()) {
-            // No initializer, falls back to prevDFG right away.
-            val counter = newVariable("counter")
-            counter.prevDFG = mutableSetOf(newLiteral(7))
-
-            val read = newReference("counter")
-            read.refersTo = counter
-            read.prevDFG = mutableSetOf(counter)
-
-            assertEquals(7, ValueEvaluator().evaluate(read))
         }
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluatorTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluatorTest.kt
@@ -839,5 +839,17 @@ class ValueEvaluatorTest {
 
             assertEquals(1, ValueEvaluator().evaluate(array))
         }
+
+        with(TestLanguageFrontend()) {
+            // No initializer, falls back to prevDFG right away.
+            val counter = newVariable("counter")
+            counter.prevDFG = mutableSetOf(newLiteral(7))
+
+            val read = newReference("counter")
+            read.refersTo = counter
+            read.prevDFG = mutableSetOf(counter)
+
+            assertEquals(7, ValueEvaluator().evaluate(read))
+        }
     }
 }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluatorTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/evaluation/ValueEvaluatorTest.kt
@@ -796,4 +796,42 @@ class ValueEvaluatorTest {
             assertEquals("{}", cond.evaluate())
         }
     }
+
+    @Test
+    fun testHandleHasInitializerWithGlobalWrites() {
+        with(TestLanguageFrontend()) {
+            // static int counter = 0;
+            val counter = newVariable("counter")
+            counter.modifiers = setOf("static")
+            counter.initializer = newLiteral(0)
+
+            // counter = 5; somewhere else, i.e. second prevDFG edge to counter.
+            val write = newReference("counter")
+            write.refersTo = counter
+            write.prevDFG = mutableSetOf(newLiteral(5))
+            counter.prevDFG = mutableSetOf(counter.initializer as Node, write)
+
+            // A read of counter, e.g. the condition of `if(counter)`.
+            val read = newReference("counter")
+            read.refersTo = counter
+            read.prevDFG = mutableSetOf(counter)
+
+            // There is a write to counter, so we cannot evaluate the value of counter.
+            assertEquals("{counter}", ValueEvaluator().evaluate(read))
+        }
+
+        with(TestLanguageFrontend()) {
+            // No writes to counter, only the initializer value.
+            val counter = newVariable("counter")
+            counter.modifiers = setOf("static")
+            counter.initializer = newLiteral(0)
+            counter.prevDFG = mutableSetOf(counter.initializer as Node)
+
+            val read = newReference("counter")
+            read.refersTo = counter
+            read.prevDFG = mutableSetOf(counter)
+
+            assertEquals(0, ValueEvaluator().evaluate(read))
+        }
+    }
 }


### PR DESCRIPTION
This PR fixes the `ValueEvaluator` by not only taking the initializer for global/static variables, but also checking whether there is a write elsewhere. 