### PR TITLE
Iterative SCC Pass

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
@@ -883,9 +883,7 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                 // Check if the value is influenced by a Parameter and if so, add this information
                 // to the functionSummary
                 val paths =
-                    value.followDFGEdgesUntilHit(
-                        collectFailedPaths = false,
-                        findAllPossiblePaths = false,
+                    value.followDFGEdgesUntilHitNodes(
                         direction = Backward(GraphToFollow.DFG),
                         sensitivities = OnlyFullDFG + FieldSensitive + ContextSensitive,
                         // We need to search interprocedural here.
@@ -912,40 +910,36 @@ open class PointsToPass(ctx: TranslationContext) : EOGStarterPass(ctx, orderDepe
                                 } || it in node.parameters
                         },
                     )
-                paths.fulfilled
-                    .mapTo(IdentitySet()) { it.nodes.last() }
-                    .forEach { sourceParamValue ->
-                        val matchingDeclarations =
-                            if (sourceParamValue is ParameterMemoryValue)
-                                node.parameters.singleOrNull {
-                                    it.name.localName == sourceParamValue.name.parent?.localName
-                                }
-                            else sourceParamValue as? Parameter
-                        if (matchingDeclarations != null) {
-                            node.functionSummary
-                                .computeIfAbsent(param) { ConcurrentHashMap.newKeySet() }
-                                .add(
-                                    FSEntry(
-                                        dstValueDepth,
-                                        matchingDeclarations,
-                                        stringToDepth(sourceParamValue.name.localName),
-                                        subAccessName,
-                                        mutableSetOf(
-                                            NodeWithPropertiesKey(
-                                                matchingDeclarations,
-                                                // Add the parameter index to indicate to the
-                                                // calculatePrevDFGs function that we need to
-                                                // replace the value of the call argument
-                                                equalLinkedHashSetOf(
-                                                    matchingDeclarations.argumentIndex
-                                                ),
-                                            )
-                                        ),
-                                        equalLinkedHashSetOf(true),
-                                    )
+                paths.forEach { sourceParamValue ->
+                    val matchingDeclarations =
+                        if (sourceParamValue is ParameterMemoryValue)
+                            node.parameters.singleOrNull {
+                                it.name.localName == sourceParamValue.name.parent?.localName
+                            }
+                        else sourceParamValue as? Parameter
+                    if (matchingDeclarations != null) {
+                        node.functionSummary
+                            .computeIfAbsent(param) { ConcurrentHashMap.newKeySet() }
+                            .add(
+                                FSEntry(
+                                    dstValueDepth,
+                                    matchingDeclarations,
+                                    stringToDepth(sourceParamValue.name.localName),
+                                    subAccessName,
+                                    mutableSetOf(
+                                        NodeWithPropertiesKey(
+                                            matchingDeclarations,
+                                            // Add the parameter index to indicate to the
+                                            // calculatePrevDFGs function that we need to
+                                            // replace the value of the call argument
+                                            equalLinkedHashSetOf(matchingDeclarations.argumentIndex),
+                                        )
+                                    ),
+                                    equalLinkedHashSetOf(true),
                                 )
-                        }
+                            )
                     }
+                }
             }
         }
     }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SccPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SccPass.kt
