### PR TITLE
Add UnknownMemoryValue for unknown MemberAccess

### DIFF
--- a/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
+++ b/cpg-core/src/main/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPass.kt
@@ -3943,6 +3943,13 @@ fun PointsToState.Element.getValues(
                                 retVal.add(Pair(it.value, it.shortFS))
                             }
                         }
+                        // To indicate that there is another value than the one of the
+                        // base, we add an UnknownMemoryValue
+                        val umv =
+                            nodesCreatingUnknownValues.computeIfAbsent(Pair(node, fieldName)) {
+                                UnknownMemoryValue(fieldName)
+                            }
+                        retVal.add(Pair(umv, false))
                     }
                 }
                 retVal

--- a/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
+++ b/cpg-language-cxx/src/test/kotlin/de/fraunhofer/aisec/cpg/passes/PointsToPassTest.kt
@@ -3311,7 +3311,7 @@ class PointsToPassTest {
         assertTrue(fsecallkeytoout2.entries.firstOrNull()?.key is Parameter)
         assertLocalName("outptr", fsecallkeytoout2.entries.firstOrNull()?.key)
         assertEquals(
-            2,
+            3,
             fsecallkeytoout2.entries
                 .singleOrNull()
                 ?.value
@@ -3354,9 +3354,9 @@ class PointsToPassTest {
             "pms",
             fssgxecallkeytoout2.filter { it.key !is Return }.entries.firstOrNull()?.key,
         )
-        // 5: 3 from the in_outptr, and 2 from the in_ucptr
+        // 6: 4 from the in_outptr, and 2 from the in_ucptr
         assertEquals(
-            5,
+            6,
             fssgxecallkeytoout2.filter { it.key !is Return }.entries.firstOrNull()?.value?.size,
         )
         assertEquals(


### PR DESCRIPTION
Until now, the PtP only returned the value of the base address of a memberAccess if an unknown offset was accessed. This PR additionally adds an UnknownMemoryValue, indicating that there might also be something we don't know anything about. 