### PR TITLE
Replace archived Eclipse CDT downloads repo with io.joern's Maven Central mirror

### DIFF
--- a/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts
@@ -35,17 +35,6 @@ repositories {
     // com.github.KuechA.SootUp:sootup.* -- see the `sootup` version in
     // gradle/libs.versions.toml.
     maven { setUrl("https://jitpack.io") }
-
-    ivy {
-        setUrl("https://download.eclipse.org/tools/cdt/releases/")
-        metadataSources {
-            artifact()
-        }
-
-        patternLayout {
-            artifact("[organisation].[module]_[revision].[ext]")
-        }
-    }
 }
 
 //

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,9 +48,11 @@ jacksonyml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yam
 eclipse-runtime = { module = "org.eclipse.platform:org.eclipse.core.runtime", version = "3.34.100"}
 osgi-service = { module = "org.osgi:org.osgi.service.prefs", version = "1.1.2"}
 icu4j = { module = "com.ibm.icu:icu4j", version = "77.1"}
-# Note: This "module" intentionally looks very weird, because the CDT version is actually part of the path of the CDT external
-# repository. In order to avoid updating the repository URL everytime a new CDT version comes out, we need to do this weird hack.
-eclipse-cdt-core = { module = "11.5/cdt-11.5.0/plugins/org.eclipse.cdt:core", version = "8.4.0.202402110645"}
+# io.joern re-publishes Eclipse CDT's core plugin as a normal Maven Central artifact (with a
+# valid groupId and correct EPL-2.0 license metadata), since the upstream Eclipse CDT downloads
+# repository is not a real Maven repository. See
+# https://repo1.maven.org/maven2/io/joern/eclipse-cdt-core/ for available/newer versions.
+eclipse-cdt-core = { module = "io.joern:eclipse-cdt-core", version = "9.2.100.202507101054+1"}
 picocli = { module = "info.picocli:picocli", version = "4.7.0"}
 picocli-codegen = { module = "info.picocli:picocli-codegen", version = "4.7.0"}
 jep = { module = "org.ninia:jep", version = "4.3.1" }  # build.yml uses grep to extract the jep verison number for CI/CD purposes


### PR DESCRIPTION
## Summary
- The Eclipse CDT downloads repository we resolved `eclipse-cdt-core` from is archived (CDT 11.5 is no longer published there) — see https://download.eclipse.org/tools/cdt/releases/.
- Separately, the "organisation" hack used to encode the CDT release-train path into the Gradle module coordinate (e.g. `11.5/cdt-11.5.0/plugins/org.eclipse.cdt:core`) produced an invalid Maven `groupId` (contains `/`) in our published POM for `cpg-language-cxx`. Maven Central's current Central Publishing Portal validation rejects this.
- Switched to [`io.joern:eclipse-cdt-core`](https://repo1.maven.org/maven2/io/joern/eclipse-cdt-core/), which re-publishes Eclipse CDT's core plugin as a normal, valid Maven Central artifact (correct groupId, correct EPL-2.0 license metadata). Currently pinned to `9.2.100.202507101054+1` (CDT 12.2's core plugin) — the latest version io.joern has mirrored so far.
- Removed the custom Ivy repository from `cpg.common-conventions.gradle.kts`, which is no longer needed.

## Test plan
- [x] `./gradlew :cpg-language-cxx:compileKotlin` succeeds
- [x] `./gradlew :cpg-language-cxx:test` passes
- [x] `./gradlew :cpg-language-cxx:dependencies --configuration compileClasspath` resolves cleanly with normal version conflict resolution (no manual exclusions needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAmhhjCLF3DKN7VJHa1NTu