@@ -69,7 +69,7 @@ class SccPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
             // To detect inner loops, we put some nodes on a blacklist and see if we can still find
             // a loop
             if (next in currentInfo.blackList) {
-                break
+                continue
             }
             if (next !in currentInfo.visited) {
                 tarjan(next, level)

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SccPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SccPass.kt
@@ -53,167 +53,250 @@ class SccPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
 
     val tarjanInfoMap = mutableMapOf<Int, TarjanInfo>()
 
+    /**
+     * One item on [tarjan]'s explicit work-stack, tagged with the decomposition [level] it's for.
+     */
+    private sealed class WorkItem(val level: Int)
+
+    /**
+     * Represents one iterative "call frame" for a DFS visit of [node]: the not-yet-processed
+     * successors are pulled lazily from [iterator], exactly like the recursive version's `for (next
+     * in bb.nextEOG)` loop.
+     */
+    private class DfsFrame(val node: Node, level: Int, val iterator: Iterator<Node>) :
+        WorkItem(level)
+
+    /**
+     * Drives the nested-loop decomposition's re-run over `sccElements` (originally a recursive
+     * `forEach`) lazily: it advances [iterator] one element at a time and only pushes a [DfsFrame]
+     * for an element that is still unvisited *at the moment its turn comes up*, mirroring the
+     * recursive version's `if (element !in innerInfo.visited) tarjan(element, innerLevel)` check.
+     * Eagerly pushing frames for every currently-unvisited element up front would use a stale
+     * visited-snapshot, since visiting one element can visit others in the same decomposition.
+     */
+    private class DecompDriver(val iterator: Iterator<Node>, level: Int) : WorkItem(level)
+
     override fun cleanup() {
         // Nothing to clean up
     }
 
-    fun tarjan(bb: Node, level: Int) {
-        val currentInfo = tarjanInfoMap.computeIfAbsent(level) { TarjanInfo(emptyList()) }
-        currentInfo.blockIDs[bb] = currentInfo.blockCounter
-        currentInfo.lowLinkValues[bb] = currentInfo.blockCounter
-        currentInfo.blockCounter++
-        currentInfo.visited.add(bb)
-        currentInfo.stack.add(0, bb)
+    private fun initNode(node: Node, info: TarjanInfo) {
+        info.blockIDs[node] = info.blockCounter
+        info.lowLinkValues[node] = info.blockCounter
+        info.blockCounter++
+        info.visited.add(node)
+        info.stack.add(0, node)
+    }
 
-        for (next in bb.nextEOG) {
-            // To detect inner loops, we put some nodes on a blacklist and see if we can still find
-            // a loop
-            if (next in currentInfo.blackList) {
-                continue
+    /**
+     * Iterative rewrite of Tarjan's algorithm using an explicit work-stack instead of JVM-stack
+     * recursion. The original recursive version's recursion depth was bounded by the longest simple
+     * path in the EOG, which overflowed the JVM stack on functions with long sequential EOG chains
+     * (e.g. flac's codec functions) - this version has no such ceiling.
+     */
+    fun tarjan(bb: Node, level: Int) {
+        val workStack = ArrayDeque<WorkItem>()
+        val startInfo = tarjanInfoMap.computeIfAbsent(level) { TarjanInfo(emptyList()) }
+        initNode(bb, startInfo)
+        workStack.addLast(DfsFrame(bb, level, bb.nextEOG.iterator()))
+
+        while (workStack.isNotEmpty()) {
+            when (val item = workStack.last()) {
+                is DfsFrame -> {
+                    val info = tarjanInfoMap.computeIfAbsent(item.level) { TarjanInfo(emptyList()) }
+                    if (item.iterator.hasNext()) {
+                        val next = item.iterator.next()
+                        // To detect inner loops, we put some nodes on a blacklist and see if we
+                        // can still find a loop
+                        if (next in info.blackList) {
+                            continue
+                        }
+                        if (next !in info.visited) {
+                            initNode(next, info)
+                            workStack.addLast(DfsFrame(next, item.level, next.nextEOG.iterator()))
+                        } else if (next in info.stack) {
+                            // If the node we came from is on the stack, we min its lowLinkValue
+                            // with the one of item.node
+                            info.lowLinkValues[item.node] =
+                                min(
+                                    info.lowLinkValues.getValue(item.node),
+                                    info.lowLinkValues.getValue(next),
+                                )
+                        }
+                    } else {
+                        workStack.removeLast()
+                        val v = item.node
+                        if (info.blockIDs[v] == info.lowLinkValues[v]) {
+                            handleSccRoot(v, info, item.level, workStack)
+                        }
+                        // Mirrors the recursive version's "if (next in stack) update lowLinkValue"
+                        // check that runs right after a recursive call returns - only valid while
+                        // we're still within the same decomposition level. Note this is a no-op
+                        // whenever handleSccRoot just ran for [v], since it always removes [v]
+                        // from the stack (trivial-SCC removal or the stack-clone pop loop).
+                        val parent = workStack.lastOrNull()
+                        if (parent is DfsFrame && parent.level == item.level && v in info.stack) {
+                            info.lowLinkValues[parent.node] =
+                                min(
+                                    info.lowLinkValues.getValue(parent.node),
+                                    info.lowLinkValues.getValue(v),
+                                )
+                        }
+                    }
+                }
+                is DecompDriver -> {
+                    val innerInfo = tarjanInfoMap.getValue(item.level)
+                    if (item.iterator.hasNext()) {
+                        val element = item.iterator.next()
+                        if (element !in innerInfo.visited) {
+                            initNode(element, innerInfo)
+                            workStack.addLast(
+                                DfsFrame(element, item.level, element.nextEOG.iterator())
+                            )
+                        }
+                    } else {
+                        workStack.removeLast()
+                    }
+                }
             }
-            if (next !in currentInfo.visited) {
-                tarjan(next, level)
-            }
-            // If the node we came from is on the stack, we min its lowLinkValue with the one of bb
-            if (next in currentInfo.stack) {
-                currentInfo.lowLinkValues[bb] =
-                    min(
-                        currentInfo.lowLinkValues.getValue(bb),
-                        currentInfo.lowLinkValues.getValue(next),
-                    )
+        }
+    }
+
+    /**
+     * Handles an SCC root [bb] found at [level] (`blockIDs[bb] == lowLinkValues[bb]`): labels the
+     * SCC's edges and, if applicable, kicks off the nested-loop decomposition by pushing a
+     * [DecompDriver] onto [workStack]. Equivalent to the recursive version's SCC-root handling
+     * block, with the final `sccElements.forEach { ... tarjan(element, innerLevel) }` replaced by
+     * that push (see [DecompDriver]).
+     */
+    private fun handleSccRoot(
+        bb: Node,
+        currentInfo: TarjanInfo,
+        level: Int,
+        workStack: ArrayDeque<WorkItem>,
+    ) {
+        // Set the lowLinkValues of all nodes on the stack to the same, as they belong to the
+        // same SCC
+        // If bb is the first element on the stack, it's a trivial SCC (AKA an isolated node),
+        // so we simply remove it again without setting any properties
+        if (
+            currentInfo.stack.first() == bb
+            // Also consider SCCs that consist of a single element, in those, the bb points to
+            // itself
+            && bb.nextEOG.none { it == bb }
+        ) {
+            currentInfo.stack.remove(bb)
+            return
+        }
+
+        // Otherwise, we found a loop, so we set the scc-property of the respective edges
+        // First, let's collect all the nodes that are part of the SCC from the stack
+        // Note: This is not necessarily equal to all nodes on the stack, we only pop from
+        // the stack until we are back at our initial node [bb]
+        log.trace("Found a SCC (Level $level): ")
+        // Can't iterate over the stack and remove items from it, so we iterate over a clone
+        val stackClone = currentInfo.stack.toList()
+        val sccElements = mutableListOf<Node>()
+
+        for (it in stackClone) {
+            currentInfo.lowLinkValues[it] = currentInfo.blockIDs[bb]!!
+            log.trace("{} ({}); ", it.location, currentInfo.lowLinkValues[it])
+            // pop the node from the real stack
+            currentInfo.stack.remove(it)
+            sccElements.add(it)
+            // once we are back at our starting node [bb], we stop
+            if (it == bb) break
+        }
+        log.trace("Done with stack clone iteration.")
+
+        // We mark the incoming SCC-edge of the loopEntryElement that comes from the loop
+        // with an SCC-flag to make the difference to a mergePoint (which also has 2
+        // incoming EOG-Edges)
+        val loopEntryElements = sccElements.filter { it.prevEOG.any { it !in sccElements } }
+        loopEntryElements.forEach { loopEntryElement ->
+            loopEntryElement.prevEOGEdges
+                .filter { edge -> edge.start in sccElements }
+                .forEach { edge ->
+                    edge.scc = level
+                    // also label the respective edges between node
+                    (edge.start as? BasicBlock)
+                        ?.endNode
+                        ?.nextEOGEdges
+                        // in case of multiple nextEOGEdges, make sure we take the one
+                        // pointing to a node that's part an sccElements-block
+                        ?.filter { it.end.basicBlock.all { it in sccElements } }
+                        ?.forEach { nodeEdge -> nodeEdge.scc = level }
+                }
+        }
+
+        // label the edge of elements that exit the SCC
+        // Find elements that have edges pointing to the outside of the SCC
+        val loopExitElements =
+            sccElements.filter { it.nextEOG.any { nextEOG -> nextEOG !in sccElements } }
+
+        // get the edges that are part of the SCC (AKA points to an element on the
+        // stack) and label them
+        loopExitElements.forEach { loopExitElement ->
+            loopExitElement.nextEOGEdges
+                .filter { edge -> edge.end in sccElements }
+                .forEach { edge ->
+                    edge.scc = level
+                    // also label the respective edges between node
+                    (edge.end as? BasicBlock)
+                        ?.startNode
+                        ?.prevEOGEdges
+                        // in case of multiple prevEOGEdges, make sure we take the one
+                        // coming from a node that's part an sccElements-block
+                        ?.filter { it.start.basicBlock.all { it in sccElements } }
+                        ?.forEach { nodeEdge -> nodeEdge.scc = level }
+                }
+        }
+
+        // Additionally label edges when a block has 2 outgoing edges, both going to other
+        // sccElements
+        // This ensures that don't end up in the nextBranchEdgesList during EOG iteration
+        // but have a higher priority
+        // Note: If sccElements have only one nextEOG edge, this is not necessary, as these
+        // edges will end up in the currentBBEdgesList list, which has the highes priority
+        // anyway
+        sccElements.forEach { sccElement ->
+            val nextSCCEdges =
+                sccElement.nextEOGEdges.filter { nextEOGEdge -> nextEOGEdge.end in sccElements }
+            if (nextSCCEdges.size > 1) {
+                nextSCCEdges.forEach { nextSCCEdge ->
+                    nextSCCEdge.scc = level
+                    // Do the same for the underlying edges
+                    // There should be exactly one edge from the endNode of the BB-Edge's
+                    // start to a node that's in the BB of the BB-Edge's end
+                    // Let's find this one and also label it
+                    val bbNextEdges =
+                        (nextSCCEdge.start as? BasicBlock)?.endNode?.nextEOGEdges?.filter {
+                            it.end.basicBlock.single() == nextSCCEdge.end
+                        }
+                    if ((bbNextEdges?.size ?: 0) > 1) {
+                        log.error("Found more than one EOG Edge matching criteria")
+                    }
+                    bbNextEdges?.forEach { bbNextEdge -> bbNextEdge.scc = level }
+                }
             }
         }
 
-        if (currentInfo.blockIDs[bb] == currentInfo.lowLinkValues[bb]) {
-            // Set the lowLinkValues of all nodes on the stack to the same, as they belong to the
-            // same SCC
-            // If bb is the first element on the stack, it's a trivial SCC (AKA an isolated node),
-            // so we simply remove it again without setting any properties
-            if (
-                currentInfo.stack.first() == bb
-                // Also consider SCCs that consist of a single element, in those, the bb points to
-                // itself
-                && bb.nextEOG.none { it == bb }
-            ) {
-                currentInfo.stack.remove(bb)
-            } else {
-                // Otherwise, we found a loop, so we set the scc-property of the respective edges
-                // First, let's collect all the nodes that are part of the SCC from the stack
-                // Note: This is not necessarily equal to all nodes on the stack, we only pop from
-                // the stack until we are back at our initial node [bb]
-                log.trace("Found a SCC (Level $level): ")
-                // Can't iterate over the stack and remove items from it, so we iterate over a clone
-                val stackClone = currentInfo.stack.toList()
-                val sccElements = mutableListOf<Node>()
-
-                for (it in stackClone) {
-                    currentInfo.lowLinkValues[it] = currentInfo.blockIDs[bb]!!
-                    log.trace("{} ({}); ", it.location, currentInfo.lowLinkValues[it])
-                    // pop the node from the real stack
-                    currentInfo.stack.remove(it)
-                    sccElements.add(it)
-                    // once we are back at our starting node [bb], we stop
-                    if (it == bb) break
-                }
-                log.trace("Done with stack clone iteration.")
-
-                // We mark the incoming SCC-edge of the loopEntryElement that comes from the loop
-                // with an SCC-flag to make the difference to a mergePoint (which also has 2
-                // incoming EOG-Edges)
-                val loopEntryElements = sccElements.filter { it.prevEOG.any { it !in sccElements } }
-                loopEntryElements.forEach { loopEntryElement ->
-                    loopEntryElement.prevEOGEdges
-                        .filter { edge -> edge.start in sccElements }
-                        .forEach { edge ->
-                            edge.scc = level
-                            // also label the respective edges between node
-                            (edge.start as? BasicBlock)
-                                ?.endNode
-                                ?.nextEOGEdges
-                                // in case of multiple nextEOGEdges, make sure we take the one
-                                // pointing to a node that's part an sccElements-block
-                                ?.filter { it.end.basicBlock.all { it in sccElements } }
-                                ?.forEach { nodeEdge -> nodeEdge.scc = level }
-                        }
-                }
-
-                // label the edge of elements that exit the SCC
-                // Find elements that have edges pointing to the outside of the SCC
-                val loopExitElements =
-                    sccElements.filter { it.nextEOG.any { nextEOG -> nextEOG !in sccElements } }
-
-                // get the edges that are part of the SCC (AKA points to an element on the
-                // stack) and label them
-                loopExitElements.forEach { loopExitElement ->
-                    loopExitElement.nextEOGEdges
-                        .filter { edge -> edge.end in sccElements }
-                        .forEach { edge ->
-                            edge.scc = level
-                            // also label the respective edges between node
-                            (edge.end as? BasicBlock)
-                                ?.startNode
-                                ?.prevEOGEdges
-                                // in case of multiple prevEOGEdges, make sure we take the one
-                                // coming from a node that's part an sccElements-block
-                                ?.filter { it.start.basicBlock.all { it in sccElements } }
-                                ?.forEach { nodeEdge -> nodeEdge.scc = level }
-                        }
-                }
-
-                // Additionally label edges when a block has 2 outgoing edges, both going to other
-                // sccElements
-                // This ensures that don't end up in the nextBranchEdgesList during EOG iteration
-                // but have a higher priority
-                // Note: If sccElements have only one nextEOG edge, this is not necessary, as these
-                // edges will end up in the currentBBEdgesList list, which has the highes priority
-                // anyway
-                sccElements.forEach { sccElement ->
-                    val nextSCCEdges =
-                        sccElement.nextEOGEdges.filter { nextEOGEdge ->
-                            nextEOGEdge.end in sccElements
-                        }
-                    if (nextSCCEdges.size > 1) {
-                        nextSCCEdges.forEach { nextSCCEdge ->
-                            nextSCCEdge.scc = level
-                            // Do the same for the underlying edges
-                            // There should be exactly one edge from the endNode of the BB-Edge's
-                            // start to a node that's in the BB of the BB-Edge's end
-                            // Let's find this one and also label it
-                            val bbNextEdges =
-                                (nextSCCEdge.start as? BasicBlock)?.endNode?.nextEOGEdges?.filter {
-                                    it.end.basicBlock.single() == nextSCCEdge.end
-                                }
-                            if ((bbNextEdges?.size ?: 0) > 1) {
-                                log.error("Found more than one EOG Edge matching criteria")
-                            }
-                            bbNextEdges?.forEach { bbNextEdge -> bbNextEdge.scc = level }
-                        }
-                    }
-                }
-
-                // find nested loops
-                if (loopEntryElements.isNotEmpty() && loopExitElements.isNotEmpty()) {
-                    // We should always first find the outer loop. Now let's see if the elements in
-                    // the
-                    // SCC again contain a loop if we remove the exit node
-                    val blackList = currentInfo.blackList.toMutableList()
-                    val innerLevel = level + 1
-                    // blacklist the exitElement that comes last in the code (hoping that this is
-                    // the very end) and see if we still have a loop, that would be an
-                    // inner loop
-                    val eliminatedElement =
-                        loopEntryElements.sortedBy { it.location?.region?.startLine }.last()
-                    blackList.add(eliminatedElement)
-                    sccElements.remove(eliminatedElement)
-                    val innerInfo =
-                        tarjanInfoMap.computeIfAbsent(innerLevel) { TarjanInfo(blackList) }
-                    sccElements.forEach { element ->
-                        if (element !in innerInfo.visited) {
-                            tarjan(element, innerLevel)
-                        }
-                    }
-                }
-            }
+        // find nested loops
+        if (loopEntryElements.isNotEmpty() && loopExitElements.isNotEmpty()) {
+            // We should always first find the outer loop. Now let's see if the elements in the
+            // SCC again contain a loop if we remove the exit node
+            val blackList = currentInfo.blackList.toMutableList()
+            val innerLevel = level + 1
+            // blacklist the exitElement that comes last in the code (hoping that this is
+            // the very end) and see if we still have a loop, that would be an
+            // inner loop
+            val eliminatedElement =
+                loopEntryElements.sortedBy { it.location?.region?.startLine }.last()
+            blackList.add(eliminatedElement)
+            sccElements.remove(eliminatedElement)
+            tarjanInfoMap.computeIfAbsent(innerLevel) { TarjanInfo(blackList) }
+            // Re-run the decomposition over the remaining sccElements lazily - see [DecompDriver].
+            workStack.addLast(DecompDriver(sccElements.iterator(), innerLevel))
         }
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SccPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SccPass.kt
@@ -47,6 +47,12 @@ import kotlin.math.min
  * nested inside it - strips the SCC's exit node and re-decomposes the remaining elements one
  * `level` deeper, using a [DecompDriver] to drive that re-run. This repeats until no further nested
  * loop remains, leaving concentric loops labeled from outermost to innermost.
+ *
+ * Each [WorkItem] carries both a [WorkItem.level] (the nesting depth reported on labeled edges) and
+ * a [WorkItem.mapKey] (which [TarjanInfo] scratch space it reads/writes). These are *not* the same
+ * value: two unrelated SCCs can legitimately decompose to the same depth (e.g. two independent
+ * sibling loops, each one level "deep") without being related at all, and giving them the same
+ * scratch space would corrupt each other's blacklist/visited state - see [nextScratchKey].
  */
 @DependsOn(EvaluationOrderGraphPass::class)
 @DependsOn(BasicBlockCollectorPass::class, softDependency = true)
@@ -63,15 +69,27 @@ class SccPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
     val tarjanInfoMap = mutableMapOf<Int, TarjanInfo>()
 
     /**
-     * One item on [tarjan]'s explicit work-stack, tagged with the decomposition [level] it's for.
+     * Generates a fresh, never-reused key into [tarjanInfoMap] for each nested-decomposition
+     * attempt (see [handleSccRoot]). Deliberately disjoint from the positive `level`/depth values
+     * (always < 0) so it can never collide with a real depth, and disjoint from every other
+     * decomposition's key so two unrelated decompositions that happen to land at the same *depth*
+     * (e.g. two independent sibling loops, each one level deep) never share [TarjanInfo].
      */
-    private sealed class WorkItem(val level: Int)
+    private var nextScratchKey = -1
+
+    /**
+     * One item on [tarjan]'s explicit work-stack: [mapKey] identifies which [TarjanInfo] in
+     * [tarjanInfoMap] this item's DFS run reads/writes (see [nextScratchKey] - *not* necessarily
+     * the same as [level]), while [level] is purely the nesting depth reported on
+     * [EvaluationOrder.scc][de.fraunhofer.aisec.cpg.graph.edges.flows.EvaluationOrder.scc].
+     */
+    private sealed class WorkItem(val mapKey: Int, val level: Int)
 
     /**
      * One DFS call frame for [node]: pulls its not-yet-visited successors lazily from [iterator].
      */
-    private class DfsFrame(val node: Node, level: Int, val iterator: Iterator<Node>) :
-        WorkItem(level)
+    private class DfsFrame(val node: Node, mapKey: Int, level: Int, val iterator: Iterator<Node>) :
+        WorkItem(mapKey, level)
 
     /**
      * Drives the nested-loop re-decomposition over `sccElements`, pushing a [DfsFrame] only for an
@@ -79,7 +97,8 @@ class SccPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
      * visit others in the same decomposition, so pushing frames for all of them up front would use
      * a stale visited-snapshot.
      */
-    private class DecompDriver(val iterator: Iterator<Node>, level: Int) : WorkItem(level)
+    private class DecompDriver(val iterator: Iterator<Node>, mapKey: Int, level: Int) :
+        WorkItem(mapKey, level)
 
     override fun cleanup() {
         // Nothing to clean up
@@ -101,12 +120,13 @@ class SccPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
         val workStack = ArrayDeque<WorkItem>()
         val startInfo = tarjanInfoMap.computeIfAbsent(level) { TarjanInfo(emptyList()) }
         initNode(bb, startInfo)
-        workStack.addLast(DfsFrame(bb, level, bb.nextEOG.iterator()))
+        workStack.addLast(DfsFrame(bb, level, level, bb.nextEOG.iterator()))
 
         while (workStack.isNotEmpty()) {
             when (val item = workStack.last()) {
                 is DfsFrame -> {
-                    val info = tarjanInfoMap.computeIfAbsent(item.level) { TarjanInfo(emptyList()) }
+                    val info =
+                        tarjanInfoMap.computeIfAbsent(item.mapKey) { TarjanInfo(emptyList()) }
                     if (item.iterator.hasNext()) {
                         val next = item.iterator.next()
                         // To detect inner loops, we put some nodes on a blacklist and see if we
@@ -116,7 +136,9 @@ class SccPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
                         }
                         if (next !in info.visited) {
                             initNode(next, info)
-                            workStack.addLast(DfsFrame(next, item.level, next.nextEOG.iterator()))
+                            workStack.addLast(
+                                DfsFrame(next, item.mapKey, item.level, next.nextEOG.iterator())
+                            )
                         } else if (next in info.stack) {
                             // If the node we came from is on the stack, we min its lowLinkValue
                             // with the one of item.node
@@ -133,10 +155,13 @@ class SccPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
                             handleSccRoot(v, info, item.level, workStack)
                         }
                         // Propagate v's lowLinkValue up to the parent frame, but only within the
-                        // same decomposition level. No-op if handleSccRoot just ran for v, since
-                        // that always removes v from the stack.
+                        // same decomposition run (same mapKey, i.e. same TarjanInfo - level alone
+                        // is not a reliable enough identity check, since two unrelated
+                        // decompositions can legitimately share the same depth). No-op if
+                        // handleSccRoot just ran for v, since that always removes v from the
+                        // stack.
                         val parent = workStack.lastOrNull()
-                        if (parent is DfsFrame && parent.level == item.level && v in info.stack) {
+                        if (parent is DfsFrame && parent.mapKey == item.mapKey && v in info.stack) {
                             info.lowLinkValues[parent.node] =
                                 min(
                                     info.lowLinkValues.getValue(parent.node),
@@ -146,13 +171,18 @@ class SccPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
                     }
                 }
                 is DecompDriver -> {
-                    val innerInfo = tarjanInfoMap.getValue(item.level)
+                    val innerInfo = tarjanInfoMap.getValue(item.mapKey)
                     if (item.iterator.hasNext()) {
                         val element = item.iterator.next()
                         if (element !in innerInfo.visited) {
                             initNode(element, innerInfo)
                             workStack.addLast(
-                                DfsFrame(element, item.level, element.nextEOG.iterator())
+                                DfsFrame(
+                                    element,
+                                    item.mapKey,
+                                    item.level,
+                                    element.nextEOG.iterator(),
+                                )
                             )
                         }
                     } else {
@@ -252,15 +282,26 @@ class SccPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
         // Find nested loops: strip the last loop-entry element (by source order, hoping it's the
         // outermost entry) and re-decompose the remaining elements one level deeper - if that
         // still contains a loop, it's a nested one.
+        //
+        // Bug fixed here: this used to look up/create the inner TarjanInfo via
+        // tarjanInfoMap.computeIfAbsent(innerLevel), keyed by the plain depth number. Two
+        // *unrelated* SCCs decomposing at the same depth (e.g. two independent sibling loops,
+        // each with a single entry==exit node - an extremely common shape, not a rare corner
+        // case) would then collide: whichever one got here second inherited the first one's
+        // blackList/visited/stack instead of getting its own, silently re-labeling the first
+        // loop's edges at the second loop's depth. Each decomposition attempt now gets its own
+        // never-reused mapKey (see [nextScratchKey]) - level/depth is still level+1 for labeling,
+        // just no longer doubles as the TarjanInfo lookup key.
         if (loopEntryElements.isNotEmpty() && loopExitElements.isNotEmpty()) {
             val blackList = currentInfo.blackList.toMutableList()
             val innerLevel = level + 1
+            val innerMapKey = nextScratchKey--
             val eliminatedElement =
                 loopEntryElements.sortedBy { it.location?.region?.startLine }.last()
             blackList.add(eliminatedElement)
             sccElements.remove(eliminatedElement)
-            tarjanInfoMap.computeIfAbsent(innerLevel) { TarjanInfo(blackList) }
-            workStack.addLast(DecompDriver(sccElements.iterator(), innerLevel))
+            tarjanInfoMap[innerMapKey] = TarjanInfo(blackList)
+            workStack.addLast(DecompDriver(sccElements.iterator(), innerMapKey, innerLevel))
         }
     }
 

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SccPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SccPass.kt
@@ -113,10 +113,13 @@ class SccPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
     }
 
     /**
-     * Runs Tarjan's algorithm from [bb] at decomposition [level]; see the class doc for the
-     * algorithm.
+     * Runs Tarjan's algorithm from [bb], the root of a top-level (not nested) decomposition; see
+     * the class doc for the algorithm. Always starts at depth 1 - nested loops found along the way
+     * are decomposed one level deeper by [handleSccRoot] itself, within the same call, not by
+     * calling [tarjan] again.
      */
-    fun tarjan(bb: Node, level: Int) {
+    fun tarjan(bb: Node) {
+        val level = 1
         val workStack = ArrayDeque<WorkItem>()
         val startInfo = tarjanInfoMap.computeIfAbsent(level) { TarjanInfo(emptyList()) }
         initNode(bb, startInfo)
@@ -310,7 +313,7 @@ class SccPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
         val bb = node.basicBlock.single() as BasicBlock
         val entry = tarjanInfoMap.computeIfAbsent(0) { TarjanInfo(emptyList()) }
         if (bb !in entry.visited) {
-            tarjan(bb, 1)
+            tarjan(bb)
         }
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SccPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SccPass.kt
@@ -308,12 +308,15 @@ class SccPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
         }
     }
 
+    // Note: no need to guard against processing the same basic block twice - EOGStarterPass
+    // creates a fresh SccPass instance per starter node and calls accept() on it exactly once
+    // (see PassManager.consumeTarget), so tarjanInfoMap is never shared across multiple accept()
+    // calls in the first place. An earlier version of this method guarded on
+    // tarjanInfoMap[0].visited, but nothing ever populated that set, so the guard was always
+    // true and never did anything.
     override fun accept(node: Node) {
         if (node.basicBlock.isEmpty()) return
         val bb = node.basicBlock.single() as BasicBlock
-        val entry = tarjanInfoMap.computeIfAbsent(0) { TarjanInfo(emptyList()) }
-        if (bb !in entry.visited) {
-            tarjan(bb)
-        }
+        tarjan(bb)
     }
 }

--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SccPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/SccPass.kt
@@ -38,6 +38,15 @@ import kotlin.math.min
  * reachable from every other node within the same subgraph (i.e., loops). In addition, we remove
  * the exit nodes of the SCC so that we can also detect nested loops. The pass labels the EOG edges
  * that are part of an SCC with the same identifier.
+ *
+ * Algorithm: [tarjan] runs the DFS with an explicit [WorkItem] stack instead of recursion, since
+ * EOGs can be deeper than the JVM call stack allows. A [DfsFrame] is one DFS call frame - a node
+ * plus its not-yet-visited successors - pushed on descent and popped on return, updating lowlink
+ * values the usual Tarjan way. When a popped frame's node turns out to be an SCC root,
+ * [handleSccRoot] labels that SCC's edges with the current [WorkItem.level], then - to find loops
+ * nested inside it - strips the SCC's exit node and re-decomposes the remaining elements one
+ * `level` deeper, using a [DecompDriver] to drive that re-run. This repeats until no further nested
+ * loop remains, leaving concentric loops labeled from outermost to innermost.
  */
 @DependsOn(EvaluationOrderGraphPass::class)
 @DependsOn(BasicBlockCollectorPass::class, softDependency = true)
@@ -59,20 +68,16 @@ class SccPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
     private sealed class WorkItem(val level: Int)
 
     /**
-     * Represents one iterative "call frame" for a DFS visit of [node]: the not-yet-processed
-     * successors are pulled lazily from [iterator], exactly like the recursive version's `for (next
-     * in bb.nextEOG)` loop.
+     * One DFS call frame for [node]: pulls its not-yet-visited successors lazily from [iterator].
      */
     private class DfsFrame(val node: Node, level: Int, val iterator: Iterator<Node>) :
         WorkItem(level)
 
     /**
-     * Drives the nested-loop decomposition's re-run over `sccElements` (originally a recursive
-     * `forEach`) lazily: it advances [iterator] one element at a time and only pushes a [DfsFrame]
-     * for an element that is still unvisited *at the moment its turn comes up*, mirroring the
-     * recursive version's `if (element !in innerInfo.visited) tarjan(element, innerLevel)` check.
-     * Eagerly pushing frames for every currently-unvisited element up front would use a stale
-     * visited-snapshot, since visiting one element can visit others in the same decomposition.
+     * Drives the nested-loop re-decomposition over `sccElements`, pushing a [DfsFrame] only for an
+     * element that is still unvisited *at the moment its turn comes up* - visiting one element can
+     * visit others in the same decomposition, so pushing frames for all of them up front would use
+     * a stale visited-snapshot.
      */
     private class DecompDriver(val iterator: Iterator<Node>, level: Int) : WorkItem(level)
 
@@ -89,10 +94,8 @@ class SccPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
     }
 
     /**
-     * Iterative rewrite of Tarjan's algorithm using an explicit work-stack instead of JVM-stack
-     * recursion. The original recursive version's recursion depth was bounded by the longest simple
-     * path in the EOG, which overflowed the JVM stack on functions with long sequential EOG chains
-     * (e.g. flac's codec functions) - this version has no such ceiling.
+     * Runs Tarjan's algorithm from [bb] at decomposition [level]; see the class doc for the
+     * algorithm.
      */
     fun tarjan(bb: Node, level: Int) {
         val workStack = ArrayDeque<WorkItem>()
@@ -129,11 +132,9 @@ class SccPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
                         if (info.blockIDs[v] == info.lowLinkValues[v]) {
                             handleSccRoot(v, info, item.level, workStack)
                         }
-                        // Mirrors the recursive version's "if (next in stack) update lowLinkValue"
-                        // check that runs right after a recursive call returns - only valid while
-                        // we're still within the same decomposition level. Note this is a no-op
-                        // whenever handleSccRoot just ran for [v], since it always removes [v]
-                        // from the stack (trivial-SCC removal or the stack-clone pop loop).
+                        // Propagate v's lowLinkValue up to the parent frame, but only within the
+                        // same decomposition level. No-op if handleSccRoot just ran for v, since
+                        // that always removes v from the stack.
                         val parent = workStack.lastOrNull()
                         if (parent is DfsFrame && parent.level == item.level && v in info.stack) {
                             info.lowLinkValues[parent.node] =
@@ -165,9 +166,7 @@ class SccPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
     /**
      * Handles an SCC root [bb] found at [level] (`blockIDs[bb] == lowLinkValues[bb]`): labels the
      * SCC's edges and, if applicable, kicks off the nested-loop decomposition by pushing a
-     * [DecompDriver] onto [workStack]. Equivalent to the recursive version's SCC-root handling
-     * block, with the final `sccElements.forEach { ... tarjan(element, innerLevel) }` replaced by
-     * that push (see [DecompDriver]).
+     * [DecompDriver] onto [workStack].
      */
     private fun handleSccRoot(
         bb: Node,
@@ -175,100 +174,69 @@ class SccPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
         level: Int,
         workStack: ArrayDeque<WorkItem>,
     ) {
-        // Set the lowLinkValues of all nodes on the stack to the same, as they belong to the
-        // same SCC
-        // If bb is the first element on the stack, it's a trivial SCC (AKA an isolated node),
-        // so we simply remove it again without setting any properties
-        if (
-            currentInfo.stack.first() == bb
-            // Also consider SCCs that consist of a single element, in those, the bb points to
-            // itself
-            && bb.nextEOG.none { it == bb }
-        ) {
+        // A trivial SCC (isolated node, or a single node with a self-loop) needs no labeling.
+        if (currentInfo.stack.first() == bb && bb.nextEOG.none { it == bb }) {
             currentInfo.stack.remove(bb)
             return
         }
 
-        // Otherwise, we found a loop, so we set the scc-property of the respective edges
-        // First, let's collect all the nodes that are part of the SCC from the stack
-        // Note: This is not necessarily equal to all nodes on the stack, we only pop from
-        // the stack until we are back at our initial node [bb]
         log.trace("Found a SCC (Level $level): ")
-        // Can't iterate over the stack and remove items from it, so we iterate over a clone
+        // Not necessarily all nodes on the stack - pop only down to bb. Clone since we can't
+        // iterate the stack while removing from it.
         val stackClone = currentInfo.stack.toList()
         val sccElements = mutableListOf<Node>()
-
         for (it in stackClone) {
             currentInfo.lowLinkValues[it] = currentInfo.blockIDs[bb]!!
             log.trace("{} ({}); ", it.location, currentInfo.lowLinkValues[it])
-            // pop the node from the real stack
             currentInfo.stack.remove(it)
             sccElements.add(it)
-            // once we are back at our starting node [bb], we stop
             if (it == bb) break
         }
         log.trace("Done with stack clone iteration.")
 
-        // We mark the incoming SCC-edge of the loopEntryElement that comes from the loop
-        // with an SCC-flag to make the difference to a mergePoint (which also has 2
-        // incoming EOG-Edges)
+        // Mark the SCC's incoming edge with an scc-flag, to tell it apart from a mergePoint
+        // (which also has 2 incoming EOG edges).
         val loopEntryElements = sccElements.filter { it.prevEOG.any { it !in sccElements } }
         loopEntryElements.forEach { loopEntryElement ->
             loopEntryElement.prevEOGEdges
                 .filter { edge -> edge.start in sccElements }
                 .forEach { edge ->
                     edge.scc = level
-                    // also label the respective edges between node
+                    // also label the corresponding BasicBlock-level edge
                     (edge.start as? BasicBlock)
                         ?.endNode
                         ?.nextEOGEdges
-                        // in case of multiple nextEOGEdges, make sure we take the one
-                        // pointing to a node that's part an sccElements-block
                         ?.filter { it.end.basicBlock.all { it in sccElements } }
                         ?.forEach { nodeEdge -> nodeEdge.scc = level }
                 }
         }
 
-        // label the edge of elements that exit the SCC
-        // Find elements that have edges pointing to the outside of the SCC
+        // Mark the SCC's outgoing (exit) edges the same way.
         val loopExitElements =
             sccElements.filter { it.nextEOG.any { nextEOG -> nextEOG !in sccElements } }
-
-        // get the edges that are part of the SCC (AKA points to an element on the
-        // stack) and label them
         loopExitElements.forEach { loopExitElement ->
             loopExitElement.nextEOGEdges
                 .filter { edge -> edge.end in sccElements }
                 .forEach { edge ->
                     edge.scc = level
-                    // also label the respective edges between node
                     (edge.end as? BasicBlock)
                         ?.startNode
                         ?.prevEOGEdges
-                        // in case of multiple prevEOGEdges, make sure we take the one
-                        // coming from a node that's part an sccElements-block
                         ?.filter { it.start.basicBlock.all { it in sccElements } }
                         ?.forEach { nodeEdge -> nodeEdge.scc = level }
                 }
         }
 
-        // Additionally label edges when a block has 2 outgoing edges, both going to other
-        // sccElements
-        // This ensures that don't end up in the nextBranchEdgesList during EOG iteration
-        // but have a higher priority
-        // Note: If sccElements have only one nextEOG edge, this is not necessary, as these
-        // edges will end up in the currentBBEdgesList list, which has the highes priority
-        // anyway
+        // A block with 2 outgoing edges that both stay inside the SCC needs labeling too, so it
+        // takes priority over the nextBranchEdgesList during EOG iteration (a single such edge
+        // would already land in the higher-priority currentBBEdgesList without this).
         sccElements.forEach { sccElement ->
             val nextSCCEdges =
                 sccElement.nextEOGEdges.filter { nextEOGEdge -> nextEOGEdge.end in sccElements }
             if (nextSCCEdges.size > 1) {
                 nextSCCEdges.forEach { nextSCCEdge ->
                     nextSCCEdge.scc = level
-                    // Do the same for the underlying edges
-                    // There should be exactly one edge from the endNode of the BB-Edge's
-                    // start to a node that's in the BB of the BB-Edge's end
-                    // Let's find this one and also label it
+                    // There should be exactly one matching BasicBlock-level edge to label too.
                     val bbNextEdges =
                         (nextSCCEdge.start as? BasicBlock)?.endNode?.nextEOGEdges?.filter {
                             it.end.basicBlock.single() == nextSCCEdge.end
@@ -281,21 +249,17 @@ class SccPass(ctx: TranslationContext) : EOGStarterPass(ctx) {
             }
         }
 
-        // find nested loops
+        // Find nested loops: strip the last loop-entry element (by source order, hoping it's the
+        // outermost entry) and re-decompose the remaining elements one level deeper - if that
+        // still contains a loop, it's a nested one.
         if (loopEntryElements.isNotEmpty() && loopExitElements.isNotEmpty()) {
-            // We should always first find the outer loop. Now let's see if the elements in the
-            // SCC again contain a loop if we remove the exit node
             val blackList = currentInfo.blackList.toMutableList()
             val innerLevel = level + 1
-            // blacklist the exitElement that comes last in the code (hoping that this is
-            // the very end) and see if we still have a loop, that would be an
-            // inner loop
             val eliminatedElement =
                 loopEntryElements.sortedBy { it.location?.region?.startLine }.last()
             blackList.add(eliminatedElement)
             sccElements.remove(eliminatedElement)
             tarjanInfoMap.computeIfAbsent(innerLevel) { TarjanInfo(blackList) }
-            // Re-run the decomposition over the remaining sccElements lazily - see [DecompDriver].
             workStack.addLast(DecompDriver(sccElements.iterator(), innerLevel))
         }
     }

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/SccPassTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/SccPassTest.kt
@@ -32,6 +32,52 @@ import kotlin.test.assertTrue
 
 class SccPassTest {
     /**
+     * Regression test for the `StackOverflowError` that the original recursive [SccPass.tarjan] hit
+     * on deep EOGs (recursion depth = longest simple path in the EOG). Hand-builds a chain of [n]
+     * plain nodes linked via `nextEOG` (same approach as
+     * [testBlacklistedNodeDoesNotAbortSuccessorScan] below, just chained deep) and runs `tarjan` on
+     * a separate [Thread] with a deliberately small stack, so the test is deterministic regardless
+     * of how many bytes the JVM uses per recursive frame on a given platform.
+     *
+     * An earlier version of this test built the chain through the real frontend/DSL (many
+     * sequential `if`s, to force basic-block boundaries via `BasicBlockCollectorPass`). That turned
+     * out unreliable in practice: `defaultPasses()` pulls in unrelated passes
+     * (`ControlFlowSensitiveDFGPass`/`SymbolResolver`) with their own complexity blowups on
+     * functions with many branches (`OutOfMemoryError` at just 3,000 `if`s), and even after
+     * trimming to the minimal passes `SccPass` needs, the resulting EOG chain was consistently far
+     * shallower than the `if` count, and default-JVM-stack-sized runs never overflowed even at very
+     * high `n`. Hand-building the chain directly avoids both problems and gives an exact, known
+     * depth.
+     */
+    @Test
+    fun testDeepEogDoesNotStackOverflow() {
+        val n = 5_000
+        val start = AnnotationMember()
+        var current = start
+        repeat(n) {
+            val next = AnnotationMember()
+            current.nextEOG.add(next)
+            current = next
+        }
+
+        var caught: Throwable? = null
+        val thread =
+            Thread(
+                null,
+                {
+                    runCatching { SccPass(TranslationContext()).tarjan(start, 1) }
+                        .onFailure { caught = it }
+                },
+                "scc-small-stack",
+                256 * 1024,
+            )
+        thread.start()
+        thread.join()
+
+        assertTrue(caught == null, "SccPass threw on a deep EOG: $caught")
+    }
+
+    /**
      * Regression test for a bug where [SccPass.tarjan] used `break` instead of `continue` when
      * hitting a blacklisted node while iterating a node's `nextEOG` successors. `break` aborts the
      * whole successor scan on the first blacklisted node, silently dropping any successors that

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/SccPassTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/SccPassTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *                    $$$$$$\  $$$$$$$\   $$$$$$\
+ *                   $$  __$$\ $$  __$$\ $$  __$$\
+ *                   $$ /  \__|$$ |  $$ |$$ /  \__|
+ *                   $$ |      $$$$$$$  |$$ |$$$$\
+ *                   $$ |      $$  ____/ $$ |\_$$ |
+ *                   $$ |  $$\ $$ |      $$ |  $$ |
+ *                   \$$$$$   |$$ |      \$$$$$   |
+ *                    \______/ \__|       \______/
+ *
+ */
+package de.fraunhofer.aisec.cpg.passes
+
+import de.fraunhofer.aisec.cpg.TranslationContext
+import de.fraunhofer.aisec.cpg.graph.AnnotationMember
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class SccPassTest {
+    /**
+     * Regression test for a bug where [SccPass.tarjan] used `break` instead of `continue` when
+     * hitting a blacklisted node while iterating a node's `nextEOG` successors. `break` aborts the
+     * whole successor scan on the first blacklisted node, silently dropping any successors that
+     * come after it - instead of just skipping that one blacklisted successor and continuing to
+     * scan the others.
+     *
+     * The blacklist is only ever non-empty for `level >= 2` (nested-loop decomposition, see
+     * [SccPass.tarjan]'s call at the end of the method), so we exercise this directly by
+     * pre-seeding a [SccPass.TarjanInfo] with a blacklist, bypassing the need for a real nested
+     * loop to be parsed from source.
+     *
+     * We use [AnnotationMember] as a stand-in graph node rather than
+     * [BasicBlock][de.fraunhofer.aisec.cpg.graph.overlays.BasicBlock]: `BasicBlock.location` is a
+     * computed property that returns a non-null placeholder even when the block is empty, which
+     * pushes [de.fraunhofer.aisec.cpg.graph.Node.equals] into structural comparison - two empty
+     * `BasicBlock`s then compare as equal to each other, breaking the distinct node identities this
+     * test depends on. Any plain [Node][de.fraunhofer.aisec.cpg.graph.Node] subclass with `location
+     * == null` correctly falls back to reference equality instead.
+     */
+    @Test
+    fun testBlacklistedNodeDoesNotAbortSuccessorScan() {
+        val pass = SccPass(TranslationContext())
+
+        val bb = AnnotationMember()
+        val blacklisted = AnnotationMember()
+        val live = AnnotationMember()
+
+        // blacklisted comes first, live comes after it - this ordering is what the `break` bug
+        // depended on to drop `live` entirely.
+        bb.nextEOG.add(blacklisted)
+        bb.nextEOG.add(live)
+
+        val level = 2
+        pass.tarjanInfoMap[level] = SccPass.TarjanInfo(listOf(blacklisted))
+
+        pass.tarjan(bb, level)
+
+        assertTrue(
+            live in pass.tarjanInfoMap.getValue(level).visited,
+            "live successor after a blacklisted one must still be visited",
+        )
+    }
+}

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/SccPassTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/SccPassTest.kt
@@ -67,7 +67,7 @@ class SccPassTest {
         start.nextEOG.add(a)
         a.nextEOG.add(end)
 
-        newPass().tarjan(start, 1)
+        newPass().tarjan(start)
 
         assertNull(start.sccTo(a))
         assertNull(a.sccTo(end))
@@ -88,7 +88,7 @@ class SccPassTest {
         a.nextEOG.add(end)
         b.nextEOG.add(end)
 
-        newPass().tarjan(start, 1)
+        newPass().tarjan(start)
 
         assertNull(start.sccTo(a))
         assertNull(start.sccTo(b))
@@ -106,7 +106,7 @@ class SccPassTest {
         a.nextEOG.add(a)
         a.nextEOG.add(end)
 
-        newPass().tarjan(start, 1)
+        newPass().tarjan(start)
 
         assertEquals(1, a.sccTo(a))
         assertNull(start.sccTo(a))
@@ -125,7 +125,7 @@ class SccPassTest {
         head.nextEOG.add(end)
         body.nextEOG.add(head)
 
-        newPass().tarjan(start, 1)
+        newPass().tarjan(start)
 
         assertEquals(1, body.sccTo(head))
         assertEquals(1, head.sccTo(body))
@@ -147,7 +147,7 @@ class SccPassTest {
         b.nextEOG.add(c)
         c.nextEOG.add(head)
 
-        newPass().tarjan(start, 1)
+        newPass().tarjan(start)
 
         assertEquals(1, c.sccTo(head), "the back-edge closing the loop must be labeled")
         assertEquals(1, head.sccTo(b), "the loop's entry continuation must be labeled")
@@ -178,7 +178,7 @@ class SccPassTest {
         d.nextEOG.add(c)
         c.nextEOG.add(end)
 
-        newPass().tarjan(start, 1)
+        newPass().tarjan(start)
 
         assertEquals(1, b.sccTo(a), "loop 1's back-edge")
         assertEquals(1, d.sccTo(c), "loop 2's back-edge")
@@ -206,7 +206,7 @@ class SccPassTest {
         innerBody.nextEOG.add(inner)
         outerBody.nextEOG.add(outer)
 
-        newPass().tarjan(start, 1)
+        newPass().tarjan(start)
 
         assertEquals(1, outerBody.sccTo(outer), "outer loop's back-edge")
         assertEquals(1, outer.sccTo(inner), "outer loop's entry continuation")
@@ -241,7 +241,7 @@ class SccPassTest {
         middleBody.nextEOG.add(b)
         outerBody.nextEOG.add(a)
 
-        newPass().tarjan(start, 1)
+        newPass().tarjan(start)
 
         assertEquals(1, outerBody.sccTo(a), "outermost loop's back-edge")
         assertEquals(2, middleBody.sccTo(b), "middle loop's back-edge")
@@ -260,10 +260,11 @@ class SccPassTest {
      * come after it - instead of just skipping that one blacklisted successor and continuing to
      * scan the others.
      *
-     * The blacklist is only ever non-empty for `level >= 2` (nested-loop decomposition, see
-     * [SccPass.tarjan]'s call at the end of the method), so we exercise this directly by
-     * pre-seeding a [SccPass.TarjanInfo] with a blacklist, bypassing the need for a real nested
-     * loop to be parsed from source.
+     * The blacklist is normally only ever non-empty for a nested decomposition (populated by
+     * [handleSccRoot] itself when it re-decomposes an SCC one level deeper - see its doc), so we
+     * exercise the same code path directly here instead: pre-seed depth 1's [SccPass.TarjanInfo]
+     * with a blacklist before calling [SccPass.tarjan] (which always starts at depth 1), bypassing
+     * the need for a real nested loop to be parsed from source.
      *
      * We use [AnnotationMember] as a stand-in graph node rather than
      * [BasicBlock][de.fraunhofer.aisec.cpg.graph.overlays.BasicBlock]: `BasicBlock.location` is a
@@ -286,10 +287,10 @@ class SccPassTest {
         bb.nextEOG.add(blacklisted)
         bb.nextEOG.add(live)
 
-        val level = 2
+        val level = 1 // tarjan() always starts at depth 1
         pass.tarjanInfoMap[level] = SccPass.TarjanInfo(listOf(blacklisted))
 
-        pass.tarjan(bb, level)
+        pass.tarjan(bb)
 
         assertTrue(
             live in pass.tarjanInfoMap.getValue(level).visited,

--- a/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/SccPassTest.kt
+++ b/cpg-core/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/SccPassTest.kt
@@ -27,54 +27,230 @@ package de.fraunhofer.aisec.cpg.passes
 
 import de.fraunhofer.aisec.cpg.TranslationContext
 import de.fraunhofer.aisec.cpg.graph.AnnotationMember
+import de.fraunhofer.aisec.cpg.graph.Node
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+/**
+ * Hand-builds small EOGs (via [AnnotationMember] as a stand-in graph node - same choice as
+ * [testBlacklistedNodeDoesNotAbortSuccessorScan] below, see its doc for why) and checks
+ * [SccPass.tarjan]'s actual output: the `scc` level [SccPass] stamps onto
+ * [EvaluationOrder][de.fraunhofer.aisec.cpg.graph.edges.flows.EvaluationOrder] edges that are part
+ * of a loop.
+ *
+ * One non-obvious thing every loop-detection test below depends on: a cycle with no connection to
+ * the outside world (no predecessor into it, no successor out of it) never gets labeled at
+ * all - [SccPass] only stamps edges adjacent to a loop's entry/exit boundary nodes (the back-edge
+ * into the entry, and the continuation edge out of it - not every edge structurally inside the
+ * cycle). This matches its real use (basic blocks always sit inside a larger EOG), but means every
+ * test here wires in a `start`/`end` node around the loop under test, even though those two nodes
+ * are otherwise irrelevant to what's being tested.
+ */
 class SccPassTest {
+
+    private fun newPass() = SccPass(TranslationContext())
+
+    /** The `scc` level of the edge from this node to [other], or `null` if there isn't one. */
+    private fun Node.sccTo(other: Node): Int? = nextEOGEdges.find { it.end == other }?.scc
+
     /**
-     * Regression test for the `StackOverflowError` that the original recursive [SccPass.tarjan] hit
-     * on deep EOGs (recursion depth = longest simple path in the EOG). Hand-builds a chain of [n]
-     * plain nodes linked via `nextEOG` (same approach as
-     * [testBlacklistedNodeDoesNotAbortSuccessorScan] below, just chained deep) and runs `tarjan` on
-     * a separate [Thread] with a deliberately small stack, so the test is deterministic regardless
-     * of how many bytes the JVM uses per recursive frame on a given platform.
-     *
-     * An earlier version of this test built the chain through the real frontend/DSL (many
-     * sequential `if`s, to force basic-block boundaries via `BasicBlockCollectorPass`). That turned
-     * out unreliable in practice: `defaultPasses()` pulls in unrelated passes
-     * (`ControlFlowSensitiveDFGPass`/`SymbolResolver`) with their own complexity blowups on
-     * functions with many branches (`OutOfMemoryError` at just 3,000 `if`s), and even after
-     * trimming to the minimal passes `SccPass` needs, the resulting EOG chain was consistently far
-     * shallower than the `if` count, and default-JVM-stack-sized runs never overflowed even at very
-     * high `n`. Hand-building the chain directly avoids both problems and gives an exact, known
-     * depth.
+     * A straight line has no back-edge at all, so nothing should ever be labeled - the baseline "no
+     * false positives" case every other test here implicitly relies on.
      */
     @Test
-    fun testDeepEogDoesNotStackOverflow() {
-        val n = 5_000
+    fun testStraightLineIsNotLabeled() {
         val start = AnnotationMember()
-        var current = start
-        repeat(n) {
-            val next = AnnotationMember()
-            current.nextEOG.add(next)
-            current = next
-        }
+        val a = AnnotationMember()
+        val end = AnnotationMember()
+        start.nextEOG.add(a)
+        a.nextEOG.add(end)
 
-        var caught: Throwable? = null
-        val thread =
-            Thread(
-                null,
-                {
-                    runCatching { SccPass(TranslationContext()).tarjan(start, 1) }
-                        .onFailure { caught = it }
-                },
-                "scc-small-stack",
-                256 * 1024,
-            )
-        thread.start()
-        thread.join()
+        newPass().tarjan(start, 1)
 
-        assertTrue(caught == null, "SccPass threw on a deep EOG: $caught")
+        assertNull(start.sccTo(a))
+        assertNull(a.sccTo(end))
+    }
+
+    /**
+     * A pure diamond (branch then merge, no back-edge) must not be mistaken for a loop either -
+     * reconverging paths are not a cycle.
+     */
+    @Test
+    fun testDiamondWithoutLoopIsNotLabeled() {
+        val start = AnnotationMember()
+        val a = AnnotationMember()
+        val b = AnnotationMember()
+        val end = AnnotationMember()
+        start.nextEOG.add(a)
+        start.nextEOG.add(b)
+        a.nextEOG.add(end)
+        b.nextEOG.add(end)
+
+        newPass().tarjan(start, 1)
+
+        assertNull(start.sccTo(a))
+        assertNull(start.sccTo(b))
+        assertNull(a.sccTo(end))
+        assertNull(b.sccTo(end))
+    }
+
+    /** A single node that loops back to itself is the smallest possible real SCC. */
+    @Test
+    fun testSelfLoopIsLabeled() {
+        val start = AnnotationMember()
+        val a = AnnotationMember()
+        val end = AnnotationMember()
+        start.nextEOG.add(a)
+        a.nextEOG.add(a)
+        a.nextEOG.add(end)
+
+        newPass().tarjan(start, 1)
+
+        assertEquals(1, a.sccTo(a))
+        assertNull(start.sccTo(a))
+        assertNull(a.sccTo(end))
+    }
+
+    /** The canonical `while` loop shape: a head with a back-edge from the loop body. */
+    @Test
+    fun testSimpleLoopIsLabeled() {
+        val start = AnnotationMember()
+        val head = AnnotationMember()
+        val body = AnnotationMember()
+        val end = AnnotationMember()
+        start.nextEOG.add(head)
+        head.nextEOG.add(body)
+        head.nextEOG.add(end)
+        body.nextEOG.add(head)
+
+        newPass().tarjan(start, 1)
+
+        assertEquals(1, body.sccTo(head))
+        assertEquals(1, head.sccTo(body))
+        assertNull(start.sccTo(head))
+        assertNull(head.sccTo(end))
+    }
+
+    /** Same as [testSimpleLoopIsLabeled], but with a 3-node loop body instead of 1 node. */
+    @Test
+    fun testLongerLoopIsLabeled() {
+        val start = AnnotationMember()
+        val head = AnnotationMember()
+        val b = AnnotationMember()
+        val c = AnnotationMember()
+        val end = AnnotationMember()
+        start.nextEOG.add(head)
+        head.nextEOG.add(b)
+        head.nextEOG.add(end)
+        b.nextEOG.add(c)
+        c.nextEOG.add(head)
+
+        newPass().tarjan(start, 1)
+
+        assertEquals(1, c.sccTo(head), "the back-edge closing the loop must be labeled")
+        assertEquals(1, head.sccTo(b), "the loop's entry continuation must be labeled")
+        assertNull(start.sccTo(head))
+        assertNull(head.sccTo(end))
+    }
+
+    /**
+     * Two independent loops, connected only by a one-way bridge from the first into the second -
+     * they must be recognized as two separate SCCs, not merged into one just because the second is
+     * reachable from the first.
+     */
+    @Test
+    fun testTwoDisjointLoopsAreNotMerged() {
+        val start = AnnotationMember()
+        val a = AnnotationMember()
+        val b = AnnotationMember()
+        val bridge = AnnotationMember()
+        val c = AnnotationMember()
+        val d = AnnotationMember()
+        val end = AnnotationMember()
+        start.nextEOG.add(a)
+        a.nextEOG.add(b)
+        b.nextEOG.add(a)
+        a.nextEOG.add(bridge)
+        bridge.nextEOG.add(c)
+        c.nextEOG.add(d)
+        d.nextEOG.add(c)
+        c.nextEOG.add(end)
+
+        newPass().tarjan(start, 1)
+
+        assertEquals(1, b.sccTo(a), "loop 1's back-edge")
+        assertEquals(1, d.sccTo(c), "loop 2's back-edge")
+        assertNull(a.sccTo(bridge), "the bridge out of loop 1 is not part of either loop")
+        assertNull(bridge.sccTo(c), "the bridge into loop 2 is not part of either loop")
+    }
+
+    /**
+     * A loop nested directly inside another: `while (outer) { while (inner) { ... } }`. Both loops
+     * must be found, and at different levels - the inner one strictly deeper than the outer one.
+     */
+    @Test
+    fun testNestedLoopHasTwoLevels() {
+        val start = AnnotationMember()
+        val outer = AnnotationMember()
+        val inner = AnnotationMember()
+        val innerBody = AnnotationMember()
+        val outerBody = AnnotationMember()
+        val end = AnnotationMember()
+        start.nextEOG.add(outer)
+        outer.nextEOG.add(inner)
+        outer.nextEOG.add(end)
+        inner.nextEOG.add(innerBody)
+        inner.nextEOG.add(outerBody)
+        innerBody.nextEOG.add(inner)
+        outerBody.nextEOG.add(outer)
+
+        newPass().tarjan(start, 1)
+
+        assertEquals(1, outerBody.sccTo(outer), "outer loop's back-edge")
+        assertEquals(1, outer.sccTo(inner), "outer loop's entry continuation")
+        assertEquals(2, innerBody.sccTo(inner), "inner loop's back-edge, one level deeper")
+        assertEquals(2, inner.sccTo(innerBody), "inner loop's entry continuation")
+        assertNull(start.sccTo(outer))
+        assertNull(outer.sccTo(end))
+    }
+
+    /**
+     * Three loops nested inside each other: `while (a) { while (b) { while (c) { ... } } }`. Each
+     * level must be found at its own, strictly increasing, level.
+     */
+    @Test
+    fun testTripleNestedLoopHasThreeLevels() {
+        val start = AnnotationMember()
+        val a = AnnotationMember()
+        val b = AnnotationMember()
+        val c = AnnotationMember()
+        val innerBody = AnnotationMember()
+        val middleBody = AnnotationMember()
+        val outerBody = AnnotationMember()
+        val end = AnnotationMember()
+        start.nextEOG.add(a)
+        a.nextEOG.add(b)
+        a.nextEOG.add(end)
+        b.nextEOG.add(c)
+        b.nextEOG.add(outerBody)
+        c.nextEOG.add(innerBody)
+        c.nextEOG.add(middleBody)
+        innerBody.nextEOG.add(c)
+        middleBody.nextEOG.add(b)
+        outerBody.nextEOG.add(a)
+
+        newPass().tarjan(start, 1)
+
+        assertEquals(1, outerBody.sccTo(a), "outermost loop's back-edge")
+        assertEquals(2, middleBody.sccTo(b), "middle loop's back-edge")
+        assertEquals(3, innerBody.sccTo(c), "innermost loop's back-edge")
+        assertEquals(1, a.sccTo(b), "outermost loop's entry continuation")
+        assertEquals(2, b.sccTo(c), "middle loop's entry continuation")
+        assertEquals(3, c.sccTo(innerBody), "innermost loop's entry continuation")
+        assertNull(start.sccTo(a))
+        assertNull(a.sccTo(end))
     }
 
     /**
@@ -99,7 +275,7 @@ class SccPassTest {
      */
     @Test
     fun testBlacklistedNodeDoesNotAbortSuccessorScan() {
-        val pass = SccPass(TranslationContext())
+        val pass = newPass()
 
         val bb = AnnotationMember()
         val blacklisted = AnnotationMember()


### PR DESCRIPTION
The current implementation of Tarjan (used in the SccPass) is recursive. This doesn't work for real-world code as the algorithm crashes due to reaching the stack limit. 
This PR transfers the algorithm to an iterative implementation, which fixes this issue.